### PR TITLE
Add wrapper scan paths and differential loop optimizations

### DIFF
--- a/phydrax/nn/models/architectures/_separable_feynmann.py
+++ b/phydrax/nn/models/architectures/_separable_feynmann.py
@@ -107,6 +107,7 @@ class SeparableFeynmaNN(_AbstractStructuredInputModel):
             output_activation=output_activation,
             keep_outputs_complex=keep_outputs_complex,
             split_input=split_input,
+            scan=scan,
         )
         self.in_size = self.model.in_size
         self.out_size = self.model.out_size

--- a/phydrax/nn/models/architectures/_separable_kan.py
+++ b/phydrax/nn/models/architectures/_separable_kan.py
@@ -113,6 +113,7 @@ class SeparableKAN(_AbstractStructuredInputModel):
             output_activation=output_activation,
             keep_outputs_complex=keep_outputs_complex,
             split_input=split_input,
+            scan=scan,
         )
         self.in_size = self.model.in_size
         self.out_size = self.model.out_size

--- a/phydrax/nn/models/architectures/_separable_mlp.py
+++ b/phydrax/nn/models/architectures/_separable_mlp.py
@@ -108,6 +108,7 @@ class SeparableMLP(_AbstractStructuredInputModel):
             output_activation=output_activation,
             keep_outputs_complex=keep_outputs_complex,
             split_input=split_input,
+            scan=scan,
         )
         self.in_size = self.model.in_size
         self.out_size = self.model.out_size

--- a/phydrax/nn/models/core/_scan_utils.py
+++ b/phydrax/nn/models/core/_scan_utils.py
@@ -91,3 +91,22 @@ def scan_apply(
 
     carry, _ = jax.lax.scan(_step, x, dynamic)
     return carry
+
+
+def scan_apply_with_data(
+    dynamic: Any,
+    static: Any,
+    carry: Any,
+    data: Any,
+    fn: Callable[[Any, Any, Any], Any],
+) -> Any:
+    """Apply a scan over packed module dynamics with aligned per-step scan data."""
+
+    def _step(carry_i: Any, packed: tuple[Any, Any]) -> tuple[Any, None]:
+        dynamic_layer, data_i = packed
+        layer = eqx.combine(dynamic_layer, static)
+        out = fn(carry_i, layer, data_i)
+        return out, None
+
+    carry_out, _ = jax.lax.scan(_step, carry, (dynamic, data))
+    return carry_out

--- a/tests/unit/nn/test_models/test_latent_contraction_minimal.py
+++ b/tests/unit/nn/test_models/test_latent_contraction_minimal.py
@@ -63,3 +63,81 @@ def test_separable_wrapper_regular_and_separable(scan):
     x2 = jnp.array([0.2, 0.4])
     ys = model((x1, x2))
     assert ys.shape == (2, 2, 2)
+
+
+def test_separable_scan_matches_loop_for_point_and_separable_tuple():
+    latent_size = 3
+    out_size = 2
+    split_input = 2
+    models = tuple(
+        MLP(
+            in_size="scalar",
+            out_size=latent_size * out_size,
+            width_size=8,
+            depth=2,
+            scan=False,
+            key=jr.key(100 + i),
+        )
+        for i in range(4)
+    )
+
+    loop_model = Separable(
+        in_size=2,
+        out_size=out_size,
+        latent_size=latent_size,
+        models=models,
+        split_input=split_input,
+        scan=False,
+    )
+    scan_model = Separable(
+        in_size=2,
+        out_size=out_size,
+        latent_size=latent_size,
+        models=models,
+        split_input=split_input,
+        scan=True,
+    )
+    assert scan_model._scan_enabled_regular
+    assert all(scan_model._scan_enabled_clone_groups)
+
+    x_point = jnp.array([0.2, -0.1], dtype=float)
+    y_point_loop = loop_model(x_point)
+    y_point_scan = scan_model(x_point)
+    assert y_point_scan.shape == y_point_loop.shape
+    assert jnp.allclose(y_point_scan, y_point_loop)
+
+    x1 = jnp.array([0.1, 0.2, 0.4], dtype=float)
+    x2 = jnp.array([-0.3, 0.0], dtype=float)
+    y_sep_loop = loop_model((x1, x2))
+    y_sep_scan = scan_model((x1, x2))
+    assert y_sep_scan.shape == y_sep_loop.shape
+    assert jnp.allclose(y_sep_scan, y_sep_loop)
+
+
+def test_separable_scan_falls_back_for_heterogeneous_models():
+    m1 = MLP(
+        in_size="scalar",
+        out_size=8,
+        width_size=8,
+        depth=2,
+        scan=False,
+        key=jr.key(7),
+    )
+    m2 = MLP(
+        in_size="scalar",
+        out_size=8,
+        hidden_sizes=(5, 7, 5),
+        scan=False,
+        key=jr.key(8),
+    )
+    model = Separable(
+        in_size=2,
+        out_size=2,
+        latent_size=4,
+        models=(m1, m2),
+        scan=True,
+    )
+    assert model.scan
+    assert not model._scan_enabled_regular
+    y = model(jnp.array([0.1, 0.2]))
+    assert y.shape == (2,)

--- a/tests/unit/test_differential_grid_backends.py
+++ b/tests/unit/test_differential_grid_backends.py
@@ -55,6 +55,26 @@ def test_partial_n_fd_matches_closed_form_periodic_to_tolerance():
     assert jnp.allclose(out, expected, rtol=2e-3, atol=2e-3)
 
 
+def test_partial_n_fd_third_order_matches_closed_form_periodic_to_tolerance():
+    geom = Interval1d(0.0, 1.0)
+
+    @geom.Function("x")
+    def u(x):
+        return jnp.sin(2.0 * jnp.pi * x[0])
+
+    d3 = partial_n(
+        u,
+        var="x",
+        order=3,
+        backend="fd",
+        periodic=True,
+    )
+    coords = FourierAxisSpec(256).materialize(jnp.array(0.0), jnp.array(1.0)).nodes
+    out = d3.func((coords,))
+    expected = -((2.0 * jnp.pi) ** 3) * jnp.cos(2.0 * jnp.pi * coords)
+    assert jnp.allclose(out, expected, rtol=1e-2, atol=1e-2)
+
+
 def test_partial_n_basis_poly_on_legendre_nodes_matches_closed_form():
     geom = Interval1d(-1.0, 1.0)
 
@@ -72,6 +92,26 @@ def test_partial_n_basis_poly_on_legendre_nodes_matches_closed_form():
     coords = LegendreAxisSpec(12).materialize(jnp.array(-1.0), jnp.array(1.0)).nodes
     out = d2.func((coords,))
     expected = 6.0 * coords
+    assert jnp.allclose(out, expected, rtol=1e-6, atol=1e-6)
+
+
+def test_partial_n_basis_poly_fourth_order_matches_closed_form():
+    geom = Interval1d(-1.0, 1.0)
+
+    @geom.Function("x")
+    def u(x):
+        return x[0] ** 6
+
+    d4 = partial_n(
+        u,
+        var="x",
+        order=4,
+        backend="basis",
+        basis="poly",
+    )
+    coords = LegendreAxisSpec(16).materialize(jnp.array(-1.0), jnp.array(1.0)).nodes
+    out = d4.func((coords,))
+    expected = 360.0 * (coords**2)
     assert jnp.allclose(out, expected, rtol=1e-6, atol=1e-6)
 
 


### PR DESCRIPTION
## Summary
- add a reusable scan helper for module scans with per-step aligned data (`scan_apply_with_data`)
- add wrapper-level scan execution paths with compatibility fallbacks:
  - `LatentContractionModel` aligned execution
  - `Separable` regular point execution
  - `Separable` clone-group execution for separable tuple inputs
- forward `scan` from separable architecture constructors into `Separable(...)`
- optimize repeated-order differential operators:
  - replace Python loops with `jax.lax.fori_loop` in FD/poly nth derivatives
  - hoist barycentric differentiation matrix construction out of per-order loop
- add tests for wrapper scan parity/fallback and higher-order differential backend behavior

## Commits
- `0d10f22` feat(nn.scan): add scan-with-data primitive
- `afea5ca` feat(nn.wrappers): add scan execution paths to separable wrappers
- `e1ef0a7` perf(differential): use fori_loop for repeated derivatives
