### PR TITLE
Fix Windows temp-folder handling for geometry CAD intermediates

### DIFF
--- a/phydrax/domain/geometry2d/_from_cad.py
+++ b/phydrax/domain/geometry2d/_from_cad.py
@@ -2,6 +2,7 @@
 #  Copyright © 2026 PHYDRA, Inc. All rights reserved.
 #
 
+import tempfile
 from collections.abc import Callable, Sequence
 from functools import cached_property
 from pathlib import Path
@@ -841,7 +842,7 @@ def Geometry2DFromPointCloud(
     if hasattr(surface, "triangulate"):
         surface = surface.triangulate()
 
-    tmp_path = Path(f"/tmp/pv_pointcloud2d_{uuid4().hex}.stl").resolve()
+    tmp_path = Path(tempfile.gettempdir(), f"pv_pointcloud2d_{uuid4().hex}.stl").resolve()
     surface.save(tmp_path)
 
     geom = Geometry2DFromCAD(tmp_path, recenter=recenter)

--- a/phydrax/domain/geometry2d/_primitives.py
+++ b/phydrax/domain/geometry2d/_primitives.py
@@ -2,6 +2,7 @@
 #  Copyright © 2026 PHYDRA, Inc. All rights reserved.
 #
 
+import tempfile
 from collections.abc import Sequence
 from pathlib import Path
 from uuid import uuid4
@@ -43,7 +44,7 @@ def Circle(
         with bd.Locations((cx, cy)):
             bd.Circle(r)
     face = sk.sketch
-    tmp = Path(f"/tmp/bd2d_circle_{uuid4().hex}.stl").resolve()
+    tmp = Path(tempfile.gettempdir(), f"bd2d_circle_{uuid4().hex}.stl").resolve()
     # Export the Face as STL and construct the geometry from it
     bd.export_stl(face, tmp, tolerance=1e-1, angular_tolerance=1e-1)
     geom = Geometry2DFromCAD(tmp, recenter=False)
@@ -82,7 +83,7 @@ def Ellipse(
         with bd.Locations((cx, cy)):
             bd.Ellipse(rx, ry)
     face = sk.sketch
-    tmp = Path(f"/tmp/bd2d_ellipse_{uuid4().hex}.stl").resolve()
+    tmp = Path(tempfile.gettempdir(), f"bd2d_ellipse_{uuid4().hex}.stl").resolve()
     bd.export_stl(face, tmp, tolerance=1e-4, angular_tolerance=1e-2)
     geom = Geometry2DFromCAD(tmp, recenter=False)
     tmp.unlink(missing_ok=True)
@@ -119,7 +120,7 @@ def Rectangle(
         with bd.Locations((cx, cy)):
             bd.Rectangle(w, h)
     face = sk.sketch
-    tmp = Path(f"/tmp/bd2d_rectangle_{uuid4().hex}.stl").resolve()
+    tmp = Path(tempfile.gettempdir(), f"bd2d_rectangle_{uuid4().hex}.stl").resolve()
     bd.export_stl(face, tmp, tolerance=1e-4, angular_tolerance=0.001)
     geom = Geometry2DFromCAD(tmp, recenter=False)
     tmp.unlink(missing_ok=True)
@@ -197,7 +198,7 @@ def Polygon(
         with bd.Locations((float(center[0]), float(center[1]))):
             bd.Polygon(*(tuple(map(float, v)) for v in rel))
     face = sk.sketch
-    tmp = Path(f"/tmp/bd2d_polygon_{uuid4().hex}.stl").resolve()
+    tmp = Path(tempfile.gettempdir(), f"bd2d_polygon_{uuid4().hex}.stl").resolve()
     bd.export_stl(face, tmp, tolerance=1e-4, angular_tolerance=0.001)
     geom = Geometry2DFromCAD(tmp, recenter=False)
     tmp.unlink(missing_ok=True)

--- a/phydrax/domain/geometry3d/_cad_io.py
+++ b/phydrax/domain/geometry3d/_cad_io.py
@@ -2,6 +2,7 @@
 #  Copyright © 2026 PHYDRA, Inc. All rights reserved.
 #
 
+import tempfile
 import warnings
 from pathlib import Path
 
@@ -19,7 +20,7 @@ def _maybe_convert_cad_to_stl(mesh_path: Path) -> tuple[Path, Path | None]:
         name = name[:-3]
     assert name.endswith(".")
 
-    stl_path = Path(f"/tmp/{name}stl").resolve()
+    stl_path = Path(tempfile.gettempdir(), f"{name}stl").resolve()
     result = bd.import_step(mesh_path)
     if not result.is_leaf:
         assert result.children

--- a/phydrax/domain/geometry3d/_constructors.py
+++ b/phydrax/domain/geometry3d/_constructors.py
@@ -3,6 +3,7 @@
 #
 
 import inspect
+import tempfile
 from pathlib import Path
 from uuid import uuid4
 
@@ -51,7 +52,7 @@ def Geometry3DFromPointCloud(
         progress_bar=bool(progress_bar),
     )
 
-    tmp_path = Path(f"/tmp/pv_pointcloud_{uuid4().hex}.stl").resolve()
+    tmp_path = Path(tempfile.gettempdir(), f"pv_pointcloud_{uuid4().hex}.stl").resolve()
     surface.save(tmp_path)
 
     geom = Geometry3DFromCAD(tmp_path, recenter=recenter)
@@ -132,7 +133,7 @@ def Geometry3DFromDEM(
     else:
         solid = surface
 
-    tmp_path = Path(f"/tmp/pv_dem_{uuid4().hex}.stl").resolve()
+    tmp_path = Path(tempfile.gettempdir(), f"pv_dem_{uuid4().hex}.stl").resolve()
     solid.save(tmp_path)
 
     geom = Geometry3DFromCAD(tmp_path, recenter=recenter)
@@ -218,7 +219,7 @@ def Geometry3DFromLidarScene(
     else:
         solid = surf
 
-    tmp_path = Path(f"/tmp/pv_lidar_{uuid4().hex}.stl").resolve()
+    tmp_path = Path(tempfile.gettempdir(), f"pv_lidar_{uuid4().hex}.stl").resolve()
     solid.save(tmp_path)
 
     geom = Geometry3DFromCAD(tmp_path, recenter=recenter)

--- a/phydrax/domain/geometry3d/_primitives.py
+++ b/phydrax/domain/geometry3d/_primitives.py
@@ -2,6 +2,7 @@
 #  Copyright © 2026 PHYDRA, Inc. All rights reserved.
 #
 
+import tempfile
 from collections.abc import Sequence
 from pathlib import Path
 from uuid import uuid4
@@ -37,7 +38,7 @@ def Sphere(
     c = np.asarray(center, dtype=float)
     r = float(radius)
     shape = bd.Sphere(r).moved(bd.Location(tuple(c)))
-    tmp = Path(f"/tmp/bd3d_sphere_{uuid4().hex}.stl").resolve()
+    tmp = Path(tempfile.gettempdir(), f"bd3d_sphere_{uuid4().hex}.stl").resolve()
     bd.export_stl(shape, tmp, tolerance=1e-3, angular_tolerance=5e-2)
     geom = Geometry3DFromCAD(tmp, recenter=False)
     tmp.unlink(missing_ok=True)
@@ -75,7 +76,7 @@ def Ellipsoid(
     shp = bd.Sphere(1.0)
     shp = bd.scale(shp, (rx, ry, rz))
     shp = shp.moved(bd.Location(tuple(c)))
-    tmp = Path(f"/tmp/bd3d_ellipsoid_{uuid4().hex}.stl").resolve()
+    tmp = Path(tempfile.gettempdir(), f"bd3d_ellipsoid_{uuid4().hex}.stl").resolve()
     bd.export_stl(shp, tmp, tolerance=1e-3, angular_tolerance=5e-2)
     geom = Geometry3DFromCAD(tmp, recenter=False)
     tmp.unlink(missing_ok=True)
@@ -109,7 +110,7 @@ def Cuboid(
     c = np.asarray(center, dtype=float)
     dx, dy, dz = [float(x) for x in dimensions]
     shp = bd.Box(dx, dy, dz).moved(bd.Location(tuple(c)))
-    tmp = Path(f"/tmp/bd3d_cuboid_{uuid4().hex}.stl").resolve()
+    tmp = Path(tempfile.gettempdir(), f"bd3d_cuboid_{uuid4().hex}.stl").resolve()
     bd.export_stl(shp, tmp, tolerance=1e-3, angular_tolerance=5e-2)
     geom = Geometry3DFromCAD(tmp, recenter=False)
     tmp.unlink(missing_ok=True)
@@ -173,7 +174,7 @@ def Cylinder(
             bd.Circle(r)
         bd.extrude(amount=h)
     shp = bp.part
-    tmp = Path(f"/tmp/bd3d_cylinder_{uuid4().hex}.stl").resolve()
+    tmp = Path(tempfile.gettempdir(), f"bd3d_cylinder_{uuid4().hex}.stl").resolve()
     bd.export_stl(shp, tmp, tolerance=1e-3, angular_tolerance=5e-2)
     geom = Geometry3DFromCAD(tmp, recenter=False)
     tmp.unlink(missing_ok=True)
@@ -216,7 +217,7 @@ def Cone(
     with bd.BuildPart(wp) as bp:
         bd.Cone(r0, r1, h)
     shp = bp.part
-    tmp = Path(f"/tmp/bd3d_cone_{uuid4().hex}.stl").resolve()
+    tmp = Path(tempfile.gettempdir(), f"bd3d_cone_{uuid4().hex}.stl").resolve()
     bd.export_stl(shp, tmp, tolerance=1e-3, angular_tolerance=5e-2)
     geom = Geometry3DFromCAD(tmp, recenter=False)
     tmp.unlink(missing_ok=True)
@@ -255,7 +256,7 @@ def Torus(
     # Build full torus. Note: partial-angle torus not exported reliably as STL with watertight volume.
     shp = bd.Torus(major_radius=major, minor_radius=minor)
     shp = shp.moved(bd.Location(tuple(c)))
-    tmp = Path(f"/tmp/bd3d_torus_{uuid4().hex}.stl").resolve()
+    tmp = Path(tempfile.gettempdir(), f"bd3d_torus_{uuid4().hex}.stl").resolve()
     bd.export_stl(shp, tmp, tolerance=5e-2, angular_tolerance=8e-2)
     geom = Geometry3DFromCAD(tmp)
     tmp.unlink(missing_ok=True)
@@ -301,7 +302,7 @@ def Wedge(
     )
     # Place the wedge so that its right-angle near corner is at x0
     shp = shp.moved(bd.Location(tuple(x0)))
-    tmp = Path(f"/tmp/bd3d_wedge_{uuid4().hex}.stl").resolve()
+    tmp = Path(tempfile.gettempdir(), f"bd3d_wedge_{uuid4().hex}.stl").resolve()
     bd.export_stl(shp, tmp, tolerance=1e-3, angular_tolerance=5e-2)
     geom = Geometry3DFromCAD(tmp, recenter=False)
     tmp.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary
- replace hardcoded Unix temp paths (`/tmp/...`) with cross-platform temp paths using `tempfile.gettempdir()`
- apply the fix across geometry CAD/mesh intermediate export paths in both 2D and 3D helpers
- ensure Windows-compatible behavior for `Square`/`Rectangle` and related geometry constructors

## Files Changed
- `phydrax/domain/geometry2d/_primitives.py`
- `phydrax/domain/geometry2d/_from_cad.py`
- `phydrax/domain/geometry3d/_primitives.py`
- `phydrax/domain/geometry3d/_constructors.py`
- `phydrax/domain/geometry3d/_cad_io.py`

## Notes
- no behavior changes beyond temp file location resolution
- temporary filenames remain unique via `uuid4()`

Closes #8
