### PR TITLE
Add HyperRectangle domain geometry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,8 @@ __pycache__
 .ruff_cache
 uv.lock
 AGENTS.md
+LLM.md
+scratch.py
+*.onnx
 dist/
 site/

--- a/phydrax/constraints/_bc_thermal.py
+++ b/phydrax/constraints/_bc_thermal.py
@@ -65,7 +65,7 @@ def ContinuousHeatFluxBoundaryConstraint(
 ) -> FunctionalConstraint:
     r"""Prescribed heat-flux (Neumann) boundary condition.
 
-    Enforces $k\\,\\partial T/\\partial n = q$ on the boundary component, where
+    Enforces $k\,\partial T/\partial n = q$ on the boundary component, where
     $q$ is the heat flux (default $0$).
 
     **Arguments:**
@@ -129,8 +129,8 @@ def ContinuousConvectionBoundaryConstraint(
 ) -> FunctionalConstraint:
     r"""Convection (Robin) boundary condition.
 
-    Enforces $k\\,\\partial T/\\partial n = h\\,(T - T_\\infty)$ on the boundary
-    component, where $T_\\infty$ is the ambient temperature (default $0$).
+    Enforces $k\,\partial T/\partial n = h\,(T - T_\infty)$ on the boundary
+    component, where $T_\infty$ is the ambient temperature (default $0$).
 
     **Arguments:**
 
@@ -138,7 +138,7 @@ def ContinuousConvectionBoundaryConstraint(
     - `component`: Boundary component.
     - `h`: Convection coefficient.
     - `k`: Thermal conductivity.
-    - `ambient_temp`: Ambient temperature $T_\\infty$ (defaults to 0).
+    - `ambient_temp`: Ambient temperature $T_\infty$ (defaults to 0).
     - `var`: Geometry variable used to compute normals.
     - `mode`: Differentiation mode (`"reverse"` or `"forward"`).
     - `num_points`: Number of boundary samples.

--- a/phydrax/domain/__init__.py
+++ b/phydrax/domain/__init__.py
@@ -64,6 +64,7 @@ from ._grid import (
     SineAxisSpec,
     UniformAxisSpec,
 )
+from ._hyperrectangle import HyperRectangle
 from ._model_function import structured
 from ._product_domain import ProductDomain
 from ._scalar import ScalarInterval
@@ -116,6 +117,7 @@ __all__ = [
     "DomainFunction",
     "structured",
     "DatasetDomain",
+    "HyperRectangle",
     "ProductStructure",
     "PointsBatch",
     "QuadratureBatch",

--- a/phydrax/domain/_hyperrectangle.py
+++ b/phydrax/domain/_hyperrectangle.py
@@ -1,0 +1,345 @@
+#
+#  Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from collections.abc import Callable, Sequence
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jaxtyping import Array, ArrayLike, Bool, Float, Key
+
+from .._doc import DOC_KEY0
+from ._base import _AbstractGeometry
+from ._grid import broadcasted_grid
+from ._sampling import get_sampler_host, seed_from_key
+from ._structure import _validate_label
+
+
+class HyperRectangle(_AbstractGeometry):
+    r"""Axis-aligned hyperrectangle in R^d.
+
+    Represents the set
+
+    ```text
+    Omega = {x in R^d : lower_i <= x_i <= upper_i for every i}
+    ```
+
+    This is the natural geometry for vector-valued feature spaces, parameter boxes,
+    and tabular supervised learning problems where each row is one point in R^d.
+    """
+
+    lower: Array
+    upper: Array
+    _label: str
+    adf: Callable[[Array], Array]
+
+    def __init__(
+        self,
+        lower: ArrayLike,
+        upper: ArrayLike,
+        *,
+        label: str = "x",
+    ):
+        lower_arr = jnp.asarray(lower, dtype=float)
+        upper_arr = jnp.asarray(upper, dtype=float)
+        if lower_arr.ndim != 1 or upper_arr.ndim != 1:
+            raise ValueError("HyperRectangle lower/upper must be one-dimensional.")
+        if lower_arr.shape != upper_arr.shape:
+            raise ValueError(
+                "HyperRectangle lower and upper must have matching shapes; "
+                f"got {lower_arr.shape} and {upper_arr.shape}."
+            )
+        if int(lower_arr.shape[0]) <= 0:
+            raise ValueError("HyperRectangle dimension must be positive.")
+        if bool(jnp.any(upper_arr <= lower_arr)):
+            raise ValueError("HyperRectangle requires upper > lower in every dimension.")
+
+        _validate_label(label)
+
+        self.lower = lower_arr
+        self.upper = upper_arr
+        self._label = str(label)
+
+    @property
+    def label(self) -> str:
+        return self._label
+
+    @property
+    def adf(self) -> Callable[[Array], Array]:
+        return self._adf
+
+    @property
+    def spatial_dim(self) -> int:
+        return int(self.lower.shape[0])
+
+    @property
+    def bounds(self) -> Float[Array, "2 spatial_dim"]:
+        return jnp.stack((self.lower, self.upper), axis=0)
+
+    @property
+    def volume(self) -> Array:
+        return jnp.prod(self.upper - self.lower)
+
+    @property
+    def boundary_measure_value(self) -> Array:
+        widths = self.upper - self.lower
+        if int(widths.shape[0]) == 1:
+            return jnp.asarray(2.0, dtype=float)
+        face_measures = self.volume / widths
+        return 2.0 * jnp.sum(face_measures)
+
+    def equivalent(self, other: object, /) -> bool:
+        if not isinstance(other, HyperRectangle):
+            return False
+        if self.label != other.label:
+            return False
+        return bool(
+            np.allclose(np.asarray(self.lower), np.asarray(other.lower))
+            and np.allclose(np.asarray(self.upper), np.asarray(other.upper))
+        )
+
+    def _points_2d(self, points: ArrayLike, /) -> tuple[Array, bool]:
+        pts = jnp.asarray(points, dtype=float)
+        dim = int(self.spatial_dim)
+
+        if pts.ndim == 0:
+            if dim != 1:
+                raise ValueError(f"Expected points with trailing dimension {dim}.")
+            return pts.reshape((1, 1)), True
+
+        if pts.ndim == 1:
+            if dim == 1:
+                return pts.reshape((-1, 1)), int(pts.shape[0]) == 1
+            if int(pts.shape[0]) != dim:
+                raise ValueError(f"Expected point with shape ({dim},), got {pts.shape}.")
+            return pts.reshape((1, dim)), True
+
+        if pts.ndim == 2 and int(pts.shape[1]) == dim:
+            return pts, False
+
+        raise ValueError(
+            f"Expected points with shape ({dim},) or (N, {dim}), got {pts.shape}."
+        )
+
+    def sample_interior(
+        self,
+        num_points: int,
+        *,
+        where: Callable | None = None,
+        sampler: str = "latin_hypercube",
+        key: Key[Array, ""] = DOC_KEY0,
+    ) -> Array:
+        lower = np.asarray(self.lower, dtype=float)
+        upper = np.asarray(self.upper, dtype=float)
+        dim = int(self.spatial_dim)
+        where_fn = where or (lambda _: True)
+
+        def _sample_interior_host(num_points, sampler, where_fn, key):
+            rng = np.random.default_rng(seed_from_key(key))
+            sampler_fn = get_sampler_host(sampler, dim=dim, seed=rng)
+            sampled = np.empty((0, dim), dtype=float)
+
+            while sampled.shape[0] < int(num_points):
+                remaining = int(num_points) - sampled.shape[0]
+                unit = sampler_fn(remaining)
+                points = lower + unit * (upper - lower)
+                if where_fn is not None:
+                    mask = np.asarray(
+                        jax.vmap(where_fn)(jnp.asarray(points, dtype=float)),
+                        dtype=bool,
+                    ).reshape((-1,))
+                    points = points[mask]
+                sampled = np.vstack((sampled, np.asarray(points, dtype=float)))
+
+            return sampled[: int(num_points)]
+
+        zeros = jnp.zeros((int(num_points), dim), dtype=float)
+        shape_dtype = jax.ShapeDtypeStruct(zeros.shape, zeros.dtype)
+        return eqx.filter_pure_callback(
+            _sample_interior_host,
+            int(num_points),
+            sampler,
+            where_fn,
+            key,
+            result_shape_dtypes=shape_dtype,
+        )
+
+    def sample_boundary(
+        self,
+        num_points: int,
+        *,
+        where: Callable | None = None,
+        sampler: str = "latin_hypercube",
+        key: Key[Array, ""] = DOC_KEY0,
+    ) -> Array:
+        lower = np.asarray(self.lower, dtype=float)
+        upper = np.asarray(self.upper, dtype=float)
+        widths = upper - lower
+        dim = int(self.spatial_dim)
+        where_fn = where or (lambda _: True)
+
+        if dim == 1:
+            face_probs = np.asarray([0.5, 0.5], dtype=float)
+        else:
+            face_measures = np.prod(widths) / widths
+            face_probs = np.repeat(face_measures, 2)
+            face_probs = face_probs / np.sum(face_probs)
+
+        def _sample_boundary_host(num_points, sampler, where_fn, key):
+            rng = np.random.default_rng(seed_from_key(key))
+            sampler_dim = max(dim - 1, 1)
+            sampler_fn = get_sampler_host(sampler, dim=sampler_dim, seed=rng)
+            sampled = np.empty((0, dim), dtype=float)
+
+            while sampled.shape[0] < int(num_points):
+                remaining = int(num_points) - sampled.shape[0]
+                face_ids = rng.choice(2 * dim, size=(remaining,), p=face_probs)
+                axes = face_ids // 2
+                sides = face_ids % 2
+                unit = sampler_fn(remaining)
+                points = np.empty((remaining, dim), dtype=float)
+
+                for row in range(remaining):
+                    axis = int(axes[row])
+                    local_col = 0
+                    for col in range(dim):
+                        if col == axis:
+                            points[row, col] = (
+                                lower[col] if sides[row] == 0 else upper[col]
+                            )
+                        else:
+                            points[row, col] = (
+                                lower[col] + unit[row, local_col] * widths[col]
+                            )
+                            local_col += 1
+
+                if where_fn is not None:
+                    mask = np.asarray(
+                        jax.vmap(where_fn)(jnp.asarray(points, dtype=float)),
+                        dtype=bool,
+                    ).reshape((-1,))
+                    points = points[mask]
+                sampled = np.vstack((sampled, np.asarray(points, dtype=float)))
+
+            return sampled[: int(num_points)]
+
+        zeros = jnp.zeros((int(num_points), dim), dtype=float)
+        shape_dtype = jax.ShapeDtypeStruct(zeros.shape, zeros.dtype)
+        return eqx.filter_pure_callback(
+            _sample_boundary_host,
+            int(num_points),
+            sampler,
+            where_fn,
+            key,
+            result_shape_dtypes=shape_dtype,
+        )
+
+    def _sample_interior_separable(
+        self,
+        num_points: int | Sequence[int],
+        *,
+        sampler: str = "latin_hypercube",
+        where: Callable | None = None,
+        key: Key[Array, ""] = DOC_KEY0,
+    ) -> tuple[tuple[Array, ...], Bool[Array, "..."]]:
+        dim = int(self.spatial_dim)
+        if isinstance(num_points, int):
+            counts = (int(num_points),) * dim
+        else:
+            counts = tuple(int(n) for n in num_points)
+            if len(counts) != dim:
+                raise ValueError(
+                    f"HyperRectangle separable sampling expects {dim} counts, got {len(counts)}."
+                )
+
+        lower = np.asarray(self.lower, dtype=float)
+        upper = np.asarray(self.upper, dtype=float)
+
+        def _sample_axes_host(counts, sampler, key):
+            rng = np.random.default_rng(seed_from_key(key))
+            axes = []
+            for i, n in enumerate(counts):
+                sampler_fn = get_sampler_host(sampler, dim=1, seed=rng)
+                unit = sampler_fn(int(n)).reshape((int(n),))
+                axes.append(lower[i] + unit * (upper[i] - lower[i]))
+            return tuple(np.asarray(axis, dtype=float) for axis in axes)
+
+        result_shape = tuple(
+            jax.ShapeDtypeStruct((int(n),), np.dtype(float)) for n in counts
+        )
+        coords = eqx.filter_pure_callback(
+            _sample_axes_host,
+            counts,
+            sampler,
+            key,
+            result_shape_dtypes=result_shape,
+        )
+        coords = tuple(jnp.asarray(c, dtype=float) for c in coords)
+
+        if where is None:
+            mask = jnp.ones(tuple(counts), dtype=bool)
+        else:
+            grid = broadcasted_grid(coords)
+            pts = grid.reshape((-1, dim))
+            mask = jax.vmap(where)(pts).reshape(tuple(counts))
+            mask = jnp.asarray(mask, dtype=bool)
+
+        return coords, mask
+
+    def _contains(self, points: Array) -> Bool[Array, " num_points"]:
+        pts, _ = self._points_2d(points)
+        return jnp.all((pts >= self.lower) & (pts <= self.upper), axis=-1)
+
+    def _on_boundary(self, points: Array) -> Bool[Array, " num_points"]:
+        pts, _ = self._points_2d(points)
+        inside = self._contains(pts)
+        lower_face = jnp.isclose(pts, self.lower)
+        upper_face = jnp.isclose(pts, self.upper)
+        return inside & jnp.any(lower_face | upper_face, axis=-1)
+
+    def _boundary_normals(self, points: Array) -> Float[Array, "num_points spatial_dim"]:
+        pts, _ = self._points_2d(points)
+        lower_face = jnp.isclose(pts, self.lower)
+        upper_face = jnp.isclose(pts, self.upper)
+        raw = upper_face.astype(float) - lower_face.astype(float)
+        raw_norm = jnp.linalg.norm(raw, axis=-1, keepdims=True)
+
+        dist_lower = jnp.abs(pts - self.lower)
+        dist_upper = jnp.abs(pts - self.upper)
+        face_dist = jnp.concatenate((dist_lower, dist_upper), axis=-1)
+        nearest = jnp.argmin(face_dist, axis=-1)
+        dim = int(self.spatial_dim)
+        nearest_axis = nearest % dim
+        nearest_sign = jnp.where(nearest < dim, -1.0, 1.0)
+        fallback = jax.nn.one_hot(nearest_axis, dim, dtype=float) * nearest_sign[:, None]
+
+        safe_raw = raw / jnp.maximum(raw_norm, jnp.finfo(float).eps)
+        normals = jnp.where(raw_norm > 0.0, safe_raw, fallback)
+        norm = jnp.linalg.norm(normals, axis=-1, keepdims=True)
+        return normals / jnp.maximum(norm, jnp.finfo(float).eps)
+
+    def _adf(self, points: Array) -> Array:
+        pts, single = self._points_2d(points)
+        center = 0.5 * (self.lower + self.upper)
+        half_width = 0.5 * (self.upper - self.lower)
+        q = jnp.abs(pts - center) - half_width
+        outside = jnp.linalg.norm(jnp.maximum(q, 0.0), axis=-1)
+        inside = jnp.minimum(jnp.max(q, axis=-1), 0.0)
+        sdf = outside + inside
+        return sdf[0] if single else sdf
+
+    def estimate_boundary_subset_measure(
+        self,
+        where: Callable[[Array], Bool[Array, ""]],
+        *,
+        num_samples: int = 4096,
+        key: Key[Array, ""] = DOC_KEY0,
+    ) -> Array:
+        pts = self.sample_boundary(int(num_samples), key=key)
+        mask = jax.vmap(where)(pts)
+        return jnp.mean(jnp.asarray(mask, dtype=float)) * self.boundary_measure_value
+
+
+__all__ = ["HyperRectangle"]

--- a/phydrax/domain/geometry3d/_utils.py
+++ b/phydrax/domain/geometry3d/_utils.py
@@ -3,7 +3,7 @@
 #
 
 from pathlib import Path
-from typing import Literal, Sequence
+from typing import Literal, overload, Sequence
 
 import meshio
 import numpy as np
@@ -40,6 +40,24 @@ def _canonicalize_mesh_arrays(
     f_sorted = f_sorted[f_order]
 
     return v_sorted, f_sorted
+
+
+@overload
+def _sanitize_meshio_mesh(
+    meshio_mesh: meshio.Mesh,
+    *,
+    output_type: Literal["trimesh"],
+    recenter: bool = True,
+) -> trimesh.Trimesh: ...
+
+
+@overload
+def _sanitize_meshio_mesh(
+    meshio_mesh: meshio.Mesh,
+    *,
+    output_type: Literal["meshio"],
+    recenter: bool = True,
+) -> meshio.Mesh: ...
 
 
 def _sanitize_meshio_mesh(

--- a/phydrax/nn/models/wrappers/_separable_wrappers.py
+++ b/phydrax/nn/models/wrappers/_separable_wrappers.py
@@ -852,4 +852,5 @@ class Separable(_AbstractStructuredInputModel):
     def _split_key(self, key: Key[Array, ""] | None, /) -> Key[Array, " n_models"]:
         if key is None:
             key = DOC_KEY0
+
         return jr.split(key, len(self.models))

--- a/phydrax/nn/optim/_bfgs_sw.py
+++ b/phydrax/nn/optim/_bfgs_sw.py
@@ -9,7 +9,7 @@ Uses a dense inverse-Hessian approximation in the flattened parameter space.
 Best suited for low/moderate dimensional problems; for large models prefer L-BFGS.
 """
 
-from typing import Any, NamedTuple
+from typing import Any, cast, NamedTuple
 
 import jax
 import jax.numpy as jnp
@@ -77,8 +77,7 @@ def _split_decay_state(state: base.OptState, /) -> tuple[BFGSState, base.OptStat
         or not isinstance(state[0], BFGSState)
     ):
         raise TypeError("Expected (BFGSState, decay_state) for optimizer state.")
-    assert isinstance(state[1], base.OptState)
-    return state[0], state[1]
+    return state[0], cast(base.OptState, state[1])
 
 
 def bfgs_sw_core(

--- a/phydrax/nn/optim/_lbfgs_sw.py
+++ b/phydrax/nn/optim/_lbfgs_sw.py
@@ -10,7 +10,7 @@ Two-loop recursion with ring-buffer history and scalar H0 scaling
 and a backtracking-ish strong Wolfe line search.
 """
 
-from typing import Any, NamedTuple
+from typing import Any, cast, NamedTuple
 
 import jax
 import jax.numpy as jnp
@@ -86,8 +86,7 @@ def _split_decay_state(state: base.OptState, /) -> tuple[LBFGSState, base.OptSta
         or not isinstance(state[0], LBFGSState)
     ):
         raise TypeError("Expected (LBFGSState, decay_state) for optimizer state.")
-    assert isinstance(state[1], base.OptState)
-    return state[0], state[1]
+    return state[0], cast(base.OptState, state[1])
 
 
 def _zeros_like_tree(tree):

--- a/phydrax/nn/optim/_ssbroyden.py
+++ b/phydrax/nn/optim/_ssbroyden.py
@@ -18,7 +18,7 @@ This keeps the Optax interface and can be chained with standard learning-rate
 and weight-decay transformations.
 """
 
-from typing import Any, NamedTuple
+from typing import Any, cast, NamedTuple
 
 import jax
 import jax.numpy as jnp
@@ -92,8 +92,7 @@ def _split_decay_state(state: base.OptState, /) -> tuple[SSBroydenState, base.Op
         or not isinstance(state[0], SSBroydenState)
     ):
         raise TypeError("Expected (SSBroydenState, decay_state) for optimizer state.")
-    assert isinstance(state[1], base.OptState)
-    return state[0], state[1]
+    return state[0], cast(base.OptState, state[1])
 
 
 def _ssbroyden_core(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ authors = [
 ]
 name = "phydrax"
 version = "0.2.2"
-requires-python = ">=3.11,<4.0"
+requires-python = ">=3.11,<3.14"
 license-files = ["LICENSE"]
 
 dependencies = [
@@ -30,6 +30,7 @@ dependencies = [
     "evosax>=0.2.0",
     "interpax>=0.3.12",
     "jax>=0.8.2",
+    "jax2onnx>=0.13.1",
     "jaxtyping>=0.3.5",
     "manifold3d>=3.3.2",
     "meshio>=5.3.5",

--- a/tests/unit/geometry/test_geometry_2d/test_from_cad_2d.py
+++ b/tests/unit/geometry/test_geometry_2d/test_from_cad_2d.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 import trimesh
 from jax import numpy as jnp
+from numpy.typing import ArrayLike
 
 from phydrax.domain.geometry2d import Geometry2DFromCAD
 
@@ -18,7 +19,9 @@ def simple_square_mesh():
     points = np.array(
         [[-0.5, -0.5, 0.0], [0.5, -0.5, 0.0], [0.5, 0.5, 0.0], [-0.5, 0.5, 0.0]]
     )
-    cells = [("triangle", np.array([[0, 1, 2], [0, 2, 3]]))]
+    cells: list[tuple[str, ArrayLike] | meshio.CellBlock] = [
+        ("triangle", np.array([[0, 1, 2], [0, 2, 3]]))
+    ]
     return meshio.Mesh(points=points, cells=cells)
 
 

--- a/tests/unit/geometry/test_hyperrectangle.py
+++ b/tests/unit/geometry/test_hyperrectangle.py
@@ -1,0 +1,136 @@
+#
+#  Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax.numpy as jnp
+import jax.random as jr
+import numpy as np
+import pytest
+
+import phydrax as phx
+
+
+def test_hyperrectangle_basic_measures():
+    geom = phx.domain.HyperRectangle(
+        lower=jnp.array([-1.0, 0.0, 2.0]),
+        upper=jnp.array([1.0, 3.0, 6.0]),
+    )
+
+    assert geom.label == "x"
+    assert geom.spatial_dim == 3
+    assert np.allclose(np.asarray(geom.bounds), [[-1.0, 0.0, 2.0], [1.0, 3.0, 6.0]])
+    assert np.isclose(float(geom.volume), 24.0)
+
+    # Surface area of a 2 x 3 x 4 cuboid: 2 * (3*4 + 2*4 + 2*3).
+    assert np.isclose(float(geom.boundary_measure_value), 52.0)
+
+
+def test_hyperrectangle_rejects_invalid_bounds():
+    with pytest.raises(ValueError, match="matching shapes"):
+        phx.domain.HyperRectangle(lower=jnp.zeros((2,)), upper=jnp.ones((3,)))
+
+    with pytest.raises(ValueError, match="upper > lower"):
+        phx.domain.HyperRectangle(
+            lower=jnp.array([0.0, 1.0]), upper=jnp.array([1.0, 1.0])
+        )
+
+
+def test_hyperrectangle_contains_boundary_normals_and_adf():
+    geom = phx.domain.HyperRectangle(
+        lower=jnp.array([0.0, -1.0]), upper=jnp.array([2.0, 3.0])
+    )
+    pts = jnp.array(
+        [
+            [1.0, 0.0],
+            [0.0, 0.0],
+            [2.0, 3.0],
+            [3.0, 0.0],
+        ]
+    )
+
+    assert np.allclose(np.asarray(geom._contains(pts)), [True, True, True, False])
+    assert np.allclose(np.asarray(geom._on_boundary(pts)), [False, True, True, False])
+
+    normals = geom._boundary_normals(jnp.array([[0.0, 0.0], [2.0, 3.0]]))
+    expected = jnp.array([[-1.0, 0.0], [1.0 / jnp.sqrt(2.0), 1.0 / jnp.sqrt(2.0)]])
+    assert np.allclose(np.asarray(normals), np.asarray(expected))
+
+    sdf = geom.adf(pts)
+    assert sdf[0] < 0.0
+    assert np.isclose(float(sdf[1]), 0.0)
+    assert np.isclose(float(sdf[2]), 0.0)
+    assert sdf[3] > 0.0
+
+
+def test_hyperrectangle_sampling_shapes_and_membership():
+    geom = phx.domain.HyperRectangle(
+        lower=jnp.array([-1.0, 0.0]), upper=jnp.array([1.0, 2.0])
+    )
+
+    interior = geom.sample_interior(16, key=jr.key(0))
+    assert interior.shape == (16, 2)
+    assert bool(jnp.all(geom._contains(interior)))
+
+    boundary = geom.sample_boundary(16, key=jr.key(1))
+    assert boundary.shape == (16, 2)
+    assert bool(jnp.all(geom._on_boundary(boundary)))
+    normals = geom._boundary_normals(boundary)
+    assert np.allclose(np.asarray(jnp.linalg.norm(normals, axis=-1)), 1.0)
+
+
+def test_hyperrectangle_coord_separable_sampling():
+    geom = phx.domain.HyperRectangle(
+        lower=jnp.array([0.0, 1.0]), upper=jnp.array([2.0, 3.0])
+    )
+    batch = geom.component().sample_coord_separable(
+        {"x": (phx.domain.UniformAxisSpec(5), phx.domain.UniformAxisSpec(7))},
+        key=jr.key(0),
+    )
+
+    x0, x1 = batch["x"]
+    assert x0.data.shape == (5,)
+    assert x1.data.shape == (7,)
+    assert batch.coord_mask_by_label["x"].data.shape == (5, 7)
+
+
+def test_hyperrectangle_discrete_interior_data_constraint_with_stacked_points():
+    geom = phx.domain.HyperRectangle(lower=jnp.zeros((2,)), upper=jnp.ones((2,)))
+
+    @geom.Function("x")
+    def u(x):
+        return x[0] + 2.0 * x[1]
+
+    points = jnp.array([[0.1, 0.2], [0.4, 0.5], [0.8, 0.3]], dtype=float)
+    values = points[:, 0] + 2.0 * points[:, 1]
+    constraint = phx.constraints.DiscreteInteriorDataConstraint(
+        "u",
+        geom,
+        points=points,
+        values=values,
+    )
+
+    loss = constraint.loss({"u": u}, key=jr.key(0))
+    assert loss < 1e-10
+
+
+def test_hyperrectangle_domain_model_gets_vector_points():
+    geom = phx.domain.HyperRectangle(lower=jnp.zeros((6,)), upper=jnp.ones((6,)))
+    model = phx.nn.SeparableMLP(
+        in_size=6,
+        out_size="scalar",
+        latent_size=4,
+        width_size=8,
+        depth=1,
+        key=jr.key(0),
+    )
+    u = geom.Model("x")(model)
+
+    batch = geom.component().sample(
+        3,
+        structure=phx.domain.ProductStructure((("x",),)),
+        key=jr.key(0),
+    )
+    out = u(batch)
+    axis = batch.structure.axis_for("x")
+    assert out.dims == (axis,)
+    assert out.data.shape == (3,)


### PR DESCRIPTION
## Summary
- Add analytic dimension-generic HyperRectangle geometry and export it from phydrax.domain
- Cover measures, sampling, ADF, normals, coord-separable batches, point constraints, and model evaluation
- Tighten related geometry/optimizer typing and update project metadata/docs cleanup