### PR TITLE
v0.2.2

### DIFF
--- a/docs/api/nn/wrappers.md
+++ b/docs/api/nn/wrappers.md
@@ -7,6 +7,7 @@ Composable model transforms that add structure or change output interpretation.
 
     - `EquinoxModel` / `EquinoxStructuredModel` adapt arbitrary Equinox/JAX callables into Phydrax models by attaching `in_size` / `out_size`.
     - `ComplexOutputModel` packs/unpacks real/imag parts into complex outputs.
+    - `Sequential` chains models so outputs of stage `i` feed stage `i+1`.
 
 ## Equinox adapters
 
@@ -121,6 +122,39 @@ assert y.shape == (4,)
 ---
 
 ## Model transforms
+
+`Sequential` is useful for embedded pipelines, for example
+`RandomFourierFeatureEmbeddings -> MLP`, then reused inside separable wrappers.
+
+```python
+import jax.random as jr
+import phydrax as phx
+
+branch = phx.nn.Sequential(
+    (
+        phx.nn.RandomFourierFeatureEmbeddings(
+            in_size="scalar",
+            out_size=64,
+            key=jr.key(0),
+        ),
+        phx.nn.MLP(
+            in_size=64,
+            out_size=16,
+            width_size=64,
+            depth=2,
+            key=jr.key(1),
+        ),
+    )
+)
+```
+
+::: phydrax.nn.Sequential
+    options:
+        members:
+            - __init__
+            - __call__
+
+---
 
 ::: phydrax.nn.MagnitudeDirectionModel
     options:

--- a/phydrax/nn/__init__.py
+++ b/phydrax/nn/__init__.py
@@ -55,6 +55,7 @@ from .models import (  # noqa: F401
     SeparableFeynmaNN,
     SeparableKAN,
     SeparableMLP,
+    Sequential,
 )
 
 
@@ -81,6 +82,7 @@ __all__ = [
     "DeepONet",
     "FNO1d",
     "FNO2d",
+    "Sequential",
     "LatentExecutionPolicy",
     "LatentContractionModel",
     "Separable",

--- a/phydrax/nn/models/__init__.py
+++ b/phydrax/nn/models/__init__.py
@@ -28,6 +28,7 @@ from .wrappers._separable_wrappers import (
     LatentExecutionPolicy,
     Separable,
 )
+from .wrappers._sequential import Sequential
 
 
 __all__ = [
@@ -45,6 +46,7 @@ __all__ = [
     "SeparableKAN",
     "SeparableFeynmaNN",
     "FeynmaNN",
+    "Sequential",
     "FNO1d",
     "FNO2d",
     "LatentExecutionPolicy",

--- a/phydrax/nn/models/wrappers/_sequential.py
+++ b/phydrax/nn/models/wrappers/_sequential.py
@@ -1,0 +1,87 @@
+#
+#  Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from collections.abc import Sequence
+from typing import Literal
+
+import jax.numpy as jnp
+import jax.random as jr
+from jaxtyping import Array, Key
+
+from ...._doc import DOC_KEY0
+from ..._utils import _canonical_size
+from ..core._base import _AbstractBaseModel, _AbstractStructuredInputModel
+
+
+class Sequential(_AbstractStructuredInputModel):
+    r"""Compose models in sequence.
+
+    Given models $(m_1,\dots,m_K)$, this wrapper evaluates
+
+    $$
+    y(x)=m_K(\cdots m_2(m_1(x))\cdots).
+    $$
+
+    Adjacent models must have compatible sizes:
+    `canonical(prev.out_size) == canonical(next.in_size)`.
+    """
+
+    models: tuple[_AbstractBaseModel, ...]
+    in_size: int | tuple[int, ...] | Literal["scalar"]
+    out_size: int | tuple[int, ...] | Literal["scalar"]
+
+    def __init__(self, models: Sequence[_AbstractBaseModel]):
+        if not models:
+            raise ValueError("Sequential requires at least one model.")
+
+        models_t = tuple(models)
+        for idx in range(1, len(models_t)):
+            prev = models_t[idx - 1]
+            curr = models_t[idx]
+            prev_out = _canonical_size(prev.out_size)
+            curr_in = _canonical_size(curr.in_size)
+            if prev_out != curr_in:
+                raise ValueError(
+                    "Sequential size mismatch at stage "
+                    f"{idx - 1}->{idx}: prev.out_size={prev.out_size!r} "
+                    f"is not compatible with curr.in_size={curr.in_size!r}."
+                )
+
+        self.models = models_t
+        self.in_size = _canonical_size(models_t[0].in_size)
+        self.out_size = _canonical_size(models_t[-1].out_size)
+
+    def __call__(
+        self,
+        x: Array | tuple[Array, ...],
+        /,
+        *,
+        key: Key[Array, ""] = DOC_KEY0,
+    ) -> Array:
+        r"""Evaluate the model pipeline.
+
+        If tuple input is provided, the first stage must support structured input.
+        """
+        if len(self.models) == 1:
+            keys = (key,)
+        else:
+            keys = tuple(jr.split(key, len(self.models)))
+
+        first_model = self.models[0]
+        if isinstance(x, tuple):
+            if not isinstance(first_model, _AbstractStructuredInputModel):
+                raise TypeError(
+                    "Sequential received tuple input, but the first stage does not "
+                    "support structured inputs."
+                )
+            y = first_model(x, key=keys[0])
+        else:
+            y = first_model(jnp.asarray(x), key=keys[0])
+
+        for model, subkey in zip(self.models[1:], keys[1:], strict=True):
+            y = model(jnp.asarray(y), key=subkey)
+        return jnp.asarray(y)
+
+
+__all__ = ["Sequential"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ authors = [
   {email = "leonard@phydra.ai", name = "Phydra Labs"}
 ]
 name = "phydrax"
-version = "0.2.1"
+version = "0.2.2"
 requires-python = ">=3.11,<4.0"
 license-files = ["LICENSE"]
 

--- a/tests/unit/nn/test_models/test_sequential_model.py
+++ b/tests/unit/nn/test_models/test_sequential_model.py
@@ -1,0 +1,68 @@
+#
+#  Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+from phydrax.nn.models import MLP, RandomFourierFeatureEmbeddings, Sequential
+
+
+def test_sequential_requires_at_least_one_model():
+    with pytest.raises(ValueError, match="at least one model"):
+        _ = Sequential(())
+
+
+def test_sequential_rff_then_mlp_shape_and_metadata():
+    model = Sequential(
+        (
+            RandomFourierFeatureEmbeddings(
+                in_size="scalar",
+                out_size=16,
+                key=jr.key(0),
+            ),
+            MLP(
+                in_size=16,
+                out_size=3,
+                width_size=8,
+                depth=1,
+                key=jr.key(1),
+            ),
+        )
+    )
+    y = model(jnp.asarray(0.25), key=jr.key(2))
+    assert model.in_size == "scalar"
+    assert model.out_size == 3
+    assert y.shape == (3,)
+
+
+def test_sequential_single_stage_matches_wrapped_model():
+    mlp = MLP(
+        in_size=2,
+        out_size="scalar",
+        width_size=16,
+        depth=2,
+        key=jr.key(0),
+    )
+    model = Sequential((mlp,))
+    x = jnp.asarray([0.1, -0.3], dtype=float)
+    y_ref = mlp(x, key=jr.key(3))
+    y_seq = model(x, key=jr.key(3))
+    assert y_seq.shape == ()
+    assert jnp.allclose(y_seq, y_ref)
+
+
+def test_sequential_rejects_adjacent_size_mismatch():
+    m1 = MLP(in_size=2, out_size=3, width_size=8, depth=1, key=jr.key(0))
+    m2 = MLP(in_size=4, out_size=1, width_size=8, depth=1, key=jr.key(1))
+    with pytest.raises(ValueError, match="Sequential size mismatch"):
+        _ = Sequential((m1, m2))
+
+
+def test_sequential_tuple_input_requires_structured_first_stage():
+    m1 = MLP(in_size=2, out_size=2, width_size=8, depth=1, key=jr.key(0))
+    m2 = MLP(in_size=2, out_size=1, width_size=8, depth=1, key=jr.key(1))
+    model = Sequential((m1, m2))
+    with pytest.raises(TypeError, match="tuple input"):
+        _ = model((jnp.asarray(0.1), jnp.asarray(0.2)), key=jr.key(2))


### PR DESCRIPTION
## Summary
- merge `Sequential` model composition wrapper into `main`
- expose `Sequential` via `phydrax.nn.models` and `phydrax.nn`
- add API docs for wrappers/Sequential usage
- add unit coverage for sequential model chaining and validation
- bump package version to `0.2.2`

## Included commits
- cbf6a0f Merge pull request #15 from phydra-labs/sequential
- fed4089 chore(release): bump version to 0.2.2
- c159fe3 feat(nn): add Sequential model wrapper with docs and tests