### PR TITLE
Add scan option across models and introduce SeparableKAN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 .tmp
 .notes
 .prompts
+.testmon*
 __pycache__
 .DS_Store
 .pytest_cache

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ model = phx.nn.MLP(
     out_size="scalar",
     width_size=16,
     depth=2,
+    # For deeper repeated stacks, consider scan=True to reduce compile cost.
+    scan=False,
     key=jr.key(0),
 )
 u = geom.Model("x")(model)

--- a/docs/api/nn/architectures.md
+++ b/docs/api/nn/architectures.md
@@ -8,6 +8,9 @@ Common end-to-end model families (dense, separable, polynomial, and complex-valu
     - `MLP` is a standard feed-forward network with optional residual connection.
     - `KAN` replaces activations with polynomial edge functions.
     - `FeynmaNN` builds complex hidden states with a sum-over-paths block.
+    - `MLP`, `KAN`, `FeynmaNN`, `FNO1d`, and `FNO2d` support `scan=True` to use
+      a scan-over-depth execution path when topology is compatible.
+    - `scan=True` is primarily a compile-time optimization for deeper repeated blocks.
 
 ::: phydrax.nn.MLP
     options:

--- a/docs/api/nn/structured.md
+++ b/docs/api/nn/structured.md
@@ -16,6 +16,8 @@ Models that exploit product-domain structure via low-rank factorization.
       exact latent-factor derivative contraction path under `backend="jet"`; if that
       path is unavailable, execution falls back according to
       `LatentExecutionPolicy.fallback`.
+    - `SeparableMLP`, `SeparableKAN`, and `SeparableFeynmaNN` forward `scan` to
+      their internal scalar submodels.
 
 ::: phydrax.nn.Separable
     options:
@@ -26,6 +28,14 @@ Models that exploit product-domain structure via low-rank factorization.
 ---
 
 ::: phydrax.nn.SeparableMLP
+    options:
+        members:
+            - __init__
+            - __call__
+
+---
+
+::: phydrax.nn.SeparableKAN
     options:
         members:
             - __init__

--- a/docs/cookbook/poisson.md
+++ b/docs/cookbook/poisson.md
@@ -33,7 +33,9 @@ with \(g(x,y)=x^2+y^2\). The exact solution is \(u^\star(x,y)=x^2+y^2\).
     def g(x):
         return x[0] ** 2 + x[1] ** 2
 
-    model = phx.nn.MLP(in_size=2, out_size="scalar", width_size=16, depth=2, key=jr.key(0))
+    model = phx.nn.MLP(
+        in_size=2, out_size="scalar", width_size=16, depth=2, scan=False, key=jr.key(0)
+    )
     u = geom.Model("x")(model)
 
     structure = phx.domain.ProductStructure((("x",),))
@@ -79,7 +81,9 @@ Instead of penalizing boundary mismatch, enforce \(u=g\) by construction using
     def g(x):
         return x[0] ** 2 + x[1] ** 2
 
-    model = phx.nn.MLP(in_size=2, out_size="scalar", width_size=16, depth=2, key=jr.key(0))
+    model = phx.nn.MLP(
+        in_size=2, out_size="scalar", width_size=16, depth=2, scan=False, key=jr.key(0)
+    )
     u = geom.Model("x")(model)
 
     structure = phx.domain.ProductStructure((("x",),))

--- a/docs/index.md
+++ b/docs/index.md
@@ -77,6 +77,8 @@ model = phx.nn.MLP(
     out_size="scalar",
     width_size=16,
     depth=2,
+    # For deeper repeated stacks, consider scan=True to reduce compile cost.
+    scan=False,
     key=jr.key(0),
 )
 u = geom.Model("x")(model)

--- a/phydrax/nn/__init__.py
+++ b/phydrax/nn/__init__.py
@@ -53,6 +53,7 @@ from .models import (  # noqa: F401
     RandomFourierFeatureEmbeddings,
     Separable,
     SeparableFeynmaNN,
+    SeparableKAN,
     SeparableMLP,
 )
 
@@ -72,6 +73,7 @@ __all__ = [
     "MagnitudeDirectionModel",
     "RandomFourierFeatureEmbeddings",
     "SeparableMLP",
+    "SeparableKAN",
     "KAN",
     "Linear",
     "MLP",

--- a/phydrax/nn/models/__init__.py
+++ b/phydrax/nn/models/__init__.py
@@ -8,6 +8,7 @@ from .architectures._fno import FNO1d, FNO2d
 from .architectures._kan import KAN
 from .architectures._mlp import MLP
 from .architectures._separable_feynmann import SeparableFeynmaNN
+from .architectures._separable_kan import SeparableKAN
 from .architectures._separable_mlp import SeparableMLP
 from .embeddings._fourier import (
     RandomFourierFeatureEmbeddings,
@@ -41,6 +42,7 @@ __all__ = [
     "MagnitudeDirectionModel",
     "DeepONet",
     "SeparableMLP",
+    "SeparableKAN",
     "SeparableFeynmaNN",
     "FeynmaNN",
     "FNO1d",

--- a/phydrax/nn/models/architectures/_separable_mlp.py
+++ b/phydrax/nn/models/architectures/_separable_mlp.py
@@ -57,12 +57,14 @@ class SeparableMLP(_AbstractStructuredInputModel):
         use_bias: bool = True,
         use_final_bias: bool = True,
         initializer: str = "glorot_normal",
+        scan: bool = False,
         key: Key[Array, ""] = DOC_KEY0,
     ):
         r"""Create a separable MLP.
 
         `SeparableMLP` forwards MLP hyperparameters to each internal scalar
-        coordinate model. The coordinate models output `latent_size * out_size`
+        coordinate model (including `scan`). The coordinate models output
+        `latent_size * out_size`
         features so the wrapper can reshape them to $(L,m)$ and contract.
         """
         in_dim = _get_size(in_size)
@@ -92,6 +94,7 @@ class SeparableMLP(_AbstractStructuredInputModel):
                 use_bias=use_bias,
                 use_final_bias=use_final_bias,
                 initializer=initializer,
+                scan=scan,
                 key=subkey,
             )
             for subkey in keys

--- a/phydrax/nn/models/core/_scan_utils.py
+++ b/phydrax/nn/models/core/_scan_utils.py
@@ -1,0 +1,93 @@
+#
+#  Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from collections.abc import Callable, Sequence
+from typing import Any
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.tree_util as jtu
+from jaxtyping import Array
+
+
+def _leaf_static_equal(a: Any, b: Any) -> bool:
+    if type(a) is not type(b):
+        return False
+    if isinstance(a, (bool, int, float, str, type(None))):
+        return a == b
+    if isinstance(a, tuple):
+        if len(a) != len(b):
+            return False
+        return all(_leaf_static_equal(x, y) for x, y in zip(a, b, strict=True))
+    if isinstance(a, list):
+        if len(a) != len(b):
+            return False
+        return all(_leaf_static_equal(x, y) for x, y in zip(a, b, strict=True))
+    if isinstance(a, dict):
+        if a.keys() != b.keys():
+            return False
+        return all(_leaf_static_equal(a[k], b[k]) for k in a)
+    return a is b
+
+
+def pack_scan_modules(modules: Sequence[Any]) -> tuple[Any | None, Any | None, bool]:
+    """Pack a sequence of Equinox modules into scan-friendly dynamic/static pytrees."""
+    if len(modules) == 0:
+        return None, None, False
+
+    dynamic0, static0 = eqx.partition(modules[0], eqx.is_array)
+    dynamic_treedef = jtu.tree_structure(dynamic0)
+    static_treedef = jtu.tree_structure(static0)
+    dynamic0_leaves = jtu.tree_leaves(dynamic0)
+    static0_leaves = jtu.tree_leaves(static0)
+    if len(dynamic0_leaves) == 0:
+        return None, None, False
+
+    dynamics = [dynamic0]
+    for module in modules[1:]:
+        dynamic_i, static_i = eqx.partition(module, eqx.is_array)
+        if jtu.tree_structure(dynamic_i) != dynamic_treedef:
+            return None, None, False
+        if jtu.tree_structure(static_i) != static_treedef:
+            return None, None, False
+
+        dynamic_i_leaves = jtu.tree_leaves(dynamic_i)
+        for x0, xi in zip(dynamic0_leaves, dynamic_i_leaves, strict=True):
+            if x0.shape != xi.shape:
+                return None, None, False
+            if x0.dtype != xi.dtype:
+                return None, None, False
+
+        static_i_leaves = jtu.tree_leaves(static_i)
+        for s0, si in zip(static0_leaves, static_i_leaves, strict=True):
+            if not _leaf_static_equal(s0, si):
+                return None, None, False
+
+        dynamics.append(dynamic_i)
+
+    stacked_dynamic = jtu.tree_map(lambda *xs: jnp.stack(xs, axis=0), *dynamics)
+    return stacked_dynamic, static0, True
+
+
+def stack_scan_dynamics(modules: Sequence[Any]) -> Any | None:
+    """Stack dynamic leaves across compatible modules along a new scan axis."""
+    if len(modules) == 0:
+        return None
+    dynamics = [eqx.partition(module, eqx.is_array)[0] for module in modules]
+    return jtu.tree_map(lambda *xs: jnp.stack(xs, axis=0), *dynamics)
+
+
+def scan_apply(
+    dynamic: Any, static: Any, x: Array, fn: Callable[[Array, Any], Array]
+) -> Array:
+    """Apply a scan over packed module dynamics, reconstructing modules each step."""
+
+    def _step(carry: Array, dynamic_layer: Any) -> tuple[Array, None]:
+        layer = eqx.combine(dynamic_layer, static)
+        out = fn(carry, layer)
+        return out, None
+
+    carry, _ = jax.lax.scan(_step, x, dynamic)
+    return carry

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,12 +60,14 @@ tests = [
     "pytest-clarity>=1.0.1",
     "pytest-rerunfailures>=16.1",
     "pytest-sugar>=1.1.1",
+    "pytest-testmon>=2.2.0",
     "pytest-xdist>=3.8.0",
 ]
 qa = [
     "ruff>=0.14.14",
     "ty>=0.0.13",
 ]
+
 
 [tool.ruff]
 line-length = 90

--- a/tests/unit/nn/test_models/test_complex_output.py
+++ b/tests/unit/nn/test_models/test_complex_output.py
@@ -8,9 +8,10 @@ import pytest
 from phydrax.nn.models import ComplexOutputModel, MLP, SeparableMLP
 
 
-def test_complex_output_single_model_vector():
+@pytest.mark.parametrize("scan", (False, True), ids=("no_scan", "scan"))
+def test_complex_output_single_model_vector(scan):
     # Single model with out_size = 2k
-    model = MLP(in_size=3, out_size=6, width_size=8, depth=2)
+    model = MLP(in_size=3, out_size=6, width_size=8, depth=2, scan=scan)
     wrapped = ComplexOutputModel(model)
 
     assert wrapped.in_size == 3
@@ -23,10 +24,11 @@ def test_complex_output_single_model_vector():
     assert y.shape == (3,)
 
 
-def test_complex_output_two_models_vector():
+@pytest.mark.parametrize("scan", (False, True), ids=("no_scan", "scan"))
+def test_complex_output_two_models_vector(scan):
     # Two models each with out_size = k
-    m_real = MLP(in_size=4, out_size=3, width_size=8, depth=2)
-    m_imag = MLP(in_size=4, out_size=3, width_size=8, depth=2)
+    m_real = MLP(in_size=4, out_size=3, width_size=8, depth=2, scan=scan)
+    m_imag = MLP(in_size=4, out_size=3, width_size=8, depth=2, scan=scan)
     wrapped = ComplexOutputModel((m_real, m_imag))
 
     assert wrapped.in_size == 4
@@ -39,10 +41,11 @@ def test_complex_output_two_models_vector():
     assert y.shape == (3,)
 
 
-def test_complex_output_two_models_scalar():
+@pytest.mark.parametrize("scan", (False, True), ids=("no_scan", "scan"))
+def test_complex_output_two_models_scalar(scan):
     # Two models with scalar outputs -> complex scalar
-    m_real = MLP(in_size=3, out_size="scalar", width_size=8, depth=2)
-    m_imag = MLP(in_size=3, out_size="scalar", width_size=8, depth=2)
+    m_real = MLP(in_size=3, out_size="scalar", width_size=8, depth=2, scan=scan)
+    m_imag = MLP(in_size=3, out_size="scalar", width_size=8, depth=2, scan=scan)
     wrapped = ComplexOutputModel((m_real, m_imag))
 
     assert wrapped.in_size == 3
@@ -60,9 +63,10 @@ def test_complex_output_two_models_scalar():
     assert yb.shape == (5,)
 
 
-def test_complex_output_single_model_k_scalar():
+@pytest.mark.parametrize("scan", (False, True), ids=("no_scan", "scan"))
+def test_complex_output_single_model_k_scalar(scan):
     # Single model with out_size = 2 (k == 1 -> scalar)
-    model = MLP(in_size=3, out_size=2, width_size=8, depth=2)
+    model = MLP(in_size=3, out_size=2, width_size=8, depth=2, scan=scan)
     wrapped = ComplexOutputModel(model)
 
     assert wrapped.in_size == 3
@@ -81,28 +85,30 @@ def test_complex_output_single_model_k_scalar():
     assert yb.shape == (5,)
 
 
-def test_complex_output_errors():
+@pytest.mark.parametrize("scan", (False, True), ids=("no_scan", "scan"))
+def test_complex_output_errors(scan):
     # Single model with odd out_size
-    bad = MLP(in_size=2, out_size=5, width_size=8, depth=2)
+    bad = MLP(in_size=2, out_size=5, width_size=8, depth=2, scan=scan)
     with pytest.raises(ValueError):
         ComplexOutputModel(bad)
 
     # Two models with mismatched out_size
-    m1 = MLP(in_size=2, out_size=2, width_size=8, depth=2)
-    m2 = MLP(in_size=2, out_size=3, width_size=8, depth=2)
+    m1 = MLP(in_size=2, out_size=2, width_size=8, depth=2, scan=scan)
+    m2 = MLP(in_size=2, out_size=3, width_size=8, depth=2, scan=scan)
     with pytest.raises(ValueError):
         ComplexOutputModel((m1, m2))
 
     # Two models with mismatched in_size
-    m3 = MLP(in_size=2, out_size=2, width_size=8, depth=2)
-    m4 = MLP(in_size=3, out_size=2, width_size=8, depth=2)
+    m3 = MLP(in_size=2, out_size=2, width_size=8, depth=2, scan=scan)
+    m4 = MLP(in_size=3, out_size=2, width_size=8, depth=2, scan=scan)
     with pytest.raises(ValueError):
         ComplexOutputModel((m3, m4))
 
 
-def test_complex_output_separable_single_model_tuple():
+@pytest.mark.parametrize("scan", (False, True), ids=("no_scan", "scan"))
+def test_complex_output_separable_single_model_tuple(scan):
     # Separable single model with out_size = 2k
-    model = SeparableMLP(in_size=2, out_size=4, width_size=8, depth=2)
+    model = SeparableMLP(in_size=2, out_size=4, width_size=8, depth=2, scan=scan)
     wrapped = ComplexOutputModel(model)
 
     assert wrapped.in_size == 2
@@ -115,10 +121,11 @@ def test_complex_output_separable_single_model_tuple():
     assert y.shape == (5, 6, 2)
 
 
-def test_complex_output_separable_two_models_tuple():
+@pytest.mark.parametrize("scan", (False, True), ids=("no_scan", "scan"))
+def test_complex_output_separable_two_models_tuple(scan):
     # Two separable models with k = 2
-    mr = SeparableMLP(in_size=2, out_size=2, width_size=8, depth=2)
-    mi = SeparableMLP(in_size=2, out_size=2, width_size=8, depth=2)
+    mr = SeparableMLP(in_size=2, out_size=2, width_size=8, depth=2, scan=scan)
+    mi = SeparableMLP(in_size=2, out_size=2, width_size=8, depth=2, scan=scan)
     wrapped = ComplexOutputModel((mr, mi))
 
     assert wrapped.in_size == 2

--- a/tests/unit/nn/test_models/test_latent_contraction_minimal.py
+++ b/tests/unit/nn/test_models/test_latent_contraction_minimal.py
@@ -10,12 +10,15 @@ import pytest
 from phydrax.nn.models import LatentContractionModel, MLP, Separable
 
 
-def test_latent_contraction_regular_and_factorwise():
+@pytest.mark.parametrize("scan", (False, True), ids=("no_scan", "scan"))
+def test_latent_contraction_regular_and_factorwise(scan):
     key = jr.key(0)
     # space model: in_size=2 -> out=latent*out=8
-    space_model = MLP(in_size=2, out_size=8, width_size=8, depth=1, key=key)
+    space_model = MLP(in_size=2, out_size=8, width_size=8, depth=1, scan=scan, key=key)
     # time model: scalar -> latent=4
-    time_model = MLP(in_size="scalar", out_size=4, width_size=8, depth=1, key=jr.key(1))
+    time_model = MLP(
+        in_size="scalar", out_size=4, width_size=8, depth=1, scan=scan, key=jr.key(1)
+    )
 
     model = LatentContractionModel(
         out_size=2,
@@ -40,11 +43,14 @@ def test_latent_contraction_regular_and_factorwise():
         _ = model((jnp.array([0.1, 0.2]),))
 
 
-def test_separable_wrapper_regular_and_separable():
+@pytest.mark.parametrize("scan", (False, True), ids=("no_scan", "scan"))
+def test_separable_wrapper_regular_and_separable(scan):
     key = jr.key(42)
     # Two scalar models for 2D
-    m1 = MLP(in_size="scalar", out_size=8, width_size=8, depth=1, key=key)
-    m2 = MLP(in_size="scalar", out_size=8, width_size=8, depth=1, key=jr.key(43))
+    m1 = MLP(in_size="scalar", out_size=8, width_size=8, depth=1, scan=scan, key=key)
+    m2 = MLP(
+        in_size="scalar", out_size=8, width_size=8, depth=1, scan=scan, key=jr.key(43)
+    )
 
     model = Separable(in_size=2, out_size=2, latent_size=4, models=(m1, m2))
 

--- a/tests/unit/nn/test_models/test_neural_operator_models.py
+++ b/tests/unit/nn/test_models/test_neural_operator_models.py
@@ -17,15 +17,25 @@ from phydrax.nn.models import DeepONet, FNO1d, FNO2d, MLP
 from phydrax.operators.differential import laplacian
 
 
-def test_deeponet_domain_model_coord_separable_output_shape():
+@pytest.mark.parametrize("scan", (False, True), ids=("no_scan", "scan"))
+def test_deeponet_domain_model_coord_separable_output_shape(scan):
     data = jnp.ones((3, 4), dtype=float)
     data_dom = DatasetDomain(data)
     geom = Interval1d(0.0, 1.0)
     domain = data_dom @ geom
 
     latent = 5
-    branch = MLP(in_size=4, out_size=latent, width_size=8, depth=2, key=jr.key(0))
-    trunk = MLP(in_size="scalar", out_size=latent, width_size=8, depth=2, key=jr.key(1))
+    branch = MLP(
+        in_size=4, out_size=latent, width_size=8, depth=2, scan=scan, key=jr.key(0)
+    )
+    trunk = MLP(
+        in_size="scalar",
+        out_size=latent,
+        width_size=8,
+        depth=2,
+        scan=scan,
+        key=jr.key(1),
+    )
     model = DeepONet(
         branch=branch,
         trunk=trunk,
@@ -52,7 +62,8 @@ def test_deeponet_domain_model_coord_separable_output_shape():
     assert jnp.all(jnp.isfinite(jnp.asarray(out.data)))
 
 
-def test_fno1d_domain_model_coord_separable_output_shape_and_basis_laplacian():
+@pytest.mark.parametrize("scan", (False, True), ids=("no_scan", "scan"))
+def test_fno1d_domain_model_coord_separable_output_shape_and_basis_laplacian(scan):
     n = 16
     data = jnp.ones((3, n), dtype=float)
     data_dom = DatasetDomain(data)
@@ -65,6 +76,7 @@ def test_fno1d_domain_model_coord_separable_output_shape_and_basis_laplacian():
         width=8,
         depth=2,
         modes=6,
+        scan=scan,
         key=jr.key(0),
     )
     u = domain.Model("data", "x")(model)
@@ -89,14 +101,16 @@ def test_fno1d_domain_model_coord_separable_output_shape_and_basis_laplacian():
     assert jnp.all(jnp.isfinite(jnp.asarray(out_lap.data)))
 
 
-def test_fno1d_rejects_point_like_x_input():
-    model = FNO1d(width=8, depth=2, modes=6, key=jr.key(0))
+@pytest.mark.parametrize("scan", (False, True), ids=("no_scan", "scan"))
+def test_fno1d_rejects_point_like_x_input(scan):
+    model = FNO1d(width=8, depth=2, modes=6, scan=scan, key=jr.key(0))
     data = jnp.ones((8,), dtype=float)
     with pytest.raises(ValueError, match="coord-separable grid evaluation"):
         _ = model((data, jnp.asarray([0.5], dtype=float)))
 
 
-def test_fno2d_domain_model_coord_separable_output_shape_and_basis_laplacian():
+@pytest.mark.parametrize("scan", (False, True), ids=("no_scan", "scan"))
+def test_fno2d_domain_model_coord_separable_output_shape_and_basis_laplacian(scan):
     nx = 12
     ny = 10
     data = jnp.ones((3, nx, ny), dtype=float)
@@ -110,6 +124,7 @@ def test_fno2d_domain_model_coord_separable_output_shape_and_basis_laplacian():
         width=8,
         depth=2,
         modes=6,
+        scan=scan,
         key=jr.key(0),
     )
     u = domain.Model("data", "x")(model)
@@ -134,8 +149,9 @@ def test_fno2d_domain_model_coord_separable_output_shape_and_basis_laplacian():
     assert jnp.all(jnp.isfinite(jnp.asarray(out_lap.data)))
 
 
-def test_fno2d_rejects_point_like_xy_input():
-    model = FNO2d(width=8, depth=2, modes=6, key=jr.key(0))
+@pytest.mark.parametrize("scan", (False, True), ids=("no_scan", "scan"))
+def test_fno2d_rejects_point_like_xy_input(scan):
+    model = FNO2d(width=8, depth=2, modes=6, scan=scan, key=jr.key(0))
     data = jnp.ones((8, 8), dtype=float)
     with pytest.raises(ValueError, match="coord-separable grid evaluation"):
         _ = model(

--- a/tests/unit/nn/test_models/test_scan_behavior.py
+++ b/tests/unit/nn/test_models/test_scan_behavior.py
@@ -1,0 +1,249 @@
+#
+#  Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import equinox as eqx
+import jax.numpy as jnp
+import jax.random as jr
+import jax.tree_util as jtu
+
+from phydrax.nn.models import FeynmaNN, FNO1d, FNO2d, KAN, MLP
+
+
+def _num_params(model) -> int:
+    dynamic, _ = eqx.partition(model, eqx.is_array)
+    leaves = jtu.tree_leaves(dynamic)
+    return sum(int(x.size) for x in leaves)
+
+
+def test_mlp_scan_parameter_count_matches_loop():
+    key = jr.key(100)
+    m_loop = MLP(in_size=3, out_size=2, width_size=8, depth=4, scan=False, key=key)
+    m_scan = MLP(in_size=3, out_size=2, width_size=8, depth=4, scan=True, key=key)
+    assert _num_params(m_scan) == _num_params(m_loop)
+
+
+def test_mlp_scan_parity_deep():
+    key = jr.key(0)
+    m_loop = MLP(in_size=3, out_size=2, width_size=8, depth=4, scan=False, key=key)
+    m_scan = MLP(in_size=3, out_size=2, width_size=8, depth=4, scan=True, key=key)
+    x = jr.normal(jr.key(1), (3,))
+    assert jnp.allclose(m_loop(x), m_scan(x))
+
+
+def test_mlp_scan_depth_edge_cases():
+    key0 = jr.key(2)
+    m0_loop = MLP(in_size=2, out_size=2, width_size=8, depth=0, scan=False, key=key0)
+    m0_scan = MLP(in_size=2, out_size=2, width_size=8, depth=0, scan=True, key=key0)
+    x0 = jr.normal(jr.key(3), (2,))
+    assert jnp.allclose(m0_loop(x0), m0_scan(x0))
+
+    key1 = jr.key(4)
+    m1_loop = MLP(in_size=2, out_size=2, width_size=8, depth=1, scan=False, key=key1)
+    m1_scan = MLP(in_size=2, out_size=2, width_size=8, depth=1, scan=True, key=key1)
+    x1 = jr.normal(jr.key(5), (2,))
+    assert jnp.allclose(m1_loop(x1), m1_scan(x1))
+
+
+def test_mlp_scan_gradient_smoke():
+    model = MLP(in_size=2, out_size=2, width_size=8, depth=3, scan=True, key=jr.key(6))
+    x = jr.normal(jr.key(7), (2,))
+
+    @eqx.filter_grad
+    def loss_fn(m, x_):
+        y = m(x_)
+        return jnp.sum(y**2)
+
+    grads = loss_fn(model, x)
+    assert grads is not None
+
+
+def test_mlp_scan_fallback_heterogeneous_hidden_sizes():
+    model = MLP(in_size=3, out_size=2, hidden_sizes=(5, 7, 5), scan=True, key=jr.key(8))
+    x = jr.normal(jr.key(9), (3,))
+    y = model(x)
+    assert y.shape == (2,)
+    assert model.scan
+    assert not model._scan_enabled
+
+
+def test_feynmann_scan_parity():
+    key = jr.key(10)
+    m_loop = FeynmaNN(
+        in_size=3, out_size=2, width_size=12, depth=3, num_paths=2, scan=False, key=key
+    )
+    m_scan = FeynmaNN(
+        in_size=3, out_size=2, width_size=12, depth=3, num_paths=2, scan=True, key=key
+    )
+    x = jr.normal(jr.key(11), (3,))
+    assert jnp.allclose(m_loop(x), m_scan(x))
+
+
+def test_feynmann_scan_parameter_count_matches_loop():
+    key = jr.key(23)
+    m_loop = FeynmaNN(
+        in_size=3, out_size=2, width_size=12, depth=3, num_paths=2, scan=False, key=key
+    )
+    m_scan = FeynmaNN(
+        in_size=3, out_size=2, width_size=12, depth=3, num_paths=2, scan=True, key=key
+    )
+    assert _num_params(m_scan) == _num_params(m_loop)
+
+
+def test_feynmann_scan_gradient_smoke():
+    model = FeynmaNN(
+        in_size=2,
+        out_size=2,
+        width_size=10,
+        depth=3,
+        num_paths=2,
+        scan=True,
+        key=jr.key(12),
+    )
+    x = jr.normal(jr.key(13), (2,))
+
+    @eqx.filter_grad
+    def loss_fn(m, x_):
+        y = m(x_)
+        return jnp.sum(y**2)
+
+    grads = loss_fn(model, x)
+    assert grads is not None
+
+
+def test_fno1d_scan_parity():
+    key = jr.key(14)
+    f_loop = FNO1d(
+        in_channels="scalar",
+        out_channels="scalar",
+        width=8,
+        depth=3,
+        modes=6,
+        scan=False,
+        key=key,
+    )
+    f_scan = FNO1d(
+        in_channels="scalar",
+        out_channels="scalar",
+        width=8,
+        depth=3,
+        modes=6,
+        scan=True,
+        key=key,
+    )
+    n = 16
+    data = jr.normal(jr.key(15), (n,))
+    x_axis = jnp.linspace(0.0, 1.0, n)
+    assert jnp.allclose(f_loop((data, x_axis)), f_scan((data, x_axis)))
+
+
+def test_fno1d_scan_parameter_count_matches_loop():
+    key = jr.key(24)
+    f_loop = FNO1d(
+        in_channels="scalar",
+        out_channels="scalar",
+        width=8,
+        depth=3,
+        modes=6,
+        scan=False,
+        key=key,
+    )
+    f_scan = FNO1d(
+        in_channels="scalar",
+        out_channels="scalar",
+        width=8,
+        depth=3,
+        modes=6,
+        scan=True,
+        key=key,
+    )
+    assert _num_params(f_scan) == _num_params(f_loop)
+
+
+def test_fno2d_scan_parity():
+    key = jr.key(16)
+    f_loop = FNO2d(
+        in_channels="scalar",
+        out_channels="scalar",
+        width=8,
+        depth=3,
+        modes=6,
+        scan=False,
+        key=key,
+    )
+    f_scan = FNO2d(
+        in_channels="scalar",
+        out_channels="scalar",
+        width=8,
+        depth=3,
+        modes=6,
+        scan=True,
+        key=key,
+    )
+    nx, ny = 10, 8
+    data = jr.normal(jr.key(17), (nx, ny))
+    x_axis = jnp.linspace(0.0, 1.0, nx)
+    y_axis = jnp.linspace(-1.0, 1.0, ny)
+    assert jnp.allclose(f_loop((data, x_axis, y_axis)), f_scan((data, x_axis, y_axis)))
+
+
+def test_fno2d_scan_parameter_count_matches_loop():
+    key = jr.key(25)
+    f_loop = FNO2d(
+        in_channels="scalar",
+        out_channels="scalar",
+        width=8,
+        depth=3,
+        modes=6,
+        scan=False,
+        key=key,
+    )
+    f_scan = FNO2d(
+        in_channels="scalar",
+        out_channels="scalar",
+        width=8,
+        depth=3,
+        modes=6,
+        scan=True,
+        key=key,
+    )
+    assert _num_params(f_scan) == _num_params(f_loop)
+
+
+def test_kan_scan_parity_uniform():
+    key = jr.key(18)
+    k_loop = KAN(
+        in_size=3, out_size=2, width_size=6, depth=4, degree=3, scan=False, key=key
+    )
+    k_scan = KAN(
+        in_size=3, out_size=2, width_size=6, depth=4, degree=3, scan=True, key=key
+    )
+    x = jr.normal(jr.key(19), (3,))
+    assert jnp.allclose(k_loop(x), k_scan(x))
+
+
+def test_kan_scan_parameter_count_matches_loop():
+    key = jr.key(22)
+    k_loop = KAN(
+        in_size=3, out_size=2, width_size=6, depth=4, degree=3, scan=False, key=key
+    )
+    k_scan = KAN(
+        in_size=3, out_size=2, width_size=6, depth=4, degree=3, scan=True, key=key
+    )
+    assert _num_params(k_scan) == _num_params(k_loop)
+
+
+def test_kan_scan_fallback_heterogeneous():
+    model = KAN(
+        in_size=3,
+        out_size=2,
+        hidden_sizes=(5, 7, 5),
+        degree=(2, 3, 4, 5),
+        scan=True,
+        key=jr.key(20),
+    )
+    x = jr.normal(jr.key(21), (3,))
+    y = model(x)
+    assert y.shape == (2,)
+    assert model.scan
+    assert not model._scan_enabled

--- a/tests/unit/nn/test_models/test_separable_kan.py
+++ b/tests/unit/nn/test_models/test_separable_kan.py
@@ -6,19 +6,18 @@ import jax.numpy as jnp
 import jax.random as jr
 import pytest
 
-from phydrax.nn.models import SeparableFeynmaNN
+from phydrax.nn.models import SeparableKAN
 
 
 @pytest.mark.parametrize("scan", (False, True), ids=("no_scan", "scan"))
-def test_separable_feynmann_vector_input_shape(scan):
-    model = SeparableFeynmaNN(
+def test_separable_kan_vector_input_shape(scan):
+    model = SeparableKAN(
         in_size=2,
         out_size=3,
         latent_size=4,
         width_size=8,
         depth=2,
         scan=scan,
-        num_paths=2,
         key=jr.key(0),
     )
     x = jr.normal(jr.key(1), (2,))
@@ -28,15 +27,14 @@ def test_separable_feynmann_vector_input_shape(scan):
 
 
 @pytest.mark.parametrize("scan", (False, True), ids=("no_scan", "scan"))
-def test_separable_feynmann_coord_separable_shape(scan):
-    model = SeparableFeynmaNN(
+def test_separable_kan_coord_separable_shape(scan):
+    model = SeparableKAN(
         in_size=2,
         out_size="scalar",
         latent_size=3,
         width_size=8,
         depth=2,
         scan=scan,
-        num_paths=2,
         key=jr.key(2),
     )
     x0 = jnp.linspace(0.0, 1.0, 5)
@@ -47,29 +45,29 @@ def test_separable_feynmann_coord_separable_shape(scan):
 
 
 @pytest.mark.parametrize("scan", (False, True), ids=("no_scan", "scan"))
-def test_separable_feynmann_scalar_requires_split_input(scan):
+def test_separable_kan_scalar_requires_split_input(scan):
     with pytest.raises(ValueError, match="requires in_size >= 2"):
-        _ = SeparableFeynmaNN(
+        _ = SeparableKAN(
             in_size="scalar",
             out_size="scalar",
             width_size=8,
             depth=1,
+            degree=3,
             scan=scan,
-            num_paths=2,
         )
 
 
 @pytest.mark.parametrize("scan", (False, True), ids=("no_scan", "scan"))
-def test_separable_feynmann_scalar_with_split_input(scan):
-    model = SeparableFeynmaNN(
+def test_separable_kan_scalar_with_split_input(scan):
+    model = SeparableKAN(
         in_size="scalar",
         out_size="scalar",
         latent_size=2,
         split_input=2,
         width_size=6,
         depth=1,
+        degree=3,
         scan=scan,
-        num_paths=2,
         key=jr.key(3),
     )
     x = jnp.asarray(0.25)

--- a/tests/unit/nn/test_tensor_value_sizes.py
+++ b/tests/unit/nn/test_tensor_value_sizes.py
@@ -4,6 +4,7 @@
 
 import jax.numpy as jnp
 import jax.random as jr
+import pytest
 
 from phydrax.nn.models import Linear, MLP, RandomFourierFeatureEmbeddings
 
@@ -33,8 +34,9 @@ def test_linear_tensor_in_scalar_out_shapes():
     assert yb.shape == (7,)
 
 
-def test_mlp_tensor_out_shapes():
-    model = MLP(in_size=2, out_size=(2, 2), hidden_sizes=(8,), key=jr.key(2))
+@pytest.mark.parametrize("scan", (False, True), ids=("no_scan", "scan"))
+def test_mlp_tensor_out_shapes(scan):
+    model = MLP(in_size=2, out_size=(2, 2), hidden_sizes=(8,), scan=scan, key=jr.key(2))
     x = jnp.ones((2,))
     y = model(x)
     assert y.shape == (2, 2)


### PR DESCRIPTION
## Summary
- add optional scan execution path to repeated-depth models (MLP, KAN, FeynmaNN, FNO1d, FNO2d)
- add SeparableKAN architecture and export it through phydrax.nn and phydrax.nn.models
- include compatibility fallback when repeated blocks are not scan-compatible
- add scan-focused unit/integration coverage and docs updates
- add pytest-testmon dependency and ignore .testmon* cache files

## Notes
- scan path stacks live layer dynamics at call time (no duplicated trainable state)
- scan is intended primarily as a compile-time optimization for deeper repeated stacks
