### PR TITLE
Meshless Finite Differences

### DIFF
--- a/docs/all-of-phydrax.md
+++ b/docs/all-of-phydrax.md
@@ -47,7 +47,7 @@ Phydrax supports two complementary evaluation regimes:
 
 ### Differentiation: AD / jets / FD / basis
 
-Differential operators support multiple backends (`backend="ad"|"jet"|"fd"|"basis"`) and autodiff modes
+Differential operators support multiple backends (`backend="ad"|"jet"|"fd"|"basis"|"mfd"`) and autodiff modes
 (`mode="reverse"|"forward"`). For deeper math, see [Appendix → Differentiation modes](appendix/differentiation_modes.md).
 
 ### Constraints: soft penalties vs enforced by construction

--- a/docs/api/constraints/discrete.md
+++ b/docs/api/constraints/discrete.md
@@ -1,5 +1,57 @@
 # Discrete constraints
 
+For `PointSetConstraint`, runtime operator knobs can be set once via
+`eval_kwargs` and are merged into each `.loss(...)` call. This is useful for
+fixed-cloud MFD pointsets, e.g.
+
+```python
+import jax.numpy as jnp
+import jax.random as jr
+import phydrax as phx
+
+geom = phx.domain.Interval1d(0.0, 1.0)
+component = geom.component()
+coords = jnp.linspace(0.0, 1.0, 32)
+points = {"x": coords.reshape((-1, 1))}
+plan = phx.operators.build_mfd_cloud_plan(points["x"], order=1, k=5)
+
+
+def _x_values(x):
+    if isinstance(x, tuple):
+        return jnp.asarray(x[0]).reshape((-1,))
+    arr = jnp.asarray(x)
+    if arr.ndim == 1:
+        return arr.reshape((-1,))
+    return arr[:, 0]
+
+
+@geom.Function("x")
+def u(x):
+    xx = _x_values(x)
+    return xx**3
+
+
+@geom.Function("x")
+def dudx_exact(x):
+    xx = _x_values(x)
+    return 3.0 * xx**2
+
+
+constraint = phx.constraints.PointSetConstraint.from_points(
+    component=component,
+    points=points,
+    residual=lambda fns: phx.operators.partial_n(
+        fns["u"], var="x", order=1, backend="mfd"
+    )
+    - dudx_exact,
+    constraint_vars=("u",),
+    eval_kwargs={"mfd_mode": "cloud", "mfd_cloud_plan": plan},
+)
+
+loss = constraint.loss({"u": u}, key=jr.key(0))
+assert jnp.isfinite(loss)
+```
+
 ## Discrete point constraints
 
 ::: phydrax.constraints.PointSetConstraint

--- a/docs/api/constraints/discrete.md
+++ b/docs/api/constraints/discrete.md
@@ -52,6 +52,10 @@ loss = constraint.loss({"u": u}, key=jr.key(0))
 assert jnp.isfinite(loss)
 ```
 
+For multi-axis cloud derivatives (for example Laplacians built from multiple
+`partial_n` operators), pass a `(axis, order) -> plan` mapping via
+`eval_kwargs={"mfd_mode": "cloud", "mfd_cloud_plans": plans}`.
+
 ## Discrete point constraints
 
 ::: phydrax.constraints.PointSetConstraint

--- a/docs/api/operators/differential.md
+++ b/docs/api/operators/differential.md
@@ -42,7 +42,9 @@ Many operators share these keywords:
 - `mfd_step`: probe spacing for point-input MFD evaluation (evaluation-time knob).
 - `mfd_mode`: point-input MFD mode, `"probe"` (default) or `"cloud"`.
 - `mfd_cloud_plan`: fixed-cloud stencil plan built with
-  `phydrax.operators.build_mfd_cloud_plan(...)` (required for `mfd_mode="cloud"`).
+  `phydrax.operators.build_mfd_cloud_plan(...)`.
+- `mfd_cloud_plans`: mapping from `(axis, order)` to `MFDCloudPlan` built with
+  `phydrax.operators.build_mfd_cloud_plans(...)`.
 
 See the guide for operator shape conventions and for the math behind surface and fractional operators.
 
@@ -52,14 +54,19 @@ See the guide for operator shape conventions and for the math behind surface and
     the symbolic operator.
 
 !!! note
-    `mfd_mode="cloud"` is currently a fixed-cloud point path for 1D variables
-    (`var_dim == 1`). Tuple/coord-separable MFD remains unchanged.
+    For `mfd_mode="cloud"`, provide either `mfd_cloud_plan` (single derivative plan)
+    or `mfd_cloud_plans` (multi-derivative plan table). Tuple/coord-separable MFD
+    remains unchanged.
 
 ## MFD cloud utilities
 
 Use these helpers to precompute and reuse fixed-cloud stencils for point-input MFD.
 
 ::: phydrax.operators.build_mfd_cloud_plan
+
+---
+
+::: phydrax.operators.build_mfd_cloud_plans
 
 ---
 

--- a/docs/api/operators/differential.md
+++ b/docs/api/operators/differential.md
@@ -4,7 +4,7 @@
     For a more detailed mathematical guide (notation, shapes, and backend behavior), see
     [Guides → Differential operators](../../guides_differential.md).
 
-## Backends (AD / jet / FD / basis)
+## Backends (AD / jet / FD / basis / MFD)
 
 Many differential operators accept a `backend` keyword:
 
@@ -19,6 +19,8 @@ Many differential operators accept a `backend` keyword:
   - `basis="sine"` / `basis="cosine"`: FFT-based spectral derivatives via odd/even extension
     (sine \(\leftrightarrow\) odd extension, cosine \(\leftrightarrow\) even extension),
   - `basis="poly"`: polynomial (barycentric) derivatives for generic 1D grids.
+- `backend="mfd"`: meshless finite differences with two-sided interior stencils and
+  explicit boundary closure modes (`hybrid`, `ghost`, `biased`).
 
 !!! note
     FFT-based bases (`fourier`/`sine`/`cosine`) assume a *uniformly-spaced* coordinate axis.
@@ -31,11 +33,37 @@ Many operators share these keywords:
 - `var`: label to differentiate with respect to (e.g. `"x"` or `"t"`). If omitted, the variable
   is inferred when possible.
 - `mode`: autodiff mode (`"reverse"` uses `jax.jacrev`, `"forward"` uses `jax.jacfwd`) for AD-based paths.
-- `backend`: `"ad"`, `"jet"`, `"fd"`, or `"basis"` (see above).
+- `backend`: `"ad"`, `"jet"`, `"fd"`, `"basis"`, or `"mfd"` (see above).
 - `basis`: basis method used when `backend="basis"`.
-- `periodic`: periodic treatment for FD stencils (used when `backend="fd"`).
+- `periodic`: periodic treatment for FD/MFD stencils (used when `backend in {"fd","mfd"}`).
+- `mfd_boundary_mode`: boundary closure policy when `backend="mfd"`:
+  `"hybrid"` (default), `"ghost"`, or `"biased"`.
+- `mfd_stencil_size`: local stencil/support size for MFD (evaluation-time knob).
+- `mfd_step`: probe spacing for point-input MFD evaluation (evaluation-time knob).
+- `mfd_mode`: point-input MFD mode, `"probe"` (default) or `"cloud"`.
+- `mfd_cloud_plan`: fixed-cloud stencil plan built with
+  `phydrax.operators.build_mfd_cloud_plan(...)` (required for `mfd_mode="cloud"`).
 
 See the guide for operator shape conventions and for the math behind surface and fractional operators.
+
+!!! note
+    The `mfd_*` options are consumed at operator evaluation time (e.g. when calling the
+    returned `DomainFunction`), so they can be tuned per-evaluation without rebuilding
+    the symbolic operator.
+
+!!! note
+    `mfd_mode="cloud"` is currently a fixed-cloud point path for 1D variables
+    (`var_dim == 1`). Tuple/coord-separable MFD remains unchanged.
+
+## MFD cloud utilities
+
+Use these helpers to precompute and reuse fixed-cloud stencils for point-input MFD.
+
+::: phydrax.operators.build_mfd_cloud_plan
+
+---
+
+::: phydrax.operators.MFDCloudPlan
 
 ## Core derivatives
 

--- a/docs/appendix/differentiation_modes.md
+++ b/docs/appendix/differentiation_modes.md
@@ -358,6 +358,12 @@ This avoids per-call local stencil solves and turns cloud MFD into a gather-plus
 pattern with static shapes, which is JIT-friendly for repeated training steps on a fixed
 point set.
 
+For multi-dimensional clouds (`x_i \in \mathbb{R}^d`), derivative plans are
+axis/order specific. In practice, Phydrax can consume either:
+
+- one plan via `mfd_cloud_plan` (single derivative operator), or
+- a plan table via `mfd_cloud_plans[(axis, order)]` for composed operators (e.g. Laplacian).
+
 ## 7. Practical guidance (what to use when)
 
 Common choices:

--- a/docs/cookbook/index.md
+++ b/docs/cookbook/index.md
@@ -38,7 +38,7 @@ See [API → Constraints → Enforced constraint ansätze](../api/constraints/en
 
 ### Differentiation backends
 
-Differential operators support multiple backends (`backend="ad"|"jet"|"fd"|"basis"`) and autodiff modes
+Differential operators support multiple backends (`backend="ad"|"jet"|"fd"|"basis"|"mfd"`) and autodiff modes
 (`mode="reverse"|"forward"`). For deep math notes, see
 [Appendix → Differentiation modes](../appendix/differentiation_modes.md).
 

--- a/docs/guides_differential.md
+++ b/docs/guides_differential.md
@@ -166,7 +166,10 @@ Boundary handling is explicit:
 Fixed-cloud mode for point inputs is also available:
 
 - Build a reusable plan once with `phx.operators.build_mfd_cloud_plan(points, order=n, k=K)`.
-- Evaluate with `mfd_mode="cloud", mfd_cloud_plan=plan`.
+- Or build a plan table with
+  `phx.operators.build_mfd_cloud_plans(points, specs=((axis, order), ...), k=K)`.
+- Evaluate with `mfd_mode="cloud"` and either `mfd_cloud_plan=plan` or
+  `mfd_cloud_plans=plans`.
 
 In cloud mode, for each anchor point $x_i$:
 
@@ -176,6 +179,10 @@ $$
 
 where $\nu(i,j)$ indexes the $j$th planned neighbor, $w_{ij}$ are precomputed
 stencil weights, and $m_{ij}\in\{0,1\}$ is the fixed-shape mask.
+
+For multi-dimensional clouds (`points.shape == (N, d)`), plans are axis-specific:
+for `partial_n(..., axis=a, order=n)`, use the `(a, n)` entry from
+`mfd_cloud_plans`.
 
 For coord-separable tuple inputs, MFD acts as an axiswise operator \(D_i^{(n)}\) on each
 axis and composes naturally for multi-D operators:

--- a/docs/guides_differential.md
+++ b/docs/guides_differential.md
@@ -107,6 +107,7 @@ Many differential operators accept a `backend` keyword:
 - `backend="jet"` uses Taylor-mode AD ("jets") for higher-order derivatives with respect to a single variable.
 - `backend="fd"` uses finite differences on coord-separable grids (and falls back to autodiff for point inputs).
 - `backend="basis"` uses basis-aware methods on coord-separable grids (and falls back to autodiff for point inputs).
+- `backend="mfd"` uses meshless finite differences for both point inputs and coord-separable axes.
 
 !!! note
     For `LatentContractionModel` wrapped via `domain.Model(...)`, `partial`,
@@ -116,6 +117,72 @@ Many differential operators accept a `backend` keyword:
     The latent contraction route is an acceleration path (not an approximation): if
     preconditions are not met, Phydrax falls back to the generic derivative path and
     applies the model's configured fallback policy (`warn`, `error`, or `silent`).
+
+### MFD backend (meshless finite differences)
+
+For `backend="mfd"`, derivatives are computed by a local meshless stencil around each
+target point \(x_\star\). Let \(\alpha\) be the derivative multi-index (or pure axis-order
+pair in `partial_n`) and let \(\{x_j\}_{j=1}^{N_s}\) be local support points. The
+approximation is
+
+$$
+\partial^\alpha u(x_\star)\;\approx\;\sum_{j=1}^{N_s} w_j^{(\alpha)}\,u(x_j),
+$$
+
+where weights \(w^{(\alpha)}\) are chosen to reproduce polynomials up to degree \(m\):
+
+$$
+\sum_{j=1}^{N_s} w_j^{(\alpha)}\,p(x_j) \;=\; \partial^\alpha p(x_\star)
+\quad \forall p\in\Pi_m.
+$$
+
+A common weighted least-squares construction uses local coordinates
+\(r_j=x_j-x_\star\), basis vector \(b(r)\), design matrix \(A_{j\beta}=b_\beta(r_j)\),
+and diagonal metric \(W=\operatorname{diag}(\omega_j)\). With
+\(d_{\alpha,\beta}=\partial^\alpha b_\beta(0)\), one standard formula is
+
+$$
+w^{(\alpha)} \;=\; W A\,(A^\top W A)^{-1}\,d_\alpha.
+$$
+
+Under standard smoothness and quasi-uniformity assumptions, the truncation error is
+typically of order
+
+$$
+\partial^\alpha u(x_\star) - \sum_j w_j^{(\alpha)}u(x_j)
+\;=\; O\!\left(h^{m+1-|\alpha|}\right),
+$$
+
+where \(h\) is a local spacing scale.
+
+Boundary handling is explicit:
+
+- `mfd_boundary_mode="ghost"` uses reflected/ghost support to preserve centered
+  (two-sided) behavior near boundaries.
+- `mfd_boundary_mode="biased"` uses one-sided/asymmetric in-domain support.
+- `mfd_boundary_mode="hybrid"` prefers centered/ghost closures and uses biased closure
+  when needed.
+
+Fixed-cloud mode for point inputs is also available:
+
+- Build a reusable plan once with `phx.operators.build_mfd_cloud_plan(points, order=n, k=K)`.
+- Evaluate with `mfd_mode="cloud", mfd_cloud_plan=plan`.
+
+In cloud mode, for each anchor point $x_i$:
+
+$$
+\partial^n u(x_i)\;\approx\;\sum_{j=1}^{K} m_{ij}\,w_{ij}\,u(x_{\nu(i,j)}),
+$$
+
+where $\nu(i,j)$ indexes the $j$th planned neighbor, $w_{ij}$ are precomputed
+stencil weights, and $m_{ij}\in\{0,1\}$ is the fixed-shape mask.
+
+For coord-separable tuple inputs, MFD acts as an axiswise operator \(D_i^{(n)}\) on each
+axis and composes naturally for multi-D operators:
+
+$$
+\Delta u \;\approx\; \sum_{i=1}^d D_i^{(2)}u.
+$$
 
 ### Jet backend (Taylor-mode / derivative jets)
 

--- a/examples/wave1d.py
+++ b/examples/wave1d.py
@@ -377,8 +377,9 @@ def _(jax, jnp, jr, phx):
             "u",
             domain,
             operator=lambda f: (
-                phx.operators.dt_n(f, var="t", order=2, backend="mfd")
-                - (float(c) ** 2) * phx.operators.laplacian(f, var="x", backend="mfd")
+                phx.operators.dt_n(f, var="t", order=2, ad_engine="jvp")
+                - (float(c) ** 2)
+                * phx.operators.laplacian(f, var="x", ad_engine="jvp")
             ),
             num_points={"x": int(num_x_interior), "t": int(num_t_interior)},
             structure=structure_xt,

--- a/examples/wave1d.py
+++ b/examples/wave1d.py
@@ -378,8 +378,7 @@ def _(jax, jnp, jr, phx):
             domain,
             operator=lambda f: (
                 phx.operators.dt_n(f, var="t", order=2, ad_engine="jvp")
-                - (float(c) ** 2)
-                * phx.operators.laplacian(f, var="x", ad_engine="jvp")
+                - (float(c) ** 2) * phx.operators.laplacian(f, var="x", ad_engine="jvp")
             ),
             num_points={"x": int(num_x_interior), "t": int(num_t_interior)},
             structure=structure_xt,

--- a/examples/wave1d.py
+++ b/examples/wave1d.py
@@ -194,8 +194,8 @@ def _():
     depth = 6
     num_iter = 100
     learning_rate = 7e-3
-    num_x_interior = 400
-    num_t_interior = 800
+    num_x_interior = 100
+    num_t_interior = 200
     nx_plot = 200
     nt_plot = 400
     seed = 0
@@ -377,8 +377,8 @@ def _(jax, jnp, jr, phx):
             "u",
             domain,
             operator=lambda f: (
-                phx.operators.dt_n(f, var="t", order=2, ad_engine="jvp")
-                - (float(c) ** 2) * phx.operators.laplacian(f, var="x", ad_engine="jvp")
+                phx.operators.dt_n(f, var="t", order=2, backend="mfd")
+                - (float(c) ** 2) * phx.operators.laplacian(f, var="x", backend="mfd")
             ),
             num_points={"x": int(num_x_interior), "t": int(num_t_interior)},
             structure=structure_xt,

--- a/examples/wave1d.py
+++ b/examples/wave1d.py
@@ -194,8 +194,8 @@ def _():
     depth = 6
     num_iter = 100
     learning_rate = 7e-3
-    num_x_interior = 100
-    num_t_interior = 200
+    num_x_interior = 400
+    num_t_interior = 800
     nx_plot = 200
     nt_plot = 400
     seed = 0

--- a/phydrax/constraints/_enforced.py
+++ b/phydrax/constraints/_enforced.py
@@ -1028,7 +1028,7 @@ def enforce_blend(
         axis: int | None,
         order: int,
         mode: Literal["reverse", "forward"],
-        backend: Literal["ad", "jet", "fd", "basis"],
+        backend: Literal["ad", "jet", "fd", "basis", "mfd"],
         basis: Literal["poly", "fourier", "sine", "cosine"],
         periodic: bool,
     ) -> DomainFunction | None:

--- a/phydrax/domain/_function.py
+++ b/phydrax/domain/_function.py
@@ -242,7 +242,7 @@ def _transpose_lifted_hook(
         axis: int | None,
         order: int,
         mode: Literal["reverse", "forward"],
-        backend: Literal["ad", "jet", "fd", "basis"],
+        backend: Literal["ad", "jet", "fd", "basis", "mfd"],
         basis: Literal["poly", "fourier", "sine", "cosine"],
         periodic: bool,
     ) -> "DomainFunction | None":
@@ -297,7 +297,7 @@ def _compose_binary_derivative_hook(
         axis: int | None,
         order: int,
         mode: Literal["reverse", "forward"],
-        backend: Literal["ad", "jet", "fd", "basis"],
+        backend: Literal["ad", "jet", "fd", "basis", "mfd"],
         basis: Literal["poly", "fourier", "sine", "cosine"],
         periodic: bool,
     ) -> "DomainFunction | None":
@@ -573,6 +573,19 @@ class DomainFunction(StrictModule):
     ) -> cx.Field:
         from ._model_function import _ConcatenatedModelCallable
 
+        blockwise_eval = kwargs.pop("_blockwise_eval", False)
+        blockwise_mode = "vmap"
+        if isinstance(blockwise_eval, str):
+            mode = blockwise_eval.strip().lower()
+            if mode not in ("vmap", "direct"):
+                raise ValueError(
+                    "_blockwise_eval string mode must be 'vmap' or 'direct'."
+                )
+            force_blockwise = True
+            blockwise_mode = mode
+        else:
+            force_blockwise = bool(blockwise_eval)
+
         def _emit_blockwise_fallback(reason: str, /) -> None:
             if isinstance(self.func, _ConcatenatedModelCallable):
                 self.func.emit_auto_fallback_warning(
@@ -807,14 +820,76 @@ class DomainFunction(StrictModule):
         if out is None:
             if fallback_reason is not None:
                 _emit_blockwise_fallback(fallback_reason)
-            if not self.deps:
-                val = self.func(key=key, **kwargs)
-                out = cx.Field(jnp.asarray(val), dims=(None,) * jnp.asarray(val).ndim)
+            if force_blockwise:
+                if structure is None:
+                    raise ValueError(
+                        "_blockwise_eval requires a structured PointsBatch input."
+                    )
+                if structure.axis_names is None:
+                    raise ValueError(
+                        "PointsBatch.structure must be canonicalized (axis_names set)."
+                    )
+                mapped_axes: list[str] = []
+                mapped_blocks: list[tuple[str, ...]] = []
+                for block, axis in zip(
+                    structure.blocks, structure.axis_names, strict=True
+                ):
+                    if any(lbl in self.deps for lbl in block):
+                        mapped_blocks.append(block)
+                        mapped_axes.append(axis)
+
+                if not self.deps:
+                    val = self.func(key=key, **kwargs)
+                    y = jnp.asarray(val)
+                else:
+                    dep_values = tuple(
+                        _unwrap_fields_to_data(points_map[d]) for d in self.deps
+                    )
+                    if blockwise_mode == "direct":
+                        y = jnp.asarray(self.func(*dep_values, key=key, **kwargs))
+                    elif mapped_blocks:
+
+                        def _call(*args):
+                            return self.func(*args, key=key, **kwargs)
+
+                        mapped = _call
+                        for block in reversed(mapped_blocks):
+                            in_axes = tuple(
+                                0 if dep in block else None for dep in self.deps
+                            )
+                            mapped = jax.vmap(mapped, in_axes=in_axes, out_axes=0)
+                        y = jnp.asarray(mapped(*dep_values))
+                    else:
+                        y = jnp.asarray(self.func(*dep_values, key=key, **kwargs))
+
+                if not mapped_axes:
+                    out = cx.Field(y, dims=(None,) * y.ndim)
+                else:
+                    used_axes: list[str] = []
+                    shape_i = 0
+                    started = False
+                    for axis in mapped_axes:
+                        if shape_i >= y.ndim:
+                            break
+                        n = _axis_size(points_map, axis)
+                        if y.shape[shape_i] == n:
+                            used_axes.append(axis)
+                            shape_i += 1
+                            started = True
+                            continue
+                        if started:
+                            break
+                    out_dims = tuple(used_axes) + (None,) * (y.ndim - shape_i)
+                    out = cx.Field(y, dims=out_dims)
             else:
-                dep_values = tuple(points_map[d] for d in self.deps)
-                out = cx.cmap(self.func, out_axes="leading")(
-                    *dep_values, key=key, **kwargs
-                )
+                if not self.deps:
+                    val = self.func(key=key, **kwargs)
+                    out = cx.Field(jnp.asarray(val), dims=(None,) * jnp.asarray(val).ndim)
+                else:
+                    dep_values = tuple(points_map[d] for d in self.deps)
+                    out = cx.cmap(self.func, out_axes="leading")(
+                        *dep_values, key=key, **kwargs
+                    )
         if not isinstance(out, cx.Field):
             raise TypeError("DomainFunction must return a coordax.Field.")
 

--- a/phydrax/operators/__init__.py
+++ b/phydrax/operators/__init__.py
@@ -44,6 +44,7 @@ from .delay import (  # noqa: F401
 from .differential import (  # noqa: F401
     bilaplacian,
     build_mfd_cloud_plan,
+    build_mfd_cloud_plans,
     caputo_time_fractional,
     caputo_time_fractional_dw,
     cauchy_from_pk2,
@@ -188,6 +189,7 @@ __all__ = [
     "caputo_time_fractional",
     "caputo_time_fractional_dw",
     "build_mfd_cloud_plan",
+    "build_mfd_cloud_plans",
     "MFDCloudPlan",
     # integral exports
     "build_ball_quadrature",

--- a/phydrax/operators/__init__.py
+++ b/phydrax/operators/__init__.py
@@ -43,6 +43,7 @@ from .delay import (  # noqa: F401
 )
 from .differential import (  # noqa: F401
     bilaplacian,
+    build_mfd_cloud_plan,
     caputo_time_fractional,
     caputo_time_fractional_dw,
     cauchy_from_pk2,
@@ -74,6 +75,7 @@ from .differential import (  # noqa: F401
     linear_elastic_orthotropic_stress_2d,
     material_derivative,
     maxwell_stress,
+    MFDCloudPlan,
     navier_stokes_divergence,
     navier_stokes_stress,
     neo_hookean_cauchy,
@@ -185,6 +187,8 @@ __all__ = [
     "riesz_fractional_derivative_gl_mc",
     "caputo_time_fractional",
     "caputo_time_fractional_dw",
+    "build_mfd_cloud_plan",
+    "MFDCloudPlan",
     # integral exports
     "build_ball_quadrature",
     "build_quadrature",

--- a/phydrax/operators/differential/__init__.py
+++ b/phydrax/operators/differential/__init__.py
@@ -5,6 +5,7 @@
 from ._domain_ops import (
     bilaplacian,
     build_mfd_cloud_plan,
+    build_mfd_cloud_plans,
     cauchy_from_pk2,
     cauchy_strain,
     cauchy_stress,
@@ -122,5 +123,6 @@ __all__ = [
     "caputo_time_fractional",
     "caputo_time_fractional_dw",
     "build_mfd_cloud_plan",
+    "build_mfd_cloud_plans",
     "MFDCloudPlan",
 ]

--- a/phydrax/operators/differential/__init__.py
+++ b/phydrax/operators/differential/__init__.py
@@ -4,6 +4,7 @@
 
 from ._domain_ops import (
     bilaplacian,
+    build_mfd_cloud_plan,
     cauchy_from_pk2,
     cauchy_strain,
     cauchy_stress,
@@ -29,6 +30,7 @@ from ._domain_ops import (
     linear_elastic_orthotropic_stress_2d,
     material_derivative,
     maxwell_stress,
+    MFDCloudPlan,
     navier_stokes_divergence,
     navier_stokes_stress,
     neo_hookean_cauchy,
@@ -119,4 +121,6 @@ __all__ = [
     "riesz_fractional_derivative_gl_mc",
     "caputo_time_fractional",
     "caputo_time_fractional_dw",
+    "build_mfd_cloud_plan",
+    "MFDCloudPlan",
 ]

--- a/phydrax/operators/differential/_domain_ops.py
+++ b/phydrax/operators/differential/_domain_ops.py
@@ -16,6 +16,7 @@ from jaxtyping import ArrayLike
 
 from ..._callable import _KeyIterAdapter
 from ..._frozendict import frozendict
+from ..._strict import StrictModule
 from ...domain._base import _AbstractGeometry
 from ...domain._domain import RelabeledDomain
 from ...domain._function import (
@@ -109,7 +110,7 @@ def _resolve_ad_mode(
 
 
 def _ensure_ad_engine_backend(
-    backend: Literal["ad", "jet", "fd", "basis"], ad_engine: _ADEngine, /
+    backend: Literal["ad", "jet", "fd", "basis", "mfd"], ad_engine: _ADEngine, /
 ) -> None:
     if backend != "ad" and ad_engine != "auto":
         raise ValueError("ad_engine is only supported when backend='ad'.")
@@ -253,7 +254,7 @@ def _try_derivative_hook(
     axis: int | None,
     order: int,
     mode: Literal["reverse", "forward"],
-    backend: Literal["ad", "jet", "fd", "basis"],
+    backend: Literal["ad", "jet", "fd", "basis", "mfd"],
     basis: Literal["poly", "fourier", "sine", "cosine"],
     periodic: bool,
 ) -> DomainFunction | None:
@@ -320,7 +321,7 @@ def _partial_eval_cache_key(
     axis_i: int,
     order_i: int,
     mode: Literal["reverse", "forward"],
-    backend: Literal["ad", "jet", "fd", "basis"],
+    backend: Literal["ad", "jet", "fd", "basis", "mfd"],
     basis: Literal["poly", "fourier", "sine", "cosine"],
     periodic: bool,
     force_generic: bool,
@@ -725,13 +726,599 @@ def _basis_nth_derivative(
     return _poly_nth_derivative(y, x, axis=axis, order=order)
 
 
+_MFDBoundaryMode = Literal["biased", "ghost", "hybrid"]
+_MFDPointMode = Literal["probe", "cloud"]
+
+
+class MFDCloudPlan(StrictModule):
+    """Precomputed fixed-cloud stencil plan for point-input MFD."""
+
+    neighbors_idx: jax.Array
+    weights: jax.Array
+    mask: jax.Array
+    axis_i: int
+    order_i: int
+    num_points: int
+    k: int
+
+    def __init__(
+        self,
+        *,
+        neighbors_idx: ArrayLike,
+        weights: ArrayLike,
+        mask: ArrayLike,
+        axis_i: int,
+        order_i: int,
+    ):
+        idx = jnp.asarray(neighbors_idx, dtype=jnp.int32)
+        w = jnp.asarray(weights, dtype=float)
+        m = jnp.asarray(mask, dtype=bool)
+        if idx.ndim != 2:
+            raise ValueError(
+                f"MFDCloudPlan.neighbors_idx must have shape (N,K), got {idx.shape}."
+            )
+        if w.shape != idx.shape:
+            raise ValueError(
+                "MFDCloudPlan.weights must match neighbors_idx shape; "
+                f"got {w.shape} and {idx.shape}."
+            )
+        if m.shape != idx.shape:
+            raise ValueError(
+                "MFDCloudPlan.mask must match neighbors_idx shape; "
+                f"got {m.shape} and {idx.shape}."
+            )
+        n = int(idx.shape[0])
+        k = int(idx.shape[1])
+        if n <= 0 or k <= 0:
+            raise ValueError("MFDCloudPlan requires positive N and K.")
+        self.neighbors_idx = idx
+        self.weights = w
+        self.mask = m
+        self.axis_i = int(axis_i)
+        self.order_i = int(order_i)
+        self.num_points = n
+        self.k = k
+
+
+def _mfd_cloud_points_1d(points: ArrayLike, /) -> jax.Array:
+    pts = jnp.asarray(points, dtype=float)
+    if pts.ndim == 1:
+        return pts.reshape((-1,))
+    if pts.ndim == 2 and int(pts.shape[1]) == 1:
+        return pts[:, 0].reshape((-1,))
+    raise ValueError(
+        "build_mfd_cloud_plan currently supports 1D point clouds only; "
+        f"expected shape (N,) or (N,1), got {pts.shape}."
+    )
+
+
+def build_mfd_cloud_plan(
+    points: ArrayLike,
+    /,
+    *,
+    order: int,
+    k: int | None = None,
+    axis: int = 0,
+) -> MFDCloudPlan:
+    """Build a fixed-size cloud stencil plan for 1D point-input MFD."""
+    order_i = int(order)
+    if order_i < 0:
+        raise ValueError("order must be non-negative.")
+    axis_i = int(axis)
+    if axis_i != 0:
+        raise ValueError("build_mfd_cloud_plan currently supports axis=0 only.")
+
+    x = _mfd_cloud_points_1d(points)
+    n = int(x.shape[0])
+    if n <= order_i:
+        raise ValueError(f"Need at least order+1 points; got n={n}, order={order_i}.")
+    if int(jnp.unique(x).shape[0]) != n:
+        raise ValueError(
+            "build_mfd_cloud_plan requires unique cloud points for stable local stencils."
+        )
+
+    k_req = int(k) if k is not None else max(5, 2 * order_i + 1)
+    k_eff = max(order_i + 1, k_req)
+    k_eff = min(k_eff, n)
+
+    dist = jnp.abs(x[:, None] - x[None, :])
+    neighbors_idx = jnp.argsort(dist, axis=1)[:, : int(k_eff)]
+
+    def _row_weights(idx_row: jax.Array, x0: jax.Array, /) -> jax.Array:
+        nodes = x[idx_row]
+        return _fd_weights_fornberg(nodes, x0, order=order_i)
+
+    weights = jax.vmap(_row_weights)(neighbors_idx, x)
+    mask = jnp.ones_like(neighbors_idx, dtype=bool)
+    return MFDCloudPlan(
+        neighbors_idx=neighbors_idx,
+        weights=weights,
+        mask=mask,
+        axis_i=axis_i,
+        order_i=order_i,
+    )
+
+
+def _mfd_normalize_stencil_size(n: int, order: int, requested: int | None, /) -> int:
+    n_i = int(n)
+    if n_i <= 1:
+        return 1
+    base = int(requested) if requested is not None else max(5, 2 * int(order) + 1)
+    size = max(int(order) + 1, int(base))
+    size = min(size, n_i)
+    if size % 2 == 0 and size > 1:
+        if (size - 1) > int(order):
+            size -= 1
+        elif (size + 1) <= n_i:
+            size += 1
+    if size <= int(order):
+        size = int(order) + 1
+    if size > n_i:
+        size = n_i
+    if size <= int(order):
+        raise ValueError(
+            f"mfd stencil is too small for order={order}; got size={size} with n={n_i}."
+        )
+    return int(size)
+
+
+def _fd_weights_fornberg(x: jax.Array, x0: jax.Array, /, *, order: int) -> jax.Array:
+    x1 = jnp.asarray(x, dtype=float).reshape((-1,))
+    x0_ = jnp.asarray(x0, dtype=float).reshape(())
+    n = int(x1.shape[0])
+    m = int(order)
+    if m < 0:
+        raise ValueError("order must be non-negative.")
+    if n == 0:
+        return jnp.zeros((0,), dtype=float)
+    if n <= m:
+        raise ValueError(f"Need at least order+1 nodes, got n={n}, order={m}.")
+
+    c = jnp.zeros((m + 1, n), dtype=float).at[0, 0].set(1.0)
+    c1 = jnp.asarray(1.0, dtype=float)
+    c4 = x1[0] - x0_
+
+    for i in range(1, n):
+        mn = min(i, m)
+        c2 = jnp.asarray(1.0, dtype=float)
+        c5 = c4
+        c4 = x1[i] - x0_
+        for j in range(i):
+            c3 = x1[i] - x1[j]
+            c2 = c2 * c3
+            if j == i - 1:
+                for k in range(mn, 0, -1):
+                    c = c.at[k, i].set(
+                        c1 * (float(k) * c[k - 1, i - 1] - c5 * c[k, i - 1]) / c2
+                    )
+                c = c.at[0, i].set(-c1 * c5 * c[0, i - 1] / c2)
+            for k in range(mn, 0, -1):
+                c = c.at[k, j].set((c4 * c[k, j] - float(k) * c[k - 1, j]) / c3)
+            c = c.at[0, j].set(c4 * c[0, j] / c3)
+        c1 = c2
+    return c[m]
+
+
+def _mfd_centered_offsets(stencil_size: int, /) -> tuple[int, ...]:
+    half = int(stencil_size) // 2
+    if int(stencil_size) % 2 == 1:
+        return tuple(range(-half, half + 1))
+    return tuple(range(-half, half))
+
+
+def _mfd_reflect_to_interval(
+    value: jax.Array, /, *, lower: jax.Array, upper: jax.Array
+) -> jax.Array:
+    lo = jnp.asarray(lower, dtype=float).reshape(())
+    hi = jnp.asarray(upper, dtype=float).reshape(())
+    width = hi - lo
+    width_safe = jnp.maximum(width, jnp.asarray(1e-12, dtype=float))
+    period = 2.0 * width_safe
+    z = jnp.mod(jnp.asarray(value, dtype=float) - lo, period)
+    reflected = lo + jnp.where(z <= width_safe, z, period - z)
+    return jnp.where(width > 0.0, reflected, jnp.broadcast_to(lo, jnp.shape(value)))
+
+
+def _mfd_biased_window_indices_all(n: int, stencil_size: int, /) -> jax.Array:
+    i = jnp.arange(int(n), dtype=int)
+    half = int(stencil_size) // 2
+    start = jnp.clip(i - int(half), 0, int(n) - int(stencil_size))
+    offsets = jnp.arange(int(stencil_size), dtype=int)
+    return start[:, None] + offsets[None, :]
+
+
+def _mfd_ghost_window_all(
+    x: jax.Array, offsets: jax.Array, /
+) -> tuple[jax.Array, jax.Array]:
+    x1 = jnp.asarray(x, dtype=float).reshape((-1,))
+    n = int(x1.shape[0])
+    p = jnp.arange(n, dtype=int)[:, None] + jnp.asarray(offsets, dtype=int)[None, :]
+
+    left = p < 0
+    right = p >= int(n)
+    j_left = jnp.clip(-p, 0, int(n) - 1)
+    j_right = jnp.clip(2 * int(n) - 2 - p, 0, int(n) - 1)
+
+    idx = jnp.where(left, j_left, jnp.where(right, j_right, p))
+    x_left = x1[0]
+    x_right = x1[-1]
+    x_center = x1[idx]
+    x_nodes = jnp.where(
+        left,
+        2.0 * x_left - x1[j_left],
+        jnp.where(right, 2.0 * x_right - x1[j_right], x_center),
+    )
+    return idx, x_nodes
+
+
+def _mfd_tuple_stencil_operator(
+    x: jax.Array,
+    /,
+    *,
+    order: int,
+    boundary_mode: _MFDBoundaryMode,
+    stencil_size: int,
+) -> tuple[jax.Array, jax.Array]:
+    x1 = jnp.asarray(x, dtype=float).reshape((-1,))
+    n = int(x1.shape[0])
+    offsets_tuple = _mfd_centered_offsets(stencil_size)
+    offsets = jnp.asarray(offsets_tuple, dtype=int)
+
+    i = jnp.arange(int(n), dtype=int)
+    idx_center = i[:, None] + offsets[None, :]
+    centered_ok = (i + int(offsets_tuple[0]) >= 0) & (i + int(offsets_tuple[-1]) < int(n))
+
+    if boundary_mode == "biased":
+        idx_boundary = _mfd_biased_window_indices_all(n, stencil_size)
+        idx = jnp.where(centered_ok[:, None], idx_center, idx_boundary)
+        x_nodes = x1[idx]
+    else:
+        idx_ghost, x_nodes_ghost = _mfd_ghost_window_all(x1, offsets)
+        idx = jnp.where(centered_ok[:, None], idx_center, idx_ghost)
+        idx_center_safe = jnp.clip(idx_center, 0, int(n) - 1)
+        x_nodes_center = x1[idx_center_safe]
+        x_nodes = jnp.where(centered_ok[:, None], x_nodes_center, x_nodes_ghost)
+
+    weights = jax.vmap(
+        lambda nodes, x0: _fd_weights_fornberg(nodes, x0, order=int(order))
+    )(x_nodes, x1)
+    return idx, weights
+
+
+def _mfd_periodic_tuple_nth_derivative(
+    y: jax.Array,
+    x: jax.Array,
+    /,
+    *,
+    axis: int,
+    order: int,
+    stencil_size: int,
+) -> jax.Array:
+    x1 = jnp.asarray(x, dtype=float).reshape((-1,))
+    n = int(x1.shape[0])
+    if n < 2:
+        return jnp.zeros_like(y)
+    offsets = _mfd_centered_offsets(stencil_size)
+    dx = x1[1] - x1[0] if n > 1 else jnp.asarray(1.0, dtype=x1.dtype).reshape(())
+    nodes = jnp.asarray(offsets, dtype=float) * jnp.asarray(dx, dtype=float)
+    weights = _fd_weights_fornberg(nodes, jnp.asarray(0.0), order=order)
+
+    out = jnp.zeros_like(y)
+    for j, off in enumerate(offsets):
+        out = out + jnp.asarray(weights[j]) * jnp.roll(y, -int(off), axis=axis)
+    return out
+
+
+def _mfd_tuple_nth_derivative(
+    y: jax.Array,
+    x: jax.Array,
+    /,
+    *,
+    axis: int,
+    order: int,
+    periodic: bool,
+    boundary_mode: _MFDBoundaryMode,
+    stencil_size: int | None,
+) -> jax.Array:
+    x1 = jnp.asarray(x, dtype=float).reshape((-1,))
+    n = int(x1.shape[0])
+    if n < 2:
+        return jnp.zeros_like(y)
+    s = _mfd_normalize_stencil_size(n, int(order), stencil_size)
+    if periodic:
+        return _mfd_periodic_tuple_nth_derivative(
+            y,
+            x1,
+            axis=axis,
+            order=int(order),
+            stencil_size=s,
+        )
+
+    out0 = jnp.moveaxis(y, int(axis), 0)
+    n0 = int(out0.shape[0])
+    if n0 != n:
+        raise ValueError(
+            f"MFD axis length mismatch: values have {n0}, coordinates have {n}."
+        )
+    idx, weights = _mfd_tuple_stencil_operator(
+        x1,
+        order=int(order),
+        boundary_mode=boundary_mode,
+        stencil_size=s,
+    )
+    vals = out0[idx, ...]
+    out = jnp.einsum("ns,ns...->n...", weights, vals)
+    return jnp.moveaxis(out, 0, int(axis))
+
+
+def _mfd_bounds_for_axis(
+    factor: _AbstractGeometry | _AbstractScalarDomain,
+    /,
+    *,
+    axis: int,
+) -> tuple[jax.Array, jax.Array] | None:
+    if isinstance(factor, _AbstractScalarDomain):
+        lo = jnp.asarray(factor.fixed("start"), dtype=float).reshape(())
+        hi = jnp.asarray(factor.fixed("end"), dtype=float).reshape(())
+        return lo, hi
+    bounds = jnp.asarray(factor.mesh_bounds, dtype=float)
+    ax = int(axis)
+    return bounds[0, ax].reshape(()), bounds[1, ax].reshape(())
+
+
+def _mfd_default_step(
+    factor: _AbstractGeometry | _AbstractScalarDomain,
+    /,
+    *,
+    axis: int,
+) -> jax.Array:
+    bounds = _mfd_bounds_for_axis(factor, axis=axis)
+    if bounds is None:
+        return jnp.asarray(1e-3, dtype=float)
+    lo, hi = bounds
+    span = jnp.maximum(jnp.asarray(hi - lo, dtype=float), jnp.asarray(1e-12, dtype=float))
+    return jnp.asarray(1e-3, dtype=float) * span
+
+
+def _mfd_shift_axis(x: jax.Array, /, *, axis: int, shift: jax.Array) -> jax.Array:
+    x_arr = jnp.asarray(x)
+    if x_arr.ndim == 0:
+        return x_arr + jnp.asarray(shift, dtype=x_arr.dtype)
+    if x_arr.ndim == 1:
+        ax = int(axis)
+        return x_arr.at[ax].add(jnp.asarray(shift, dtype=x_arr.dtype))
+    ax = int(axis)
+    return x_arr.at[..., ax].add(jnp.asarray(shift, dtype=x_arr.dtype))
+
+
+def _mfd_eval_u_on_point_batch(
+    u: DomainFunction,
+    /,
+    *,
+    args: Sequence[Any],
+    key: Any,
+    runtime_kwargs: Mapping[str, Any],
+    num_points: int,
+) -> jax.Array:
+    n = int(num_points)
+    in_axes: list[int | None] = []
+    call_args: list[Any] = []
+    for arg in args:
+        arr = jnp.asarray(arg)
+        if arr.ndim > 0 and int(arr.shape[0]) == n:
+            in_axes.append(0)
+            call_args.append(arr)
+        else:
+            in_axes.append(None)
+            call_args.append(arg)
+
+    def _eval_single(*single_args: Any) -> jax.Array:
+        return jnp.asarray(u.func(*single_args, key=key, **runtime_kwargs))
+
+    return jax.vmap(_eval_single, in_axes=tuple(in_axes))(*tuple(call_args))
+
+
+def _mfd_point_nth_derivative_cloud(
+    u: DomainFunction,
+    /,
+    *,
+    args: Sequence[Any],
+    idx: int,
+    key: Any,
+    runtime_kwargs: Mapping[str, Any],
+    var_dim: int,
+    axis_i: int,
+    order_i: int,
+    plan: MFDCloudPlan,
+) -> jax.Array:
+    if int(var_dim) != 1:
+        raise ValueError("mfd_mode='cloud' currently supports only var_dim==1.")
+    if int(axis_i) != int(plan.axis_i):
+        raise ValueError(
+            f"mfd_cloud_plan axis mismatch: operator axis={axis_i}, plan axis={plan.axis_i}."
+        )
+    if int(order_i) != int(plan.order_i):
+        raise ValueError(
+            "mfd_cloud_plan order mismatch: "
+            f"operator order={order_i}, plan order={plan.order_i}."
+        )
+
+    x0 = jnp.asarray(args[idx], dtype=float)
+    if x0.ndim == 1:
+        n = int(x0.shape[0])
+    elif x0.ndim == 2 and int(x0.shape[1]) == 1:
+        n = int(x0.shape[0])
+    else:
+        raise ValueError(
+            "mfd_mode='cloud' requires point-batch inputs with shape (N,) or (N,1) "
+            f"for var_dim==1; got {x0.shape}."
+        )
+    if n != int(plan.num_points):
+        raise ValueError(
+            "mfd_cloud_plan num_points mismatch: "
+            f"plan has N={plan.num_points}, runtime input has N={n}."
+        )
+
+    y = _mfd_eval_u_on_point_batch(
+        u,
+        args=args,
+        key=key,
+        runtime_kwargs=runtime_kwargs,
+        num_points=n,
+    )
+    if y.ndim == 0 or int(y.shape[0]) != n:
+        raise ValueError(
+            "mfd_mode='cloud' expects batched function output with leading axis N; "
+            f"got output shape {y.shape} for N={n}."
+        )
+
+    vals = y[plan.neighbors_idx, ...]
+    weights = jnp.where(plan.mask, plan.weights, 0.0)
+    return jnp.einsum("nk,nk...->n...", weights, vals)
+
+
+def _mfd_point_nth_derivative(
+    u: DomainFunction,
+    /,
+    *,
+    args: Sequence[Any],
+    idx: int,
+    key: Any,
+    runtime_kwargs: Mapping[str, Any],
+    var_dim: int,
+    axis_i: int,
+    order_i: int,
+    periodic: bool,
+    factor: _AbstractGeometry | _AbstractScalarDomain,
+    boundary_mode: _MFDBoundaryMode,
+    stencil_size: int | None,
+    step_override: Any | None,
+) -> jax.Array:
+    x0 = args[idx]
+    x_arr = jnp.asarray(x0, dtype=float)
+
+    s = int(stencil_size) if stencil_size is not None else max(5, 2 * int(order_i) + 1)
+    if s <= int(order_i):
+        s = int(order_i) + 1
+    if s % 2 == 0:
+        s += 1
+    half = int(s) // 2
+    offsets_center = tuple(range(-half, half + 1))
+    h = (
+        jnp.asarray(step_override, dtype=float).reshape(())
+        if step_override is not None
+        else _mfd_default_step(factor, axis=axis_i)
+    )
+    h = jnp.maximum(jnp.abs(h), jnp.asarray(1e-12, dtype=float))
+    h_pow = jnp.power(h, int(order_i))
+    bounds = _mfd_bounds_for_axis(factor, axis=axis_i)
+    weight_cache: dict[tuple[int, ...], jax.Array] = {}
+
+    def _weights_for_offsets(offsets: tuple[int, ...], /) -> jax.Array:
+        cached = weight_cache.get(offsets)
+        if cached is None:
+            nodes_unit = jnp.asarray(offsets, dtype=float)
+            cached = _fd_weights_fornberg(nodes_unit, jnp.asarray(0.0), order=order_i)
+            weight_cache[offsets] = cached
+        return cached / h_pow
+
+    def _eval_with_offsets(offsets: tuple[int, ...], /, *, reflect: bool) -> jax.Array:
+        weights = _weights_for_offsets(offsets)
+        offsets_arr = jnp.asarray(offsets, dtype=float)
+
+        def _eval_single(off: jax.Array, /) -> jax.Array:
+            shift = jnp.asarray(off, dtype=float).reshape(()) * h
+            if int(var_dim) == 1:
+                xi = x_arr + shift
+            else:
+                xi = _mfd_shift_axis(x_arr, axis=axis_i, shift=shift)
+
+            if bounds is not None:
+                lo, hi = bounds
+                if periodic:
+                    width = hi - lo
+                    width_safe = jnp.maximum(width, jnp.asarray(1e-12, dtype=float))
+                    if var_dim == 1:
+                        wrapped = lo + jnp.mod(xi - lo, width_safe)
+                        xi = jnp.where(
+                            width > 0.0, wrapped, jnp.broadcast_to(lo, xi.shape)
+                        )
+                    else:
+                        coord = xi[int(axis_i)] if xi.ndim == 1 else xi[..., int(axis_i)]
+                        wrapped = lo + jnp.mod(coord - lo, width_safe)
+                        coord = jnp.where(
+                            width > 0.0, wrapped, jnp.broadcast_to(lo, coord.shape)
+                        )
+                        if xi.ndim == 1:
+                            xi = xi.at[int(axis_i)].set(coord)
+                        else:
+                            xi = xi.at[..., int(axis_i)].set(coord)
+                elif reflect:
+                    if var_dim == 1:
+                        xi = _mfd_reflect_to_interval(xi, lower=lo, upper=hi)
+                    else:
+                        coord = xi[int(axis_i)] if xi.ndim == 1 else xi[..., int(axis_i)]
+                        coord = _mfd_reflect_to_interval(coord, lower=lo, upper=hi)
+                        if xi.ndim == 1:
+                            xi = xi.at[int(axis_i)].set(coord)
+                        else:
+                            xi = xi.at[..., int(axis_i)].set(coord)
+
+            call_args = tuple(xi if i == idx else args[i] for i in range(len(args)))
+            return jnp.asarray(u.func(*call_args, key=key, **runtime_kwargs))
+
+        stacked = jax.vmap(_eval_single)(offsets_arr)
+        return jnp.tensordot(weights, stacked, axes=(0, 0))
+
+    if periodic:
+        return _eval_with_offsets(offsets_center, reflect=False)
+
+    if bounds is None:
+        if boundary_mode == "biased":
+            return _eval_with_offsets(offsets_center, reflect=False)
+        return _eval_with_offsets(offsets_center, reflect=True)
+
+    lo, hi = bounds
+    if int(var_dim) == 1:
+        xi0 = x_arr
+    elif x_arr.ndim == 1:
+        xi0 = x_arr[int(axis_i)]
+    else:
+        xi0 = x_arr[..., int(axis_i)]
+    need_left = xi0 - jnp.asarray(float(half), dtype=float) * h < lo
+    need_right = xi0 + jnp.asarray(float(half), dtype=float) * h > hi
+    if boundary_mode in ("ghost", "hybrid"):
+        return _eval_with_offsets(offsets_center, reflect=True)
+
+    offsets_left = tuple(range(0, int(s)))
+    offsets_right = tuple(range(-int(s) + 1, 1))
+
+    if jnp.asarray(need_left).ndim == 0:
+        return jax.lax.cond(
+            need_left,
+            lambda _: _eval_with_offsets(offsets_left, reflect=False),
+            lambda _: jax.lax.cond(
+                need_right,
+                lambda __: _eval_with_offsets(offsets_right, reflect=False),
+                lambda __: _eval_with_offsets(offsets_center, reflect=False),
+                operand=None,
+            ),
+            operand=None,
+        )
+
+    out_center = _eval_with_offsets(offsets_center, reflect=False)
+    out_left = _eval_with_offsets(offsets_left, reflect=False)
+    out_right = _eval_with_offsets(offsets_right, reflect=False)
+    return jnp.where(need_left, out_left, jnp.where(need_right, out_right, out_center))
+
+
 def grad(
     u: DomainFunction,
     /,
     *,
     var: str | None = None,
     mode: Literal["reverse", "forward"] = "reverse",
-    backend: Literal["ad", "fd", "basis"] = "ad",
+    backend: Literal["ad", "fd", "basis", "mfd"] = "ad",
     basis: Literal["poly", "fourier", "sine", "cosine"] = "poly",
     periodic: bool = False,
     ad_engine: _ADEngine = "auto",
@@ -764,8 +1351,11 @@ def grad(
       - `"ad"`: autodiff (works for point batches and coord-separable batches).
       - `"fd"`: finite differences on coord-separable grids (falls back to `"ad"`).
       - `"basis"`: spectral/barycentric methods on coord-separable grids (falls back to `"ad"`).
+      - `"mfd"`: meshless finite differences with two-sided interior stencils and
+        boundary closures.
     - `basis`: Basis method used when `backend="basis"`.
-    - `periodic`: Whether to treat the differentiated axis as periodic (used by `backend="fd"`).
+    - `periodic`: Whether to treat the differentiated axis as periodic (used by
+      `backend="fd"` and `backend="mfd"` tuple/point paths).
 
     **Notes:**
 
@@ -849,15 +1439,41 @@ def grad(
         )
 
     idx = u.deps.index(var)
+    mfd_partials: tuple[DomainFunction, ...] = ()
+    if backend == "mfd":
+        mfd_partials = tuple(
+            partial_n(
+                u,
+                var=var,
+                axis=None if int(var_dim) == 1 else i,
+                order=1,
+                mode=mode_eff,
+                backend="mfd",
+                basis=basis,
+                periodic=periodic,
+                ad_engine="auto",
+            )
+            for i in range(int(var_dim))
+        )
 
     def _grad(*args, key=None, **kwargs):
         x0 = args[idx]
+
+        if backend == "mfd":
+            terms = [
+                jnp.asarray(d_i.func(*args, key=key, **kwargs)) for d_i in mfd_partials
+            ]
+            if int(var_dim) == 1:
+                if isinstance(factor, _AbstractScalarDomain):
+                    return terms[0]
+                return terms[0][..., None]
+            return jnp.stack(terms, axis=-1)
 
         def f(xi):
             call_args = tuple(xi if i == idx else args[i] for i in range(len(args)))
             return u.func(*call_args, key=key, **kwargs)
 
-        if isinstance(x0, tuple) and backend != "ad":
+        if isinstance(x0, tuple) and backend in ("fd", "basis"):
             coords = tuple(jnp.asarray(xi) for xi in x0)
             if len(coords) != var_dim:
                 raise ValueError(
@@ -1210,7 +1826,7 @@ def directional_derivative(
     *,
     var: str = "x",
     mode: Literal["reverse", "forward"] = "reverse",
-    backend: Literal["ad", "fd", "basis"] = "ad",
+    backend: Literal["ad", "fd", "basis", "mfd"] = "ad",
     basis: Literal["poly", "fourier", "sine", "cosine"] = "poly",
     periodic: bool = False,
     ad_engine: _ADEngine = "auto",
@@ -1281,7 +1897,7 @@ def div(
     *,
     var: str | None = None,
     mode: Literal["reverse", "forward"] = "reverse",
-    backend: Literal["ad", "fd", "basis"] = "ad",
+    backend: Literal["ad", "fd", "basis", "mfd"] = "ad",
     basis: Literal["poly", "fourier", "sine", "cosine"] = "poly",
     periodic: bool = False,
     ad_engine: _ADEngine = "auto",
@@ -1348,7 +1964,7 @@ def curl(
     *,
     var: str | None = None,
     mode: Literal["reverse", "forward"] = "reverse",
-    backend: Literal["ad", "fd", "basis"] = "ad",
+    backend: Literal["ad", "fd", "basis", "mfd"] = "ad",
     basis: Literal["poly", "fourier", "sine", "cosine"] = "poly",
     periodic: bool = False,
     ad_engine: _ADEngine = "auto",
@@ -1419,7 +2035,7 @@ def div_tensor(
     *,
     var: str | None = None,
     mode: Literal["reverse", "forward"] = "reverse",
-    backend: Literal["ad", "fd", "basis"] = "ad",
+    backend: Literal["ad", "fd", "basis", "mfd"] = "ad",
     basis: Literal["poly", "fourier", "sine", "cosine"] = "poly",
     periodic: bool = False,
     ad_engine: _ADEngine = "auto",
@@ -1479,7 +2095,7 @@ def cauchy_strain(
     *,
     var: str | None = None,
     mode: Literal["reverse", "forward"] = "reverse",
-    backend: Literal["ad", "fd", "basis"] = "ad",
+    backend: Literal["ad", "fd", "basis", "mfd"] = "ad",
     basis: Literal["poly", "fourier", "sine", "cosine"] = "poly",
     periodic: bool = False,
     ad_engine: _ADEngine = "auto",
@@ -1527,7 +2143,7 @@ def strain_rate(
     *,
     var: str | None = None,
     mode: Literal["reverse", "forward"] = "reverse",
-    backend: Literal["ad", "fd", "basis"] = "ad",
+    backend: Literal["ad", "fd", "basis", "mfd"] = "ad",
     basis: Literal["poly", "fourier", "sine", "cosine"] = "poly",
     periodic: bool = False,
     ad_engine: _ADEngine = "auto",
@@ -1551,7 +2167,7 @@ def strain_rate_magnitude(
     *,
     var: str | None = None,
     mode: Literal["reverse", "forward"] = "reverse",
-    backend: Literal["ad", "fd", "basis"] = "ad",
+    backend: Literal["ad", "fd", "basis", "mfd"] = "ad",
     basis: Literal["poly", "fourier", "sine", "cosine"] = "poly",
     periodic: bool = False,
     ad_engine: _ADEngine = "auto",
@@ -1613,7 +2229,7 @@ def cauchy_stress(
     mu: DomainFunction | ArrayLike,
     var: str | None = None,
     mode: Literal["reverse", "forward"] = "reverse",
-    backend: Literal["ad", "fd", "basis"] = "ad",
+    backend: Literal["ad", "fd", "basis", "mfd"] = "ad",
     basis: Literal["poly", "fourier", "sine", "cosine"] = "poly",
     periodic: bool = False,
     ad_engine: _ADEngine = "auto",
@@ -1671,7 +2287,7 @@ def div_cauchy_stress(
     mu: DomainFunction | ArrayLike,
     var: str | None = None,
     mode: Literal["reverse", "forward"] = "reverse",
-    backend: Literal["ad", "fd", "basis"] = "ad",
+    backend: Literal["ad", "fd", "basis", "mfd"] = "ad",
     basis: Literal["poly", "fourier", "sine", "cosine"] = "poly",
     periodic: bool = False,
     ad_engine: _ADEngine = "auto",
@@ -1728,7 +2344,7 @@ def viscous_stress(
     lambda_: DomainFunction | ArrayLike | None = None,
     var: str | None = None,
     mode: Literal["reverse", "forward"] = "reverse",
-    backend: Literal["ad", "fd", "basis"] = "ad",
+    backend: Literal["ad", "fd", "basis", "mfd"] = "ad",
     basis: Literal["poly", "fourier", "sine", "cosine"] = "poly",
     periodic: bool = False,
     ad_engine: _ADEngine = "auto",
@@ -1792,7 +2408,7 @@ def navier_stokes_stress(
     lambda_: DomainFunction | ArrayLike | None = None,
     var: str | None = None,
     mode: Literal["reverse", "forward"] = "reverse",
-    backend: Literal["ad", "fd", "basis"] = "ad",
+    backend: Literal["ad", "fd", "basis", "mfd"] = "ad",
     basis: Literal["poly", "fourier", "sine", "cosine"] = "poly",
     periodic: bool = False,
     ad_engine: _ADEngine = "auto",
@@ -1849,7 +2465,7 @@ def navier_stokes_divergence(
     lambda_: DomainFunction | ArrayLike | None = None,
     var: str | None = None,
     mode: Literal["reverse", "forward"] = "reverse",
-    backend: Literal["ad", "fd", "basis"] = "ad",
+    backend: Literal["ad", "fd", "basis", "mfd"] = "ad",
     basis: Literal["poly", "fourier", "sine", "cosine"] = "poly",
     periodic: bool = False,
     ad_engine: _ADEngine = "auto",
@@ -1905,7 +2521,7 @@ def laplacian(
     *,
     var: str | None = None,
     mode: Literal["reverse", "forward"] = "reverse",
-    backend: Literal["ad", "jet", "fd", "basis"] = "ad",
+    backend: Literal["ad", "jet", "fd", "basis", "mfd"] = "ad",
     basis: Literal["poly", "fourier", "sine", "cosine"] = "poly",
     periodic: bool = False,
     ad_engine: _ADEngine = "auto",
@@ -1931,8 +2547,10 @@ def laplacian(
         (and enables latent Jet fast paths when available).
       - `"fd"`: uses finite differences on coord-separable grids (falls back to `"ad"`).
       - `"basis"`: uses spectral/barycentric methods on coord-separable grids (falls back to `"ad"`).
+      - `"mfd"`: meshless finite differences for point and coord-separable inputs.
     - `basis`: Basis method used when `backend="basis"`.
-    - `periodic`: Whether to treat differentiated axes as periodic (used by `backend="fd"`).
+    - `periodic`: Whether to treat differentiated axes as periodic (used by
+      `backend="fd"` and `backend="mfd"`).
     - `ad_engine`: AD execution strategy used when `backend="ad"`:
       - `"auto"`: existing mixed strategy (default).
       - `"reverse"` / `"forward"`: force Jacobian AD mode.
@@ -1960,8 +2578,8 @@ def laplacian(
             domain=u.domain, deps=u.deps, func=_zero, metadata=out_metadata
         )
 
-    if backend not in ("ad", "jet", "fd", "basis"):
-        raise ValueError("backend must be 'ad', 'jet', 'fd', or 'basis'.")
+    if backend not in ("ad", "jet", "fd", "basis", "mfd"):
+        raise ValueError("backend must be 'ad', 'jet', 'fd', 'basis', or 'mfd'.")
     _ensure_ad_engine_backend(backend, ad_engine)
     mode_eff = _resolve_ad_mode(mode, ad_engine)
 
@@ -2055,7 +2673,7 @@ def bilaplacian(
     *,
     var: str | None = None,
     mode: Literal["reverse", "forward"] = "reverse",
-    backend: Literal["ad", "jet", "fd", "basis"] = "ad",
+    backend: Literal["ad", "jet", "fd", "basis", "mfd"] = "ad",
     basis: Literal["poly", "fourier", "sine", "cosine"] = "poly",
     periodic: bool = False,
     ad_engine: _ADEngine = "auto",
@@ -2100,7 +2718,7 @@ def bilaplacian(
     _ensure_ad_engine_backend(backend, ad_engine)
     mode_eff = _resolve_ad_mode(mode, ad_engine)
 
-    if backend == "fd" or backend == "basis":
+    if backend == "fd" or backend == "basis" or backend == "mfd":
         return laplacian(
             laplacian(
                 u,
@@ -2129,7 +2747,7 @@ def bilaplacian(
         )
 
     if backend != "jet":
-        raise ValueError("backend must be 'ad', 'jet', 'fd', or 'basis'.")
+        raise ValueError("backend must be 'ad', 'jet', 'fd', 'basis', or 'mfd'.")
 
     idx = u.deps.index(var)
 
@@ -2363,7 +2981,7 @@ def partial_n(
     axis: int | None = None,
     order: int,
     mode: Literal["reverse", "forward"] = "reverse",
-    backend: Literal["ad", "jet", "fd", "basis"] = "ad",
+    backend: Literal["ad", "jet", "fd", "basis", "mfd"] = "ad",
     basis: Literal["poly", "fourier", "sine", "cosine"] = "poly",
     periodic: bool = False,
     ad_engine: _ADEngine = "auto",
@@ -2390,8 +3008,10 @@ def partial_n(
       - `"jet"`: uses Jet expansions for $n\ge 2$ (point inputs and coord-separable inputs).
       - `"fd"`: finite differences on coord-separable grids (falls back to `"ad"` for point inputs).
       - `"basis"`: spectral/barycentric methods on coord-separable grids (falls back to `"ad"` for point inputs).
+      - `"mfd"`: meshless finite differences for point inputs and coord-separable grids.
     - `basis`: Basis method used when `backend="basis"`.
-    - `periodic`: Whether to treat the differentiated axis as periodic (used by `backend="fd"`).
+    - `periodic`: Whether to treat the differentiated axis as periodic (used by
+      `backend="fd"` and `backend="mfd"`).
 
     **Returns:**
 
@@ -2436,7 +3056,7 @@ def partial_n(
             ad_engine="auto",
         )
 
-    _, var_dim = _factor_and_dim(u, var)
+    factor, var_dim = _factor_and_dim(u, var)
     out_metadata = _strip_derivative_hook_metadata(u.metadata)
 
     if var not in u.deps:
@@ -2512,6 +3132,54 @@ def partial_n(
                 cache[cache_key] = out
             return out
 
+        mfd_boundary_mode: _MFDBoundaryMode = "hybrid"
+        mfd_stencil_size: int | None = None
+        mfd_step: Any | None = None
+        mfd_mode: _MFDPointMode = "probe"
+        mfd_cloud_plan: MFDCloudPlan | None = None
+        if backend == "mfd":
+            mfd_boundary_mode_raw = runtime_kwargs.pop("mfd_boundary_mode", "hybrid")
+            mfd_boundary_mode_str = str(mfd_boundary_mode_raw).lower()
+            if mfd_boundary_mode_str == "biased":
+                mfd_boundary_mode = "biased"
+            elif mfd_boundary_mode_str == "ghost":
+                mfd_boundary_mode = "ghost"
+            elif mfd_boundary_mode_str == "hybrid":
+                mfd_boundary_mode = "hybrid"
+            else:
+                raise ValueError(
+                    "mfd_boundary_mode must be one of 'biased', 'ghost', or 'hybrid'."
+                )
+            mfd_stencil_size_raw = runtime_kwargs.pop("mfd_stencil_size", None)
+            mfd_stencil_size = (
+                int(mfd_stencil_size_raw) if mfd_stencil_size_raw is not None else None
+            )
+            if mfd_stencil_size is not None and mfd_stencil_size <= 0:
+                raise ValueError("mfd_stencil_size must be positive.")
+            mfd_step_raw = runtime_kwargs.pop("mfd_step", None)
+            if mfd_step_raw is not None:
+                step_arr = jnp.asarray(mfd_step_raw)
+                if step_arr.ndim != 0:
+                    raise ValueError("mfd_step must be a scalar.")
+                mfd_step = mfd_step_raw
+            mfd_mode_raw = runtime_kwargs.pop("mfd_mode", "probe")
+            mfd_mode_str = str(mfd_mode_raw).lower()
+            if mfd_mode_str == "probe":
+                mfd_mode = "probe"
+            elif mfd_mode_str == "cloud":
+                mfd_mode = "cloud"
+            else:
+                raise ValueError("mfd_mode must be one of 'probe' or 'cloud'.")
+            mfd_cloud_plan_raw = runtime_kwargs.pop("mfd_cloud_plan", None)
+            if mfd_mode == "cloud":
+                if mfd_cloud_plan_raw is None:
+                    raise ValueError(
+                        "mfd_mode='cloud' requires mfd_cloud_plan at evaluation time."
+                    )
+                if not isinstance(mfd_cloud_plan_raw, MFDCloudPlan):
+                    raise TypeError("mfd_cloud_plan must be an instance of MFDCloudPlan.")
+                mfd_cloud_plan = mfd_cloud_plan_raw
+
         x0 = args[idx]
 
         if backend == "ad" or backend == "jet":
@@ -2564,6 +3232,63 @@ def partial_n(
             return _return(
                 _basis_nth_derivative(
                     y, coords[axis_i], axis=axis_pos, order=order_i, basis=basis
+                )
+            )
+
+        if backend == "mfd":
+            if isinstance(x0, tuple):
+                coords = tuple(jnp.asarray(xi) for xi in x0)
+                if len(coords) != var_dim:
+                    raise ValueError(
+                        f"coord-separable partial_n expects {var_dim} coordinate arrays for var={var!r}."
+                    )
+                if not all(xi.ndim == 1 for xi in coords):
+                    raise ValueError(
+                        "coord-separable partial_n requires a tuple of 1D coordinate arrays."
+                    )
+                y = jnp.asarray(u.func(*args, key=key, **runtime_kwargs))
+                axis_pos = _coord_axis_position(args, arg_index=idx, coord_index=axis_i)
+                return _return(
+                    _mfd_tuple_nth_derivative(
+                        y,
+                        coords[axis_i],
+                        axis=axis_pos,
+                        order=order_i,
+                        periodic=bool(periodic),
+                        boundary_mode=mfd_boundary_mode,
+                        stencil_size=mfd_stencil_size,
+                    )
+                )
+            if mfd_mode == "cloud":
+                assert mfd_cloud_plan is not None
+                return _return(
+                    _mfd_point_nth_derivative_cloud(
+                        u,
+                        args=args,
+                        idx=idx,
+                        key=key,
+                        runtime_kwargs=runtime_kwargs,
+                        var_dim=int(var_dim),
+                        axis_i=int(axis_i),
+                        order_i=int(order_i),
+                        plan=mfd_cloud_plan,
+                    )
+                )
+            return _return(
+                _mfd_point_nth_derivative(
+                    u,
+                    args=args,
+                    idx=idx,
+                    key=key,
+                    runtime_kwargs=runtime_kwargs,
+                    var_dim=int(var_dim),
+                    axis_i=int(axis_i),
+                    order_i=int(order_i),
+                    periodic=bool(periodic),
+                    factor=factor,
+                    boundary_mode=mfd_boundary_mode,
+                    stencil_size=mfd_stencil_size,
+                    step_override=mfd_step,
                 )
             )
 
@@ -2755,7 +3480,7 @@ def div_k_grad(
     *,
     var: str | None = None,
     mode: Literal["reverse", "forward"] = "reverse",
-    backend: Literal["ad", "fd", "basis"] = "ad",
+    backend: Literal["ad", "fd", "basis", "mfd"] = "ad",
     basis: Literal["poly", "fourier", "sine", "cosine"] = "poly",
     periodic: bool = False,
     ad_engine: _ADEngine = "auto",
@@ -3135,7 +3860,7 @@ def div_K_grad(
     *,
     var: str | None = None,
     mode: Literal["reverse", "forward"] = "reverse",
-    backend: Literal["ad", "fd", "basis"] = "ad",
+    backend: Literal["ad", "fd", "basis", "mfd"] = "ad",
     basis: Literal["poly", "fourier", "sine", "cosine"] = "poly",
     periodic: bool = False,
     ad_engine: _ADEngine = "auto",

--- a/phydrax/operators/differential/_hooks.py
+++ b/phydrax/operators/differential/_hooks.py
@@ -23,7 +23,7 @@ DerivativeHook: TypeAlias = Callable[
 ]
 
 DerivativeMode: TypeAlias = Literal["reverse", "forward"]
-DerivativeBackend: TypeAlias = Literal["ad", "jet", "fd", "basis"]
+DerivativeBackend: TypeAlias = Literal["ad", "jet", "fd", "basis", "mfd"]
 DerivativeBasis: TypeAlias = Literal["poly", "fourier", "sine", "cosine"]
 
 

--- a/phydrax/solver/_enforced_constraint_pipeline.py
+++ b/phydrax/solver/_enforced_constraint_pipeline.py
@@ -1062,7 +1062,7 @@ class _BoundaryBlendOverlay(StrictModule):
             axis: int | None,
             order: int,
             mode: Literal["reverse", "forward"],
-            backend: Literal["ad", "jet", "fd", "basis"],
+            backend: Literal["ad", "jet", "fd", "basis", "mfd"],
             basis: Literal["poly", "fourier", "sine", "cosine"],
             periodic: bool,
         ) -> DomainFunction | None:
@@ -1678,7 +1678,7 @@ class _InteriorDataOverlay(StrictModule):
             axis: int | None,
             order: int,
             mode: Literal["reverse", "forward"],
-            backend: Literal["ad", "jet", "fd", "basis"],
+            backend: Literal["ad", "jet", "fd", "basis", "mfd"],
             basis: Literal["poly", "fourier", "sine", "cosine"],
             periodic: bool,
         ) -> DomainFunction | None:

--- a/tests/unit/constraints/test_pointset_constraint.py
+++ b/tests/unit/constraints/test_pointset_constraint.py
@@ -4,9 +4,12 @@
 
 import jax.numpy as jnp
 import jax.random as jr
+import optax
 
 from phydrax.constraints import PointSetConstraint
 from phydrax.domain import Interval1d
+from phydrax.operators import build_mfd_cloud_plan, partial_n
+from phydrax.solver import FunctionalSolver
 
 
 def test_pointset_penalty_mean_and_sum():
@@ -38,3 +41,121 @@ def test_pointset_penalty_mean_and_sum():
     )
     loss_sum = c_sum.loss({"u": u}, key=jr.key(0))
     assert jnp.allclose(loss_sum, 6.0)
+
+
+def _x_values(x):
+    x_arr = jnp.asarray(x, dtype=float)
+    if x_arr.ndim == 0:
+        return x_arr.reshape(())
+    if x_arr.ndim == 1:
+        if int(x_arr.shape[0]) == 1:
+            return x_arr[0]
+        return x_arr
+    if x_arr.ndim == 2 and int(x_arr.shape[1]) == 1:
+        return x_arr[:, 0]
+    raise ValueError(f"Unsupported x shape {x_arr.shape}.")
+
+
+def test_pointset_eval_kwargs_enable_mfd_cloud_mode():
+    geom = Interval1d(0.0, 1.0)
+    component = geom.component()
+    coords = jnp.linspace(0.0, 1.0, 64)
+    points = {"x": coords.reshape((-1, 1))}
+
+    @geom.Function("x")
+    def u(x):
+        xx = _x_values(x)
+        return xx**3
+
+    @geom.Function("x")
+    def dudx_exact(x):
+        xx = _x_values(x)
+        return 3.0 * xx**2
+
+    plan = build_mfd_cloud_plan(points["x"], order=1, k=5)
+
+    constraint = PointSetConstraint.from_points(
+        component=component,
+        points=points,
+        residual=lambda fns: partial_n(fns["u"], var="x", order=1, backend="mfd")
+        - dudx_exact,
+        constraint_vars=("u",),
+        reduction="mean",
+        eval_kwargs={"mfd_mode": "cloud", "mfd_cloud_plan": plan},
+    )
+    loss = constraint.loss({"u": u}, key=jr.key(0))
+    assert jnp.allclose(loss, 0.0, rtol=1e-7, atol=1e-7)
+
+
+def test_pointset_from_operator_cloud_mode_sum_reduction():
+    geom = Interval1d(0.0, 1.0)
+    component = geom.component()
+    coords = jnp.linspace(0.0, 1.0, 32)
+    points = {"x": coords.reshape((-1, 1))}
+
+    @geom.Function("x")
+    def u(x):
+        xx = _x_values(x)
+        return xx**3
+
+    @geom.Function("x")
+    def dudx_exact(x):
+        xx = _x_values(x)
+        return 3.0 * xx**2
+
+    plan = build_mfd_cloud_plan(points["x"], order=1, k=5)
+    points_batch = PointSetConstraint.from_points(
+        component=component,
+        points=points,
+        residual=lambda fns: fns["u"] - fns["u"],
+    ).points
+    constraint = PointSetConstraint.from_operator(
+        points=points_batch,
+        operator=lambda f: partial_n(f, var="x", order=1, backend="mfd") - dudx_exact,
+        constraint_vars="u",
+        reduction="sum",
+        eval_kwargs={"mfd_mode": "cloud", "mfd_cloud_plan": plan},
+    )
+    loss = constraint.loss({"u": u}, key=jr.key(0))
+    assert jnp.allclose(loss, 0.0, rtol=1e-7, atol=1e-7)
+
+
+def test_pointset_cloud_mode_solver_jit_smoke():
+    geom = Interval1d(0.0, 1.0)
+    component = geom.component()
+    coords = jnp.linspace(0.0, 1.0, 40)
+    points = {"x": coords.reshape((-1, 1))}
+
+    @geom.Function("x")
+    def u(x):
+        xx = _x_values(x)
+        return xx**3
+
+    @geom.Function("x")
+    def dudx_exact(x):
+        xx = _x_values(x)
+        return 3.0 * xx**2
+
+    plan = build_mfd_cloud_plan(points["x"], order=1, k=5)
+    constraint = PointSetConstraint.from_points(
+        component=component,
+        points=points,
+        residual=lambda fns: partial_n(fns["u"], var="x", order=1, backend="mfd")
+        - dudx_exact,
+        constraint_vars=("u",),
+        reduction="mean",
+        eval_kwargs={"mfd_mode": "cloud", "mfd_cloud_plan": plan},
+    )
+    solver = FunctionalSolver(functions={"u": u}, constraints=[constraint])
+    init_loss = solver.loss(key=jr.key(0))
+    trained = solver.solve(
+        num_iter=2,
+        optim=optax.adam(1e-3),
+        seed=0,
+        jit=True,
+        keep_best=False,
+        log_every=0,
+    )
+    final_loss = trained.loss(key=jr.key(1))
+    assert jnp.isfinite(init_loss)
+    assert jnp.isfinite(final_loss)

--- a/tests/unit/constraints/test_pointset_constraint.py
+++ b/tests/unit/constraints/test_pointset_constraint.py
@@ -7,8 +7,12 @@ import jax.random as jr
 import optax
 
 from phydrax.constraints import PointSetConstraint
-from phydrax.domain import Interval1d
-from phydrax.operators import build_mfd_cloud_plan, partial_n
+from phydrax.domain import Interval1d, Square
+from phydrax.operators import (
+    build_mfd_cloud_plan,
+    build_mfd_cloud_plans,
+    partial_n,
+)
 from phydrax.solver import FunctionalSolver
 
 
@@ -53,6 +57,15 @@ def _x_values(x):
         return x_arr
     if x_arr.ndim == 2 and int(x_arr.shape[1]) == 1:
         return x_arr[:, 0]
+    raise ValueError(f"Unsupported x shape {x_arr.shape}.")
+
+
+def _xy_values(x):
+    x_arr = jnp.asarray(x, dtype=float)
+    if x_arr.ndim == 1:
+        return x_arr[0], x_arr[1]
+    if x_arr.ndim == 2 and int(x_arr.shape[1]) == 2:
+        return x_arr[:, 0], x_arr[:, 1]
     raise ValueError(f"Unsupported x shape {x_arr.shape}.")
 
 
@@ -141,6 +154,122 @@ def test_pointset_cloud_mode_solver_jit_smoke():
         component=component,
         points=points,
         residual=lambda fns: partial_n(fns["u"], var="x", order=1, backend="mfd")
+        - dudx_exact,
+        constraint_vars=("u",),
+        reduction="mean",
+        eval_kwargs={"mfd_mode": "cloud", "mfd_cloud_plan": plan},
+    )
+    solver = FunctionalSolver(functions={"u": u}, constraints=[constraint])
+    init_loss = solver.loss(key=jr.key(0))
+    trained = solver.solve(
+        num_iter=2,
+        optim=optax.adam(1e-3),
+        seed=0,
+        jit=True,
+        keep_best=False,
+        log_every=0,
+    )
+    final_loss = trained.loss(key=jr.key(1))
+    assert jnp.isfinite(init_loss)
+    assert jnp.isfinite(final_loss)
+
+
+def test_pointset_eval_kwargs_enable_mfd_cloud_mode_nd():
+    geom = Square(center=(0.0, 0.0), side=2.0)
+    component = geom.component()
+    a = jnp.linspace(-1.0, 1.0, 8)
+    xx, yy = jnp.meshgrid(a, a, indexing="ij")
+    pts = jnp.stack((xx.reshape((-1,)), yy.reshape((-1,))), axis=-1)
+    points = {"x": pts}
+
+    @geom.Function("x")
+    def u(x):
+        x0, y0 = _xy_values(x)
+        return x0**3 + y0**2
+
+    @geom.Function("x")
+    def dudx_exact(x):
+        x0, _ = _xy_values(x)
+        return 3.0 * x0**2
+
+    plan = build_mfd_cloud_plan(points["x"], order=1, axis=0, k=20, degree=3)
+    constraint = PointSetConstraint.from_points(
+        component=component,
+        points=points,
+        residual=lambda fns: partial_n(fns["u"], var="x", axis=0, order=1, backend="mfd")
+        - dudx_exact,
+        constraint_vars=("u",),
+        reduction="mean",
+        eval_kwargs={"mfd_mode": "cloud", "mfd_cloud_plan": plan},
+    )
+    loss = constraint.loss({"u": u}, key=jr.key(0))
+    assert jnp.allclose(loss, 0.0, rtol=3e-4, atol=3e-4)
+
+
+def test_pointset_from_operator_cloud_mode_nd_with_plan_table():
+    geom = Square(center=(0.0, 0.0), side=2.0)
+    component = geom.component()
+    a = jnp.linspace(-1.0, 1.0, 7)
+    xx, yy = jnp.meshgrid(a, a, indexing="ij")
+    pts = jnp.stack((xx.reshape((-1,)), yy.reshape((-1,))), axis=-1)
+    points = {"x": pts}
+
+    @geom.Function("x")
+    def u(x):
+        x0, y0 = _xy_values(x)
+        return x0**2 + y0**3
+
+    @geom.Function("x")
+    def dudy_exact(x):
+        _, y0 = _xy_values(x)
+        return 3.0 * y0**2
+
+    plans = build_mfd_cloud_plans(
+        points["x"],
+        specs=((0, 1), (1, 1)),
+        k=20,
+        degree=3,
+    )
+    points_batch = PointSetConstraint.from_points(
+        component=component,
+        points=points,
+        residual=lambda fns: fns["u"] - fns["u"],
+    ).points
+    constraint = PointSetConstraint.from_operator(
+        points=points_batch,
+        operator=lambda f: partial_n(f, var="x", axis=1, order=1, backend="mfd")
+        - dudy_exact,
+        constraint_vars="u",
+        reduction="sum",
+        eval_kwargs={"mfd_mode": "cloud", "mfd_cloud_plans": plans},
+    )
+    loss = constraint.loss({"u": u}, key=jr.key(0))
+    assert jnp.allclose(loss, 0.0, rtol=4e-4, atol=4e-4)
+
+
+def test_pointset_cloud_mode_nd_solver_jit_smoke():
+    geom = Square(center=(0.0, 0.0), side=2.0)
+    component = geom.component()
+    a = jnp.linspace(-1.0, 1.0, 6)
+    xx, yy = jnp.meshgrid(a, a, indexing="ij")
+    pts = jnp.stack((xx.reshape((-1,)), yy.reshape((-1,))), axis=-1)
+    points = {"x": pts}
+
+    @geom.Function("x")
+    def u(x):
+        x0, y0 = _xy_values(x)
+        return x0**3 + y0**2
+
+    @geom.Function("x")
+    def dudx_exact(x):
+        x0, _ = _xy_values(x)
+        return 3.0 * x0**2
+
+    plan = build_mfd_cloud_plan(points["x"], order=1, axis=0, k=18, degree=3)
+    constraint = PointSetConstraint.from_points(
+        component=component,
+        points=points,
+        residual=lambda fns: partial_n(fns["u"], var="x", axis=0, order=1, backend="mfd")
         - dudx_exact,
         constraint_vars=("u",),
         reduction="mean",

--- a/tests/unit/operators/test_differential_operators/test_mfd_backend.py
+++ b/tests/unit/operators/test_differential_operators/test_mfd_backend.py
@@ -1,0 +1,238 @@
+#
+#  Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax.numpy as jnp
+import pytest
+
+from phydrax.domain import FourierAxisSpec, Interval1d
+from phydrax.operators.differential import laplacian, partial_n
+
+
+def test_partial_n_mfd_matches_closed_form_periodic():
+    geom = Interval1d(0.0, 1.0)
+
+    @geom.Function("x")
+    def u(x):
+        return jnp.sin(2.0 * jnp.pi * x[0])
+
+    d1 = partial_n(
+        u,
+        var="x",
+        order=1,
+        backend="mfd",
+        periodic=True,
+    )
+    coords = FourierAxisSpec(256).materialize(jnp.array(0.0), jnp.array(1.0)).nodes
+    out = d1.func((coords,))
+    expected = 2.0 * jnp.pi * jnp.cos(2.0 * jnp.pi * coords)
+    assert jnp.allclose(out, expected, rtol=2e-3, atol=2e-3)
+
+
+def test_partial_n_mfd_biased_boundary_polynomial_exact():
+    geom = Interval1d(0.0, 1.0)
+
+    @geom.Function("x")
+    def u(x):
+        return x[0] ** 3
+
+    d1 = partial_n(
+        u,
+        var="x",
+        order=1,
+        backend="mfd",
+        periodic=False,
+    )
+    coords = jnp.linspace(0.0, 1.0, 64)
+    out = d1.func(
+        (coords,),
+        mfd_boundary_mode="biased",
+        mfd_stencil_size=5,
+    )
+    expected = 3.0 * coords**2
+    assert jnp.allclose(out, expected, rtol=1e-6, atol=1e-6)
+
+
+def test_laplacian_mfd_matches_second_partial_in_1d_periodic():
+    geom = Interval1d(0.0, 1.0)
+
+    @geom.Function("x")
+    def u(x):
+        return jnp.sin(2.0 * jnp.pi * x[0])
+
+    lap = laplacian(
+        u,
+        var="x",
+        backend="mfd",
+        periodic=True,
+    )
+    d2 = partial_n(
+        u,
+        var="x",
+        order=2,
+        backend="mfd",
+        periodic=True,
+    )
+    coords = FourierAxisSpec(128).materialize(jnp.array(0.0), jnp.array(1.0)).nodes
+    out_lap = lap.func((coords,))
+    out_d2 = d2.func((coords,))
+    assert jnp.allclose(out_lap, out_d2, rtol=1e-6, atol=1e-6)
+
+
+def test_partial_n_mfd_point_matches_closed_form():
+    geom = Interval1d(0.0, 1.0)
+
+    @geom.Function("x")
+    def u(x):
+        return x[0] ** 3
+
+    d1 = partial_n(u, var="x", order=1, backend="mfd")
+    x = jnp.array([0.4], dtype=float)
+    out = jnp.asarray(d1.func(x, mfd_step=1e-4, mfd_stencil_size=5))
+    expected = jnp.asarray(3.0 * x[0] ** 2)
+    assert jnp.allclose(out, expected, rtol=1e-4, atol=1e-4)
+
+
+def test_partial_n_mfd_point_biased_boundary_polynomial_exact():
+    geom = Interval1d(0.0, 1.0)
+
+    @geom.Function("x")
+    def u(x):
+        return x[0] ** 3
+
+    d1 = partial_n(u, var="x", order=1, backend="mfd")
+    x = jnp.array([1e-3], dtype=float)
+    out = jnp.asarray(
+        d1.func(
+            x,
+            mfd_boundary_mode="biased",
+            mfd_step=1e-2,
+            mfd_stencil_size=5,
+        )
+    )
+    expected = jnp.asarray(3.0 * x[0] ** 2)
+    assert jnp.allclose(out, expected, rtol=1e-5, atol=1e-5)
+
+
+def test_partial_n_mfd_point_vectorized_input_matches_closed_form():
+    geom = Interval1d(0.0, 1.0)
+
+    @geom.Function("x")
+    def u(x):
+        x_arr = jnp.asarray(x)
+        if x_arr.ndim == 1 and int(x_arr.shape[0]) == 1:
+            xx = x_arr[0]
+        else:
+            xx = x_arr
+        return xx**3
+
+    d1 = partial_n(u, var="x", order=1, backend="mfd")
+    x = jnp.linspace(0.0, 1.0, 64)
+    out = jnp.asarray(
+        d1.func(
+            x,
+            mfd_boundary_mode="biased",
+            mfd_step=1.0 / 64.0,
+            mfd_stencil_size=5,
+        )
+    )
+    expected = 3.0 * x**2
+    assert out.shape == expected.shape
+    assert jnp.allclose(out, expected, rtol=1e-4, atol=1e-4)
+
+
+def test_partial_n_mfd_rejects_ad_engine_override():
+    geom = Interval1d(0.0, 1.0)
+
+    @geom.Function("x")
+    def u(x):
+        return x[0] ** 2
+
+    with pytest.raises(ValueError, match="backend='ad'"):
+        partial_n(u, var="x", order=1, backend="mfd", ad_engine="jvp")
+
+
+def test_partial_n_mfd_tuple_preserves_trailing_channels():
+    geom = Interval1d(0.0, 1.0)
+
+    @geom.Function("x")
+    def u(x):
+        xx = x[0]
+        return jnp.stack(
+            (
+                xx**3,
+                jnp.sin(2.0 * jnp.pi * xx),
+            ),
+            axis=-1,
+        )
+
+    d1 = partial_n(u, var="x", order=1, backend="mfd")
+    coords = jnp.linspace(0.0, 1.0, 128)
+    out = d1.func(
+        (coords,),
+        mfd_boundary_mode="ghost",
+        mfd_stencil_size=5,
+    )
+    expected = jnp.stack(
+        (
+            3.0 * coords**2,
+            2.0 * jnp.pi * jnp.cos(2.0 * jnp.pi * coords),
+        ),
+        axis=-1,
+    )
+
+    assert out.shape == expected.shape
+    assert jnp.allclose(out[2:-2, 0], expected[2:-2, 0], rtol=1e-6, atol=1e-6)
+    assert jnp.allclose(out[2:-2, 1], expected[2:-2, 1], rtol=2e-3, atol=2e-3)
+
+
+def test_partial_n_mfd_tuple_channels_biased_boundary_polynomial_exact():
+    geom = Interval1d(0.0, 1.0)
+
+    @geom.Function("x")
+    def u(x):
+        xx = x[0]
+        return jnp.stack(
+            (
+                xx**3,
+                jnp.sin(2.0 * jnp.pi * xx),
+            ),
+            axis=-1,
+        )
+
+    d1 = partial_n(u, var="x", order=1, backend="mfd")
+    coords = jnp.linspace(0.0, 1.0, 128)
+    out = d1.func(
+        (coords,),
+        mfd_boundary_mode="biased",
+        mfd_stencil_size=5,
+    )
+    expected_poly = 3.0 * coords**2
+    expected_sin = 2.0 * jnp.pi * jnp.cos(2.0 * jnp.pi * coords)
+
+    assert out.shape == (coords.shape[0], 2)
+    assert jnp.allclose(out[:, 0], expected_poly, rtol=1e-6, atol=1e-6)
+    assert jnp.allclose(out[2:-2, 1], expected_sin[2:-2], rtol=2e-3, atol=2e-3)
+
+
+def test_partial_n_mfd_tuple_hybrid_matches_ghost():
+    geom = Interval1d(0.0, 1.0)
+
+    @geom.Function("x")
+    def u(x):
+        return x[0] ** 4 + x[0]
+
+    d1 = partial_n(u, var="x", order=1, backend="mfd")
+    coords = jnp.linspace(0.0, 1.0, 96)
+
+    out_ghost = d1.func(
+        (coords,),
+        mfd_boundary_mode="ghost",
+        mfd_stencil_size=5,
+    )
+    out_hybrid = d1.func(
+        (coords,),
+        mfd_boundary_mode="hybrid",
+        mfd_stencil_size=5,
+    )
+    assert jnp.allclose(out_hybrid, out_ghost, rtol=0.0, atol=0.0)

--- a/tests/unit/operators/test_differential_operators/test_mfd_cloud_backend.py
+++ b/tests/unit/operators/test_differential_operators/test_mfd_cloud_backend.py
@@ -8,6 +8,8 @@ import pytest
 from phydrax.domain import Interval1d, Square
 from phydrax.operators.differential import (
     build_mfd_cloud_plan,
+    build_mfd_cloud_plans,
+    laplacian,
     MFDCloudPlan,
     partial_n,
 )
@@ -24,6 +26,22 @@ def _x_values(x):
     if x_arr.ndim == 2 and int(x_arr.shape[1]) == 1:
         return x_arr[:, 0]
     raise ValueError(f"Unsupported x shape {x_arr.shape}.")
+
+
+def _xy_values(x):
+    x_arr = jnp.asarray(x, dtype=float)
+    if x_arr.ndim == 1:
+        return x_arr[0], x_arr[1]
+    if x_arr.ndim == 2 and int(x_arr.shape[1]) == 2:
+        return x_arr[:, 0], x_arr[:, 1]
+    raise ValueError(f"Unsupported x shape {x_arr.shape}.")
+
+
+def _square_points(n: int = 7):
+    a = jnp.linspace(-1.0, 1.0, int(n))
+    xx, yy = jnp.meshgrid(a, a, indexing="ij")
+    pts = jnp.stack((xx.reshape((-1,)), yy.reshape((-1,))), axis=-1)
+    return pts
 
 
 def test_partial_n_mfd_cloud_polynomial_exact_on_irregular_points():
@@ -62,6 +80,25 @@ def test_partial_n_mfd_cloud_polynomial_exact_on_irregular_points():
     assert jnp.allclose(out, expected, rtol=1e-6, atol=1e-6)
 
 
+def test_partial_n_mfd_cloud_second_derivative_polynomial_exact():
+    geom = Interval1d(0.0, 1.0)
+
+    @geom.Function("x")
+    def u(x):
+        xx = _x_values(x)
+        return xx**4
+
+    coords = jnp.array(
+        [0.0, 0.01, 0.03, 0.06, 0.10, 0.16, 0.23, 0.32, 0.43, 0.56, 0.71, 0.88, 1.0],
+        dtype=float,
+    )
+    plan = build_mfd_cloud_plan(coords, order=2, k=7)
+    d2 = partial_n(u, var="x", order=2, backend="mfd")
+    out = jnp.asarray(d2.func(coords, mfd_mode="cloud", mfd_cloud_plan=plan))
+    expected = 12.0 * coords**2
+    assert jnp.allclose(out, expected, rtol=1e-5, atol=1e-5)
+
+
 def test_partial_n_mfd_cloud_zero_mask_zeroes_output():
     geom = Interval1d(0.0, 1.0)
 
@@ -97,85 +134,48 @@ def test_partial_n_mfd_cloud_requires_plan_and_matching_size():
     coords = jnp.linspace(0.0, 1.0, 16)
     plan = build_mfd_cloud_plan(coords, order=1, k=5)
 
-    with pytest.raises(ValueError, match="requires mfd_cloud_plan"):
+    with pytest.raises(ValueError, match="requires mfd_cloud_plan or mfd_cloud_plans"):
         d1.func(coords, mfd_mode="cloud")
     with pytest.raises(ValueError, match="num_points mismatch"):
         d1.func(coords[:-1], mfd_mode="cloud", mfd_cloud_plan=plan)
 
 
-def test_partial_n_mfd_cloud_rejects_vector_var():
+def test_partial_n_mfd_cloud_2d_axis_first_derivative_polynomial_exact():
     geom = Square(center=(0.0, 0.0), side=2.0)
+    points = _square_points(7)
 
     @geom.Function("x")
     def u(x):
-        x_arr = jnp.asarray(x, dtype=float)
-        if x_arr.ndim == 1:
-            return x_arr[0] + x_arr[1]
-        return x_arr[..., 0] + x_arr[..., 1]
+        xx, yy = _xy_values(x)
+        return xx**3 + xx * yy + 0.5 * yy**2
 
-    d1 = partial_n(u, var="x", axis=0, order=1, backend="mfd")
-    pts = jnp.stack(
-        (
-            jnp.linspace(-1.0, 1.0, 8),
-            jnp.linspace(-1.0, 1.0, 8),
-        ),
-        axis=-1,
-    )
-    plan = build_mfd_cloud_plan(jnp.linspace(-1.0, 1.0, 8), order=1, k=5)
-
-    with pytest.raises(ValueError, match="var_dim==1"):
-        d1.func(pts, mfd_mode="cloud", mfd_cloud_plan=plan)
+    d1x = partial_n(u, var="x", axis=0, order=1, backend="mfd")
+    plan = build_mfd_cloud_plan(points, order=1, axis=0, k=20, degree=3)
+    out = jnp.asarray(d1x.func(points, mfd_mode="cloud", mfd_cloud_plan=plan))
+    xx, yy = _xy_values(points)
+    expected = 3.0 * xx**2 + yy
+    assert out.shape == expected.shape
+    assert jnp.allclose(out, expected, rtol=2e-4, atol=2e-4)
 
 
-def test_build_mfd_cloud_plan_rejects_non_1d_points():
-    pts = jnp.zeros((10, 2), dtype=float)
-    with pytest.raises(ValueError, match="1D point clouds only"):
-        build_mfd_cloud_plan(pts, order=1, k=5)
+def test_partial_n_mfd_cloud_2d_axis_second_derivative_polynomial_exact():
+    geom = Square(center=(0.0, 0.0), side=2.0)
+    points = _square_points(7)
 
+    @geom.Function("x")
+    def u(x):
+        xx, yy = _xy_values(x)
+        return xx**2 + xx * yy + yy**3
 
-def test_build_mfd_cloud_plan_rejects_duplicate_points():
-    pts = jnp.array([0.0, 0.2, 0.2, 0.7], dtype=float)
-    with pytest.raises(ValueError, match="requires unique cloud points"):
-        build_mfd_cloud_plan(pts, order=1, k=3)
-
-
-def test_build_mfd_cloud_plan_rejects_insufficient_points_for_order():
-    pts = jnp.array([0.0, 1.0], dtype=float)
-    with pytest.raises(ValueError, match="Need at least order\\+1 points"):
-        build_mfd_cloud_plan(pts, order=2, k=3)
-
-
-def test_build_mfd_cloud_plan_rejects_axis_not_zero():
-    pts = jnp.linspace(0.0, 1.0, 8)
-    with pytest.raises(ValueError, match="supports axis=0 only"):
-        build_mfd_cloud_plan(pts, order=1, axis=1)
-
-
-def test_mfd_cloud_plan_shape_validation():
-    with pytest.raises(ValueError, match="neighbors_idx must have shape"):
-        MFDCloudPlan(
-            neighbors_idx=jnp.zeros((4,), dtype=jnp.int32),
-            weights=jnp.zeros((4,), dtype=float),
-            mask=jnp.zeros((4,), dtype=bool),
-            axis_i=0,
-            order_i=1,
-        )
-    with pytest.raises(ValueError, match="weights must match"):
-        MFDCloudPlan(
-            neighbors_idx=jnp.zeros((4, 3), dtype=jnp.int32),
-            weights=jnp.zeros((4, 2), dtype=float),
-            mask=jnp.ones((4, 3), dtype=bool),
-            axis_i=0,
-            order_i=1,
-        )
-    with pytest.raises(ValueError, match="mask must match"):
-        MFDCloudPlan(
-            neighbors_idx=jnp.zeros((4, 3), dtype=jnp.int32),
-            weights=jnp.zeros((4, 3), dtype=float),
-            mask=jnp.ones((4, 2), dtype=bool),
-            axis_i=0,
-            order_i=1,
-        )
+    d2x = partial_n(u, var="x", axis=0, order=2, backend="mfd")
+    plan = build_mfd_cloud_plan(points, order=2, axis=0, k=20, degree=3)
+    out = jnp.asarray(d2x.func(points, mfd_mode="cloud", mfd_cloud_plan=plan))
+    expected = jnp.full((points.shape[0],), 2.0)
+    assert out.shape == expected.shape
+    xx, yy = _xy_values(points)
+    interior = (jnp.abs(xx) < 0.6) & (jnp.abs(yy) < 0.6)
+    assert jnp.allclose(out[interior], expected[interior], rtol=2e-3, atol=2e-3)
+    assert jnp.max(jnp.abs(out - expected)) < 0.2
 
 
 def test_partial_n_mfd_cloud_plan_order_axis_mismatch_errors():
@@ -201,12 +201,51 @@ def test_partial_n_mfd_cloud_plan_order_axis_mismatch_errors():
         mask=base_plan.mask,
         axis_i=1,
         order_i=base_plan.order_i,
+        var_dim=2,
     )
     d1 = partial_n(u, var="x", order=1, backend="mfd")
     with pytest.raises(ValueError, match="order mismatch"):
         d1.func(coords, mfd_mode="cloud", mfd_cloud_plan=bad_order_plan)
-    with pytest.raises(ValueError, match="axis mismatch"):
+    with pytest.raises(ValueError, match="var_dim mismatch"):
         d1.func(coords, mfd_mode="cloud", mfd_cloud_plan=bad_axis_plan)
+
+
+def test_partial_n_mfd_cloud_plan_axis_mismatch_errors_nd():
+    geom = Square(center=(0.0, 0.0), side=2.0)
+    points = _square_points(6)
+
+    @geom.Function("x")
+    def u(x):
+        xx, yy = _xy_values(x)
+        return xx + yy
+
+    d1x = partial_n(u, var="x", axis=0, order=1, backend="mfd")
+    plan_axis1 = build_mfd_cloud_plan(points, order=1, axis=1, k=16, degree=2)
+    with pytest.raises(ValueError, match="axis mismatch"):
+        d1x.func(points, mfd_mode="cloud", mfd_cloud_plan=plan_axis1)
+
+
+def test_partial_n_mfd_cloud_plan_var_dim_mismatch_errors():
+    geom = Square(center=(0.0, 0.0), side=2.0)
+    points = _square_points(6)
+
+    @geom.Function("x")
+    def u(x):
+        xx, yy = _xy_values(x)
+        return xx + yy
+
+    plan = build_mfd_cloud_plan(points, order=1, axis=0, k=16, degree=2)
+    bad_var_dim_plan = MFDCloudPlan(
+        neighbors_idx=plan.neighbors_idx,
+        weights=plan.weights,
+        mask=plan.mask,
+        axis_i=plan.axis_i,
+        order_i=plan.order_i,
+        var_dim=1,
+    )
+    d1 = partial_n(u, var="x", axis=0, order=1, backend="mfd")
+    with pytest.raises(ValueError, match="var_dim mismatch"):
+        d1.func(points, mfd_mode="cloud", mfd_cloud_plan=bad_var_dim_plan)
 
 
 def test_partial_n_mfd_cloud_preserves_channels_and_partial_mask():
@@ -239,6 +278,119 @@ def test_partial_n_mfd_cloud_preserves_channels_and_partial_mask():
     assert jnp.any(jnp.abs(out_masked) > 0.0)
 
 
+def test_partial_n_mfd_cloud_plan_table_lookup_for_axis_order():
+    geom = Square(center=(0.0, 0.0), side=2.0)
+    points = _square_points(7)
+
+    @geom.Function("x")
+    def u(x):
+        xx, yy = _xy_values(x)
+        return xx**3 + yy**3
+
+    plans = build_mfd_cloud_plans(points, specs=((0, 1), (1, 1)), k=20, degree=3)
+    d1x = partial_n(u, var="x", axis=0, order=1, backend="mfd")
+    out = jnp.asarray(d1x.func(points, mfd_mode="cloud", mfd_cloud_plans=plans))
+    xx, _ = _xy_values(points)
+    expected = 3.0 * xx**2
+    assert jnp.allclose(out, expected, rtol=3e-4, atol=3e-4)
+
+    d2x = partial_n(u, var="x", axis=0, order=2, backend="mfd")
+    with pytest.raises(ValueError, match="missing required key"):
+        d2x.func(points, mfd_mode="cloud", mfd_cloud_plans=plans)
+
+
+def test_laplacian_mfd_cloud_nd_uses_axis_specific_plans():
+    geom = Square(center=(0.0, 0.0), side=2.0)
+    points = _square_points(7)
+
+    @geom.Function("x")
+    def u(x):
+        xx, yy = _xy_values(x)
+        return xx**2 + yy**2
+
+    plans = build_mfd_cloud_plans(points, specs=((0, 2), (1, 2)), k=20, degree=3)
+    lap = laplacian(u, var="x", backend="mfd")
+    out = jnp.asarray(lap.func(points, mfd_mode="cloud", mfd_cloud_plans=plans))
+    expected = jnp.full((points.shape[0],), 4.0)
+    assert jnp.allclose(out, expected, rtol=3e-4, atol=3e-4)
+
+
+def test_build_mfd_cloud_plan_rejects_axis_out_of_range():
+    pts = _square_points(5)
+    with pytest.raises(ValueError, match=r"axis must be in \[0,2\)"):
+        build_mfd_cloud_plan(pts, order=1, axis=2, k=8)
+
+
+def test_build_mfd_cloud_plan_rejects_duplicate_points():
+    pts = jnp.array([0.0, 0.2, 0.2, 0.7], dtype=float)
+    with pytest.raises(ValueError, match="requires unique cloud points"):
+        build_mfd_cloud_plan(pts, order=1, k=3)
+
+
+def test_build_mfd_cloud_plan_rejects_insufficient_points_for_order():
+    pts = jnp.array([0.0, 1.0], dtype=float)
+    with pytest.raises(ValueError, match="Need at least order\\+1 points"):
+        build_mfd_cloud_plan(pts, order=2, k=3)
+
+
+def test_build_mfd_cloud_plan_rejects_insufficient_neighbors_for_basis():
+    pts = _square_points(4)
+    with pytest.raises(ValueError, match="k is too small"):
+        build_mfd_cloud_plan(pts, order=1, axis=0, k=6, degree=4)
+
+
+def test_build_mfd_cloud_plan_rejects_degenerate_local_geometry():
+    x = jnp.linspace(-1.0, 1.0, 24)
+    pts = jnp.stack((x, jnp.zeros_like(x)), axis=-1)
+    with pytest.raises(ValueError, match="rank-deficient|ill-conditioned"):
+        build_mfd_cloud_plan(pts, order=1, axis=1, k=10, degree=2)
+
+
+def test_mfd_cloud_plan_shape_validation():
+    with pytest.raises(ValueError, match="neighbors_idx must have shape"):
+        MFDCloudPlan(
+            neighbors_idx=jnp.zeros((4,), dtype=jnp.int32),
+            weights=jnp.zeros((4,), dtype=float),
+            mask=jnp.zeros((4,), dtype=bool),
+            axis_i=0,
+            order_i=1,
+        )
+    with pytest.raises(ValueError, match="weights must match"):
+        MFDCloudPlan(
+            neighbors_idx=jnp.zeros((4, 3), dtype=jnp.int32),
+            weights=jnp.zeros((4, 2), dtype=float),
+            mask=jnp.ones((4, 3), dtype=bool),
+            axis_i=0,
+            order_i=1,
+        )
+    with pytest.raises(ValueError, match="mask must match"):
+        MFDCloudPlan(
+            neighbors_idx=jnp.zeros((4, 3), dtype=jnp.int32),
+            weights=jnp.zeros((4, 3), dtype=float),
+            mask=jnp.ones((4, 2), dtype=bool),
+            axis_i=0,
+            order_i=1,
+        )
+    with pytest.raises(ValueError, match="axis_i must be in"):
+        MFDCloudPlan(
+            neighbors_idx=jnp.zeros((4, 3), dtype=jnp.int32),
+            weights=jnp.zeros((4, 3), dtype=float),
+            mask=jnp.ones((4, 3), dtype=bool),
+            axis_i=2,
+            order_i=1,
+            var_dim=2,
+        )
+    with pytest.raises(ValueError, match="degree must be >="):
+        MFDCloudPlan(
+            neighbors_idx=jnp.zeros((4, 3), dtype=jnp.int32),
+            weights=jnp.zeros((4, 3), dtype=float),
+            mask=jnp.ones((4, 3), dtype=bool),
+            axis_i=0,
+            order_i=2,
+            degree=1,
+        )
+
+
 def test_partial_n_mfd_tuple_ignores_cloud_mode_kwargs():
     geom = Interval1d(0.0, 1.0)
 
@@ -258,22 +410,3 @@ def test_partial_n_mfd_tuple_ignores_cloud_mode_kwargs():
         mfd_cloud_plan=plan,
     )
     assert jnp.allclose(out_base, out_cloud_kwargs, rtol=0.0, atol=0.0)
-
-
-def test_partial_n_mfd_cloud_second_derivative_polynomial_exact():
-    geom = Interval1d(0.0, 1.0)
-
-    @geom.Function("x")
-    def u(x):
-        xx = _x_values(x)
-        return xx**4
-
-    coords = jnp.array(
-        [0.0, 0.01, 0.03, 0.06, 0.10, 0.16, 0.23, 0.32, 0.43, 0.56, 0.71, 0.88, 1.0],
-        dtype=float,
-    )
-    plan = build_mfd_cloud_plan(coords, order=2, k=7)
-    d2 = partial_n(u, var="x", order=2, backend="mfd")
-    out = jnp.asarray(d2.func(coords, mfd_mode="cloud", mfd_cloud_plan=plan))
-    expected = 12.0 * coords**2
-    assert jnp.allclose(out, expected, rtol=1e-5, atol=1e-5)

--- a/tests/unit/operators/test_differential_operators/test_mfd_cloud_backend.py
+++ b/tests/unit/operators/test_differential_operators/test_mfd_cloud_backend.py
@@ -1,0 +1,279 @@
+#
+#  Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax.numpy as jnp
+import pytest
+
+from phydrax.domain import Interval1d, Square
+from phydrax.operators.differential import (
+    build_mfd_cloud_plan,
+    MFDCloudPlan,
+    partial_n,
+)
+
+
+def _x_values(x):
+    x_arr = jnp.asarray(x, dtype=float)
+    if x_arr.ndim == 0:
+        return x_arr.reshape(())
+    if x_arr.ndim == 1:
+        if int(x_arr.shape[0]) == 1:
+            return x_arr[0]
+        return x_arr
+    if x_arr.ndim == 2 and int(x_arr.shape[1]) == 1:
+        return x_arr[:, 0]
+    raise ValueError(f"Unsupported x shape {x_arr.shape}.")
+
+
+def test_partial_n_mfd_cloud_polynomial_exact_on_irregular_points():
+    geom = Interval1d(0.0, 1.0)
+
+    @geom.Function("x")
+    def u(x):
+        xx = _x_values(x)
+        return xx**3
+
+    coords = jnp.array(
+        [
+            0.00,
+            0.02,
+            0.05,
+            0.09,
+            0.14,
+            0.20,
+            0.27,
+            0.35,
+            0.44,
+            0.54,
+            0.65,
+            0.77,
+            0.90,
+            1.00,
+        ],
+        dtype=float,
+    )
+    plan = build_mfd_cloud_plan(coords, order=1, k=5)
+
+    d1 = partial_n(u, var="x", order=1, backend="mfd")
+    out = jnp.asarray(d1.func(coords, mfd_mode="cloud", mfd_cloud_plan=plan))
+    expected = 3.0 * coords**2
+    assert out.shape == expected.shape
+    assert jnp.allclose(out, expected, rtol=1e-6, atol=1e-6)
+
+
+def test_partial_n_mfd_cloud_zero_mask_zeroes_output():
+    geom = Interval1d(0.0, 1.0)
+
+    @geom.Function("x")
+    def u(x):
+        xx = _x_values(x)
+        return jnp.sin(2.0 * jnp.pi * xx)
+
+    coords = jnp.linspace(0.0, 1.0, 32)
+    plan = build_mfd_cloud_plan(coords, order=1, k=7)
+    zero_mask_plan = MFDCloudPlan(
+        neighbors_idx=plan.neighbors_idx,
+        weights=plan.weights,
+        mask=jnp.zeros_like(plan.mask),
+        axis_i=plan.axis_i,
+        order_i=plan.order_i,
+    )
+
+    d1 = partial_n(u, var="x", order=1, backend="mfd")
+    out = jnp.asarray(d1.func(coords, mfd_mode="cloud", mfd_cloud_plan=zero_mask_plan))
+    assert jnp.allclose(out, jnp.zeros_like(coords), rtol=0.0, atol=0.0)
+
+
+def test_partial_n_mfd_cloud_requires_plan_and_matching_size():
+    geom = Interval1d(0.0, 1.0)
+
+    @geom.Function("x")
+    def u(x):
+        xx = _x_values(x)
+        return xx**2
+
+    d1 = partial_n(u, var="x", order=1, backend="mfd")
+    coords = jnp.linspace(0.0, 1.0, 16)
+    plan = build_mfd_cloud_plan(coords, order=1, k=5)
+
+    with pytest.raises(ValueError, match="requires mfd_cloud_plan"):
+        d1.func(coords, mfd_mode="cloud")
+    with pytest.raises(ValueError, match="num_points mismatch"):
+        d1.func(coords[:-1], mfd_mode="cloud", mfd_cloud_plan=plan)
+
+
+def test_partial_n_mfd_cloud_rejects_vector_var():
+    geom = Square(center=(0.0, 0.0), side=2.0)
+
+    @geom.Function("x")
+    def u(x):
+        x_arr = jnp.asarray(x, dtype=float)
+        if x_arr.ndim == 1:
+            return x_arr[0] + x_arr[1]
+        return x_arr[..., 0] + x_arr[..., 1]
+
+    d1 = partial_n(u, var="x", axis=0, order=1, backend="mfd")
+    pts = jnp.stack(
+        (
+            jnp.linspace(-1.0, 1.0, 8),
+            jnp.linspace(-1.0, 1.0, 8),
+        ),
+        axis=-1,
+    )
+    plan = build_mfd_cloud_plan(jnp.linspace(-1.0, 1.0, 8), order=1, k=5)
+
+    with pytest.raises(ValueError, match="var_dim==1"):
+        d1.func(pts, mfd_mode="cloud", mfd_cloud_plan=plan)
+
+
+def test_build_mfd_cloud_plan_rejects_non_1d_points():
+    pts = jnp.zeros((10, 2), dtype=float)
+    with pytest.raises(ValueError, match="1D point clouds only"):
+        build_mfd_cloud_plan(pts, order=1, k=5)
+
+
+def test_build_mfd_cloud_plan_rejects_duplicate_points():
+    pts = jnp.array([0.0, 0.2, 0.2, 0.7], dtype=float)
+    with pytest.raises(ValueError, match="requires unique cloud points"):
+        build_mfd_cloud_plan(pts, order=1, k=3)
+
+
+def test_build_mfd_cloud_plan_rejects_insufficient_points_for_order():
+    pts = jnp.array([0.0, 1.0], dtype=float)
+    with pytest.raises(ValueError, match="Need at least order\\+1 points"):
+        build_mfd_cloud_plan(pts, order=2, k=3)
+
+
+def test_build_mfd_cloud_plan_rejects_axis_not_zero():
+    pts = jnp.linspace(0.0, 1.0, 8)
+    with pytest.raises(ValueError, match="supports axis=0 only"):
+        build_mfd_cloud_plan(pts, order=1, axis=1)
+
+
+def test_mfd_cloud_plan_shape_validation():
+    with pytest.raises(ValueError, match="neighbors_idx must have shape"):
+        MFDCloudPlan(
+            neighbors_idx=jnp.zeros((4,), dtype=jnp.int32),
+            weights=jnp.zeros((4,), dtype=float),
+            mask=jnp.zeros((4,), dtype=bool),
+            axis_i=0,
+            order_i=1,
+        )
+    with pytest.raises(ValueError, match="weights must match"):
+        MFDCloudPlan(
+            neighbors_idx=jnp.zeros((4, 3), dtype=jnp.int32),
+            weights=jnp.zeros((4, 2), dtype=float),
+            mask=jnp.ones((4, 3), dtype=bool),
+            axis_i=0,
+            order_i=1,
+        )
+    with pytest.raises(ValueError, match="mask must match"):
+        MFDCloudPlan(
+            neighbors_idx=jnp.zeros((4, 3), dtype=jnp.int32),
+            weights=jnp.zeros((4, 3), dtype=float),
+            mask=jnp.ones((4, 2), dtype=bool),
+            axis_i=0,
+            order_i=1,
+        )
+
+
+def test_partial_n_mfd_cloud_plan_order_axis_mismatch_errors():
+    geom = Interval1d(0.0, 1.0)
+
+    @geom.Function("x")
+    def u(x):
+        xx = _x_values(x)
+        return xx**2
+
+    coords = jnp.linspace(0.0, 1.0, 32)
+    base_plan = build_mfd_cloud_plan(coords, order=1, k=5)
+    bad_order_plan = MFDCloudPlan(
+        neighbors_idx=base_plan.neighbors_idx,
+        weights=base_plan.weights,
+        mask=base_plan.mask,
+        axis_i=base_plan.axis_i,
+        order_i=2,
+    )
+    bad_axis_plan = MFDCloudPlan(
+        neighbors_idx=base_plan.neighbors_idx,
+        weights=base_plan.weights,
+        mask=base_plan.mask,
+        axis_i=1,
+        order_i=base_plan.order_i,
+    )
+    d1 = partial_n(u, var="x", order=1, backend="mfd")
+    with pytest.raises(ValueError, match="order mismatch"):
+        d1.func(coords, mfd_mode="cloud", mfd_cloud_plan=bad_order_plan)
+    with pytest.raises(ValueError, match="axis mismatch"):
+        d1.func(coords, mfd_mode="cloud", mfd_cloud_plan=bad_axis_plan)
+
+
+def test_partial_n_mfd_cloud_preserves_channels_and_partial_mask():
+    geom = Interval1d(0.0, 1.0)
+
+    @geom.Function("x")
+    def u(x):
+        xx = _x_values(x)
+        return jnp.stack((xx**3, xx**2), axis=-1)
+
+    coords = jnp.linspace(0.0, 1.0, 48)
+    plan = build_mfd_cloud_plan(coords, order=1, k=5)
+    partial_mask = jnp.ones_like(plan.mask)
+    partial_mask = partial_mask.at[:, -1].set(False)
+    masked_plan = MFDCloudPlan(
+        neighbors_idx=plan.neighbors_idx,
+        weights=plan.weights,
+        mask=partial_mask,
+        axis_i=plan.axis_i,
+        order_i=plan.order_i,
+    )
+    d1 = partial_n(u, var="x", order=1, backend="mfd")
+    out_full = jnp.asarray(d1.func(coords, mfd_mode="cloud", mfd_cloud_plan=plan))
+    out_masked = jnp.asarray(
+        d1.func(coords, mfd_mode="cloud", mfd_cloud_plan=masked_plan)
+    )
+    assert out_full.shape == (coords.shape[0], 2)
+    assert out_masked.shape == out_full.shape
+    assert not jnp.allclose(out_full, out_masked, rtol=1e-12, atol=1e-12)
+    assert jnp.any(jnp.abs(out_masked) > 0.0)
+
+
+def test_partial_n_mfd_tuple_ignores_cloud_mode_kwargs():
+    geom = Interval1d(0.0, 1.0)
+
+    @geom.Function("x")
+    def u(x):
+        return jnp.sin(2.0 * jnp.pi * x[0])
+
+    d1 = partial_n(u, var="x", order=1, backend="mfd")
+    coords = jnp.linspace(0.0, 1.0, 96)
+    plan = build_mfd_cloud_plan(coords, order=1, k=5)
+    out_base = d1.func((coords,), mfd_boundary_mode="biased", mfd_stencil_size=5)
+    out_cloud_kwargs = d1.func(
+        (coords,),
+        mfd_boundary_mode="biased",
+        mfd_stencil_size=5,
+        mfd_mode="cloud",
+        mfd_cloud_plan=plan,
+    )
+    assert jnp.allclose(out_base, out_cloud_kwargs, rtol=0.0, atol=0.0)
+
+
+def test_partial_n_mfd_cloud_second_derivative_polynomial_exact():
+    geom = Interval1d(0.0, 1.0)
+
+    @geom.Function("x")
+    def u(x):
+        xx = _x_values(x)
+        return xx**4
+
+    coords = jnp.array(
+        [0.0, 0.01, 0.03, 0.06, 0.10, 0.16, 0.23, 0.32, 0.43, 0.56, 0.71, 0.88, 1.0],
+        dtype=float,
+    )
+    plan = build_mfd_cloud_plan(coords, order=2, k=7)
+    d2 = partial_n(u, var="x", order=2, backend="mfd")
+    out = jnp.asarray(d2.func(coords, mfd_mode="cloud", mfd_cloud_plan=plan))
+    expected = 12.0 * coords**2
+    assert jnp.allclose(out, expected, rtol=1e-5, atol=1e-5)


### PR DESCRIPTION
## Summary

This PR adds a new meshless finite-difference backend (backend="mfd") across differential
operators, including both tuple/coord-separable and point-input paths. It also introduces
fixed-cloud plan precomputation, extends cloud mode to ND point clouds, wires cloud
options into PointSetConstraint, and adds broad test/docs coverage.

## Key Changes

### Operators

- Added backend="mfd" support in differential backend plumbing and hook typing.
- Added runtime MFD options:
- mfd_boundary_mode ("hybrid" | "ghost" | "biased")
- mfd_stencil_size
- mfd_step
- mfd_mode ("probe" | "cloud")
- mfd_cloud_plan
- mfd_cloud_plans (mapping keyed by (axis, order))
- Added MFDCloudPlan and cloud plan builders:
- build_mfd_cloud_plan(...)
- build_mfd_cloud_plans(..., specs=((axis, order), ...))
- Cloud mode now supports ND point clouds ((N,d)) with axis/order-specific plan
  resolution.
- Kept tuple/coord-separable MFD path unchanged.

### Domain/Constraint integration

- Added eval_kwargs support to PointSetConstraint (__init__, from_points, from_operator).
- PointSetConstraint.loss(...) now merges constructor/runtime kwargs and supports cloud-
  mode evaluation flow.
- Added runtime-kwarg filtering in Domain.Function wrappers so mfd_* kwargs don’t leak
  into user functions without **kwargs.
- Added _blockwise_eval control path in DomainFunction to support cloud pointset
  execution behavior.

### API Exports

- Exported/re-exported:
- phydrax.operators.build_mfd_cloud_plan
- phydrax.operators.build_mfd_cloud_plans
- phydrax.operators.MFDCloudPlan

### Tests

- Added tests/unit/operators/test_differential_operators/test_mfd_backend.py.
- Added/expanded tests/unit/operators/test_differential_operators/
  test_mfd_cloud_backend.py:
- 1D cloud regression cases
- ND cloud derivative cases
- (axis, order) plan-table lookup
- mismatch/shape/degeneracy edge cases
- tuple-path invariance with cloud kwargs
- Expanded tests/unit/constraints/test_pointset_constraint.py:
- cloud eval kwargs in pointset constraints
- ND cloud and plan-table paths
- solver smoke tests

### Docs

- Updated:
- docs/api/operators/differential.md
- docs/guides_differential.md
- docs/appendix/differentiation_modes.md
- docs/api/constraints/discrete.md
- docs/all-of-phydrax.md
- docs/cookbook/index.md
- Added MFD math/boundary handling guidance and cloud-mode API usage, including
  mfd_cloud_plans.