### PR TITLE
Add ragged trajectory and supervised dataset workflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.cache
 *.stl
 *.phx
+*.png
 .venv
 .tmp
 .notes
@@ -20,5 +21,7 @@ AGENTS.md
 LLM.md
 scratch.py
 *.onnx
+*.tfevents*
 dist/
 site/
+_gitignore/

--- a/docs/all-of-phydrax.md
+++ b/docs/all-of-phydrax.md
@@ -214,6 +214,22 @@ To model operators \(G: f \mapsto u(\cdot)\), represent the domain as a product
 DeepONet/FNO. See [API → Domain → Composition](api/domain/composition.md) and
 [API → NN → Architectures](api/nn/architectures.md).
 
+For row-indexed trajectories with a shared time step but different sequence
+lengths, use `TrajectoryDatasetDomain` and `RaggedTimeSeriesDataConstraint`. This
+keeps each sampled time tied to the dataset row that owns it while still allowing
+time residuals and other `DomainFunction` operators.
+
+When a row has static covariates and observed ragged signals, keep those semantics
+separate: put the static covariates in the `TrajectoryDatasetDomain` input row,
+expose measured signals with `TrajectorySignal`, and supervise row-level targets
+with `TrajectoryCaseDataConstraint`. Observed trajectory signals and domain arrays
+are JAX-traceable fixed state, not solver parameters.
+
+If trajectory data must be exact, use `enforce_ragged_time_series` to build a hard
+ansatz and train only the remaining physics constraints. Linear interpolation covers
+first-order time residuals; cubic-Hermite interpolation covers second-order time
+residuals and optional selected output components.
+
 ## Notation
 
 We use $x$ for spatial variables, $t$ for time, and $u(x, t)$ for fields. A typical
@@ -227,7 +243,7 @@ Below are the common SciML regimes expressed in Phydrax’s primitives.
   Start at [Getting started](index.md) and then [Guides → Constraints](guides_constraints.md).
 - **Enforced BC/IC**: build ansätze with `enforce_dirichlet` / `enforce_initial` / etc., and stage them via solver pipelines.
   See [API → Solver → Enforced constraint pipelines](api/solver/enforced_constraints.md).
-- **Data assimilation / hybrid physics–data**: add `DiscreteInteriorDataConstraint` / `DiscreteTimeDataConstraint` alongside PDE residuals.
+- **Data assimilation / hybrid physics-data**: add `DiscreteInteriorDataConstraint`, `DiscreteTimeDataConstraint`, `SupervisedDatasetConstraint`, `RaggedTimeSeriesDataConstraint`, or `TrajectoryCaseDataConstraint` alongside PDE residuals. Use `TrajectorySignal` for fixed measured forcings/covariates on ragged trajectory domains, and `eval_constraints` for held-out data diagnostics.
   See [API → Constraints → Discrete](api/constraints/discrete.md).
 - **Inverse problems (unknown coefficients/parameters)**: represent unknowns as additional fields or domain parameters, and couple them in residual operators.
   See [API → Domain → Functions](api/domain/functions.md) and [API → Constraints](api/constraints/index.md).
@@ -250,7 +266,7 @@ Below are the common SciML regimes expressed in Phydrax’s primitives.
 - [Solvers and training](guides_solver.md)
 - [API reference](api/phydrax.md)
 - `phydrax.domain` for geometry, time, and sampling.
-- `phydrax.data_utils` for CSV loading and array scaling.
+- `phydrax.data_utils` for CSV loading, array scaling, and case-index splits.
 - `phydrax.constraints` for loss terms and enforced constraints.
 - `phydrax.operators` for PDE operators.
 - `phydrax.nn` for models and wrappers.

--- a/docs/api/constraints/discrete.md
+++ b/docs/api/constraints/discrete.md
@@ -6,9 +6,12 @@ For `PointSetConstraint`, runtime operator knobs can be set once via
 `PointSetConstraint.weight` can be a scalar global multiplier or a
 `DomainFunction` evaluated pointwise on the anchor set.
 
-Data-fit constraints created by `DiscreteInteriorDataConstraint` and
-`DiscreteTimeDataConstraint` attach supervised-data diagnostics used by
-`FunctionalSolver.solve(...)` logging:
+Data-fit constraints created by `DiscreteInteriorDataConstraint`,
+`DiscreteTimeDataConstraint`, and `SupervisedDatasetConstraint` attach
+supervised-data diagnostics used by `FunctionalSolver.solve(...)` logging.
+`RaggedTimeSeriesDataConstraint` provides the same diagnostics for
+trajectory-valued targets, and `TrajectoryCaseDataConstraint` provides them for
+per-row scalar/vector targets on a `TrajectoryDatasetDomain`:
 
 - `data_accuracy`
 - `data_relative_l2_error`
@@ -32,6 +35,195 @@ Data-fit constraints created by `DiscreteInteriorDataConstraint` and
 ---
 
 ::: phydrax.constraints.DiscreteTimeDataConstraint
+
+## Supervised dataset constraints
+
+Use `SupervisedDatasetConstraint` when a `DatasetDomain` row is the sampled
+empirical case and the target is aligned by row index. This is the finite-case
+counterpart to `DiscreteInteriorDataConstraint`: the latter treats observed inputs
+as points in a continuous coordinate domain, while this treats the empirical row
+measure itself as the domain.
+
+```python
+import jax.numpy as jnp
+import phydrax as phx
+
+rows = jnp.asarray([[0.0, 1.0], [1.0, 2.0], [2.0, 4.0]])
+targets = rows[:, 0] + 2.0 * rows[:, 1]
+domain = phx.domain.DatasetDomain(rows)
+
+@domain.Function("data")
+def exact(row):
+    return row[0] + 2.0 * row[1]
+
+constraint = phx.constraints.SupervisedDatasetConstraint(
+    "u",
+    domain.component(),
+    targets,
+    num_cases=16,
+)
+
+loss = constraint.loss({"u": exact})
+metrics = constraint.data_metrics({"u": exact})
+```
+
+Pass `indices=...` to restrict sampling to a train/validation subset of dataset
+rows. This is the recommended way to pair `SupervisedDatasetConstraint` with
+`FunctionalSolver(eval_constraints=...)`.
+
+::: phydrax.constraints.SupervisedDatasetConstraint
+    options:
+        members:
+            - __init__
+            - sample
+            - data_metrics
+            - loss
+
+---
+
+::: phydrax.constraints.SupervisedDatasetBatch
+
+## Ragged trajectory constraints
+
+Use `RaggedTimeSeriesDataConstraint` when each dataset row has a vector-valued time
+series with the same `dt` but a row-specific length.
+
+```python
+import jax.numpy as jnp
+import phydrax as phx
+
+inputs = jnp.asarray([[0.0], [1.0], [2.0]])
+lengths = jnp.asarray([2, 4, 3])
+domain = phx.domain.TrajectoryDatasetDomain(inputs, lengths, dt=0.5)
+
+times = domain.start + domain.dt * jnp.arange(domain.max_length)
+values = inputs[:, 0, None] + times[None, :]
+
+@domain.Function("data", "t")
+def exact(data, t):
+    return data[0] + t
+
+constraint = phx.constraints.RaggedTimeSeriesDataConstraint(
+    "u",
+    domain.component(),
+    values,
+    num_points=16,
+)
+loss = constraint.loss({"u": exact})
+metrics = constraint.data_metrics({"u": exact})
+```
+
+Pass `case_indices=...` to restrict sampling to selected trajectory rows. For
+ragged train/test splits this keeps every observed time point from a held-out
+trajectory out of the training data constraint.
+
+::: phydrax.constraints.RaggedTimeSeriesDataConstraint
+    options:
+        members:
+            - __init__
+            - sample
+            - data_metrics
+            - loss
+
+---
+
+::: phydrax.constraints.RaggedTimeSeriesBatch
+
+## Fixed trajectory signals and case targets
+
+Use `TrajectorySignal` when ragged time-series data is an observed input/forcing
+rather than a supervised output. It returns a fixed `DomainFunction` over
+`(data, t)`, so physics residuals can consume it alongside learned fields. Include
+the fixed signal in the solver's `functions` mapping under the same name used by
+the residual constraint.
+
+Use `TrajectoryCaseDataConstraint` when the target belongs to the dataset row, not
+to every time point. This is the right shape for scalar/vector labels such as
+parameters, final summaries, or class logits.
+
+```python
+static = jnp.asarray([[0.0, 1.0], [1.0, 2.0], [2.0, 4.0]])
+lengths = jnp.asarray([2, 4, 3])
+domain = phx.domain.TrajectoryDatasetDomain(static, lengths, dt=0.5)
+
+times = domain.start + domain.dt * jnp.arange(domain.max_length)
+forcing_values = static[:, 0, None] + times[None, :]
+forcing = phx.constraints.TrajectorySignal(
+    domain,
+    forcing_values,
+    interpolation="linear",
+)
+
+targets = jnp.stack((static[:, 0] + static[:, 1], static[:, 0] - static[:, 1]), axis=-1)
+case_data = phx.constraints.TrajectoryCaseDataConstraint(
+    "theta",
+    domain.component(),
+    targets,
+    num_cases=32,
+)
+
+physics = phx.constraints.FunctionalConstraint.from_operator(
+    component=domain.component(),
+    operator=lambda u, s: phx.operators.partial_t(u, var="t")
+    - phx.operators.partial_t(s, var="t"),
+    constraint_vars=("u", "forcing"),
+    num_points=128,
+    structure=phx.domain.ProductStructure((("data", "t"),)),
+)
+```
+
+`TrajectorySignal(interpolation="linear")` supports first time derivatives.
+`interpolation="cubic_hermite"` supports first and second time derivatives.
+`interpolation="nearest"` is for value lookup only. Trajectory signals are fixed
+numeric state: they can be traced through JAX residuals but are excluded from
+solver optimizer parameters.
+`TrajectoryCaseDataConstraint` also accepts `case_indices=...` for row-level
+train/eval splits.
+
+::: phydrax.constraints.TrajectorySignal
+
+---
+
+::: phydrax.constraints.TrajectoryCaseDataConstraint
+    options:
+        members:
+            - __init__
+            - sample
+            - data_metrics
+            - loss
+
+---
+
+::: phydrax.constraints.TrajectoryCaseDataBatch
+
+## Hard ragged trajectory enforcement
+
+`enforce_ragged_time_series` converts a free model into a hard ansatz that exactly
+matches every observed ragged trajectory node. Use this when the data should define
+the solution manifold and the solver should train only physics residuals.
+
+```python
+@domain.Function("data", "t")
+def u_free(data, t):
+    return data[0] + t
+
+u = phx.constraints.enforce_ragged_time_series(
+    u_free,
+    domain,
+    forcing_values,
+    interpolation="cubic_hermite",
+    gate="sin4",
+)
+```
+
+`interpolation="linear"` supports value enforcement and first time derivatives.
+`interpolation="cubic_hermite"` supports first and second time derivatives using
+finite-difference node slopes. `gate="sin2"` is compact and smooth for first-order
+physics; `gate="sin4"` keeps the gate flatter at observed nodes and is the better
+default for second-order time residuals. Pass `components=[...]` to hard-enforce
+only selected trailing output components while leaving the others free.
+
+::: phydrax.constraints.enforce_ragged_time_series
 
 ## Discrete boundary / initial constraints
 

--- a/docs/api/data_utils/index.md
+++ b/docs/api/data_utils/index.md
@@ -7,3 +7,5 @@ constraints, or model inference code.
 
 - `CSVReader` reads CSV files with Polars and returns JAX arrays for numeric data.
 - `scalers` provides immutable JAX-compatible scaling modules.
+- `train_test_split_indices` and `kfold_indices` create deterministic case-index
+  splits for `DatasetDomain`, `TrajectoryDatasetDomain`, and empirical constraints.

--- a/docs/api/data_utils/splits.md
+++ b/docs/api/data_utils/splits.md
@@ -1,0 +1,24 @@
+# Splits
+
+Index split helpers return JAX integer arrays. Use them with
+`SupervisedDatasetConstraint(indices=...)`,
+`RaggedTimeSeriesDataConstraint(case_indices=...)`, and
+`TrajectoryCaseDataConstraint(case_indices=...)`.
+
+```python
+import jax.random as jr
+import phydrax as phx
+
+train_idx, test_idx = phx.data_utils.train_test_split_indices(
+    10,
+    test_fraction=0.2,
+    key=jr.key(0),
+)
+folds = phx.data_utils.kfold_indices(10, 5, key=jr.key(1))
+```
+
+::: phydrax.data_utils.train_test_split_indices
+
+---
+
+::: phydrax.data_utils.kfold_indices

--- a/docs/api/domain/composition.md
+++ b/docs/api/domain/composition.md
@@ -21,7 +21,17 @@ cleanly with:
 
 - `ProductDomain` composition via `@`,
 - structured sampling (`dense_structure=ProductStructure((("data",),))`),
-- `Domain.Model(...)` for building operator-learning models that take `(data, coords...)`.
+- `Domain.Model(...)` for building either flat pointwise models or structured
+  operator models over `(data, coords...)`.
+
+`Domain.Model(...)` defaults to each model's declared input mode. Dense models and
+separable vector models use flat concatenation; operator models such as `DeepONet`
+use structured tuple inputs. Override this with `input_mode="flat"` or
+`input_mode="structured"` when needed.
+
+For row-indexed time series with different sequence lengths, use
+[`TrajectoryDatasetDomain`](trajectory_dataset.md). It is not a plain rectangular
+product: the dataset row and sampled time are coupled.
 
 ### Measure semantics
 

--- a/docs/api/domain/index.md
+++ b/docs/api/domain/index.md
@@ -11,3 +11,7 @@ Use `HyperRectangle` for analytic axis-aligned boxes where a point is naturally 
 single vector, such as `R^6 -> scalar` supervised learning inputs. Use product
 domains when each coordinate factor should keep its own label and sampling
 structure.
+
+Use `TrajectoryDatasetDomain` when each dataset row has a vector-valued trajectory
+with a shared `dt` but row-specific length. It keeps `data` and `t` paired so
+physics residuals at `t` only sample valid times for the selected dataset row.

--- a/docs/api/domain/sampling.md
+++ b/docs/api/domain/sampling.md
@@ -16,6 +16,9 @@ Phydrax supports two complementary structured sampling modes:
   unary labels (geometry and/or scalar intervals) and evaluates on the implied Cartesian grid (with an interior mask).
   This is the natural mode for FFT/basis/spectral operators and neural operators (FNO, DeepONet).
 
+`TrajectoryDatasetDomain` is paired-only: its dataset row and time label must stay
+on the same sampling axis.
+
 Coord-separable sampling is driven by `DomainComponent.sample_coord_separable(...)`, which takes:
 
 - `coord_separable`: a mapping from unary label (e.g. `"x"` or `"t"`) to either

--- a/docs/api/domain/trajectory_dataset.md
+++ b/docs/api/domain/trajectory_dataset.md
@@ -1,0 +1,71 @@
+# Trajectory Dataset Domain
+
+`TrajectoryDatasetDomain` represents a finite dataset where each row owns its own
+time horizon. Use it for models of the form `u(data, t)` when each dataset element is
+a function, parameter vector, forcing, or latent descriptor and the associated time
+series is ragged.
+
+Unlike `DatasetDomain(...) @ TimeInterval(...)`, this domain samples `data` and `t`
+as a coupled pair. `FixedEnd()` means the end time for the sampled dataset row, not a
+single global end time.
+
+Use a paired structure containing both labels, even for `FixedStart()`, `FixedEnd()`,
+or `Fixed(value)` time components, because the sampled time may still depend on the
+dataset row.
+
+Coord-separable trajectory sampling is intentionally unsupported. Use paired
+mini-batches for physics residuals and ragged data constraints.
+
+For exact branch-conditional data, pair this domain with
+`phydrax.constraints.enforce_ragged_time_series(...)`. The enforcer uses the
+row index carried by trajectory batches, so the hard condition is tied to the
+dataset element rather than inferred from branch values. Linear hard interpolation
+supports first-order time residuals; `cubic_hermite` supports second-order time
+residuals and optional selected-component enforcement.
+
+If the trajectory data is an observed input rather than the learned field, use
+`phydrax.constraints.TrajectorySignal(...)` to expose it as a fixed
+`DomainFunction` over `(data, t)`. If the target is attached to the dataset row
+itself, use `phydrax.constraints.TrajectoryCaseDataConstraint(...)` so the target
+is supervised once per case rather than repeated over time. Fixed signals and
+domain arrays remain non-trainable solver state even though they are JAX arrays.
+
+Measure modes:
+
+- `case_time_probability`: default expectation-style weighting.
+- `time_integral_average`: average, over dataset rows, of each row's time integral.
+- `time_integral_sum`: sum, over dataset rows, of each row's time integral.
+
+```python
+import jax.numpy as jnp
+import jax.random as jr
+import phydrax as phx
+
+inputs = jnp.asarray([[0.0], [1.0], [2.0]])
+lengths = jnp.asarray([2, 4, 3])
+
+domain = phx.domain.TrajectoryDatasetDomain(inputs, lengths, dt=0.5)
+component = domain.component()
+structure = phx.domain.ProductStructure((("data", "t"),))
+batch = component.sample(8, structure=structure, key=jr.key(0))
+```
+
+::: phydrax.domain.TrajectoryDatasetDomain
+    options:
+        members:
+            - __init__
+            - labels
+            - data_label
+            - time_label
+            - measure_mode
+            - sampling_mode
+            - size
+            - max_length
+            - total_observations
+            - durations
+            - end_times
+            - factor
+            - equivalent
+            - input_rows
+            - observation_times
+            - points_from_case_time

--- a/docs/api/nn/architectures.md
+++ b/docs/api/nn/architectures.md
@@ -46,6 +46,13 @@ Phydrax's `Domain.Model(...)` wrapper will pass dependency arguments to models a
 - **point inputs** (dense sampling): coordinate arrays with leading batch axes, or
 - **coord-separable inputs**: tuples of 1D coordinate axes (from `CoordSeparableBatch`).
 
+`supports_structured_input()` and default domain packing are distinct. Dense models
+and separable coordinate models such as `SeparableMLP(in_size=d)` default to flat
+point packing, so `domain.Model("x", "t")(model)` passes a vector of size `d`.
+Operator models such as `DeepONet` and `FNO` default to structured packing. Pass
+`input_mode="structured"` or `structured=True` to force tuple packing, and
+`input_mode="flat"` to force MLP-style concatenation.
+
 !!! note
     Input conventions:
 

--- a/docs/api/nn/structured.md
+++ b/docs/api/nn/structured.md
@@ -9,6 +9,11 @@ Models that exploit product-domain structure via low-rank factorization.
     - `LatentContractionModel` generalizes this to named factor models and flexible inputs.
     - `LatentExecutionPolicy` controls grouped-vs-flat planning preferences and fallback behavior.
       Supported topology modes are `grouped`, `flat`, `best_effort_flat`, and `strict_flat`.
+    - `SeparableMLP`, `SeparableKAN`, and `SeparableFeynmaNN` are drop-in pointwise
+      replacements for dense vector models in `Domain.Model(...)`: by default their
+      dependencies are flattened into one vector, then each scalar coordinate is sent
+      to its own internal model. Use `input_mode="structured"` or `structured=True`
+      when you intentionally want tuple/coord-separable input packing.
     - `LatentContractionModel` supports layout hints `auto`, `dense_points`,
       `coord_separable`, `hybrid`, and `full_tensor`.
     - Any automatic fallback can be configured to warn, error, or stay silent.

--- a/docs/api/solver/functional_solver.md
+++ b/docs/api/solver/functional_solver.md
@@ -11,6 +11,7 @@ For a conceptual overview (loss evaluation, enforced pipelines, training loop be
 
     - `loss(...)` evaluates the total objective at the current parameters.
     - `ansatz_functions()` returns fields after applying enforced pipelines (if configured).
+    - `partition_functions()` exposes the trainable/non-trainable state split used by `solve(...)`.
     - `solve(...)` updates parameters inside `functions` using Optax or evosax optimizers.
     - `solve(..., tensorboard_log_dir=...)` writes TensorBoard scalar logs.
     - Discrete data constraints report data-fit diagnostics alongside their loss.
@@ -49,5 +50,7 @@ loss1 = solver.loss(key=jr.key(1))
             - __init__
             - ansatz_functions
             - __getitem__
+            - partition_functions
+            - trainable_functions
             - loss
             - solve

--- a/docs/cookbook/operator_learning.md
+++ b/docs/cookbook/operator_learning.md
@@ -17,6 +17,11 @@ In Phydrax, \(\Omega_{\text{data}}\) is represented by `DatasetDomain`, and oper
 `DatasetDomain` stores an in-memory PyTree of arrays with a shared leading dataset axis, and samples by indexing.
 See [API → Domain → Composition](../api/domain/composition.md).
 
+For row-indexed time series with a shared `dt` and different lengths, use
+`TrajectoryDatasetDomain` instead of `DatasetDomain @ TimeInterval`. It keeps the
+dataset row and sampled time coupled so physics residuals and ragged supervised data
+constraints see only valid `(data, t)` pairs.
+
 ## DeepONet skeleton on \(\Omega_{\text{data}}\times\Omega_x\) {: data-toc-label="DeepONet skeleton on Ω_data × Ω_x"}
 
 Assume each dataset sample contains a vector of coefficients \(c\in\mathbb{R}^K\) that parameterizes an input.

--- a/docs/cookbook/poisson.md
+++ b/docs/cookbook/poisson.md
@@ -134,7 +134,7 @@ evaluate on the implied Cartesian grid. For a 2D geometry label `"x"`, coord-sep
         depth=2,
         key=jr.key(0),
     )
-    u = geom.Model("x")(model)
+    u = geom.Model("x", input_mode="structured")(model)
 
     batch = geom.component().sample_coord_separable({"x": (32, 32)}, key=jr.key(1))
 

--- a/docs/guides_constraints.md
+++ b/docs/guides_constraints.md
@@ -122,6 +122,137 @@ For sensor/anchor data (discrete samples), Phydrax provides constraints that do 
 component, but instead evaluate on explicit point sets (and typically reduce by mean/integral in
 an analogous way).
 
+For ragged trajectory data indexed by a `TrajectoryDatasetDomain`, use
+`RaggedTimeSeriesDataConstraint`. It samples valid `(data, t)` pairs, compares the
+model against the stored time-series values, and reports the same supervised metrics
+as other data-fit constraints.
+
+```python
+import jax.numpy as jnp
+import phydrax as phx
+
+inputs = jnp.asarray([[0.0], [1.0], [2.0]])
+lengths = jnp.asarray([2, 4, 3])
+domain = phx.domain.TrajectoryDatasetDomain(inputs, lengths, dt=0.5)
+
+times = domain.start + domain.dt * jnp.arange(domain.max_length)
+values = inputs[:, 0, None] + times[None, :]
+
+@domain.Function("data", "t")
+def exact(data, t):
+    return data[0] + t
+
+constraint = phx.constraints.RaggedTimeSeriesDataConstraint(
+    "u",
+    domain.component(),
+    values,
+    num_points=16,
+    sampling="observation_uniform",
+)
+
+loss = constraint.loss({"u": exact})
+metrics = constraint.data_metrics({"u": exact})
+```
+
+Use `case_indices=...` to restrict a ragged data constraint to a train or
+validation set of trajectory rows. This is case-level splitting: every observed
+time point for an excluded case stays excluded.
+
+When the ragged time series is an observed input/forcing rather than the learned
+field itself, expose it as a fixed function with `TrajectorySignal`. Include the
+fixed signal in the solver's `functions` mapping under the same name used by
+`constraint_vars`.
+It remains JAX-traceable numeric state but is not optimized by `solve(...)`.
+
+```python
+forcing = phx.constraints.TrajectorySignal(
+    domain,
+    values,
+    interpolation="linear",
+)
+
+physics = phx.constraints.FunctionalConstraint.from_operator(
+    component=domain.component(),
+    operator=lambda u, s: phx.operators.partial_t(u, var="t")
+    - phx.operators.partial_t(s, var="t"),
+    constraint_vars=("u", "forcing"),
+    num_points=128,
+    structure=phx.domain.ProductStructure((("data", "t"),)),
+)
+```
+
+For labels attached to the dataset row rather than to every time point, use
+`TrajectoryCaseDataConstraint`:
+
+```python
+targets = jnp.asarray([[1.0, 0.0], [2.0, -1.0], [3.0, -2.0]])
+
+case_data = phx.constraints.TrajectoryCaseDataConstraint(
+    "theta",
+    domain.component(),
+    targets,
+    num_cases=32,
+)
+```
+
+For non-time empirical rows, use `DatasetDomain` with
+`SupervisedDatasetConstraint`. The domain owns the row payloads, and the constraint
+owns aligned targets:
+
+```python
+rows = jnp.asarray([[0.0, 1.0], [1.0, 2.0], [2.0, 4.0]])
+dataset_targets = rows[:, 0] + 2.0 * rows[:, 1]
+dataset_domain = phx.domain.DatasetDomain(rows)
+
+@dataset_domain.Function("data")
+def u(row):
+    return row[0] + 2.0 * row[1]
+
+data = phx.constraints.SupervisedDatasetConstraint(
+    "u",
+    dataset_domain.component(),
+    dataset_targets,
+    num_cases=32,
+)
+```
+
+Use `indices=...` to train or evaluate on an explicit subset of dataset rows.
+`phydrax.data_utils.train_test_split_indices(...)` and
+`phydrax.data_utils.kfold_indices(...)` return index arrays for these arguments.
+
+For exact row-wise enforcement, use a hard ansatz instead of a data loss:
+
+```python
+@domain.Function("data", "t")
+def u_free(data, t):
+    return data[0] + t
+
+@domain.Function()
+def rhs():
+    return 1.0
+
+u = phx.constraints.enforce_ragged_time_series(
+    u_free,
+    domain,
+    values,
+    interpolation="cubic_hermite",
+    gate="sin4",
+)
+
+physics = phx.constraints.FunctionalConstraint.from_operator(
+    component=domain.component(),
+    operator=lambda u_fn: phx.operators.partial_t(u_fn, var="t") - rhs,
+    constraint_vars="u",
+    num_points=128,
+    structure=phx.domain.ProductStructure((("data", "t"),)),
+)
+```
+
+The hard ansatz matches every observed node by construction, so the data constraint
+can be kept only for diagnostics. Use `interpolation="linear"` for first-order
+physics, or `interpolation="cubic_hermite"` when second time derivatives appear in
+the residual. `components=[0, 2]` enforces only selected trailing output components.
+
 ## Integral equality constraints
 
 Integral constraints enforce targets of the form

--- a/docs/guides_domain.md
+++ b/docs/guides_domain.md
@@ -64,6 +64,102 @@ data = phx.constraints.DiscreteInteriorDataConstraint(
 domain is a product with multiple labels. The function receives each row as one
 `(d,)` vector named `"x"`.
 
+## Empirical dataset domains
+
+Use `DatasetDomain` when the row itself is an empirical case or condition. This is
+the right shape when rows are PyTrees, multimodal inputs, branch conditions, or
+finite cases that will later be paired with physical coordinates.
+
+For row-aligned scalar/vector targets on the empirical rows themselves, use
+`SupervisedDatasetConstraint`:
+
+```python
+import jax.numpy as jnp
+import phydrax as phx
+
+rows = jnp.asarray([[0.0, 1.0], [1.0, 2.0], [2.0, 4.0]])
+targets = rows[:, 0] + 2.0 * rows[:, 1]
+dataset_domain = phx.domain.DatasetDomain(rows)
+
+@dataset_domain.Function("data")
+def u(row):
+    return row[0] + 2.0 * row[1]
+
+constraint = phx.constraints.SupervisedDatasetConstraint(
+    "u",
+    dataset_domain.component(),
+    targets,
+    num_cases=32,
+)
+```
+
+Use `HyperRectangle` when the feature dimensions are continuous variables of the
+problem. Use `DatasetDomain` when the empirical row distribution is the domain you
+want to average over.
+
+## Ragged trajectory dataset domains
+
+Use `TrajectoryDatasetDomain` when each dataset element represents a function,
+forcing, parameter vector, or latent descriptor and has an associated time series
+with a shared `dt` but a row-specific length.
+
+This is different from `DatasetDomain(...) @ TimeInterval(...)`: a plain product
+domain creates a rectangular product and does not know that each dataset row has
+its own end time. `TrajectoryDatasetDomain` keeps the `data` and `t` labels paired,
+so sampling and fixed-end slices are row-aware.
+
+Because the row and time are coupled, use `ProductStructure((("data", "t"),))`
+for trajectory sampling, including fixed-time components.
+The same paired batches support hard branch-conditional data enforcement through
+`enforce_ragged_time_series`; choose `cubic_hermite` interpolation when second time
+derivatives are part of the physics residual.
+
+Keep static case features and time-varying signals separate. Store static scalars
+or vectors in the `inputs` rows, and expose observed ragged signals with
+`TrajectorySignal` when residuals need them. Per-case scalar/vector labels should
+use `TrajectoryCaseDataConstraint` rather than being repeated as constant time
+series.
+
+```python
+import jax.numpy as jnp
+import jax.random as jr
+import phydrax as phx
+
+inputs = jnp.asarray([[0.0], [1.0], [2.0]])
+lengths = jnp.asarray([2, 4, 3])
+trajectory_domain = phx.domain.TrajectoryDatasetDomain(inputs, lengths, dt=0.5)
+
+component = trajectory_domain.component()
+structure = phx.domain.ProductStructure((("data", "t"),))
+batch = component.sample(8, structure=structure, key=jr.key(0))
+
+@trajectory_domain.Function("data", "t")
+def u(data, t):
+    return data[0] + t
+
+values = u(batch)
+```
+
+```python
+signal_values = (
+    inputs[:, 0, None]
+    + trajectory_domain.dt * jnp.arange(trajectory_domain.max_length)[None, :]
+)
+forcing = phx.constraints.TrajectorySignal(
+    trajectory_domain,
+    signal_values,
+    interpolation="linear",
+)
+
+targets = jnp.asarray([[1.0, 0.0], [2.0, -1.0], [3.0, -2.0]])
+case_target = phx.constraints.TrajectoryCaseDataConstraint(
+    "theta",
+    trajectory_domain.component(),
+    targets,
+    num_cases=32,
+)
+```
+
 Functions on a domain are wrapped as `DomainFunction`s. The key idea is that a `DomainFunction`
 declares which labels it depends on, and operators/constraints use those labels consistently.
 

--- a/docs/guides_integrals.md
+++ b/docs/guides_integrals.md
@@ -25,6 +25,10 @@ The measure depends on the factor type and the component selection:
 - **Dataset factors** (`DatasetDomain`):
   - `Interior()`: either \(\mu(\Omega_{\text{data}})=1\) (`measure="probability"`) or
     \(\mu(\Omega_{\text{data}})=N\) (`measure="count"`).
+- **Trajectory datasets** (`TrajectoryDatasetDomain`):
+  - default paired weights estimate an expectation over valid row-time samples;
+  - `measure="time_integral_average"` estimates the average row-wise time integral;
+  - `measure="time_integral_sum"` estimates the sum of row-wise time integrals.
 
 ## Sampling structure: paired vs coord-separable
 

--- a/docs/guides_solver.md
+++ b/docs/guides_solver.md
@@ -8,6 +8,7 @@ A `FunctionalSolver` is a lightweight orchestrator that holds:
 
 - `functions`: a mapping `{name: DomainFunction}` of the current fields,
 - `constraints`: a list/tuple of constraint objects, each producing a scalar loss,
+- `eval_constraints`: optional constraints used only for diagnostics/logging,
 - optional `constraint_pipelines`: enforced-constraint pipelines that replace raw fields with ansatz
   functions satisfying selected conditions exactly.
 
@@ -16,6 +17,11 @@ The total objective is the sum of constraint losses:
 $$
 L = \sum_i \ell_i.
 $$
+
+`eval_constraints` are evaluated against the same current ansatz functions, but
+they do not contribute to `loss(...)`, gradients, optimizer state, or best-model
+selection. Use them for validation folds, held-out cases, or non-training
+diagnostics.
 
 ## Loss evaluation (`loss(...)`)
 
@@ -42,10 +48,24 @@ types and constructors.
 ## Training (`solve(...)`)
 
 `FunctionalSolver.solve(...)` runs an optimization loop over the parameters contained inside
-`solver.functions`. Under the hood it uses Equinox to split the function PyTree into:
+`solver.functions`. Under the hood it uses a Phydrax-aware Equinox partition to split
+the function PyTree into:
 
-- **trainable parameters**: inexact arrays (floating/complex arrays),
-- **static part**: everything else.
+- **trainable parameters**: inexact arrays inside trainable models/functions,
+- **non-trainable state**: domains, observed data tables, fixed trajectory signals,
+  hard-enforcement lookup tables, integer metadata, and other fixed state.
+
+This distinction matters for physics-data problems. Observed data may be a JAX
+array so it can participate in JIT-compiled residuals, but it is not an optimizer
+parameter and is excluded from gradients, optimizer state, and weight decay.
+Explicit learnable fields created through model wrappers or `Domain.Parameter(...)`
+remain trainable. Literal constant `DomainFunction` values are treated as fixed
+state; use `Domain.Parameter(...)` when a scalar/vector coefficient should be
+optimized.
+
+Use `solver.partition_functions()` to inspect the exact split, or
+`solver.trainable_functions()` when an external optimizer needs the trainable PyTree
+shape.
 
 ### Optimizer support
 
@@ -79,13 +99,26 @@ of those outputs.
 - `tensorboard_every`: TensorBoard scalar cadence. By default it follows `log_every`
   when `log_every > 0`, otherwise it writes every iteration.
 
-For data-fit constraints created by `DiscreteInteriorDataConstraint` or
-`DiscreteTimeDataConstraint`, per-constraint logs also include supervised-data
-diagnostics:
+For data-fit constraints created by `DiscreteInteriorDataConstraint`,
+`DiscreteTimeDataConstraint`, `SupervisedDatasetConstraint`,
+`RaggedTimeSeriesDataConstraint`, or `TrajectoryCaseDataConstraint`,
+per-constraint logs also include supervised-data diagnostics:
 
 - `data_accuracy`: `1 - data_relative_l2_error`
 - `data_relative_l2_error`: prediction-target relative L2 error
 - `data_rmse`: root mean squared prediction-target error
+
+When ragged trajectory data is enforced with
+`enforce_ragged_time_series(...)`, the data is part of the ansatz rather than a
+loss term. In that case, train with physics constraints only and keep a
+`RaggedTimeSeriesDataConstraint` outside the solver if you want diagnostics. Use
+`interpolation="cubic_hermite"` when the physics residual needs second time
+derivatives.
+
+TensorBoard writes aggregate training scalars under `train/...`, training
+constraint scalars under `train/constraints/...`, and eval-only constraint scalars
+under `eval/constraints/...`. The legacy `constraints/...` train tags are also
+emitted for existing dashboards.
 
 ```text
 solver = solver.solve(
@@ -103,6 +136,48 @@ View the run with:
 ```bash
 tensorboard --logdir runs
 ```
+
+## Train/eval empirical constraints
+
+Use index-scoped empirical constraints for held-out validation. For ordinary
+row-wise data, split the row indices and give training indices to `constraints`
+and validation indices to `eval_constraints`:
+
+```python
+import jax.numpy as jnp
+import jax.random as jr
+import phydrax as phx
+
+rows = jnp.asarray([[0.0], [0.2], [0.4], [0.6], [0.8], [1.0]])
+targets = 1.0 + 2.0 * rows[:, 0]
+domain = phx.domain.DatasetDomain(rows)
+train_idx, val_idx = phx.data_utils.train_test_split_indices(
+    domain.size,
+    test_fraction=0.2,
+    key=jr.key(0),
+)
+
+train_data = phx.constraints.SupervisedDatasetConstraint(
+    "u",
+    domain.component(),
+    targets,
+    num_cases=32,
+    indices=train_idx,
+    label="train_data",
+)
+val_data = phx.constraints.SupervisedDatasetConstraint(
+    "u",
+    domain.component(),
+    targets,
+    num_cases=32,
+    indices=val_idx,
+    label="val_data",
+)
+```
+
+For ragged trajectories, use `case_indices=...` on
+`RaggedTimeSeriesDataConstraint` or `TrajectoryCaseDataConstraint`. The split is
+by dataset row, so all observations from a held-out trajectory remain held out.
 
 ## Minimal example
 
@@ -156,7 +231,7 @@ import phydrax as phx
 # solver = phx.solver.FunctionalSolver(functions={"u": u}, constraints=[constraint])
 
 # evosax expects a "solution" PyTree matching the trainable parameter structure.
-params, _ = eqx.partition(solver.functions, eqx.is_inexact_array)
+params = solver.trainable_functions()
 algo = evo_algos.Open_ES(population_size=8, solution=params)
 
 solver = solver.solve(num_iter=20, optim=algo, seed=0)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -113,6 +113,7 @@ nav:
             - Geometry (2D): "api/domain/geometry2d.md"
             - Geometry (3D): "api/domain/geometry3d.md"
             - HyperRectangle: "api/domain/hyperrectangle.md"
+            - Trajectory dataset: "api/domain/trajectory_dataset.md"
             - Composition: "api/domain/composition.md"
             - Sampling: "api/domain/sampling.md"
             - Components: "api/domain/components.md"
@@ -121,6 +122,7 @@ nav:
             - Overview: "api/data_utils/index.md"
             - CSV reader: "api/data_utils/csv.md"
             - Scalers: "api/data_utils/scalers.md"
+            - Splits: "api/data_utils/splits.md"
         - Operators:
             - Overview: "api/operators/index.md"
             - Differential: "api/operators/differential.md"

--- a/phydrax/_trainable.py
+++ b/phydrax/_trainable.py
@@ -1,0 +1,59 @@
+#
+#  Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from typing import Any
+
+import equinox as eqx
+from jaxtyping import PyTree
+
+
+class NonTrainableState:
+    """Marker for numeric state that must remain fixed during solver training."""
+
+
+def is_non_trainable_leaf(node: Any, /) -> bool:
+    """Return whether a PyTree node should be kept wholly non-trainable."""
+    from .domain._domain import _AbstractDomain
+
+    return isinstance(node, (NonTrainableState, _AbstractDomain))
+
+
+def is_trainable_leaf(node: Any, /) -> bool:
+    """Return whether a PyTree leaf should be optimized by FunctionalSolver."""
+    if is_non_trainable_leaf(node):
+        return False
+    return bool(eqx.is_inexact_array(node))
+
+
+def partition_trainable(tree: PyTree[Any], /) -> tuple[PyTree[Any], PyTree[Any]]:
+    """Split a PyTree into trainable and non-trainable parts."""
+    return eqx.partition(
+        tree,
+        is_trainable_leaf,
+        is_leaf=is_non_trainable_leaf,
+    )
+
+
+def combine_trainable(
+    trainable: PyTree[Any],
+    non_trainable: PyTree[Any],
+    /,
+) -> PyTree[Any]:
+    """Recombine trees produced by `partition_trainable`."""
+    return eqx.combine(
+        trainable,
+        non_trainable,
+        is_leaf=is_non_trainable_leaf,
+    )
+
+
+__all__ = [
+    "NonTrainableState",
+    "combine_trainable",
+    "is_non_trainable_leaf",
+    "is_trainable_leaf",
+    "partition_trainable",
+]

--- a/phydrax/constraints/__init__.py
+++ b/phydrax/constraints/__init__.py
@@ -12,7 +12,7 @@ domain functions and typically return a scalar loss term $\\ell(u)$.
 
 - **Pointwise** constraints for PDE residuals and boundary conditions.
 - **Integral** constraints for global conservation or averages.
-- **Discrete** constraints for sensors and labeled data.
+- **Discrete** constraints for sensors, labeled data, and ragged trajectories.
 - **Enforced** constraints that build an ansatz satisfying boundary or initial data.
 
 ## Typical loss form
@@ -132,11 +132,43 @@ from ._ode import (
     InitialODEConstraint,
 )
 from ._pointset import PointSetConstraint
+from ._ragged_time_series import (
+    RaggedTimeSeriesBatch,
+    RaggedTimeSeriesDataConstraint,
+)
+from ._ragged_time_series_enforced import (
+    enforce_ragged_time_series,
+    RaggedTimeSeriesHardGate,
+    RaggedTimeSeriesHardInterpolation,
+)
+from ._supervised_dataset import (
+    SupervisedDatasetBatch,
+    SupervisedDatasetConstraint,
+)
+from ._trajectory_data import (
+    TrajectoryCaseDataBatch,
+    TrajectoryCaseDataConstraint,
+    TrajectoryCaseTime,
+    TrajectorySignal,
+    TrajectorySignalInterpolation,
+)
 
 
 __all__ = [
     "FunctionalConstraint",
     "PointSetConstraint",
+    "RaggedTimeSeriesBatch",
+    "RaggedTimeSeriesDataConstraint",
+    "RaggedTimeSeriesHardGate",
+    "RaggedTimeSeriesHardInterpolation",
+    "enforce_ragged_time_series",
+    "TrajectoryCaseDataBatch",
+    "TrajectoryCaseDataConstraint",
+    "TrajectoryCaseTime",
+    "TrajectorySignal",
+    "TrajectorySignalInterpolation",
+    "SupervisedDatasetBatch",
+    "SupervisedDatasetConstraint",
     "IntegralEqualityConstraint",
     "ContinuousPointwiseInteriorConstraint",
     "ContinuousInitialFunctionConstraint",

--- a/phydrax/constraints/_data_metrics.py
+++ b/phydrax/constraints/_data_metrics.py
@@ -3,7 +3,8 @@
 #
 
 import jax.numpy as jnp
-from jaxtyping import Array
+import jax.random as jr
+from jaxtyping import Array, ArrayLike, Key
 
 
 def supervised_data_metrics(
@@ -48,4 +49,106 @@ def _align_data_metric_shapes(pred: Array, target: Array, /) -> tuple[Array, Arr
     raise ValueError(
         "Data metric prediction and target shapes are incompatible: "
         f"prediction={pred_arr.shape}, target={target_arr.shape}."
+    )
+
+
+def supervised_per_sample_squared_error(
+    prediction: Array,
+    target: Array,
+    /,
+) -> Array:
+    """Return one squared-error scalar per leading sample."""
+    pred_arr, target_arr = _align_data_metric_shapes(prediction, target)
+    residual = pred_arr - target_arr
+    squared = residual * residual
+    if squared.ndim <= 1:
+        return squared.reshape((-1,))
+    return jnp.sum(squared.reshape((int(squared.shape[0]), -1)), axis=1)
+
+
+def reduce_supervised_loss(
+    per_sample: Array,
+    /,
+    *,
+    reduction: str,
+) -> Array:
+    """Reduce per-sample supervised losses with a common mean/sum policy."""
+    per_sample_arr = jnp.asarray(per_sample, dtype=float)
+    if reduction == "mean":
+        reduced = jnp.mean(per_sample_arr)
+    elif reduction == "sum":
+        reduced = jnp.sum(per_sample_arr)
+    else:
+        raise ValueError("reduction must be either 'mean' or 'sum'.")
+    return jnp.asarray(reduced, dtype=float).reshape(())
+
+
+def validate_supervised_targets(
+    values: ArrayLike,
+    /,
+    *,
+    leading_size: int,
+    name: str,
+) -> Array:
+    """Validate a target array with a leading empirical-case axis."""
+    arr = jnp.asarray(values, dtype=float)
+    if arr.ndim == 0:
+        raise ValueError(f"{name} values must have shape (N, ...).")
+    if int(arr.shape[0]) != int(leading_size):
+        raise ValueError(
+            f"{name} leading axis must be N={int(leading_size)}, got {arr.shape[0]}."
+        )
+    return arr
+
+
+def validate_case_indices(
+    indices: ArrayLike | None,
+    /,
+    *,
+    size: int,
+    name: str = "indices",
+) -> Array | None:
+    """Validate an optional non-empty 1D integer index subset."""
+    if indices is None:
+        return None
+    raw = jnp.asarray(indices)
+    if raw.ndim != 1:
+        raise ValueError(f"{name} must have shape (K,), got {raw.shape}.")
+    if int(raw.shape[0]) <= 0:
+        raise ValueError(f"{name} must be non-empty.")
+    idx = raw.astype(jnp.int32)
+    if bool(jnp.any(idx != raw)):
+        raise ValueError(f"{name} must contain integer indices.")
+    if bool(jnp.any(idx < 0)) or bool(jnp.any(idx >= int(size))):
+        raise ValueError(f"{name} must be within [0, {int(size)}).")
+    return idx
+
+
+def sample_case_indices(
+    *,
+    size: int,
+    num_samples: int,
+    key: Key[Array, ""],
+    indices: Array | None = None,
+) -> Array:
+    """Sample empirical-case indices uniformly from all cases or a subset."""
+    n = int(num_samples)
+    if n < 0:
+        raise ValueError("num_samples must be non-negative.")
+    if n == 0:
+        return jnp.zeros((0,), dtype=jnp.int32)
+    if indices is None:
+        return _random_int(key, n=n, maxval=int(size))
+    idx = jnp.asarray(indices, dtype=jnp.int32).reshape((-1,))
+    positions = _random_int(key, n=n, maxval=int(idx.shape[0]))
+    return idx[positions]
+
+
+def _random_int(key: Key[Array, ""], /, *, n: int, maxval: int) -> Array:
+    return jr.randint(
+        key,
+        shape=(int(n),),
+        minval=0,
+        maxval=int(maxval),
+        dtype=jnp.int32,
     )

--- a/phydrax/constraints/_functional.py
+++ b/phydrax/constraints/_functional.py
@@ -14,7 +14,7 @@ from jaxtyping import Array, ArrayLike, Key
 from .._doc import DOC_KEY0
 from .._strict import StrictModule
 from ..domain._components import DomainComponent, DomainComponentUnion
-from ..domain._function import DomainFunction
+from ..domain._function import batch_aware_callable, BatchAwareCallable, DomainFunction
 from ..domain._structure import (
     CoordSeparableBatch,
     PointsBatch,
@@ -30,11 +30,35 @@ from ._sampling_spec import (
 )
 
 
-class _SquaredFrobeniusResidual(StrictModule):
+class _SquaredFrobeniusResidual(StrictModule, BatchAwareCallable):
     residual: DomainFunction
 
     def __init__(self, residual: DomainFunction):
         self.residual = residual
+
+    def use_batch_call(self) -> bool:
+        return batch_aware_callable(self.residual.func) is not None
+
+    def __call_batch__(
+        self,
+        batch: PointsBatch | CoordSeparableBatch,
+        /,
+        *,
+        key: Key[Array, ""] = DOC_KEY0,
+        **kwargs: Any,
+    ) -> cx.Field:
+        y = self.residual(batch, key=key, **kwargs)
+        if not isinstance(y, cx.Field):
+            raise TypeError("Expected residual to return a coordax.Field.")
+
+        data = jnp.asarray(y.data)
+        dims = y.dims
+        squared = data * data
+        reduction_axes = [i for i, dim in enumerate(dims) if dim is None]
+        for axis in reversed(reduction_axes):
+            squared = jnp.sum(squared, axis=axis)
+            dims = dims[:axis] + dims[axis + 1 :]
+        return cx.Field(squared, dims=dims)
 
     def __call__(self, *args: Any, key=None, **kwargs: Any):
         y = jnp.asarray(self.residual.func(*args, key=key, **kwargs))

--- a/phydrax/constraints/_ragged_time_series.py
+++ b/phydrax/constraints/_ragged_time_series.py
@@ -1,0 +1,382 @@
+#
+#  Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Literal
+
+import coordax as cx
+import jax.numpy as jnp
+import jax.random as jr
+from jaxtyping import Array, ArrayLike, Key
+
+from .._doc import DOC_KEY0
+from .._strict import StrictModule
+from ..domain._components import DomainComponent
+from ..domain._function import DomainFunction
+from ..domain._structure import PointsBatch, ProductStructure
+from ..domain._trajectory_dataset import TrajectoryDatasetDomain
+from ._base import AbstractSamplingConstraint
+from ._data_metrics import (
+    reduce_supervised_loss,
+    sample_case_indices as _sample_case_indices,
+    supervised_data_metrics,
+    supervised_per_sample_squared_error,
+    validate_case_indices,
+)
+
+
+RaggedTimeSeriesSampling = Literal[
+    "observation_uniform",
+    "case_uniform",
+    "case_time_uniform",
+]
+RaggedTimeSeriesInterpolation = Literal["nearest", "linear"]
+
+
+class RaggedTimeSeriesBatch(StrictModule):
+    """A sampled mini-batch from a ragged trajectory dataset."""
+
+    points: PointsBatch
+    target: Array
+    case_indices: Array
+    time_indices: Array
+    times: Array
+
+    def __init__(
+        self,
+        *,
+        points: PointsBatch,
+        target: ArrayLike,
+        case_indices: ArrayLike,
+        time_indices: ArrayLike,
+        times: ArrayLike,
+    ):
+        self.points = points
+        self.target = jnp.asarray(target, dtype=float)
+        self.case_indices = jnp.asarray(case_indices, dtype=jnp.int32)
+        self.time_indices = jnp.asarray(time_indices, dtype=jnp.int32)
+        self.times = jnp.asarray(times, dtype=float)
+
+
+def _flat_observation_indices(
+    domain: TrajectoryDatasetDomain,
+    case_indices: Array | None = None,
+    /,
+) -> tuple[Array, Array]:
+    flat_cases = domain.flat_case_indices
+    flat_times = domain.flat_time_indices
+    if case_indices is None:
+        return flat_cases, flat_times
+    allowed = jnp.asarray(case_indices, dtype=jnp.int32).reshape((-1,))
+    mask = jnp.any(flat_cases[:, None] == allowed[None, :], axis=1)
+    cases = flat_cases[mask]
+    times = flat_times[mask]
+    if int(cases.shape[0]) <= 0:
+        raise ValueError("case_indices contain no valid trajectory observations.")
+    return cases, times
+
+
+def _validate_values(domain: TrajectoryDatasetDomain, values: ArrayLike, /) -> Array:
+    arr = jnp.asarray(values, dtype=float)
+    if arr.ndim < 2:
+        raise ValueError(
+            "Ragged time-series values must have shape (N, T, ...) with a time axis."
+        )
+    if int(arr.shape[0]) != domain.size:
+        raise ValueError(
+            f"values leading axis must be N={domain.size}, got {arr.shape[0]}."
+        )
+    if int(arr.shape[1]) < domain.max_length:
+        raise ValueError(
+            "values time axis must have at least "
+            f"{domain.max_length} entries, got {arr.shape[1]}."
+        )
+    return arr
+
+
+def _gather_nearest(values: Array, case_indices: Array, time_indices: Array, /) -> Array:
+    return values[case_indices, time_indices]
+
+
+def _gather_linear(
+    values: Array,
+    case_indices: Array,
+    tau: Array,
+    lengths: Array,
+    /,
+) -> tuple[Array, Array]:
+    lower = jnp.floor(tau).astype(jnp.int32)
+    upper = jnp.minimum(lower + 1, lengths - 1)
+    frac = tau - lower.astype(float)
+    lower_values = values[case_indices, lower]
+    upper_values = values[case_indices, upper]
+    frac_shape = (int(frac.shape[0]),) + (1,) * max(values.ndim - 2, 0)
+    frac_w = frac.reshape(frac_shape)
+    target = (1.0 - frac_w) * lower_values + frac_w * upper_values
+    return target, lower
+
+
+class RaggedTimeSeriesDataConstraint(AbstractSamplingConstraint):
+    """Supervised data constraint for ragged trajectories on a TrajectoryDatasetDomain.
+
+    This constraint samples observed or interpolated `(data, t)` pairs, evaluates a
+    model function at those paired points, and penalizes disagreement with the stored
+    ragged time-series targets.
+    """
+
+    constraint_vars: tuple[str, ...]
+    component: DomainComponent
+    structure: ProductStructure
+    dense_structure: ProductStructure | None
+    num_points: int
+    sampler: str
+    over: str | tuple[str, ...] | None
+    reduction: Literal["mean", "sum"]
+    values: Array
+    weight: Array
+    pointwise_weight: DomainFunction | None
+    case_indices: Array | None
+    observation_case_indices: Array
+    observation_time_indices: Array
+    observation_count: int
+    label: str | None
+    sampling: RaggedTimeSeriesSampling
+    interpolation: RaggedTimeSeriesInterpolation
+    data_accuracy_eps: Array
+
+    def __init__(
+        self,
+        constraint_var: str,
+        component: DomainComponent,
+        values: ArrayLike,
+        /,
+        *,
+        num_points: int,
+        structure: ProductStructure | None = None,
+        sampling: RaggedTimeSeriesSampling = "observation_uniform",
+        interpolation: RaggedTimeSeriesInterpolation = "nearest",
+        weight: DomainFunction | ArrayLike = 1.0,
+        reduction: Literal["mean", "sum"] = "mean",
+        case_indices: ArrayLike | None = None,
+        label: str | None = None,
+        data_accuracy_eps: float = 1e-12,
+    ):
+        if not isinstance(component.domain, TrajectoryDatasetDomain):
+            raise TypeError(
+                "RaggedTimeSeriesDataConstraint requires a TrajectoryDatasetDomain component."
+            )
+        n = int(num_points)
+        if n <= 0:
+            raise ValueError("num_points must be positive.")
+
+        sampling_str = str(sampling)
+        if sampling_str not in (
+            "observation_uniform",
+            "case_uniform",
+            "case_time_uniform",
+        ):
+            raise ValueError(
+                "sampling must be 'observation_uniform', 'case_uniform', "
+                "or 'case_time_uniform'."
+            )
+        sampling_value: RaggedTimeSeriesSampling
+        if sampling_str == "observation_uniform":
+            sampling_value = "observation_uniform"
+        elif sampling_str == "case_uniform":
+            sampling_value = "case_uniform"
+        else:
+            sampling_value = "case_time_uniform"
+
+        interpolation_str = str(interpolation)
+        if interpolation_str not in ("nearest", "linear"):
+            raise ValueError("interpolation must be either 'nearest' or 'linear'.")
+        interpolation_value: RaggedTimeSeriesInterpolation
+        if interpolation_str == "nearest":
+            interpolation_value = "nearest"
+        else:
+            interpolation_value = "linear"
+
+        reduction_str = str(reduction)
+        if reduction_str not in ("mean", "sum"):
+            raise ValueError("reduction must be either 'mean' or 'sum'.")
+        reduction_value: Literal["mean", "sum"]
+        if reduction_str == "mean":
+            reduction_value = "mean"
+        else:
+            reduction_value = "sum"
+
+        domain = component.domain
+        self.constraint_vars = (str(constraint_var),)
+        self.component = component
+        self.structure = structure or ProductStructure((domain.labels,))
+        self.dense_structure = None
+        self.num_points = n
+        self.sampler = sampling_value
+        self.over = None
+        self.reduction = reduction_value
+        self.values = _validate_values(domain, values)
+        if isinstance(weight, DomainFunction):
+            self.weight = jnp.asarray(1.0, dtype=float)
+            self.pointwise_weight = weight
+        else:
+            self.weight = jnp.asarray(weight, dtype=float)
+            self.pointwise_weight = None
+        self.case_indices = validate_case_indices(
+            case_indices,
+            size=domain.size,
+            name="case_indices",
+        )
+        obs_cases, obs_times = _flat_observation_indices(domain, self.case_indices)
+        self.observation_case_indices = obs_cases
+        self.observation_time_indices = obs_times
+        self.observation_count = int(obs_cases.shape[0])
+        self.label = None if label is None else str(label)
+        self.sampling = sampling_value
+        self.interpolation = interpolation_value
+        self.data_accuracy_eps = jnp.asarray(float(data_accuracy_eps), dtype=float)
+
+    @property
+    def domain(self) -> TrajectoryDatasetDomain:
+        domain = self.component.domain
+        if not isinstance(domain, TrajectoryDatasetDomain):
+            raise TypeError(
+                "RaggedTimeSeriesDataConstraint domain is not a trajectory domain."
+            )
+        return domain
+
+    def sample(
+        self,
+        *,
+        key: Key[Array, ""] = DOC_KEY0,
+    ) -> Any:
+        domain = self.domain
+        n = int(self.num_points)
+        key_case, key_time = jr.split(key)
+
+        if self.sampling == "observation_uniform":
+            flat_cases = self.observation_case_indices
+            flat_times = self.observation_time_indices
+            obs_idx = jr.randint(
+                key,
+                shape=(n,),
+                minval=0,
+                maxval=self.observation_count,
+                dtype=jnp.int32,
+            )
+            case_indices = flat_cases[obs_idx]
+            time_indices = flat_times[obs_idx]
+            times = domain.observation_times(case_indices, time_indices)
+            target = _gather_nearest(self.values, case_indices, time_indices)
+        else:
+            case_indices = _sample_case_indices(
+                size=domain.size,
+                num_samples=n,
+                key=key_case,
+                indices=self.case_indices,
+            )
+            lengths = domain.lengths[case_indices]
+            if self.sampling == "case_time_uniform":
+                tau = jr.uniform(key_time, shape=(n,)) * (lengths.astype(float) - 1.0)
+                if self.interpolation == "linear":
+                    target, time_indices = _gather_linear(
+                        self.values, case_indices, tau, lengths
+                    )
+                else:
+                    time_indices = jnp.rint(tau).astype(jnp.int32)
+                    time_indices = jnp.clip(time_indices, 0, lengths - 1)
+                    target = _gather_nearest(self.values, case_indices, time_indices)
+                times = domain.start + domain.dt * tau
+            else:
+                u = jr.uniform(key_time, shape=(n,))
+                time_indices = jnp.floor(u * lengths.astype(float)).astype(jnp.int32)
+                time_indices = jnp.clip(time_indices, 0, lengths - 1)
+                times = domain.observation_times(case_indices, time_indices)
+                target = _gather_nearest(self.values, case_indices, time_indices)
+
+        points = domain.points_from_case_time(
+            case_indices,
+            times,
+            structure=self.structure,
+            time_indices=time_indices,
+        )
+        return RaggedTimeSeriesBatch(
+            points=points,
+            target=target,
+            case_indices=case_indices,
+            time_indices=time_indices,
+            times=times,
+        )
+
+    def _prediction(
+        self,
+        functions: Mapping[str, DomainFunction],
+        batch: RaggedTimeSeriesBatch,
+        /,
+        *,
+        key: Key[Array, ""] = DOC_KEY0,
+        **kwargs: Any,
+    ) -> cx.Field:
+        var = self.constraint_vars[0]
+        prediction = functions[var](batch.points, key=key, **kwargs)
+        if not isinstance(prediction, cx.Field):
+            raise TypeError("Expected data prediction to return a coordax.Field.")
+        return prediction
+
+    def data_metrics(
+        self,
+        functions: Mapping[str, DomainFunction],
+        /,
+        *,
+        key: Key[Array, ""] = DOC_KEY0,
+        batch: RaggedTimeSeriesBatch | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Array]:
+        batch_ = self.sample(key=key) if batch is None else batch
+        prediction = self._prediction(functions, batch_, key=key, **kwargs)
+        return supervised_data_metrics(
+            jnp.asarray(prediction.data, dtype=float),
+            batch_.target,
+            eps=self.data_accuracy_eps,
+        )
+
+    def loss(
+        self,
+        functions: Mapping[str, DomainFunction],
+        /,
+        *,
+        key: Key[Array, ""] = DOC_KEY0,
+        iter_: int | None = None,
+        batch: RaggedTimeSeriesBatch | None = None,
+        **kwargs: Any,
+    ) -> Array:
+        del iter_
+        batch_ = self.sample(key=key) if batch is None else batch
+        prediction = self._prediction(functions, batch_, key=key, **kwargs)
+        per_sample = supervised_per_sample_squared_error(
+            jnp.asarray(prediction.data, dtype=float),
+            batch_.target,
+        )
+
+        if self.pointwise_weight is not None:
+            w = self.pointwise_weight(batch_.points, key=key, **kwargs)
+            if not isinstance(w, cx.Field):
+                raise TypeError("pointwise weight must return a coordax.Field.")
+            w_arr = jnp.asarray(w.data, dtype=float)
+            if w_arr.ndim == 0:
+                per_sample = per_sample * w_arr
+            else:
+                per_sample = per_sample * jnp.squeeze(w_arr).reshape((-1,))
+
+        reduced = reduce_supervised_loss(per_sample, reduction=self.reduction)
+        return self.weight * jnp.asarray(reduced, dtype=float).reshape(())
+
+
+__all__ = [
+    "RaggedTimeSeriesBatch",
+    "RaggedTimeSeriesDataConstraint",
+    "RaggedTimeSeriesInterpolation",
+    "RaggedTimeSeriesSampling",
+]

--- a/phydrax/constraints/_ragged_time_series_enforced.py
+++ b/phydrax/constraints/_ragged_time_series_enforced.py
@@ -1,0 +1,604 @@
+#
+#  Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from math import comb
+from typing import Any, Literal
+
+import coordax as cx
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array, ArrayLike, Key
+
+from .._doc import DOC_KEY0
+from .._strict import StrictModule
+from .._trainable import NonTrainableState
+from ..domain._function import BatchAwareCallable, DomainFunction
+from ..domain._structure import CoordSeparableBatch, PointsBatch
+from ..domain._trajectory_dataset import (
+    TRAJECTORY_CASE_INDEX_KEY,
+    TRAJECTORY_TIME_INDEX_KEY,
+    TrajectoryDatasetDomain,
+)
+from ..operators.differential._hooks import with_derivative_hook
+
+
+RaggedTimeSeriesHardInterpolation = Literal["linear", "cubic_hermite"]
+RaggedTimeSeriesHardGate = Literal["sin2", "sin4"]
+
+
+def _field_array(batch: PointsBatch, key: str, /) -> Array:
+    if key not in batch:
+        raise ValueError(
+            "Ragged time-series evaluation requires trajectory batches "
+            f"with internal field {key!r}."
+        )
+    field = batch[key]
+    if not isinstance(field, cx.Field):
+        raise TypeError(f"Expected batch[{key!r}] to be a coordax.Field.")
+    return jnp.asarray(field.data)
+
+
+def _broadcast_like(values: Array, reference: Array, /) -> Array:
+    arr = jnp.asarray(values, dtype=float)
+    ref = jnp.asarray(reference, dtype=float)
+    if arr.ndim == ref.ndim:
+        return arr
+    if arr.ndim != 1:
+        raise ValueError(
+            f"Cannot broadcast shape {arr.shape} against reference shape {ref.shape}."
+        )
+    return arr.reshape((int(arr.shape[0]),) + (1,) * (ref.ndim - 1))
+
+
+def _validate_values(domain: TrajectoryDatasetDomain, values: ArrayLike, /) -> Array:
+    arr = jnp.asarray(values, dtype=float)
+    if arr.ndim < 2:
+        raise ValueError("values must have shape (N, T, ...) with a time axis.")
+    if int(arr.shape[0]) != domain.size:
+        raise ValueError(
+            f"values leading axis must be N={domain.size}, got {arr.shape[0]}."
+        )
+    if int(arr.shape[1]) < domain.max_length:
+        raise ValueError(
+            "values time axis must have at least "
+            f"{domain.max_length} entries, got {arr.shape[1]}."
+        )
+    return arr
+
+
+def _validate_components(components: Sequence[int] | None, /) -> tuple[int, ...] | None:
+    if components is None:
+        return None
+    out = tuple(int(component) for component in components)
+    if not out:
+        raise ValueError("components must be non-empty when provided.")
+    if any(component < 0 for component in out):
+        raise ValueError("components must contain non-negative indices.")
+    if len(set(out)) != len(out):
+        raise ValueError("components must not contain duplicate indices.")
+    return out
+
+
+def _blend_components(
+    free: Array,
+    hard: Array,
+    components: tuple[int, ...] | None,
+    /,
+) -> Array:
+    free_arr = jnp.asarray(free, dtype=float)
+    hard_arr = jnp.asarray(hard, dtype=float)
+    if components is None:
+        return hard_arr
+    if free_arr.ndim < 2:
+        raise ValueError("components require a vector-valued trailing output axis.")
+    width = int(free_arr.shape[-1])
+    for component in components:
+        if component >= width:
+            raise ValueError(
+                f"component index {component} is out of bounds for output width {width}."
+            )
+    component_idx = jnp.asarray(components, dtype=jnp.int32)
+    mask = jnp.zeros((width,), dtype=float).at[component_idx].set(1.0)
+    mask = mask.reshape((1,) * (free_arr.ndim - 1) + (width,))
+    return free_arr + mask * (hard_arr - free_arr)
+
+
+class _RaggedTimeSeriesTable(StrictModule, NonTrainableState):
+    domain: TrajectoryDatasetDomain
+    values: Array
+    interpolation: RaggedTimeSeriesHardInterpolation
+    gate: RaggedTimeSeriesHardGate
+    snap_tol: Array
+
+    def __init__(
+        self,
+        *,
+        domain: TrajectoryDatasetDomain,
+        values: ArrayLike,
+        interpolation: RaggedTimeSeriesHardInterpolation,
+        gate: RaggedTimeSeriesHardGate,
+        snap_tol: float,
+    ):
+        if interpolation not in ("linear", "cubic_hermite"):
+            raise ValueError("interpolation must be either 'linear' or 'cubic_hermite'.")
+        if gate not in ("sin2", "sin4"):
+            raise ValueError("gate must be either 'sin2' or 'sin4'.")
+        snap = float(snap_tol)
+        if snap < 0.0:
+            raise ValueError("snap_tol must be non-negative.")
+        self.domain = domain
+        self.values = _validate_values(domain, values)
+        self.interpolation = interpolation
+        self.gate = gate
+        self.snap_tol = jnp.asarray(snap, dtype=float)
+
+    def max_derivative_order(self) -> int:
+        if self.interpolation == "linear":
+            return 1
+        return 2
+
+    def _geometry(
+        self,
+        batch: PointsBatch,
+        /,
+    ) -> tuple[Array, Array, Array, Array, Array, Array, Array, Array, Array]:
+        case_idx = _field_array(batch, TRAJECTORY_CASE_INDEX_KEY).astype(jnp.int32)
+        time_idx = _field_array(batch, TRAJECTORY_TIME_INDEX_KEY).astype(jnp.int32)
+        t = _field_array(batch, self.domain.time_label).astype(float)
+        values = jax.lax.stop_gradient(self.values)
+        start = jax.lax.stop_gradient(self.domain.start)
+        dt = jax.lax.stop_gradient(self.domain.dt)
+
+        lengths = self.domain.lengths[case_idx]
+        max_tau = lengths.astype(float) - 1.0
+        tau_raw = (t - start) / dt
+        tau = jnp.clip(tau_raw, 0.0, max_tau)
+
+        max_left = jnp.maximum(lengths - 2, 0)
+        k0 = jnp.floor(tau).astype(jnp.int32)
+        k0 = jnp.clip(k0, 0, max_left)
+        k1 = jnp.minimum(k0 + 1, lengths - 1)
+        s = jnp.where(lengths > 1, tau - k0.astype(float), 0.0)
+
+        node_idx = jnp.clip(time_idx, 0, lengths - 1)
+        node_t = self.domain.observation_times(case_idx, node_idx)
+        on_node = jnp.abs(t - node_t) <= self.snap_tol
+        return case_idx, k0, k1, s, on_node, node_idx, lengths, values, dt
+
+    def _node_slope(
+        self,
+        values: Array,
+        case_idx: Array,
+        node_idx: Array,
+        lengths: Array,
+        dt: Array,
+        /,
+    ) -> Array:
+        prev_idx = jnp.maximum(node_idx - 1, 0)
+        next_idx = jnp.minimum(node_idx + 1, lengths - 1)
+        steps = jnp.maximum(next_idx - prev_idx, 1).astype(float)
+        diff = values[case_idx, next_idx] - values[case_idx, prev_idx]
+        return diff / (dt * _broadcast_like(steps, diff))
+
+    def _linear_targets(
+        self,
+        *,
+        max_order: int,
+        case_idx: Array,
+        k0: Array,
+        k1: Array,
+        s: Array,
+        on_node: Array,
+        node_idx: Array,
+        values: Array,
+        dt: Array,
+    ) -> tuple[Array, ...]:
+        y0 = values[case_idx, k0]
+        y1 = values[case_idx, k1]
+        s_b = _broadcast_like(s, y0)
+        target = (1.0 - s_b) * y0 + s_b * y1
+        node_target = values[case_idx, node_idx]
+        on_node_b = _broadcast_like(on_node.astype(float), target)
+        target = on_node_b * node_target + (1.0 - on_node_b) * target
+        if int(max_order) == 0:
+            return (target,)
+        target_dt = (y1 - y0) / dt
+        return (target, target_dt)
+
+    def _cubic_hermite_targets(
+        self,
+        *,
+        max_order: int,
+        case_idx: Array,
+        k0: Array,
+        k1: Array,
+        s: Array,
+        on_node: Array,
+        node_idx: Array,
+        lengths: Array,
+        values: Array,
+        dt: Array,
+    ) -> tuple[Array, ...]:
+        y0 = values[case_idx, k0]
+        y1 = values[case_idx, k1]
+        m0 = self._node_slope(values, case_idx, k0, lengths, dt)
+        m1 = self._node_slope(values, case_idx, k1, lengths, dt)
+
+        s2 = s * s
+        s3 = s2 * s
+        h00 = _broadcast_like(2.0 * s3 - 3.0 * s2 + 1.0, y0)
+        h10 = _broadcast_like(s3 - 2.0 * s2 + s, y0)
+        h01 = _broadcast_like(-2.0 * s3 + 3.0 * s2, y0)
+        h11 = _broadcast_like(s3 - s2, y0)
+        target = h00 * y0 + h10 * dt * m0 + h01 * y1 + h11 * dt * m1
+
+        node_target = values[case_idx, node_idx]
+        on_node_b = _broadcast_like(on_node.astype(float), target)
+        target = on_node_b * node_target + (1.0 - on_node_b) * target
+        if int(max_order) == 0:
+            return (target,)
+
+        h00_d1 = _broadcast_like(6.0 * s2 - 6.0 * s, y0)
+        h10_d1 = _broadcast_like(3.0 * s2 - 4.0 * s + 1.0, y0)
+        h01_d1 = _broadcast_like(-6.0 * s2 + 6.0 * s, y0)
+        h11_d1 = _broadcast_like(3.0 * s2 - 2.0 * s, y0)
+        target_dt = (h00_d1 * y0 + h10_d1 * dt * m0 + h01_d1 * y1 + h11_d1 * dt * m1) / dt
+        if int(max_order) == 1:
+            return (target, target_dt)
+
+        h00_d2 = _broadcast_like(12.0 * s - 6.0, y0)
+        h10_d2 = _broadcast_like(6.0 * s - 4.0, y0)
+        h01_d2 = _broadcast_like(-12.0 * s + 6.0, y0)
+        h11_d2 = _broadcast_like(6.0 * s - 2.0, y0)
+        target_d2t = (h00_d2 * y0 + h10_d2 * dt * m0 + h01_d2 * y1 + h11_d2 * dt * m1) / (
+            dt * dt
+        )
+        return (target, target_dt, target_d2t)
+
+    def _sin2_gate_derivatives(
+        self,
+        s: Array,
+        on_node: Array,
+        dt: Array,
+        max_order: int,
+        /,
+    ) -> tuple[Array, ...]:
+        pi_s = jnp.pi * s
+        gate = jnp.sin(pi_s) ** 2
+        gate = jnp.where(on_node, 0.0, gate)
+        if int(max_order) == 0:
+            return (gate,)
+        gate_dt = (jnp.pi / dt) * jnp.sin(2.0 * pi_s)
+        gate_dt = jnp.where(on_node, 0.0, gate_dt)
+        if int(max_order) == 1:
+            return (gate, gate_dt)
+        gate_d2t = (2.0 * jnp.pi * jnp.pi / (dt * dt)) * jnp.cos(2.0 * pi_s)
+        return (gate, gate_dt, gate_d2t)
+
+    def _sin4_gate_derivatives(
+        self,
+        s: Array,
+        on_node: Array,
+        dt: Array,
+        max_order: int,
+        /,
+    ) -> tuple[Array, ...]:
+        sin_pi = jnp.sin(jnp.pi * s)
+        cos_pi = jnp.cos(jnp.pi * s)
+        sin2 = sin_pi * sin_pi
+        gate = sin2 * sin2
+        gate = jnp.where(on_node, 0.0, gate)
+        if int(max_order) == 0:
+            return (gate,)
+        gate_dt = (4.0 * jnp.pi / dt) * sin2 * sin_pi * cos_pi
+        gate_dt = jnp.where(on_node, 0.0, gate_dt)
+        if int(max_order) == 1:
+            return (gate, gate_dt)
+        gate_d2t = (
+            4.0
+            * jnp.pi
+            * jnp.pi
+            / (dt * dt)
+            * (3.0 * sin2 * cos_pi * cos_pi - sin2 * sin2)
+        )
+        gate_d2t = jnp.where(on_node, 0.0, gate_d2t)
+        return (gate, gate_dt, gate_d2t)
+
+    def evaluate(
+        self,
+        batch: PointsBatch,
+        /,
+        *,
+        max_order: int,
+    ) -> tuple[tuple[Array, ...], tuple[Array, ...]]:
+        order = int(max_order)
+        limit = self.max_derivative_order()
+        if order > limit:
+            raise ValueError(
+                f"interpolation={self.interpolation!r} supports hard time "
+                f"derivatives only up to order {limit}."
+            )
+        (
+            case_idx,
+            k0,
+            k1,
+            s,
+            on_node,
+            node_idx,
+            lengths,
+            values,
+            dt,
+        ) = self._geometry(batch)
+
+        if self.interpolation == "linear":
+            targets = self._linear_targets(
+                max_order=order,
+                case_idx=case_idx,
+                k0=k0,
+                k1=k1,
+                s=s,
+                on_node=on_node,
+                node_idx=node_idx,
+                values=values,
+                dt=dt,
+            )
+        else:
+            targets = self._cubic_hermite_targets(
+                max_order=order,
+                case_idx=case_idx,
+                k0=k0,
+                k1=k1,
+                s=s,
+                on_node=on_node,
+                node_idx=node_idx,
+                lengths=lengths,
+                values=values,
+                dt=dt,
+            )
+
+        if self.gate == "sin2":
+            gates = self._sin2_gate_derivatives(s, on_node, dt, order)
+        else:
+            gates = self._sin4_gate_derivatives(s, on_node, dt, order)
+        return targets, gates
+
+
+class _RaggedTimeSeriesHardAnsatz(StrictModule, BatchAwareCallable):
+    u_free: DomainFunction
+    table: _RaggedTimeSeriesTable
+    components: tuple[int, ...] | None
+
+    def __init__(
+        self,
+        *,
+        u_free: DomainFunction,
+        table: _RaggedTimeSeriesTable,
+        components: tuple[int, ...] | None,
+    ):
+        self.u_free = u_free
+        self.table = table
+        self.components = components
+
+    def __call__(self, *args: Any, key=None, **kwargs: Any) -> Array:
+        del args, key, kwargs
+        raise TypeError(
+            "Ragged time-series hard enforcement requires PointsBatch evaluation."
+        )
+
+    def __call_batch__(
+        self,
+        batch: PointsBatch | CoordSeparableBatch,
+        /,
+        *,
+        key: Key[Array, ""] = DOC_KEY0,
+        **kwargs: Any,
+    ) -> cx.Field:
+        if not isinstance(batch, PointsBatch):
+            raise TypeError(
+                "Ragged time-series hard enforcement requires PointsBatch evaluation."
+            )
+        free = self.u_free(batch, key=key, **kwargs)
+        targets, gates = self.table.evaluate(batch, max_order=0)
+        free_arr = jnp.asarray(free.data, dtype=float)
+        target = targets[0]
+        gate_b = _broadcast_like(gates[0], free_arr)
+        hard = target + gate_b * (free_arr - target)
+        out = _blend_components(free_arr, hard, self.components)
+        return cx.Field(out, dims=free.dims)
+
+
+class _RaggedTimeSeriesHardAnsatzDerivative(StrictModule, BatchAwareCallable):
+    order: int
+    u_free_derivatives: tuple[DomainFunction, ...]
+    table: _RaggedTimeSeriesTable
+    components: tuple[int, ...] | None
+
+    def __init__(
+        self,
+        *,
+        order: int,
+        u_free_derivatives: tuple[DomainFunction, ...],
+        table: _RaggedTimeSeriesTable,
+        components: tuple[int, ...] | None,
+    ):
+        self.order = int(order)
+        self.u_free_derivatives = tuple(u_free_derivatives)
+        self.table = table
+        self.components = components
+
+    def __call__(self, *args: Any, key=None, **kwargs: Any) -> Array:
+        del args, key, kwargs
+        raise TypeError(
+            "Ragged time-series hard derivative requires PointsBatch evaluation."
+        )
+
+    def __call_batch__(
+        self,
+        batch: PointsBatch | CoordSeparableBatch,
+        /,
+        *,
+        key: Key[Array, ""] = DOC_KEY0,
+        **kwargs: Any,
+    ) -> cx.Field:
+        if not isinstance(batch, PointsBatch):
+            raise TypeError(
+                "Ragged time-series hard derivative requires PointsBatch evaluation."
+            )
+        targets, gates = self.table.evaluate(batch, max_order=self.order)
+        free_fields = tuple(
+            fn(batch, key=key, **kwargs) for fn in self.u_free_derivatives
+        )
+        free_arrays = tuple(jnp.asarray(field.data, dtype=float) for field in free_fields)
+
+        hard = targets[self.order]
+        for gate_order in range(self.order + 1):
+            free_order = self.order - gate_order
+            delta = free_arrays[free_order] - targets[free_order]
+            gate_b = _broadcast_like(gates[gate_order], delta)
+            hard = hard + float(comb(self.order, gate_order)) * gate_b * delta
+
+        out = _blend_components(free_arrays[self.order], hard, self.components)
+        return cx.Field(out, dims=free_fields[self.order].dims)
+
+
+def enforce_ragged_time_series(
+    u_free: DomainFunction,
+    domain: TrajectoryDatasetDomain,
+    values: ArrayLike,
+    /,
+    *,
+    interpolation: RaggedTimeSeriesHardInterpolation = "linear",
+    gate: RaggedTimeSeriesHardGate = "sin2",
+    time_var: str = "t",
+    components: Sequence[int] | None = None,
+    snap_tol: float = 1e-10,
+) -> DomainFunction:
+    """Return a hard ansatz that exactly matches row-wise ragged time-series data.
+
+    The returned `DomainFunction` is evaluated on trajectory `PointsBatch` objects
+    that carry the internal row/time indices emitted by `TrajectoryDatasetDomain`.
+    `interpolation="linear"` supports first-order time derivatives. Use
+    `interpolation="cubic_hermite"` for second-order time derivatives, preferably
+    with `gate="sin4"`.
+
+    When `components` is provided, only those trailing output components are
+    hard-enforced; the remaining components are passed through from `u_free`.
+    """
+    if not isinstance(domain, TrajectoryDatasetDomain):
+        raise TypeError("enforce_ragged_time_series requires a TrajectoryDatasetDomain.")
+    if time_var != domain.time_label:
+        raise ValueError(
+            f"time_var must match the trajectory time label {domain.time_label!r}."
+        )
+    if not u_free.domain.equivalent(domain):
+        raise ValueError("u_free must be defined on the provided trajectory domain.")
+
+    components_ = _validate_components(components)
+    table = _RaggedTimeSeriesTable(
+        domain=domain,
+        values=values,
+        interpolation=interpolation,
+        gate=gate,
+        snap_tol=float(snap_tol),
+    )
+
+    base = DomainFunction(
+        domain=u_free.domain,
+        deps=u_free.deps,
+        func=_RaggedTimeSeriesHardAnsatz(
+            u_free=u_free,
+            table=table,
+            components=components_,
+        ),
+        metadata={},
+    )
+
+    def _make_hook(offset: int, /):
+        def _hook(
+            *,
+            var: str,
+            axis: int | None,
+            order: int,
+            mode,
+            backend,
+            basis,
+            periodic: bool,
+        ) -> DomainFunction | None:
+            if backend not in ("ad", "jet"):
+                return None
+            if var != domain.time_label:
+                return None
+            if axis is not None:
+                return None
+            n = int(offset) + int(order)
+            return _make_derivative(
+                n,
+                mode=mode,
+                backend=backend,
+                basis=basis,
+                periodic=periodic,
+            )
+
+        return _hook
+
+    def _make_derivative(
+        order: int,
+        /,
+        *,
+        mode,
+        backend,
+        basis,
+        periodic: bool,
+    ) -> DomainFunction:
+        n = int(order)
+        if n < 0:
+            raise ValueError("order must be non-negative.")
+        if n == 0:
+            return with_derivative_hook(base, _make_hook(0))
+        limit = table.max_derivative_order()
+        if n > limit:
+            raise ValueError(
+                f"interpolation={table.interpolation!r} supports hard time "
+                f"derivatives only up to order {limit}."
+            )
+
+        from ..operators.differential._domain_ops import partial_n
+
+        u_free_derivatives = tuple(
+            partial_n(
+                u_free,
+                var=domain.time_label,
+                axis=None,
+                order=k,
+                mode=mode,
+                backend=backend,
+                basis=basis,
+                periodic=periodic,
+            )
+            for k in range(n + 1)
+        )
+        out = DomainFunction(
+            domain=u_free.domain,
+            deps=u_free.deps,
+            func=_RaggedTimeSeriesHardAnsatzDerivative(
+                order=n,
+                u_free_derivatives=u_free_derivatives,
+                table=table,
+                components=components_,
+            ),
+            metadata={},
+        )
+        return with_derivative_hook(out, _make_hook(n))
+
+    return with_derivative_hook(base, _make_hook(0))
+
+
+__all__ = [
+    "RaggedTimeSeriesHardGate",
+    "RaggedTimeSeriesHardInterpolation",
+    "enforce_ragged_time_series",
+]

--- a/phydrax/constraints/_supervised_dataset.py
+++ b/phydrax/constraints/_supervised_dataset.py
@@ -1,0 +1,234 @@
+#
+#  Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Literal
+
+import coordax as cx
+import jax.numpy as jnp
+from jaxtyping import Array, ArrayLike, Key
+
+from .._doc import DOC_KEY0
+from .._strict import StrictModule
+from ..domain._components import DomainComponent
+from ..domain._dataset import DatasetDomain
+from ..domain._function import DomainFunction
+from ..domain._structure import PointsBatch, ProductStructure
+from ._base import AbstractSamplingConstraint
+from ._data_metrics import (
+    reduce_supervised_loss,
+    sample_case_indices,
+    supervised_data_metrics,
+    supervised_per_sample_squared_error,
+    validate_case_indices,
+    validate_supervised_targets,
+)
+
+
+class SupervisedDatasetBatch(StrictModule):
+    """A sampled mini-batch of row-aligned supervised dataset data."""
+
+    points: PointsBatch
+    target: Array
+    indices: Array
+
+    def __init__(
+        self,
+        *,
+        points: PointsBatch,
+        target: ArrayLike,
+        indices: ArrayLike,
+    ):
+        self.points = points
+        self.target = jnp.asarray(target, dtype=float)
+        self.indices = jnp.asarray(indices, dtype=jnp.int32)
+
+
+def _validate_targets(domain: DatasetDomain, values: ArrayLike, /) -> Array:
+    return validate_supervised_targets(
+        values,
+        leading_size=domain.size,
+        name="supervised dataset target",
+    )
+
+
+class SupervisedDatasetConstraint(AbstractSamplingConstraint):
+    """Supervise row-aligned targets on a DatasetDomain.
+
+    `DatasetDomain` owns the empirical row payloads. This constraint owns the aligned
+    targets and samples row indices so predictions and targets stay synchronized.
+    """
+
+    constraint_vars: tuple[str, ...]
+    component: DomainComponent
+    structure: ProductStructure
+    dense_structure: ProductStructure | None
+    num_points: int
+    sampler: str
+    over: str | tuple[str, ...] | None
+    reduction: Literal["mean", "sum"]
+    values: Array
+    weight: Array
+    pointwise_weight: DomainFunction | None
+    indices: Array | None
+    label: str | None
+    data_accuracy_eps: Array
+
+    def __init__(
+        self,
+        constraint_var: str,
+        component: DomainComponent,
+        values: ArrayLike,
+        /,
+        *,
+        num_cases: int,
+        structure: ProductStructure | None = None,
+        sampler: str = "uniform",
+        weight: DomainFunction | ArrayLike = 1.0,
+        reduction: Literal["mean", "sum"] = "mean",
+        indices: ArrayLike | None = None,
+        label: str | None = None,
+        data_accuracy_eps: float = 1e-12,
+    ):
+        if not isinstance(component.domain, DatasetDomain):
+            raise TypeError(
+                "SupervisedDatasetConstraint requires a DatasetDomain component."
+            )
+        n = int(num_cases)
+        if n <= 0:
+            raise ValueError("num_cases must be positive.")
+        reduction_str = str(reduction)
+        if reduction_str not in ("mean", "sum"):
+            raise ValueError("reduction must be either 'mean' or 'sum'.")
+        reduction_value: Literal["mean", "sum"]
+        if reduction_str == "mean":
+            reduction_value = "mean"
+        else:
+            reduction_value = "sum"
+        sampler_str = str(sampler)
+        if sampler_str != "uniform":
+            raise ValueError(
+                "SupervisedDatasetConstraint supports only uniform sampling."
+            )
+
+        domain = component.domain
+        self.constraint_vars = (str(constraint_var),)
+        self.component = component
+        self.structure = structure or ProductStructure((domain.labels,))
+        self.dense_structure = None
+        self.num_points = n
+        self.sampler = sampler_str
+        self.over = None
+        self.reduction = reduction_value
+        self.values = _validate_targets(domain, values)
+        if isinstance(weight, DomainFunction):
+            self.weight = jnp.asarray(1.0, dtype=float)
+            self.pointwise_weight = weight
+        else:
+            self.weight = jnp.asarray(weight, dtype=float)
+            self.pointwise_weight = None
+        self.indices = validate_case_indices(
+            indices,
+            size=domain.size,
+            name="indices",
+        )
+        self.label = None if label is None else str(label)
+        self.data_accuracy_eps = jnp.asarray(float(data_accuracy_eps), dtype=float)
+
+    @property
+    def domain(self) -> DatasetDomain:
+        domain = self.component.domain
+        if not isinstance(domain, DatasetDomain):
+            raise TypeError("SupervisedDatasetConstraint domain is not a DatasetDomain.")
+        return domain
+
+    def sample(
+        self,
+        *,
+        key: Key[Array, ""] = DOC_KEY0,
+    ) -> Any:
+        domain = self.domain
+        indices = sample_case_indices(
+            size=domain.size,
+            num_samples=int(self.num_points),
+            key=key,
+            indices=self.indices,
+        )
+        points = domain.points_from_indices(indices, structure=self.structure)
+        return SupervisedDatasetBatch(
+            points=points,
+            target=self.values[indices],
+            indices=indices,
+        )
+
+    def _prediction(
+        self,
+        functions: Mapping[str, DomainFunction],
+        batch: SupervisedDatasetBatch,
+        /,
+        *,
+        key: Key[Array, ""] = DOC_KEY0,
+        **kwargs: Any,
+    ) -> cx.Field:
+        var = self.constraint_vars[0]
+        prediction = functions[var](batch.points, key=key, **kwargs)
+        if not isinstance(prediction, cx.Field):
+            raise TypeError("Expected dataset prediction to return a coordax.Field.")
+        return prediction
+
+    def data_metrics(
+        self,
+        functions: Mapping[str, DomainFunction],
+        /,
+        *,
+        key: Key[Array, ""] = DOC_KEY0,
+        batch: SupervisedDatasetBatch | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Array]:
+        batch_ = self.sample(key=key) if batch is None else batch
+        prediction = self._prediction(functions, batch_, key=key, **kwargs)
+        return supervised_data_metrics(
+            jnp.asarray(prediction.data, dtype=float),
+            batch_.target,
+            eps=self.data_accuracy_eps,
+        )
+
+    def loss(
+        self,
+        functions: Mapping[str, DomainFunction],
+        /,
+        *,
+        key: Key[Array, ""] = DOC_KEY0,
+        iter_: int | None = None,
+        batch: SupervisedDatasetBatch | None = None,
+        **kwargs: Any,
+    ) -> Array:
+        del iter_
+        batch_ = self.sample(key=key) if batch is None else batch
+        prediction = self._prediction(functions, batch_, key=key, **kwargs)
+        per_sample = supervised_per_sample_squared_error(
+            jnp.asarray(prediction.data, dtype=float),
+            batch_.target,
+        )
+
+        if self.pointwise_weight is not None:
+            w = self.pointwise_weight(batch_.points, key=key, **kwargs)
+            if not isinstance(w, cx.Field):
+                raise TypeError("pointwise weight must return a coordax.Field.")
+            w_arr = jnp.asarray(w.data, dtype=float)
+            if w_arr.ndim == 0:
+                per_sample = per_sample * w_arr
+            else:
+                per_sample = per_sample * jnp.squeeze(w_arr).reshape((-1,))
+
+        reduced = reduce_supervised_loss(per_sample, reduction=self.reduction)
+        return self.weight * jnp.asarray(reduced, dtype=float).reshape(())
+
+
+__all__ = [
+    "SupervisedDatasetBatch",
+    "SupervisedDatasetConstraint",
+]

--- a/phydrax/constraints/_trajectory_data.py
+++ b/phydrax/constraints/_trajectory_data.py
@@ -1,0 +1,520 @@
+#
+#  Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Literal
+
+import coordax as cx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+from jaxtyping import Array, ArrayLike, Key
+
+from .._doc import DOC_KEY0
+from .._strict import StrictModule
+from .._trainable import NonTrainableState
+from ..domain._components import DomainComponent
+from ..domain._function import BatchAwareCallable, DomainFunction
+from ..domain._structure import CoordSeparableBatch, PointsBatch, ProductStructure
+from ..domain._trajectory_dataset import (
+    TRAJECTORY_CASE_INDEX_KEY,
+    TrajectoryDatasetDomain,
+)
+from ..operators.differential._hooks import with_derivative_hook
+from ._base import AbstractSamplingConstraint
+from ._data_metrics import (
+    reduce_supervised_loss,
+    sample_case_indices as _sample_case_indices_uniform,
+    supervised_data_metrics,
+    supervised_per_sample_squared_error,
+    validate_case_indices,
+    validate_supervised_targets,
+)
+from ._ragged_time_series_enforced import _RaggedTimeSeriesTable, _validate_values
+
+
+TrajectorySignalInterpolation = Literal["nearest", "linear", "cubic_hermite"]
+TrajectoryCaseTime = Literal["start", "end"] | float
+
+
+class TrajectoryCaseDataBatch(StrictModule):
+    """A sampled mini-batch of case-level trajectory-domain data."""
+
+    points: PointsBatch
+    target: Array
+    case_indices: Array
+    times: Array
+
+    def __init__(
+        self,
+        *,
+        points: PointsBatch,
+        target: ArrayLike,
+        case_indices: ArrayLike,
+        times: ArrayLike,
+    ):
+        self.points = points
+        self.target = jnp.asarray(target, dtype=float)
+        self.case_indices = jnp.asarray(case_indices, dtype=jnp.int32)
+        self.times = jnp.asarray(times, dtype=float)
+
+
+def _validate_case_values(domain: TrajectoryDatasetDomain, values: ArrayLike, /) -> Array:
+    return validate_supervised_targets(
+        values,
+        leading_size=domain.size,
+        name="case target",
+    )
+
+
+def _time_selection(
+    domain: TrajectoryDatasetDomain,
+    case_indices: Array,
+    time: TrajectoryCaseTime,
+    /,
+) -> tuple[Array, Array]:
+    if time == "start":
+        n = int(case_indices.shape[0])
+        return (
+            jnp.full((n,), domain.start, dtype=float),
+            jnp.zeros((n,), dtype=jnp.int32),
+        )
+    if time == "end":
+        return domain.end_times[case_indices], domain.lengths[case_indices] - 1
+
+    value = _fixed_case_time_value(time)
+    time_indices = jnp.rint((value - domain.start) / domain.dt).astype(jnp.int32)
+    n = int(case_indices.shape[0])
+    return (
+        jnp.full((n,), value, dtype=float),
+        jnp.full((n,), time_indices, dtype=jnp.int32),
+    )
+
+
+def _sample_case_indices(
+    domain: TrajectoryDatasetDomain,
+    n: int,
+    key: Key[Array, ""],
+    time: TrajectoryCaseTime,
+    /,
+    *,
+    indices: Array | None = None,
+) -> Array:
+    if time == "start" or time == "end":
+        return _sample_case_indices_uniform(
+            size=domain.size,
+            num_samples=n,
+            key=key,
+            indices=indices,
+        )
+
+    value = _fixed_case_time_value(time)
+    valid = (domain.start <= value) & (value <= domain.end_times)
+    if indices is not None:
+        allowed = jnp.asarray(indices, dtype=jnp.int32).reshape((-1,))
+        valid = valid[allowed]
+        probs = valid.astype(float) / jnp.sum(valid.astype(float))
+        positions = jr.choice(key, int(allowed.shape[0]), shape=(n,), p=probs)
+        return allowed[positions].astype(jnp.int32)
+    probs = valid.astype(float) / jnp.sum(valid.astype(float))
+    return jr.choice(key, domain.size, shape=(n,), p=probs).astype(jnp.int32)
+
+
+def _fixed_case_time_value(time: TrajectoryCaseTime, /) -> Array:
+    if isinstance(time, str):
+        raise ValueError("case_time must be 'start', 'end', or a floating time value.")
+    return jnp.asarray(float(time), dtype=float).reshape(())
+
+
+class TrajectoryCaseDataConstraint(AbstractSamplingConstraint):
+    """Supervise per-case targets on a TrajectoryDatasetDomain.
+
+    The target has one row per trajectory case, for example scalar material
+    parameters, class logits, or final scalar outputs attached to each dataset row.
+    Case-only functions such as `theta(data)` ignore the representative time carried
+    by the sampled trajectory batch; trajectory functions `theta(data, t)` are
+    evaluated at the configured `case_time`.
+    """
+
+    constraint_vars: tuple[str, ...]
+    component: DomainComponent
+    structure: ProductStructure
+    dense_structure: ProductStructure | None
+    num_points: int
+    sampler: str
+    over: str | tuple[str, ...] | None
+    reduction: Literal["mean", "sum"]
+    values: Array
+    case_time: TrajectoryCaseTime
+    weight: Array
+    pointwise_weight: DomainFunction | None
+    case_indices: Array | None
+    label: str | None
+    data_accuracy_eps: Array
+
+    def __init__(
+        self,
+        constraint_var: str,
+        component: DomainComponent,
+        values: ArrayLike,
+        /,
+        *,
+        num_cases: int,
+        structure: ProductStructure | None = None,
+        case_time: TrajectoryCaseTime = "start",
+        weight: DomainFunction | ArrayLike = 1.0,
+        reduction: Literal["mean", "sum"] = "mean",
+        case_indices: ArrayLike | None = None,
+        label: str | None = None,
+        data_accuracy_eps: float = 1e-12,
+    ):
+        if not isinstance(component.domain, TrajectoryDatasetDomain):
+            raise TypeError(
+                "TrajectoryCaseDataConstraint requires a TrajectoryDatasetDomain component."
+            )
+        n = int(num_cases)
+        if n <= 0:
+            raise ValueError("num_cases must be positive.")
+        reduction_str = str(reduction)
+        if reduction_str not in ("mean", "sum"):
+            raise ValueError("reduction must be either 'mean' or 'sum'.")
+        reduction_value: Literal["mean", "sum"]
+        if reduction_str == "mean":
+            reduction_value = "mean"
+        else:
+            reduction_value = "sum"
+
+        domain = component.domain
+        case_indices_arr = validate_case_indices(
+            case_indices,
+            size=domain.size,
+            name="case_indices",
+        )
+
+        if case_time != "start" and case_time != "end":
+            value = _fixed_case_time_value(case_time)
+            valid = (domain.start <= value) & (value <= domain.end_times)
+            if case_indices_arr is not None:
+                valid = valid[case_indices_arr]
+            if not bool(jnp.any(valid)):
+                raise ValueError(
+                    "No trajectory cases are valid at the requested case time."
+                )
+
+        self.constraint_vars = (str(constraint_var),)
+        self.component = component
+        self.structure = structure or ProductStructure((domain.labels,))
+        self.dense_structure = None
+        self.num_points = n
+        self.sampler = "case_uniform"
+        self.over = None
+        self.reduction = reduction_value
+        self.values = _validate_case_values(domain, values)
+        self.case_time = case_time
+        if isinstance(weight, DomainFunction):
+            self.weight = jnp.asarray(1.0, dtype=float)
+            self.pointwise_weight = weight
+        else:
+            self.weight = jnp.asarray(weight, dtype=float)
+            self.pointwise_weight = None
+        self.case_indices = case_indices_arr
+        self.label = None if label is None else str(label)
+        self.data_accuracy_eps = jnp.asarray(float(data_accuracy_eps), dtype=float)
+
+    @property
+    def domain(self) -> TrajectoryDatasetDomain:
+        domain = self.component.domain
+        if not isinstance(domain, TrajectoryDatasetDomain):
+            raise TypeError(
+                "TrajectoryCaseDataConstraint domain is not a trajectory domain."
+            )
+        return domain
+
+    def sample(
+        self,
+        *,
+        key: Key[Array, ""] = DOC_KEY0,
+    ) -> Any:
+        domain = self.domain
+        case_indices = _sample_case_indices(
+            domain,
+            int(self.num_points),
+            key,
+            self.case_time,
+            indices=self.case_indices,
+        )
+        times, time_indices = _time_selection(domain, case_indices, self.case_time)
+        points = domain.points_from_case_time(
+            case_indices,
+            times,
+            structure=self.structure,
+            time_indices=time_indices,
+        )
+        return TrajectoryCaseDataBatch(
+            points=points,
+            target=self.values[case_indices],
+            case_indices=case_indices,
+            times=times,
+        )
+
+    def _prediction(
+        self,
+        functions: Mapping[str, DomainFunction],
+        batch: TrajectoryCaseDataBatch,
+        /,
+        *,
+        key: Key[Array, ""] = DOC_KEY0,
+        **kwargs: Any,
+    ) -> cx.Field:
+        var = self.constraint_vars[0]
+        prediction = functions[var](batch.points, key=key, **kwargs)
+        if not isinstance(prediction, cx.Field):
+            raise TypeError("Expected case data prediction to return a coordax.Field.")
+        return prediction
+
+    def data_metrics(
+        self,
+        functions: Mapping[str, DomainFunction],
+        /,
+        *,
+        key: Key[Array, ""] = DOC_KEY0,
+        batch: TrajectoryCaseDataBatch | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Array]:
+        batch_ = self.sample(key=key) if batch is None else batch
+        prediction = self._prediction(functions, batch_, key=key, **kwargs)
+        return supervised_data_metrics(
+            jnp.asarray(prediction.data, dtype=float),
+            batch_.target,
+            eps=self.data_accuracy_eps,
+        )
+
+    def loss(
+        self,
+        functions: Mapping[str, DomainFunction],
+        /,
+        *,
+        key: Key[Array, ""] = DOC_KEY0,
+        iter_: int | None = None,
+        batch: TrajectoryCaseDataBatch | None = None,
+        **kwargs: Any,
+    ) -> Array:
+        del iter_
+        batch_ = self.sample(key=key) if batch is None else batch
+        prediction = self._prediction(functions, batch_, key=key, **kwargs)
+        per_sample = supervised_per_sample_squared_error(
+            jnp.asarray(prediction.data, dtype=float),
+            batch_.target,
+        )
+
+        if self.pointwise_weight is not None:
+            w = self.pointwise_weight(batch_.points, key=key, **kwargs)
+            if not isinstance(w, cx.Field):
+                raise TypeError("pointwise weight must return a coordax.Field.")
+            w_arr = jnp.asarray(w.data, dtype=float)
+            if w_arr.ndim == 0:
+                per_sample = per_sample * w_arr
+            else:
+                per_sample = per_sample * jnp.squeeze(w_arr).reshape((-1,))
+
+        reduced = reduce_supervised_loss(per_sample, reduction=self.reduction)
+        return self.weight * jnp.asarray(reduced, dtype=float).reshape(())
+
+
+class _NearestTrajectorySignal(StrictModule, BatchAwareCallable, NonTrainableState):
+    domain: TrajectoryDatasetDomain
+    values: Array
+
+    def __init__(self, *, domain: TrajectoryDatasetDomain, values: ArrayLike):
+        self.domain = domain
+        self.values = _validate_values(domain, values)
+
+    def __call__(self, *args: Any, key=None, **kwargs: Any) -> Array:
+        del args, key, kwargs
+        raise TypeError("TrajectorySignal requires PointsBatch evaluation.")
+
+    def __call_batch__(
+        self,
+        batch: PointsBatch | CoordSeparableBatch,
+        /,
+        *,
+        key: Key[Array, ""] = DOC_KEY0,
+        **kwargs: Any,
+    ) -> cx.Field:
+        del key, kwargs
+        if not isinstance(batch, PointsBatch):
+            raise TypeError("TrajectorySignal requires PointsBatch evaluation.")
+        if TRAJECTORY_CASE_INDEX_KEY not in batch:
+            raise ValueError(
+                "TrajectorySignal requires trajectory batches with internal case indices."
+            )
+        case_field = batch[TRAJECTORY_CASE_INDEX_KEY]
+        time_field = batch[self.domain.time_label]
+        if not isinstance(case_field, cx.Field):
+            raise TypeError("Trajectory case indices must be stored as a Field.")
+        if not isinstance(time_field, cx.Field):
+            raise TypeError("Trajectory time values must be stored as a Field.")
+        case_idx = jnp.asarray(case_field.data, dtype=jnp.int32)
+        t = jnp.asarray(time_field.data, dtype=float)
+        tau = jnp.rint((t - self.domain.start) / self.domain.dt).astype(jnp.int32)
+        lengths = self.domain.lengths[case_idx]
+        time_idx = jnp.clip(tau, 0, lengths - 1)
+        values = jax.lax.stop_gradient(self.values)
+        out = values[case_idx, time_idx]
+        dims = time_field.dims + (None,) * max(out.ndim - len(time_field.dims), 0)
+        return cx.Field(out, dims=dims)
+
+
+class _InterpolatedTrajectorySignal(StrictModule, BatchAwareCallable, NonTrainableState):
+    table: _RaggedTimeSeriesTable
+    order: int
+
+    def __init__(self, *, table: _RaggedTimeSeriesTable, order: int = 0):
+        self.table = table
+        self.order = int(order)
+
+    def __call__(self, *args: Any, key=None, **kwargs: Any) -> Array:
+        del args, key, kwargs
+        raise TypeError("TrajectorySignal requires PointsBatch evaluation.")
+
+    def __call_batch__(
+        self,
+        batch: PointsBatch | CoordSeparableBatch,
+        /,
+        *,
+        key: Key[Array, ""] = DOC_KEY0,
+        **kwargs: Any,
+    ) -> cx.Field:
+        del key, kwargs
+        if not isinstance(batch, PointsBatch):
+            raise TypeError("TrajectorySignal requires PointsBatch evaluation.")
+        time_field = batch[self.table.domain.time_label]
+        if not isinstance(time_field, cx.Field):
+            raise TypeError("Trajectory time values must be stored as a Field.")
+        targets, _gates = self.table.evaluate(batch, max_order=self.order)
+        out = targets[self.order]
+        dims = time_field.dims + (None,) * max(out.ndim - len(time_field.dims), 0)
+        return cx.Field(out, dims=dims)
+
+
+def TrajectorySignal(
+    domain: TrajectoryDatasetDomain,
+    values: ArrayLike,
+    /,
+    *,
+    interpolation: TrajectorySignalInterpolation = "linear",
+    time_var: str | None = None,
+    snap_tol: float = 1e-10,
+) -> DomainFunction:
+    """Expose fixed ragged trajectory data as a DomainFunction over `(data, t)`."""
+    if not isinstance(domain, TrajectoryDatasetDomain):
+        raise TypeError("TrajectorySignal requires a TrajectoryDatasetDomain.")
+    var = domain.time_label if time_var is None else str(time_var)
+    if var != domain.time_label:
+        raise ValueError(
+            f"time_var must match the trajectory time label {domain.time_label!r}."
+        )
+
+    interpolation_str = str(interpolation)
+    if interpolation_str not in ("nearest", "linear", "cubic_hermite"):
+        raise ValueError("interpolation must be 'nearest', 'linear', or 'cubic_hermite'.")
+
+    if interpolation_str == "nearest":
+        base = DomainFunction(
+            domain=domain,
+            deps=domain.labels,
+            func=_NearestTrajectorySignal(domain=domain, values=values),
+            metadata={},
+        )
+
+        def _nearest_hook(
+            *,
+            var: str,
+            axis: int | None,
+            order: int,
+            mode,
+            backend,
+            basis,
+            periodic: bool,
+        ) -> DomainFunction | None:
+            del mode, backend, basis, periodic
+            if var != domain.time_label or axis is not None:
+                return None
+            if int(order) == 0:
+                return with_derivative_hook(base, _nearest_hook)
+            raise ValueError(
+                "TrajectorySignal with interpolation='nearest' is not differentiable; "
+                "use interpolation='linear' or 'cubic_hermite' for time derivatives."
+            )
+
+        return with_derivative_hook(base, _nearest_hook)
+
+    interpolation_value: Literal["linear", "cubic_hermite"]
+    if interpolation_str == "linear":
+        interpolation_value = "linear"
+    else:
+        interpolation_value = "cubic_hermite"
+    table = _RaggedTimeSeriesTable(
+        domain=domain,
+        values=values,
+        interpolation=interpolation_value,
+        gate="sin2",
+        snap_tol=float(snap_tol),
+    )
+    base = DomainFunction(
+        domain=domain,
+        deps=domain.labels,
+        func=_InterpolatedTrajectorySignal(table=table, order=0),
+        metadata={},
+    )
+
+    def _make_hook(offset: int, /):
+        def _hook(
+            *,
+            var: str,
+            axis: int | None,
+            order: int,
+            mode,
+            backend,
+            basis,
+            periodic: bool,
+        ) -> DomainFunction | None:
+            del mode, basis, periodic
+            if backend not in ("ad", "jet"):
+                return None
+            if var != domain.time_label:
+                return None
+            if axis is not None:
+                return None
+            n = int(offset) + int(order)
+            limit = table.max_derivative_order()
+            if n > limit:
+                raise ValueError(
+                    f"interpolation={table.interpolation!r} supports trajectory "
+                    f"signal time derivatives only up to order {limit}."
+                )
+            if n == 0:
+                return with_derivative_hook(base, _make_hook(0))
+            out = DomainFunction(
+                domain=domain,
+                deps=domain.labels,
+                func=_InterpolatedTrajectorySignal(table=table, order=n),
+                metadata={},
+            )
+            return with_derivative_hook(out, _make_hook(n))
+
+        return _hook
+
+    return with_derivative_hook(base, _make_hook(0))
+
+
+__all__ = [
+    "TrajectoryCaseDataBatch",
+    "TrajectoryCaseDataConstraint",
+    "TrajectoryCaseTime",
+    "TrajectorySignal",
+    "TrajectorySignalInterpolation",
+]

--- a/phydrax/data_utils/__init__.py
+++ b/phydrax/data_utils/__init__.py
@@ -11,6 +11,7 @@ that return JAX-compatible arrays where possible.
 
 from . import scalers
 from ._csv_reader import CSVReader
+from ._splits import kfold_indices, train_test_split_indices
 from .scalers import (
     AffineScaler,
     MaxAbsScaler,
@@ -24,10 +25,12 @@ from .scalers import (
 __all__ = [
     "AffineScaler",
     "CSVReader",
+    "kfold_indices",
     "MaxAbsScaler",
     "MinMaxScaler",
     "NormScaler",
     "StdScaler",
+    "train_test_split_indices",
     "scalers",
     "scaler_transform_fn",
 ]

--- a/phydrax/data_utils/_splits.py
+++ b/phydrax/data_utils/_splits.py
@@ -1,0 +1,89 @@
+#
+#  Copyright 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+from jaxtyping import Array, Key
+
+from .._doc import DOC_KEY0
+
+
+def _permutation(
+    num_cases: int,
+    /,
+    *,
+    key: Key[Array, ""] = DOC_KEY0,
+    shuffle: bool = True,
+) -> Array:
+    n = int(num_cases)
+    if n <= 0:
+        raise ValueError("num_cases must be positive.")
+    indices = jnp.arange(n, dtype=jnp.int32)
+    if not bool(shuffle):
+        return indices
+    return jr.permutation(key, indices)
+
+
+def train_test_split_indices(
+    num_cases: int,
+    /,
+    *,
+    test_fraction: float = 0.2,
+    key: Key[Array, ""] = DOC_KEY0,
+    shuffle: bool = True,
+) -> tuple[Array, Array]:
+    """Return `(train_indices, test_indices)` for finite empirical cases."""
+    n = int(num_cases)
+    if n < 2:
+        raise ValueError("num_cases must be at least 2 for a train/test split.")
+    fraction = float(test_fraction)
+    if not 0.0 < fraction < 1.0:
+        raise ValueError("test_fraction must be strictly between 0 and 1.")
+
+    perm = _permutation(n, key=key, shuffle=shuffle)
+    n_test = int(round(float(n) * fraction))
+    n_test = min(max(n_test, 1), n - 1)
+    return perm[n_test:], perm[:n_test]
+
+
+def kfold_indices(
+    num_cases: int,
+    num_folds: int,
+    /,
+    *,
+    key: Key[Array, ""] = DOC_KEY0,
+    shuffle: bool = True,
+) -> tuple[tuple[Array, Array], ...]:
+    """Return `(train_indices, validation_indices)` pairs for K-fold splits."""
+    n = int(num_cases)
+    k = int(num_folds)
+    if n < 2:
+        raise ValueError("num_cases must be at least 2 for K-fold splits.")
+    if k < 2:
+        raise ValueError("num_folds must be at least 2.")
+    if k > n:
+        raise ValueError("num_folds cannot exceed num_cases.")
+
+    perm = _permutation(n, key=key, shuffle=shuffle)
+    base = n // k
+    remainder = n % k
+    folds: list[tuple[Array, Array]] = []
+    offset = 0
+    for fold in range(k):
+        size = base + (1 if fold < remainder else 0)
+        start = offset
+        stop = offset + size
+        validation = perm[start:stop]
+        train = jnp.concatenate((perm[:start], perm[stop:]), axis=0)
+        folds.append((train, validation))
+        offset = stop
+    return tuple(folds)
+
+
+__all__ = [
+    "kfold_indices",
+    "train_test_split_indices",
+]

--- a/phydrax/domain/__init__.py
+++ b/phydrax/domain/__init__.py
@@ -14,6 +14,7 @@ explicit coordinate labels.
 - Scalar domains like `Interval1d`, `ScalarInterval`, and `TimeInterval`.
 - Geometry in 2D and 3D (`Square`, `Sphere`, `Geometry2DFromCAD`, etc.).
 - Product domains via the `@` operator, e.g. $\\Omega = \\Omega_x \\times \\Omega_t$.
+- Dataset domains for operator learning and ragged row-indexed trajectories.
 - `DomainFunction` wrappers that carry domain metadata.
 
 ## Structured sampling
@@ -75,6 +76,9 @@ from ._structure import (
     QuadratureBatch,
 )
 from ._time import TimeInterval
+from ._trajectory_dataset import (
+    TrajectoryDatasetDomain,
+)
 
 # Re-export geometry submodule objects (unary domains)
 from .geometry1d import Interval1d  # noqa: F401
@@ -117,6 +121,7 @@ __all__ = [
     "DomainFunction",
     "structured",
     "DatasetDomain",
+    "TrajectoryDatasetDomain",
     "HyperRectangle",
     "ProductStructure",
     "PointsBatch",

--- a/phydrax/domain/_components.py
+++ b/phydrax/domain/_components.py
@@ -323,6 +323,12 @@ class DomainComponent(StrictModule):
         For scalar boundaries $\{a,b\}$ this uses counting measure (mass $2$), and for
         fixed slices uses unit mass.
         """
+        from ._trajectory_dataset import trajectory_component_measure
+
+        custom = trajectory_component_measure(self)
+        if custom is not None:
+            return custom
+
         m = jnp.array(1.0, dtype=float)
         for lbl in self.domain.labels:
             comp = self.spec.component_for(lbl)
@@ -376,6 +382,20 @@ class DomainComponent(StrictModule):
         sampler: str = "latin_hypercube",
         key: Key[Array, ""] = DOC_KEY0,
     ) -> PointsBatch:
+        from ._trajectory_dataset import (
+            sample_trajectory_component,
+            TrajectoryDatasetDomain,
+        )
+
+        if isinstance(self.domain, TrajectoryDatasetDomain):
+            return sample_trajectory_component(
+                self,
+                num_points,
+                structure=structure,
+                sampler=sampler,
+                key=key,
+            )
+
         fixed_labels = frozenset(
             lbl
             for lbl in self.domain.labels
@@ -508,6 +528,14 @@ class DomainComponent(StrictModule):
         This is useful when an operator factorizes across coordinate axes, or when a
         Cartesian grid is desired for quadrature-like reductions.
         """
+        from ._trajectory_dataset import TrajectoryDatasetDomain
+
+        if isinstance(self.domain, TrajectoryDatasetDomain):
+            raise ValueError(
+                "TrajectoryDatasetDomain requires paired data-time sampling; "
+                "coord-separable trajectory sampling is not supported."
+            )
+
         coord_labels = tuple(lbl for lbl in self.domain.labels if lbl in coord_separable)
         for lbl in coord_labels:
             if lbl not in self.domain.labels:

--- a/phydrax/domain/_dataset.py
+++ b/phydrax/domain/_dataset.py
@@ -6,13 +6,19 @@ from __future__ import annotations
 
 from typing import Literal
 
+import coordax as cx
 import jax
 import jax.numpy as jnp
 import jax.random as jr
 from jaxtyping import Array, ArrayLike, Key, PyTree
 
 from .._doc import DOC_KEY0
+from .._frozendict import frozendict
 from ._domain import _AbstractUnaryDomain
+from ._structure import PointsBatch, ProductStructure
+
+
+DATASET_INDEX_KEY = "__phydrax_dataset_index__"
 
 
 class DatasetDomain(_AbstractUnaryDomain):
@@ -92,15 +98,66 @@ class DatasetDomain(_AbstractUnaryDomain):
         sampler: str = "uniform",
         key: Key[Array, ""] = DOC_KEY0,
     ) -> PyTree[Array]:
+        idx = self.sample_indices(num_points, sampler=sampler, key=key)
+        return self.input_rows(idx)
+
+    def sample_indices(
+        self,
+        num_points: int,
+        *,
+        sampler: str = "uniform",
+        key: Key[Array, ""] = DOC_KEY0,
+    ) -> Array:
         del sampler
         n = int(num_points)
         if n < 0:
             raise ValueError("num_points must be non-negative.")
         if n == 0:
-            return jax.tree_util.tree_map(lambda a: jnp.asarray(a)[:0], self.data)
+            return jnp.zeros((0,), dtype=jnp.int32)
 
-        idx = jr.randint(key, shape=(n,), minval=0, maxval=int(self._size))
+        return jr.randint(
+            key,
+            shape=(n,),
+            minval=0,
+            maxval=int(self._size),
+            dtype=jnp.int32,
+        )
+
+    def input_rows(self, indices: ArrayLike, /) -> PyTree[Array]:
+        idx = jnp.asarray(indices, dtype=jnp.int32)
         return jax.tree_util.tree_map(lambda a: jnp.asarray(a)[idx], self.data)
+
+    def points_from_indices(
+        self,
+        indices: ArrayLike,
+        /,
+        *,
+        structure: ProductStructure | None = None,
+    ) -> PointsBatch:
+        structure_in = structure or ProductStructure(((self.label,),))
+        structure_out = structure_in.canonicalize(self.labels)
+        axis = structure_out.axis_for(self.label)
+        if axis is None:
+            raise ValueError(
+                f"DatasetDomain points require a sampling axis for label {self.label!r}."
+            )
+
+        idx = jnp.asarray(indices, dtype=jnp.int32).reshape((-1,))
+        rows = self.input_rows(idx)
+
+        def _to_field(v: ArrayLike):
+            arr = jnp.asarray(v)
+            if arr.ndim == 0:
+                raise ValueError(
+                    "DatasetDomain indexed rows must retain a leading sample axis."
+                )
+            return cx.Field(arr, dims=(axis,) + (None,) * (arr.ndim - 1))
+
+        points = {
+            self.label: jax.tree_util.tree_map(_to_field, rows),
+            DATASET_INDEX_KEY: cx.Field(idx, dims=(axis,)),
+        }
+        return PointsBatch(points=frozendict(points), structure=structure_out)
 
     def equivalent(self, other: object, /) -> bool:
         if not isinstance(other, DatasetDomain):
@@ -128,4 +185,4 @@ class DatasetDomain(_AbstractUnaryDomain):
         return True
 
 
-__all__ = ["DatasetDomain"]
+__all__ = ["DATASET_INDEX_KEY", "DatasetDomain"]

--- a/phydrax/domain/_domain.py
+++ b/phydrax/domain/_domain.py
@@ -5,7 +5,7 @@
 import abc
 import inspect
 from collections.abc import Callable, Mapping
-from typing import Any, TYPE_CHECKING
+from typing import Any, Literal, TYPE_CHECKING
 
 import jax.numpy as jnp
 
@@ -186,9 +186,29 @@ class _AbstractDomain(StrictModule):
 
         return decorator
 
-    def Model(self, *deps: str, structured: bool = False):
+    def Model(
+        self,
+        *deps: str,
+        structured: bool = False,
+        input_mode: Literal["flat", "structured"] | None = None,
+    ):
+        """Wrap a neural model as a `DomainFunction`.
+
+        By default each model chooses its own domain input mode. Dense and separable
+        pointwise models use flat concatenation, while operator models may request
+        structured tuple inputs. `structured=True` is a compatibility alias for
+        `input_mode="structured"`.
+        """
         from ._function import DomainFunction
         from ._model_function import _ConcatenatedModelCallable, StructuredCallable
+
+        if structured and input_mode is not None:
+            raise ValueError("Use either structured=True or input_mode=..., not both.")
+        mode: Literal["flat", "structured"] | None = input_mode
+        if structured:
+            mode = "structured"
+        if mode is not None and mode not in ("flat", "structured"):
+            raise ValueError("input_mode must be either 'flat' or 'structured'.")
 
         deps_ = self.labels if not deps else deps
         for dep in deps_:
@@ -203,7 +223,7 @@ class _AbstractDomain(StrictModule):
             return DomainFunction(
                 domain=self,
                 deps=deps_,
-                func=_ConcatenatedModelCallable(model),
+                func=_ConcatenatedModelCallable(model, input_mode=mode),
             )
 
         return decorator
@@ -215,7 +235,7 @@ class _AbstractDomain(StrictModule):
         transform: Callable[[Any], Any] | None = None,
         metadata: Mapping[str, Any] | None = None,
     ):
-        from ._function import _ConstCallable, _UnaryCallable, DomainFunction
+        from ._function import _TrainableConstCallable, _UnaryCallable, DomainFunction
 
         if init is None:
             raise TypeError("Domain.Parameter requires init to be array-like, not None.")
@@ -225,7 +245,12 @@ class _AbstractDomain(StrictModule):
             raw = raw.astype(float)
 
         if transform is None:
-            return DomainFunction(domain=self, deps=(), func=raw, metadata=metadata)
+            return DomainFunction(
+                domain=self,
+                deps=(),
+                func=_TrainableConstCallable(raw),
+                metadata=metadata,
+            )
 
         if not callable(transform):
             raise TypeError("Domain.Parameter transform must be a callable or None.")
@@ -233,7 +258,7 @@ class _AbstractDomain(StrictModule):
         return DomainFunction(
             domain=self,
             deps=(),
-            func=_UnaryCallable(_ConstCallable(raw), transform),
+            func=_UnaryCallable(_TrainableConstCallable(raw), transform),
             metadata=metadata,
         )
 

--- a/phydrax/domain/_function.py
+++ b/phydrax/domain/_function.py
@@ -12,12 +12,40 @@ import jax
 import jax.numpy as jnp
 from jaxtyping import Array, ArrayLike, Key, PyTree
 
-from .._callable import _ensure_special_kwonly_args
+from .._callable import _ensure_special_kwonly_args, _KeyIterAdapter
 from .._doc import DOC_KEY0
 from .._frozendict import frozendict
 from .._strict import StrictModule
+from .._trainable import NonTrainableState
 from ._domain import _AbstractDomain
 from ._structure import CoordSeparableBatch, Points, PointsBatch
+
+
+class BatchAwareCallable:
+    """Marker for callables that need the structured batch object during evaluation."""
+
+    def use_batch_call(self) -> bool:
+        return True
+
+    def __call_batch__(
+        self,
+        batch: PointsBatch | CoordSeparableBatch,
+        /,
+        *,
+        key: Key[Array, ""] = DOC_KEY0,
+        **kwargs: Any,
+    ) -> cx.Field:
+        raise NotImplementedError
+
+
+def batch_aware_callable(func: Callable, /) -> BatchAwareCallable | None:
+    """Return the batch-aware callable inside Phydrax's keyword adapter, if present."""
+    inner = func
+    while isinstance(inner, _KeyIterAdapter):
+        inner = inner.func
+    if isinstance(inner, BatchAwareCallable) and inner.use_batch_call():
+        return inner
+    return None
 
 
 def _first_field_leaf(tree: PyTree[Any]) -> cx.Field:
@@ -133,12 +161,25 @@ def _rank1_leading_broadcast_op(
     return op(left, right)
 
 
-class _ConstCallable(StrictModule):
+class _ConstCallable(StrictModule, NonTrainableState):
     value: jax.Array
 
     def __init__(self, value: ArrayLike | None):
         if value is None:
             raise TypeError("DomainFunction constants must be array-like, not None.")
+        self.value = jnp.asarray(value)
+
+    def __call__(self, *args, key=None, **kwargs):
+        del args, key, kwargs
+        return self.value
+
+
+class _TrainableConstCallable(StrictModule):
+    value: jax.Array
+
+    def __init__(self, value: ArrayLike | None):
+        if value is None:
+            raise TypeError("Domain.Parameter constants must be array-like, not None.")
         self.value = jnp.asarray(value)
 
     def __call__(self, *args, key=None, **kwargs):
@@ -172,7 +213,7 @@ class _SwapAxesCallable(StrictModule):
         return jnp.swapaxes(self.func(*args, key=key, **kwargs), self.axis1, self.axis2)
 
 
-class _BinaryCallable(StrictModule):
+class _BinaryCallable(StrictModule, BatchAwareCallable):
     a: "DomainFunction"
     b: "DomainFunction"
     op: Callable[[Any, Any], Any]
@@ -196,6 +237,28 @@ class _BinaryCallable(StrictModule):
         self.a_pos = tuple(int(i) for i in a_pos)
         self.b_pos = tuple(int(i) for i in b_pos)
         self.reverse = bool(reverse)
+
+    def use_batch_call(self) -> bool:
+        return (batch_aware_callable(self.a.func) is not None) or (
+            batch_aware_callable(self.b.func) is not None
+        )
+
+    def __call_batch__(
+        self,
+        batch: PointsBatch | CoordSeparableBatch,
+        /,
+        *,
+        key: Key[Array, ""] = DOC_KEY0,
+        **kwargs: Any,
+    ) -> cx.Field:
+        left_fn = self.b if self.reverse else self.a
+        right_fn = self.a if self.reverse else self.b
+        left = left_fn(batch, key=key, **kwargs)
+        right = right_fn(batch, key=key, **kwargs)
+        out = self.op(left, right)
+        if not isinstance(out, cx.Field):
+            raise TypeError("Batch-aware binary DomainFunction must return a Field.")
+        return out
 
     def __call__(self, *args, key=None, **kwargs):
         a_args = [args[i] for i in self.a_pos]
@@ -681,7 +744,11 @@ class DomainFunction(StrictModule):
                     axis_order.append(axis)
 
             axis_order = list(_dedupe_axes(axis_order))
-            y = jnp.asarray(self.func(*args, key=key, **kwargs))
+            call_kwargs = kwargs
+            if any(isinstance(arg, tuple) for arg in args):
+                call_kwargs = dict(kwargs)
+                call_kwargs["_phydrax_model_input_mode"] = "structured"
+            y = jnp.asarray(self.func(*args, key=key, **call_kwargs))
             if y.ndim < len(axis_order):
                 return (
                     None,
@@ -705,6 +772,18 @@ class DomainFunction(StrictModule):
                 points_map = points
                 dense_structure = None
                 coord_axes_by_label = None
+
+        batch_func = batch_aware_callable(self.func)
+        if batch_func is not None:
+            if not isinstance(points, (PointsBatch, CoordSeparableBatch)):
+                raise TypeError(
+                    "Batch-aware DomainFunction evaluation requires a PointsBatch "
+                    "or CoordSeparableBatch input."
+                )
+            out = batch_func.__call_batch__(points, key=key, **kwargs)
+            if not isinstance(out, cx.Field):
+                raise TypeError("Batch-aware DomainFunction must return a coordax.Field.")
+            return out
 
         for lbl in self.domain.labels:
             if lbl not in points_map:

--- a/phydrax/domain/_model_function.py
+++ b/phydrax/domain/_model_function.py
@@ -12,7 +12,7 @@ import jax.numpy as jnp
 
 from .._callable import _ensure_special_kwonly_args
 from .._strict import StrictModule
-from ..nn.models.core._base import _AbstractBaseModel
+from ..nn.models.core._base import _AbstractBaseModel, DomainInputMode
 
 
 class StructuredCallable(StrictModule):
@@ -35,19 +35,39 @@ def structured(func: Callable, /) -> StructuredCallable:
 class _ConcatenatedModelCallable(StrictModule):
     raw_model: Any
     model: Callable
+    input_mode: DomainInputMode
     supports_structured_input: bool
     supports_blockwise_input: bool
     warn_on_auto_fallback: bool
 
-    def __init__(self, model: Callable, /):
+    def __init__(
+        self,
+        model: Callable,
+        /,
+        *,
+        input_mode: DomainInputMode | None = None,
+    ):
         self.raw_model = model
         supports_structured_input = isinstance(model, StructuredCallable)
         supports_blockwise_input = False
         warn_on_auto_fallback = False
-        if isinstance(model, _AbstractBaseModel) and model.supports_structured_input():
-            supports_structured_input = True
+        inferred_mode: DomainInputMode = (
+            "structured" if supports_structured_input else "flat"
+        )
+        if isinstance(model, _AbstractBaseModel):
+            inferred_mode = model.domain_input_mode()
+            supports_structured_input = model.supports_structured_input()
             supports_blockwise_input = model.supports_blockwise_input()
             warn_on_auto_fallback = model.warn_on_auto_fallback()
+        mode = inferred_mode if input_mode is None else input_mode
+        if mode not in ("flat", "structured"):
+            raise ValueError("input_mode must be either 'flat' or 'structured'.")
+        if mode == "structured" and not supports_structured_input:
+            raise ValueError(
+                "input_mode='structured' requires a model that supports structured inputs. "
+                "Use structured=True for plain callables that intentionally accept tuple inputs."
+            )
+        self.input_mode = mode
         self.supports_structured_input = bool(supports_structured_input)
         self.supports_blockwise_input = bool(supports_blockwise_input)
         self.warn_on_auto_fallback = bool(warn_on_auto_fallback)
@@ -61,7 +81,18 @@ class _ConcatenatedModelCallable(StrictModule):
         if not args:
             raise ValueError("Model callable requires at least one positional input.")
 
-        if self.supports_structured_input:
+        input_mode = kwargs.pop("_phydrax_model_input_mode", self.input_mode)
+        if input_mode not in ("flat", "structured"):
+            raise ValueError(
+                "_phydrax_model_input_mode must be either 'flat' or 'structured'."
+            )
+        if input_mode == "structured" and not self.supports_structured_input:
+            raise ValueError(
+                "Structured model input was requested, but this model does not "
+                "support structured inputs."
+            )
+
+        if input_mode == "structured":
 
             def _as_array_or_tuple(value: Any):
                 if isinstance(value, tuple):
@@ -80,19 +111,51 @@ class _ConcatenatedModelCallable(StrictModule):
                 x_in = tuple(packed)
             return self.model(x_in, key=key, iter_=iter_, **kwargs)
 
-        for a in args:
-            if isinstance(a, tuple):
+        arrays: list[Any] = []
+        for value in args:
+            if isinstance(value, tuple):
                 raise ValueError(
                     "Model callable does not support structured inputs; got a tuple argument. "
                     "Use a model that supports_structured_input() or explicitly materialize the grid."
                 )
-            arr = jnp.asarray(a)
-            if arr.ndim > 1:
+            arrays.append(jnp.asarray(value))
+
+        if len(arrays) == 1:
+            x_in = arrays[0]
+            return self.model(x_in, key=key, iter_=iter_, **kwargs)
+
+        leading_shape: tuple[int, ...] | None = None
+        for arr in arrays:
+            if arr.ndim < 2:
+                continue
+            candidate = tuple(int(i) for i in arr.shape[:-1])
+            if leading_shape is None:
+                leading_shape = candidate
+                continue
+            if candidate != leading_shape:
                 raise ValueError(
-                    "Model callable does not support batched/structured inputs; got input with shape "
-                    f"{arr.shape}. Use a model that supports_structured_input() or explicitly materialize the grid."
+                    "Flat model packing requires batched inputs to share leading "
+                    f"shape; got {candidate} and {leading_shape}."
                 )
 
-        parts = [jnp.asarray(x).reshape((-1,)) for x in args]
-        x_in = parts[0] if len(parts) == 1 else jnp.concatenate(parts, axis=0)
+        if leading_shape is None:
+            parts = [arr.reshape((-1,)) for arr in arrays]
+            x_in = jnp.concatenate(parts, axis=0)
+            return self.model(x_in, key=key, iter_=iter_, **kwargs)
+
+        parts = []
+        for arr in arrays:
+            if arr.ndim == 0:
+                part = jnp.broadcast_to(arr, leading_shape + (1,))
+            elif tuple(int(i) for i in arr.shape) == leading_shape:
+                part = arr.reshape(leading_shape + (1,))
+            elif tuple(int(i) for i in arr.shape[:-1]) == leading_shape:
+                part = arr.reshape(leading_shape + (int(arr.shape[-1]),))
+            else:
+                raise ValueError(
+                    "Flat model packing could not align input with shape "
+                    f"{arr.shape} to leading batch shape {leading_shape}."
+                )
+            parts.append(part)
+        x_in = jnp.concatenate(parts, axis=-1)
         return self.model(x_in, key=key, iter_=iter_, **kwargs)

--- a/phydrax/domain/_trajectory_dataset.py
+++ b/phydrax/domain/_trajectory_dataset.py
@@ -1,0 +1,613 @@
+#
+#  Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Literal
+
+import coordax as cx
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+from jaxtyping import Array, ArrayLike, Key, PyTree
+
+from .._doc import DOC_KEY0
+from .._frozendict import frozendict
+from ._components import (
+    Boundary,
+    Fixed,
+    FixedEnd,
+    FixedStart,
+    Interior,
+)
+from ._dataset import DatasetDomain
+from ._domain import _AbstractDomain, _AbstractUnaryDomain
+from ._scalar import ScalarInterval
+from ._structure import _validate_label, NumPoints, PointsBatch, ProductStructure
+
+
+TrajectoryMeasure = Literal[
+    "case_time_probability",
+    "time_integral_average",
+    "time_integral_sum",
+]
+TrajectorySampling = Literal["case_time_uniform", "observation_uniform"]
+
+TRAJECTORY_CASE_INDEX_KEY = "__phydrax_trajectory_case_index"
+TRAJECTORY_TIME_INDEX_KEY = "__phydrax_trajectory_time_index"
+
+
+def _tree_leading_axis_size(tree: PyTree[ArrayLike], /) -> int:
+    leaves = jax.tree_util.tree_leaves(tree)
+    if not leaves:
+        raise ValueError("TrajectoryDatasetDomain requires at least one input leaf.")
+
+    first = jnp.asarray(leaves[0])
+    if first.ndim == 0:
+        raise ValueError("Trajectory input leaves must have a leading dataset axis.")
+    n = int(first.shape[0])
+    if n <= 0:
+        raise ValueError("Trajectory input leading axis must be non-empty.")
+
+    for leaf in leaves:
+        arr = jnp.asarray(leaf)
+        if arr.ndim == 0:
+            raise ValueError("Trajectory input leaves must have a leading dataset axis.")
+        if int(arr.shape[0]) != n:
+            raise ValueError(
+                "TrajectoryDatasetDomain requires all input leaves to share the same "
+                f"leading axis; got {int(arr.shape[0])} and {n}."
+            )
+    return n
+
+
+def _as_lengths(lengths: ArrayLike, n: int, /) -> Array:
+    arr = jnp.asarray(lengths)
+    if arr.ndim != 1:
+        raise ValueError(f"lengths must have shape (N,), got {arr.shape}.")
+    if int(arr.shape[0]) != n:
+        raise ValueError(f"lengths must have length {n}, got {int(arr.shape[0])}.")
+    arr_i = arr.astype(jnp.int32)
+    if bool(jnp.any(arr_i <= 0)):
+        raise ValueError("All trajectory lengths must be positive.")
+    if bool(jnp.any(arr_i != arr)):
+        raise ValueError("Trajectory lengths must be integer-valued.")
+    return arr_i
+
+
+def _as_scalar(name: str, value: ArrayLike, /) -> Array:
+    arr = jnp.asarray(value, dtype=float)
+    if arr.shape != ():
+        raise ValueError(f"{name} must be scalar, got shape {arr.shape}.")
+    return arr.reshape(())
+
+
+def _as_sample_count(num_points: NumPoints, /) -> int:
+    if isinstance(num_points, int):
+        n = int(num_points)
+    else:
+        if len(num_points) != 1:
+            raise ValueError(
+                "TrajectoryDatasetDomain requires paired sampling with one sample count."
+            )
+        n = int(num_points[0])
+    if n < 0:
+        raise ValueError("num_points must be non-negative.")
+    return n
+
+
+def _single_axis_for_trajectory(
+    domain: "TrajectoryDatasetDomain",
+    structure: ProductStructure,
+    /,
+) -> tuple[ProductStructure, str]:
+    structure = structure.canonicalize(domain.labels, fixed_labels=frozenset())
+    if len(structure.blocks) != 1:
+        raise ValueError(
+            "TrajectoryDatasetDomain sampling requires the data and time labels to be "
+            "sampled in one paired block."
+        )
+    block = frozenset(structure.blocks[0])
+    if block != frozenset(domain.labels):
+        raise ValueError(
+            "TrajectoryDatasetDomain sampling requires a paired block containing "
+            f"{domain.labels}."
+        )
+    axis_names = structure.axis_names
+    if axis_names is None:
+        raise ValueError("Trajectory ProductStructure must be canonicalized.")
+    return structure, axis_names[0]
+
+
+class TrajectoryDatasetDomain(_AbstractDomain):
+    """A coupled finite-function and time domain for ragged trajectory data.
+
+    Each dataset row represents one input/function/parameterization. The same row also
+    owns a valid time interval sampled at constant spacing `dt`, with per-row length
+    supplied by `lengths`.
+
+    The domain exposes two labels, by default `("data", "t")`, but samples them as a
+    coupled pair. This is the right domain for models `u(data, t)` when each dataset
+    element has its own trajectory horizon.
+    """
+
+    inputs: PyTree[Array]
+    lengths: Array
+    dt: Array
+    start: Array
+    _data_label: str
+    _time_label: str
+    _measure: TrajectoryMeasure
+    _sampling: TrajectorySampling
+    _data_factor: DatasetDomain
+    _time_factor: ScalarInterval
+    _max_length: int
+    _total_observations: int
+    _flat_case_indices: Array
+    _flat_time_indices: Array
+
+    def __init__(
+        self,
+        inputs: PyTree[ArrayLike],
+        lengths: ArrayLike,
+        /,
+        *,
+        dt: ArrayLike,
+        start: ArrayLike = 0.0,
+        data_label: str = "data",
+        time_label: str = "t",
+        measure: TrajectoryMeasure = "case_time_probability",
+        sampling: TrajectorySampling = "case_time_uniform",
+    ):
+        _validate_label(str(data_label))
+        _validate_label(str(time_label))
+        if str(data_label) == str(time_label):
+            raise ValueError("data_label and time_label must be distinct.")
+
+        arrays = jax.tree_util.tree_map(lambda x: jnp.asarray(x), inputs)
+        n = _tree_leading_axis_size(arrays)
+        lengths_arr = _as_lengths(lengths, n)
+        dt_arr = _as_scalar("dt", dt)
+        if bool(dt_arr <= 0):
+            raise ValueError("dt must be positive.")
+        start_arr = _as_scalar("start", start)
+
+        measure_str = str(measure)
+        if measure_str not in (
+            "case_time_probability",
+            "time_integral_average",
+            "time_integral_sum",
+        ):
+            raise ValueError(
+                "measure must be one of 'case_time_probability', "
+                "'time_integral_average', or 'time_integral_sum'."
+            )
+        measure_value: TrajectoryMeasure
+        if measure_str == "case_time_probability":
+            measure_value = "case_time_probability"
+        elif measure_str == "time_integral_average":
+            measure_value = "time_integral_average"
+        else:
+            measure_value = "time_integral_sum"
+
+        sampling_str = str(sampling)
+        if sampling_str not in ("case_time_uniform", "observation_uniform"):
+            raise ValueError(
+                "sampling must be either 'case_time_uniform' or 'observation_uniform'."
+            )
+        sampling_value: TrajectorySampling
+        if sampling_str == "case_time_uniform":
+            sampling_value = "case_time_uniform"
+        else:
+            sampling_value = "observation_uniform"
+
+        max_length = int(jnp.max(lengths_arr))
+        total_observations = int(jnp.sum(lengths_arr))
+        flat_case_parts: list[Array] = []
+        flat_time_parts: list[Array] = []
+        for i, length in enumerate(list(map(int, lengths_arr.tolist()))):
+            flat_case_parts.append(jnp.full((length,), i, dtype=jnp.int32))
+            flat_time_parts.append(jnp.arange(length, dtype=jnp.int32))
+        # ScalarInterval requires a non-degenerate interval. Single-sample trajectories
+        # still expose a tiny support interval for metadata; actual samples stay at start.
+        support_steps = max(max_length - 1, 1)
+        end = start_arr + dt_arr * float(support_steps)
+
+        self.inputs = arrays
+        self.lengths = lengths_arr
+        self.dt = dt_arr
+        self.start = start_arr
+        self._data_label = str(data_label)
+        self._time_label = str(time_label)
+        self._measure = measure_value
+        self._sampling = sampling_value
+        self._data_factor = DatasetDomain(
+            arrays, label=str(data_label), measure="probability"
+        )
+        self._time_factor = ScalarInterval(
+            float(start_arr), float(end), label=str(time_label)
+        )
+        self._max_length = max_length
+        self._total_observations = total_observations
+        self._flat_case_indices = jnp.concatenate(flat_case_parts, axis=0)
+        self._flat_time_indices = jnp.concatenate(flat_time_parts, axis=0)
+
+    @property
+    def labels(self) -> tuple[str, ...]:
+        return (self._data_label, self._time_label)
+
+    @property
+    def data_label(self) -> str:
+        return self._data_label
+
+    @property
+    def time_label(self) -> str:
+        return self._time_label
+
+    @property
+    def measure_mode(self) -> TrajectoryMeasure:
+        return self._measure
+
+    @property
+    def sampling_mode(self) -> TrajectorySampling:
+        return self._sampling
+
+    @property
+    def size(self) -> int:
+        return int(self.lengths.shape[0])
+
+    @property
+    def max_length(self) -> int:
+        return int(self._max_length)
+
+    @property
+    def total_observations(self) -> int:
+        return int(self._total_observations)
+
+    @property
+    def flat_case_indices(self) -> Array:
+        return self._flat_case_indices
+
+    @property
+    def flat_time_indices(self) -> Array:
+        return self._flat_time_indices
+
+    @property
+    def durations(self) -> Array:
+        return (self.lengths.astype(float) - 1.0) * self.dt
+
+    @property
+    def end_times(self) -> Array:
+        return self.start + self.durations
+
+    def factor(self, label: str, /) -> _AbstractUnaryDomain:
+        if label == self._data_label:
+            return self._data_factor
+        if label == self._time_label:
+            return self._time_factor
+        raise KeyError(f"Label {label!r} not in domain {self.labels}.")
+
+    def equivalent(self, other: object, /) -> bool:
+        if not isinstance(other, TrajectoryDatasetDomain):
+            return False
+        if self.labels != other.labels:
+            return False
+        if self.measure_mode != other.measure_mode:
+            return False
+        if self.sampling_mode != other.sampling_mode:
+            return False
+        if self.max_length != other.max_length:
+            return False
+        if self.size != other.size:
+            return False
+        if bool(jnp.any(self.lengths != other.lengths)):
+            return False
+        if bool(jnp.any(self.dt != other.dt)):
+            return False
+        if bool(jnp.any(self.start != other.start)):
+            return False
+        if self.inputs_tree_structure() != other.inputs_tree_structure():
+            return False
+        leaves_a = jax.tree_util.tree_leaves(self.inputs)
+        leaves_b = jax.tree_util.tree_leaves(other.inputs)
+        for a, b in zip(leaves_a, leaves_b, strict=True):
+            arr_a = jnp.asarray(a)
+            arr_b = jnp.asarray(b)
+            if arr_a.shape != arr_b.shape:
+                return False
+            if arr_a.dtype != arr_b.dtype:
+                return False
+        return True
+
+    def inputs_tree_structure(self) -> Any:
+        return jax.tree_util.tree_structure(self.inputs)
+
+    def input_rows(self, case_indices: ArrayLike, /) -> PyTree[Array]:
+        idx = jnp.asarray(case_indices, dtype=jnp.int32)
+        return jax.tree_util.tree_map(lambda a: jnp.asarray(a)[idx], self.inputs)
+
+    def observation_times(
+        self, case_indices: ArrayLike, time_indices: ArrayLike, /
+    ) -> Array:
+        del case_indices
+        return self.start + self.dt * jnp.asarray(time_indices, dtype=float)
+
+    def points_from_case_time(
+        self,
+        case_indices: ArrayLike,
+        times: ArrayLike,
+        /,
+        *,
+        structure: ProductStructure | None = None,
+        time_indices: ArrayLike | None = None,
+    ) -> PointsBatch:
+        structure_in = structure or ProductStructure((self.labels,))
+        structure_, axis = _single_axis_for_trajectory(self, structure_in)
+        case_idx = jnp.asarray(case_indices, dtype=jnp.int32).reshape((-1,))
+        time_arr = jnp.asarray(times, dtype=float).reshape((-1,))
+        if int(case_idx.shape[0]) != int(time_arr.shape[0]):
+            raise ValueError("case_indices and times must have the same length.")
+        if time_indices is None:
+            time_idx = jnp.rint((time_arr - self.start) / self.dt).astype(jnp.int32)
+        else:
+            time_idx = jnp.asarray(time_indices, dtype=jnp.int32).reshape((-1,))
+            if int(time_idx.shape[0]) != int(case_idx.shape[0]):
+                raise ValueError(
+                    "time_indices must have the same length as case_indices."
+                )
+
+        data_samples = self.input_rows(case_idx)
+
+        def _to_field(v: ArrayLike):
+            arr = jnp.asarray(v)
+            if arr.ndim == 0:
+                raise ValueError(
+                    "Trajectory input rows must retain a leading sample axis."
+                )
+            return cx.Field(arr, dims=(axis,) + (None,) * (arr.ndim - 1))
+
+        points: dict[str, Any] = {
+            self._data_label: jax.tree_util.tree_map(_to_field, data_samples),
+            self._time_label: cx.Field(time_arr, dims=(axis,)),
+            TRAJECTORY_CASE_INDEX_KEY: cx.Field(case_idx, dims=(axis,)),
+            TRAJECTORY_TIME_INDEX_KEY: cx.Field(time_idx, dims=(axis,)),
+        }
+        return PointsBatch(points=frozendict(points), structure=structure_)
+
+
+def _flat_observation_indices(domain: TrajectoryDatasetDomain, /) -> tuple[Array, Array]:
+    return domain.flat_case_indices, domain.flat_time_indices
+
+
+def _sample_cases_uniform(
+    domain: TrajectoryDatasetDomain, n: int, key: Key[Array, ""], /
+) -> Array:
+    return jr.randint(key, shape=(n,), minval=0, maxval=domain.size, dtype=jnp.int32)
+
+
+def _sample_valid_cases(
+    valid: Array,
+    n: int,
+    key: Key[Array, ""],
+    /,
+) -> Array:
+    valid_f = jnp.asarray(valid, dtype=float)
+    valid_count = jnp.sum(valid_f)
+    checked_count = eqx.error_if(
+        valid_count,
+        valid_count <= 0,
+        "No trajectories are valid for this fixed time component.",
+    )
+    probs = valid_f / checked_count
+    return jr.choice(key, int(valid.shape[0]), shape=(n,), p=probs).astype(jnp.int32)
+
+
+def _component_times(
+    domain: TrajectoryDatasetDomain,
+    component,
+    case_indices: Array,
+    n: int,
+    key: Key[Array, ""],
+    /,
+) -> tuple[Array, Array]:
+    comp = component.spec.component_for(domain.time_label)
+    lengths = domain.lengths[case_indices]
+    durations = (lengths.astype(float) - 1.0) * domain.dt
+
+    if isinstance(comp, Interior):
+        if domain.sampling_mode == "observation_uniform":
+            flat_cases, flat_times = _flat_observation_indices(domain)
+            obs_idx = jr.randint(
+                key,
+                shape=(n,),
+                minval=0,
+                maxval=domain.total_observations,
+                dtype=jnp.int32,
+            )
+            time_idx = flat_times[obs_idx]
+            return domain.observation_times(flat_cases[obs_idx], time_idx), time_idx
+        u = jr.uniform(key, shape=(n,))
+        times = domain.start + u * durations
+        time_idx = jnp.rint((times - domain.start) / domain.dt).astype(jnp.int32)
+        time_idx = jnp.clip(time_idx, 0, lengths - 1)
+        return times, time_idx
+
+    if isinstance(comp, FixedStart):
+        return jnp.full((n,), domain.start, dtype=float), jnp.zeros((n,), dtype=jnp.int32)
+
+    if isinstance(comp, FixedEnd):
+        time_idx = lengths - 1
+        return domain.end_times[case_indices], time_idx
+
+    if isinstance(comp, Fixed):
+        value = jnp.asarray(comp.value, dtype=float).reshape(())
+        time_idx = jnp.rint((value - domain.start) / domain.dt).astype(jnp.int32)
+        return (
+            jnp.full((n,), value, dtype=float),
+            jnp.full((n,), time_idx, dtype=jnp.int32),
+        )
+
+    if isinstance(comp, Boundary):
+        pick_end = jr.bernoulli(key, p=0.5, shape=(n,))
+        time_idx = jnp.where(pick_end, lengths - 1, 0).astype(jnp.int32)
+        times = jnp.where(pick_end, domain.end_times[case_indices], domain.start)
+        return times, time_idx
+
+    raise TypeError(f"Unsupported trajectory time component {type(comp).__name__}.")
+
+
+def sample_trajectory_component(
+    component,
+    num_points: NumPoints,
+    *,
+    structure: ProductStructure,
+    sampler: str = "latin_hypercube",
+    key: Key[Array, ""] = DOC_KEY0,
+) -> PointsBatch:
+    del sampler
+    domain = component.domain
+    if not isinstance(domain, TrajectoryDatasetDomain):
+        raise TypeError("sample_trajectory_component requires a TrajectoryDatasetDomain.")
+
+    data_comp = component.spec.component_for(domain.data_label)
+    if not isinstance(data_comp, Interior):
+        raise TypeError(
+            "TrajectoryDatasetDomain supports only Interior() for the data label."
+        )
+
+    n = _as_sample_count(num_points)
+    structure_, _axis = _single_axis_for_trajectory(domain, structure)
+    if n == 0:
+        return domain.points_from_case_time(
+            jnp.zeros((0,), dtype=jnp.int32),
+            jnp.zeros((0,), dtype=float),
+            structure=structure_,
+            time_indices=jnp.zeros((0,), dtype=jnp.int32),
+        )
+
+    case_key, time_key = jr.split(key)
+    time_comp = component.spec.component_for(domain.time_label)
+    if isinstance(time_comp, Fixed):
+        fixed_value = jnp.asarray(time_comp.value, dtype=float).reshape(())
+        valid = (domain.start <= fixed_value) & (fixed_value <= domain.end_times)
+        case_indices = _sample_valid_cases(valid, n, case_key)
+    elif domain.sampling_mode == "observation_uniform" and isinstance(
+        time_comp, Interior
+    ):
+        flat_cases, flat_times = _flat_observation_indices(domain)
+        obs_idx = jr.randint(
+            time_key,
+            shape=(n,),
+            minval=0,
+            maxval=domain.total_observations,
+            dtype=jnp.int32,
+        )
+        case_indices = flat_cases[obs_idx]
+        times = domain.observation_times(case_indices, flat_times[obs_idx])
+        return domain.points_from_case_time(
+            case_indices,
+            times,
+            structure=structure_,
+            time_indices=flat_times[obs_idx],
+        )
+    else:
+        case_indices = _sample_cases_uniform(domain, n, case_key)
+
+    times, time_indices = _component_times(domain, component, case_indices, n, time_key)
+    return domain.points_from_case_time(
+        case_indices,
+        times,
+        structure=structure_,
+        time_indices=time_indices,
+    )
+
+
+def trajectory_default_quadrature_total_weight(
+    component, batch: PointsBatch, /
+) -> cx.Field | None:
+    domain = component.domain
+    if not isinstance(domain, TrajectoryDatasetDomain):
+        return None
+    structure, axis = _single_axis_for_trajectory(domain, batch.structure)
+    del structure
+    if TRAJECTORY_CASE_INDEX_KEY not in batch:
+        return None
+    case_field = batch[TRAJECTORY_CASE_INDEX_KEY]
+    if not isinstance(case_field, cx.Field):
+        raise TypeError("Trajectory case indices must be stored as a coordax.Field.")
+    case_idx = jnp.asarray(case_field.data, dtype=jnp.int32)
+    n = int(case_idx.shape[0])
+    if n == 0:
+        return cx.Field(jnp.zeros((0,), dtype=float), dims=(axis,))
+
+    time_comp = component.spec.component_for(domain.time_label)
+    point_mass = isinstance(time_comp, (FixedStart, FixedEnd, Fixed))
+    boundary = isinstance(time_comp, Boundary)
+    durations = domain.durations[case_idx]
+
+    if domain.measure_mode == "case_time_probability":
+        per_sample = jnp.ones((n,), dtype=float)
+    elif point_mass:
+        per_sample = jnp.ones((n,), dtype=float)
+    elif boundary:
+        per_sample = jnp.full((n,), 2.0, dtype=float)
+    else:
+        per_sample = durations
+
+    if domain.measure_mode == "time_integral_sum":
+        per_sample = per_sample * float(domain.size)
+
+    return cx.Field(per_sample / float(n), dims=(axis,))
+
+
+def trajectory_component_measure(component, /) -> Array | None:
+    domain = component.domain
+    if not isinstance(domain, TrajectoryDatasetDomain):
+        return None
+
+    time_comp = component.spec.component_for(domain.time_label)
+    point_mass = isinstance(time_comp, (FixedStart, FixedEnd, Fixed))
+    boundary = isinstance(time_comp, Boundary)
+
+    if domain.measure_mode == "case_time_probability":
+        return jnp.asarray(1.0, dtype=float)
+
+    if point_mass:
+        measure = jnp.asarray(1.0, dtype=float)
+    elif boundary:
+        measure = jnp.asarray(2.0, dtype=float)
+    else:
+        measure = jnp.mean(domain.durations)
+
+    if domain.measure_mode == "time_integral_sum":
+        measure = measure * float(domain.size)
+    return jnp.asarray(measure, dtype=float)
+
+
+def trajectory_quadrature_weights_by_axis(
+    component, batch: PointsBatch, /
+) -> Mapping[str, cx.Field] | None:
+    domain = component.domain
+    if not isinstance(domain, TrajectoryDatasetDomain):
+        return None
+    _structure, axis = _single_axis_for_trajectory(domain, batch.structure)
+    w = trajectory_default_quadrature_total_weight(component, batch)
+    if w is None:
+        return None
+    return {axis: w}
+
+
+__all__ = [
+    "TRAJECTORY_CASE_INDEX_KEY",
+    "TRAJECTORY_TIME_INDEX_KEY",
+    "TrajectoryDatasetDomain",
+    "TrajectoryMeasure",
+    "TrajectorySampling",
+    "sample_trajectory_component",
+    "trajectory_component_measure",
+    "trajectory_default_quadrature_total_weight",
+    "trajectory_quadrature_weights_by_axis",
+]

--- a/phydrax/nn/__init__.py
+++ b/phydrax/nn/__init__.py
@@ -11,7 +11,7 @@ separable models, and latent contraction models over product domains.
 ## Highlights
 
 - `MLP` and `Linear` for dense models.
-- `Separable` and `SeparableMLP` for coord-separable inputs.
+- `Separable` and `SeparableMLP` for pointwise separable and coord-separable inputs.
 - `LatentContractionModel` for product-domain factorization.
 - `LatentExecutionPolicy` for structured execution fallback behavior.
 

--- a/phydrax/nn/models/architectures/_separable_feynmann.py
+++ b/phydrax/nn/models/architectures/_separable_feynmann.py
@@ -3,14 +3,14 @@
 #
 
 from collections.abc import Callable
-from typing import Literal
+from typing import ClassVar, Literal
 
 import jax.random as jr
 from jaxtyping import Array, Key
 
 from ...._doc import DOC_KEY0
 from ..._utils import _get_size
-from ..core._base import _AbstractStructuredInputModel
+from ..core._base import _AbstractStructuredInputModel, DomainInputMode
 from ..wrappers._separable_wrappers import Separable
 from ._feynmann import FeynmaNN
 
@@ -34,6 +34,8 @@ class SeparableFeynmaNN(_AbstractStructuredInputModel):
     in_size: int | Literal["scalar"]
     out_size: int | Literal["scalar"]
     model: _AbstractStructuredInputModel
+    _domain_input_mode: ClassVar[DomainInputMode] = "flat"
+    _supports_blockwise_input: bool = True
 
     def __init__(
         self,

--- a/phydrax/nn/models/architectures/_separable_kan.py
+++ b/phydrax/nn/models/architectures/_separable_kan.py
@@ -3,14 +3,14 @@
 #
 
 from collections.abc import Callable, Sequence
-from typing import Literal
+from typing import ClassVar, Literal
 
 import jax.random as jr
 from jaxtyping import Array, Key
 
 from ...._doc import DOC_KEY0
 from ..._utils import _get_size
-from ..core._base import _AbstractStructuredInputModel
+from ..core._base import _AbstractStructuredInputModel, DomainInputMode
 from ..wrappers._separable_wrappers import Separable
 from ._kan import KAN
 
@@ -34,6 +34,8 @@ class SeparableKAN(_AbstractStructuredInputModel):
     in_size: int | Literal["scalar"]
     out_size: int | Literal["scalar"]
     model: _AbstractStructuredInputModel
+    _domain_input_mode: ClassVar[DomainInputMode] = "flat"
+    _supports_blockwise_input: bool = True
 
     def __init__(
         self,

--- a/phydrax/nn/models/architectures/_separable_mlp.py
+++ b/phydrax/nn/models/architectures/_separable_mlp.py
@@ -3,7 +3,7 @@
 #
 
 from collections.abc import Callable, Sequence
-from typing import Literal
+from typing import ClassVar, Literal
 
 import jax
 import jax.random as jr
@@ -11,7 +11,7 @@ from jaxtyping import Array, Key
 
 from ...._doc import DOC_KEY0
 from ..._utils import _get_size
-from ..core._base import _AbstractStructuredInputModel
+from ..core._base import _AbstractStructuredInputModel, DomainInputMode
 from ..wrappers._separable_wrappers import Separable
 from ._mlp import MLP
 
@@ -21,8 +21,11 @@ class SeparableMLP(_AbstractStructuredInputModel):
 
     This builds one scalar-input `MLP` per coordinate (and per `split_input`
     clone), then wraps them in `phydrax.nn.Separable` to form a low-rank separable
-    approximation. With latent size $L$ and output size $m$, the resulting model
-    has the form
+    approximation. It is drop-in compatible with dense vector models under
+    `Domain.Model(...)`: ordinary pointwise domain calls flatten dependencies into
+    one vector, then this model sends each scalar vector coordinate through its own
+    internal MLP. With latent size $L$ and output size $m$, the resulting model has
+    the form
 
     $$
     u_o(x)=\sum_{\ell=1}^{L}\prod_{i=1}^{d} g_{i,\ell,o}(x_i),
@@ -35,6 +38,8 @@ class SeparableMLP(_AbstractStructuredInputModel):
     in_size: int | Literal["scalar"]
     out_size: int | Literal["scalar"]
     model: _AbstractStructuredInputModel
+    _domain_input_mode: ClassVar[DomainInputMode] = "flat"
+    _supports_blockwise_input: bool = True
 
     def __init__(
         self,

--- a/phydrax/nn/models/core/_base.py
+++ b/phydrax/nn/models/core/_base.py
@@ -3,12 +3,15 @@
 #
 
 from abc import abstractmethod
-from typing import Literal
+from typing import ClassVar, Literal, TypeAlias
 
 from jaxtyping import Array, Key
 
 from ...._doc import DOC_KEY0
 from ...._strict import AbstractAttribute, StrictModule
+
+
+DomainInputMode: TypeAlias = Literal["flat", "structured"]
 
 
 class _AbstractBaseModel(StrictModule):
@@ -30,6 +33,7 @@ class _AbstractBaseModel(StrictModule):
     _supports_structured_input: bool = False
     _supports_blockwise_input: bool = False
     _warn_on_auto_fallback: bool = False
+    _domain_input_mode: ClassVar[DomainInputMode] = "flat"
 
     @classmethod
     def supports_structured_input(cls) -> bool:
@@ -42,11 +46,16 @@ class _AbstractBaseModel(StrictModule):
     def warn_on_auto_fallback(self) -> bool:
         return bool(self._warn_on_auto_fallback)
 
+    @classmethod
+    def domain_input_mode(cls) -> DomainInputMode:
+        return cls._domain_input_mode
+
 
 class _AbstractStructuredInputModel(_AbstractBaseModel):
     """Abstract base class for models that accept structured (tuple) inputs."""
 
     _supports_structured_input: bool = True
+    _domain_input_mode: ClassVar[DomainInputMode] = "structured"
 
     @abstractmethod
     def __call__(

--- a/phydrax/nn/models/wrappers/_separable_wrappers.py
+++ b/phydrax/nn/models/wrappers/_separable_wrappers.py
@@ -6,7 +6,7 @@ import functools as ft
 import string
 import warnings
 from collections.abc import Callable, Mapping, Sequence
-from typing import Any, Literal
+from typing import Any, ClassVar, Literal
 
 import jax
 import jax.numpy as jnp
@@ -18,7 +18,11 @@ from ...._doc import DOC_KEY0
 from ...._strict import StrictModule
 from ..._utils import _get_size, _identity
 from .._utils import _contract_str, _stack_separable
-from ..core._base import _AbstractBaseModel, _AbstractStructuredInputModel
+from ..core._base import (
+    _AbstractBaseModel,
+    _AbstractStructuredInputModel,
+    DomainInputMode,
+)
 from ..core._scan_utils import (
     pack_scan_modules,
     scan_apply_with_data,
@@ -542,11 +546,15 @@ class Separable(_AbstractStructuredInputModel):
     u_o(x)=\sum_{\ell=1}^{L}\prod_{i=1}^{d} g_{i,\ell,o}(x_i).
     $$
 
-    Supports regular array inputs and separable tuple inputs (a tuple of 1D coordinate arrays).
+    Supports regular array inputs and separable tuple inputs (a tuple of 1D coordinate
+    arrays). Under `Domain.Model(...)`, regular pointwise calls default to flat
+    vector packing so this wrapper can replace dense vector models.
     """
 
     in_size: int | Literal["scalar"]
     out_size: int | Literal["scalar"]
+    _domain_input_mode: ClassVar[DomainInputMode] = "flat"
+    _supports_blockwise_input: bool = True
 
     latent_size: int
     models: tuple[_AbstractBaseModel, ...]
@@ -657,8 +665,8 @@ class Separable(_AbstractStructuredInputModel):
         **Inputs:**
 
         - `x`: either a single point of shape `(d,)` (or scalar `()` in the
-          replicated scalar-input case), or a separable tuple `(x_1,...,x_d)` of
-          1D coordinate arrays.
+          replicated scalar-input case), a batch of points with shape `(..., d)`,
+          or a separable tuple `(x_1,...,x_d)` of 1D coordinate arrays.
         """
         # If the input is a tuple of arrays, dispatch to the dedicated paths.
         # - separable: a tuple of 1D coordinate arrays
@@ -754,6 +762,36 @@ class Separable(_AbstractStructuredInputModel):
                         idx += 1
                 outputs = ft.reduce(jnp.multiply, out_list, jnp.array(1.0))
                 out = contract("lo->o", self._reshape_latents(outputs))
+        elif x_arr.ndim >= 2:
+            if int(x_arr.shape[-1]) != in_dim:
+                raise ValueError(
+                    f"Expected trailing shape ({in_dim},) got {x_arr.shape}."
+                )
+            coord_inputs = jnp.moveaxis(x_arr, -1, 0)
+            scan_inputs = jnp.repeat(coord_inputs, clones, axis=0)
+            scan_out = _scan_regular(scan_inputs)
+            if scan_out is not None:
+                leading_shape = tuple(int(i) for i in scan_out.shape[:-1])
+                latent_shape = leading_shape + (
+                    self.latent_size,
+                    _get_size(self.out_size),
+                )
+                out = contract("...lo->...o", scan_out.reshape(latent_shape))
+            else:
+                out_list = []
+                idx = 0
+                for i in range(in_dim):
+                    xi = x_arr[..., i]
+                    for _ in range(clones):
+                        out_list.append(self.models[idx](xi, key=keys[idx]))
+                        idx += 1
+                outputs = ft.reduce(jnp.multiply, out_list, jnp.array(1.0))
+                leading_shape = tuple(int(i) for i in outputs.shape[:-1])
+                latent_shape = leading_shape + (
+                    self.latent_size,
+                    _get_size(self.out_size),
+                )
+                out = contract("...lo->...o", outputs.reshape(latent_shape))
         else:
             raise ValueError(
                 f"Invalid input shape {x_arr.shape}. Expected ({in_dim},). "

--- a/phydrax/operators/integral/_batch_ops.py
+++ b/phydrax/operators/integral/_batch_ops.py
@@ -120,6 +120,12 @@ def _label_measure(component: DomainComponent, label: str, /) -> Array:
 def _default_quadrature_total_weight(
     component: DomainComponent, batch: PointsBatch, /
 ) -> cx.Field:
+    from ...domain._trajectory_dataset import trajectory_default_quadrature_total_weight
+
+    custom = trajectory_default_quadrature_total_weight(component, batch)
+    if custom is not None:
+        return custom
+
     if batch.structure.axis_names is None:
         raise ValueError("PointsBatch.structure must be canonicalized (axis_names set).")
 
@@ -169,6 +175,12 @@ def build_quadrature(
 
     - A `QuadratureBatch` with per-axis weights compatible with `batch`.
     """
+    from ...domain._trajectory_dataset import trajectory_quadrature_weights_by_axis
+
+    custom = trajectory_quadrature_weights_by_axis(component, batch)
+    if custom is not None:
+        return QuadratureBatch(batch, weights_by_axis=custom)
+
     if batch.structure.axis_names is None:
         raise ValueError("PointsBatch.structure must be canonicalized (axis_names set).")
 

--- a/phydrax/solver/_functional_solver.py
+++ b/phydrax/solver/_functional_solver.py
@@ -27,6 +27,25 @@ from ._enforced_constraint_pipeline import (
 )
 
 
+def _constraints_tuple(
+    value: AbstractConstraint | Sequence[AbstractConstraint],
+    /,
+    *,
+    name: str,
+) -> tuple[AbstractConstraint, ...]:
+    if isinstance(value, AbstractConstraint):
+        out = (value,)
+    else:
+        out = tuple(value)
+    bad = tuple(c for c in out if not isinstance(c, AbstractConstraint))
+    if bad:
+        raise TypeError(
+            f"All {name} must be instances of AbstractConstraint; got "
+            f"{tuple(type(c).__name__ for c in bad)!r}."
+        )
+    return out
+
+
 class FunctionalSolver(StrictModule):
     r"""Assemble constraints into a differentiable scalar loss.
 
@@ -34,6 +53,7 @@ class FunctionalSolver(StrictModule):
 
     - a mapping of named fields (as `DomainFunction`s), e.g. $u_\theta$;
     - a collection of constraints $\ell_i$ producing scalar penalties.
+    - optional eval-only constraints for validation diagnostics.
 
     The solver loss is the (weighted) sum
 
@@ -53,13 +73,16 @@ class FunctionalSolver(StrictModule):
 
     **Training**
 
-    `solve(...)` optimizes the inexact-array leaves inside `functions` (via Equinox
-    partitioning), and passes an `iter_` counter through to constraint losses so that
+    `solve(...)` optimizes trainable inexact-array leaves inside `functions` (via a
+    Phydrax-aware Equinox partition). Domains and fixed observed-data state remain
+    numeric/JAX-traceable but are excluded from gradients and optimizer updates.
+    The solver also passes an `iter_` counter through to constraint losses so that
     constraints can implement schedules.
     """
 
     functions: frozendict[str, DomainFunction]
     constraints: tuple[AbstractConstraint, ...]
+    eval_constraints: tuple[AbstractConstraint, ...]
     constraint_pipelines: EnforcedConstraintPipelines | None
 
     def __init__(
@@ -67,6 +90,7 @@ class FunctionalSolver(StrictModule):
         *,
         functions: Mapping[str, DomainFunction],
         constraints: AbstractConstraint | Sequence[AbstractConstraint],
+        eval_constraints: AbstractConstraint | Sequence[AbstractConstraint] = (),
         constraint_pipelines: EnforcedConstraintPipelines | None = None,
         constraint_terms: Sequence[
             SingleFieldEnforcedConstraint | MultiFieldEnforcedConstraint
@@ -84,6 +108,7 @@ class FunctionalSolver(StrictModule):
 
         - `functions`: Mapping `{name: DomainFunction}` defining the fields.
         - `constraints`: One or more `AbstractConstraint` instances.
+        - `eval_constraints`: Optional constraints evaluated only for logging/diagnostics.
         - `constraint_pipelines`: Optional pre-built enforced constraint pipelines. If provided,
           do not also pass `constraint_terms`/`interior_data_terms`.
         - `constraint_terms`: Enforced constraint terms used to build `EnforcedConstraintPipelines`
@@ -96,19 +121,11 @@ class FunctionalSolver(StrictModule):
         - `boundary_weight_key`: PRNG key used to draw boundary blending references.
         """
         self.functions = frozendict(functions)
-
-        if isinstance(constraints, AbstractConstraint):
-            self.constraints = (constraints,)
-        else:
-            self.constraints = tuple(constraints)
-            bad = tuple(
-                c for c in self.constraints if not isinstance(c, AbstractConstraint)
-            )
-            if bad:
-                raise TypeError(
-                    "All constraints must be instances of AbstractConstraint; got "
-                    f"{tuple(type(c).__name__ for c in bad)!r}."
-                )
+        self.constraints = _constraints_tuple(constraints, name="constraints")
+        self.eval_constraints = _constraints_tuple(
+            eval_constraints,
+            name="eval_constraints",
+        )
 
         if constraint_pipelines is not None and (constraint_terms or interior_data_terms):
             raise ValueError(
@@ -142,6 +159,17 @@ class FunctionalSolver(StrictModule):
     def __getitem__(self, var: str) -> DomainFunction:
         """Convenience accessor: return the (ansatz) field named `var`."""
         return self.ansatz_functions()[var]
+
+    def partition_functions(self) -> tuple[Any, Any]:
+        """Return `(trainable, non_trainable)` function PyTrees used by `solve()`."""
+        from .._trainable import partition_trainable
+
+        return partition_trainable(self.functions)
+
+    def trainable_functions(self) -> Any:
+        """Return the trainable function PyTree used as optimizer/evolution state."""
+        trainable, _non_trainable = self.partition_functions()
+        return trainable
 
     def loss(
         self,
@@ -190,7 +218,8 @@ class FunctionalSolver(StrictModule):
     ) -> "FunctionalSolver":
         """Run the training loop and return an updated solver.
 
-        The optimization updates the inexact-array leaves of `self.functions`.
+        The optimization updates trainable inexact-array leaves of `self.functions`.
+        Domains and fixed observed-data state are kept non-trainable.
 
         - If `optim` is an Optax `GradientTransformation`, a standard gradient step is used.
         - If `optim` is an Optax `GradientTransformationExtraArgs`, a line-search style update is used.

--- a/phydrax/solver/_functional_train.py
+++ b/phydrax/solver/_functional_train.py
@@ -8,7 +8,7 @@ import inspect
 import time
 from contextlib import nullcontext
 from pathlib import Path
-from typing import Any, TYPE_CHECKING
+from typing import Any, Protocol, runtime_checkable, TYPE_CHECKING
 
 import equinox as eqx
 import jax
@@ -17,13 +17,24 @@ import jax.random as jr
 import optax
 from jax import core as jcore
 
-from ..constraints._functional import FunctionalConstraint
-from ..constraints._pointset import PointSetConstraint
+from .._trainable import combine_trainable, partition_trainable
 from ..operators.differential._runtime import derivative_runtime_context
 
 
 if TYPE_CHECKING:
     from ._functional_solver import FunctionalSolver
+
+
+@runtime_checkable
+class _SupportsDataMetrics(Protocol):
+    def data_metrics(
+        self,
+        functions: Any,
+        /,
+        *,
+        key: Any,
+        **kwargs: Any,
+    ) -> dict[str, Any]: ...
 
 
 def _constraint_label(constraint: Any, /) -> str:
@@ -115,6 +126,31 @@ def _tensorboard_every(
     return every
 
 
+def _write_constraint_tensorboard_scalars(
+    writer: _TensorBoardLogger,
+    *,
+    step: int,
+    namespace: str,
+    constraint_names: tuple[str, ...],
+    terms: Any,
+    data_metrics: tuple[dict[str, Any], ...],
+    write_legacy: bool = False,
+) -> None:
+    terms_arr = jnp.asarray(terms, dtype=float)
+    for i, (name, val) in enumerate(
+        zip(constraint_names, list(map(float, terms_arr)), strict=True)
+    ):
+        base = _constraint_tag(i, name)
+        prefix = f"{namespace}/{base}"
+        writer.scalar(f"{prefix}/loss", val, step)
+        if write_legacy:
+            writer.scalar(f"{base}/loss", val, step)
+        for metric_name, metric_value in data_metrics[i].items():
+            writer.scalar(f"{prefix}/{metric_name}", metric_value, step)
+            if write_legacy:
+                writer.scalar(f"{base}/{metric_name}", metric_value, step)
+
+
 def _log_tensorboard_scalars(
     writer: _TensorBoardLogger,
     *,
@@ -122,9 +158,12 @@ def _log_tensorboard_scalars(
     loss: Any,
     best_loss: float,
     iter_time_s: float,
-    constraint_names: tuple[str, ...],
-    terms: Any,
-    data_metrics: tuple[dict[str, Any], ...],
+    train_constraint_names: tuple[str, ...],
+    train_terms: Any,
+    train_data_metrics: tuple[dict[str, Any], ...],
+    eval_constraint_names: tuple[str, ...],
+    eval_terms: Any,
+    eval_data_metrics: tuple[dict[str, Any], ...],
     log_constraints: bool,
 ) -> None:
     writer.scalar("train/loss", loss, step)
@@ -134,14 +173,23 @@ def _log_tensorboard_scalars(
     if not log_constraints:
         return
 
-    terms_arr = jnp.asarray(terms, dtype=float)
-    for i, (name, val) in enumerate(
-        zip(constraint_names, list(map(float, terms_arr)), strict=True)
-    ):
-        prefix = _constraint_tag(i, name)
-        writer.scalar(f"{prefix}/loss", val, step)
-        for metric_name, metric_value in data_metrics[i].items():
-            writer.scalar(f"{prefix}/{metric_name}", metric_value, step)
+    _write_constraint_tensorboard_scalars(
+        writer,
+        step=step,
+        namespace="train",
+        constraint_names=train_constraint_names,
+        terms=train_terms,
+        data_metrics=train_data_metrics,
+        write_legacy=True,
+    )
+    _write_constraint_tensorboard_scalars(
+        writer,
+        step=step,
+        namespace="eval",
+        constraint_names=eval_constraint_names,
+        terms=eval_terms,
+        data_metrics=eval_data_metrics,
+    )
 
 
 def solve(
@@ -206,7 +254,7 @@ def solve(
     )
 
     with log_ctx as log_fp, tb_ctx as tb_writer:
-        params, static = eqx.partition(self.functions, eqx.is_inexact_array)
+        params, non_trainable = partition_trainable(self.functions)
         log_every_ = int(log_every)
         if log_every_ < 0:
             raise ValueError("log_every must be >= 0.")
@@ -220,9 +268,10 @@ def solve(
             raise ValueError("tensorboard_flush_every must be positive.")
         log_constraints_ = bool(log_constraints)
         constraint_names = tuple(_constraint_label(c) for c in self.constraints)
+        eval_constraint_names = tuple(_constraint_label(c) for c in self.eval_constraints)
 
-        def _loss_wrt_params(params_, solver, key, iter_):
-            functions = eqx.combine(params_, static)
+        def _loss_wrt_params(params_, non_trainable_, solver, key, iter_):
+            functions = combine_trainable(params_, non_trainable_)
             if solver.constraint_pipelines is None:
                 enforced = functions
             else:
@@ -246,17 +295,45 @@ def solve(
                     return total, jnp.stack(terms, axis=0)
                 return total, jnp.zeros((0,), dtype=float)
 
-        def _data_metrics_wrt_params(params_, solver, key, iter_):
-            functions = eqx.combine(params_, static)
+        def _enforced_functions_wrt_params(params_, non_trainable_, solver):
+            functions = combine_trainable(params_, non_trainable_)
             if solver.constraint_pipelines is None:
-                enforced = functions
-            else:
-                enforced = solver.constraint_pipelines.apply(functions)
-            keys = jr.split(key, len(solver.constraints))
+                return functions
+            return solver.constraint_pipelines.apply(functions)
+
+        def _terms_wrt_constraints(
+            params_,
+            non_trainable_,
+            solver,
+            constraints,
+            key,
+            iter_,
+        ):
+            enforced = _enforced_functions_wrt_params(params_, non_trainable_, solver)
+            keys = jr.split(key, len(constraints))
+            terms: list[jax.Array] = []
+            with derivative_runtime_context():
+                for c, k in zip(constraints, keys, strict=True):
+                    term = c.loss(enforced, key=k, iter_=iter_)
+                    terms.append(jnp.asarray(term, dtype=float).reshape(()))
+            if terms:
+                return jnp.stack(terms, axis=0)
+            return jnp.zeros((0,), dtype=float)
+
+        def _data_metrics_wrt_constraints(
+            params_,
+            non_trainable_,
+            solver,
+            constraints,
+            key,
+            iter_,
+        ):
+            enforced = _enforced_functions_wrt_params(params_, non_trainable_, solver)
+            keys = jr.split(key, len(constraints))
             metrics: list[dict[str, Any]] = []
             with derivative_runtime_context():
-                for c, k in zip(solver.constraints, keys, strict=True):
-                    if isinstance(c, (FunctionalConstraint, PointSetConstraint)):
+                for c, k in zip(constraints, keys, strict=True):
+                    if isinstance(c, _SupportsDataMetrics):
                         metrics.append(c.data_metrics(enforced, key=k, iter_=iter_))
                     else:
                         metrics.append({})
@@ -266,14 +343,16 @@ def solve(
 
         is_linesearch = _opt_linesearch is not None
 
-        def solve_step(params_, opt_state, solver, key, iter_):
+        def solve_step(params_, non_trainable_, opt_state, solver, key, iter_):
             if is_linesearch:
                 import jax.tree_util as jtu
 
                 def _value_fn(p):
-                    return _loss_wrt_params(p, solver, key, iter_)[0]
+                    return _loss_wrt_params(p, non_trainable_, solver, key, iter_)[0]
 
-                (value, _terms0), grads = loss_fn(params_, solver, key, iter_)
+                (value, _terms0), grads = loss_fn(
+                    params_, non_trainable_, solver, key, iter_
+                )
                 grads = jtu.tree_map(
                     lambda a: (
                         jnp.nan_to_num(a, nan=0.0, posinf=0.0, neginf=0.0)
@@ -293,10 +372,14 @@ def solve(
                     value_fn=_value_fn,
                 )
                 params_ = eqx.apply_updates(params_, updates)
-                loss_val, terms = _loss_wrt_params(params_, solver, key, iter_)
+                loss_val, terms = _loss_wrt_params(
+                    params_, non_trainable_, solver, key, iter_
+                )
                 return params_, opt_state, loss_val, terms
 
-            (loss_val, terms), grads = loss_fn(params_, solver, key, iter_)
+            (loss_val, terms), grads = loss_fn(
+                params_, non_trainable_, solver, key, iter_
+            )
             assert _opt_standard is not None
             updates, opt_state = _opt_standard.update(grads, opt_state, params_)
             params_ = eqx.apply_updates(params_, updates)
@@ -320,7 +403,7 @@ def solve(
             rng, subkey = jr.split(rng)
             iter_ = jnp.asarray(epoch + 1, dtype=float)
             params, opt_state, loss_val, terms = solve_step(
-                params, opt_state, self, subkey, iter_
+                params, non_trainable, opt_state, self, subkey, iter_
             )
             if keep_best:
                 loss_f = float(loss_val)
@@ -331,9 +414,38 @@ def solve(
             step = epoch + 1
             console_step = log_every_ > 0 and (step % log_every_ == 0)
             tensorboard_step = tb_every_ is not None and (step % tb_every_ == 0)
-            data_metrics: tuple[dict[str, Any], ...] = tuple({} for _ in self.constraints)
+            train_data_metrics: tuple[dict[str, Any], ...] = tuple(
+                {} for _ in self.constraints
+            )
+            eval_terms = jnp.zeros((0,), dtype=float)
+            eval_data_metrics: tuple[dict[str, Any], ...] = tuple(
+                {} for _ in self.eval_constraints
+            )
             if log_constraints_ and (console_step or tensorboard_step):
-                data_metrics = _data_metrics_wrt_params(params, self, subkey, iter_)
+                train_data_metrics = _data_metrics_wrt_constraints(
+                    params,
+                    non_trainable,
+                    self,
+                    self.constraints,
+                    jr.fold_in(subkey, 1),
+                    iter_,
+                )
+                eval_terms = _terms_wrt_constraints(
+                    params,
+                    non_trainable,
+                    self,
+                    self.eval_constraints,
+                    jr.fold_in(subkey, 2),
+                    iter_,
+                )
+                eval_data_metrics = _data_metrics_wrt_constraints(
+                    params,
+                    non_trainable,
+                    self,
+                    self.eval_constraints,
+                    jr.fold_in(subkey, 3),
+                    iter_,
+                )
 
             if console_step:
                 loss_f = float(loss_val)
@@ -349,8 +461,24 @@ def solve(
                     for i, (name, val) in enumerate(
                         zip(constraint_names, list(map(float, terms_arr)), strict=True)
                     ):
-                        suffix = _metric_suffix(data_metrics[i])
-                        print(f"  [{i}] {name}: {val:.6e}{suffix}", file=out_file)
+                        suffix = _metric_suffix(train_data_metrics[i])
+                        print(
+                            f"  [train {i}] {name}: {val:.6e}{suffix}",
+                            file=out_file,
+                        )
+                    eval_terms_arr = jnp.asarray(eval_terms, dtype=float)
+                    for i, (name, val) in enumerate(
+                        zip(
+                            eval_constraint_names,
+                            list(map(float, eval_terms_arr)),
+                            strict=True,
+                        )
+                    ):
+                        suffix = _metric_suffix(eval_data_metrics[i])
+                        print(
+                            f"  [eval {i}] {name}: {val:.6e}{suffix}",
+                            file=out_file,
+                        )
             if tensorboard_step and tb_writer is not None:
                 loss_f = float(loss_val)
                 best_display = best_loss if keep_best else loss_f
@@ -360,16 +488,19 @@ def solve(
                     loss=loss_val,
                     best_loss=best_display,
                     iter_time_s=iter_time_s,
-                    constraint_names=constraint_names,
-                    terms=terms,
-                    data_metrics=data_metrics,
+                    train_constraint_names=constraint_names,
+                    train_terms=terms,
+                    train_data_metrics=train_data_metrics,
+                    eval_constraint_names=eval_constraint_names,
+                    eval_terms=eval_terms,
+                    eval_data_metrics=eval_data_metrics,
                     log_constraints=log_constraints_,
                 )
                 if step % tb_flush_every_ == 0:
                     tb_writer.flush()
 
         chosen = best_params if keep_best else params
-        functions = eqx.combine(chosen, static)
+        functions = combine_trainable(chosen, non_trainable)
         return eqx.tree_at(lambda s: s.functions, self, functions)
 
 
@@ -391,7 +522,7 @@ def _solve_evosax(
 ) -> "FunctionalSolver":
     from ..constraints._base import AbstractSamplingConstraint
 
-    params, static = eqx.partition(self.functions, eqx.is_inexact_array)
+    params, non_trainable = partition_trainable(self.functions)
     log_every_ = int(log_every)
     if log_every_ < 0:
         raise ValueError("log_every must be >= 0.")
@@ -405,11 +536,12 @@ def _solve_evosax(
         raise ValueError("tensorboard_flush_every must be positive.")
     log_constraints_ = bool(log_constraints)
     constraint_names = tuple(_constraint_label(c) for c in self.constraints)
+    eval_constraint_names = tuple(_constraint_label(c) for c in self.eval_constraints)
 
     algo_params = algo.default_params
 
-    def _loss_for_params(p, solver, key, iter_, batches):
-        functions = eqx.combine(p, static)
+    def _loss_for_params(p, non_trainable_, solver, key, iter_, batches):
+        functions = combine_trainable(p, non_trainable_)
         if solver.constraint_pipelines is None:
             enforced = functions
         else:
@@ -424,8 +556,8 @@ def _solve_evosax(
                     total = total + c.loss(enforced, key=k, iter_=iter_, batch=b)
         return total
 
-    def _terms_for_params(p, solver, key, iter_, batches):
-        functions = eqx.combine(p, static)
+    def _terms_for_params(p, non_trainable_, solver, key, iter_, batches):
+        functions = combine_trainable(p, non_trainable_)
         if solver.constraint_pipelines is None:
             enforced = functions
         else:
@@ -443,17 +575,31 @@ def _solve_evosax(
             return jnp.stack(terms, axis=0)
         return jnp.zeros((0,), dtype=float)
 
-    def _data_metrics_for_params(p, solver, key, iter_):
-        functions = eqx.combine(p, static)
+    def _enforced_functions_for_params(p, non_trainable_, solver):
+        functions = combine_trainable(p, non_trainable_)
         if solver.constraint_pipelines is None:
-            enforced = functions
-        else:
-            enforced = solver.constraint_pipelines.apply(functions)
-        keys = jr.split(key, len(solver.constraints))
+            return functions
+        return solver.constraint_pipelines.apply(functions)
+
+    def _terms_for_constraints(p, non_trainable_, solver, constraints, key, iter_):
+        enforced = _enforced_functions_for_params(p, non_trainable_, solver)
+        keys = jr.split(key, len(constraints))
+        terms: list[jax.Array] = []
+        with derivative_runtime_context():
+            for c, k in zip(constraints, keys, strict=True):
+                term = c.loss(enforced, key=k, iter_=iter_)
+                terms.append(jnp.asarray(term, dtype=float).reshape(()))
+        if terms:
+            return jnp.stack(terms, axis=0)
+        return jnp.zeros((0,), dtype=float)
+
+    def _data_metrics_for_constraints(p, non_trainable_, solver, constraints, key, iter_):
+        enforced = _enforced_functions_for_params(p, non_trainable_, solver)
+        keys = jr.split(key, len(constraints))
         metrics: list[dict[str, Any]] = []
         with derivative_runtime_context():
-            for c, k in zip(solver.constraints, keys, strict=True):
-                if isinstance(c, (FunctionalConstraint, PointSetConstraint)):
+            for c, k in zip(constraints, keys, strict=True):
+                if isinstance(c, _SupportsDataMetrics):
                     metrics.append(c.data_metrics(enforced, key=k, iter_=iter_))
                 else:
                     metrics.append({})
@@ -523,11 +669,25 @@ def _solve_evosax(
 
             eval_key_shared = jr.fold_in(eval_key, 1)
             losses = jax.vmap(
-                lambda p: loss_fn(p, self, eval_key_shared, iter_, batches_tuple)
+                lambda p: loss_fn(
+                    p,
+                    non_trainable,
+                    self,
+                    eval_key_shared,
+                    iter_,
+                    batches_tuple,
+                )
             )(population)
             evo_state, _ = algo.tell(tell_key, population, losses, evo_state, algo_params)
             cand_params = algo.get_mean(evo_state)
-            cand_loss = loss_fn(cand_params, self, eval_key_shared, iter_, batches_tuple)
+            cand_loss = loss_fn(
+                cand_params,
+                non_trainable,
+                self,
+                eval_key_shared,
+                iter_,
+                batches_tuple,
+            )
 
             if keep_best:
                 loss_f = float(cand_loss)
@@ -540,17 +700,48 @@ def _solve_evosax(
             step = epoch + 1
             console_step = log_every_ > 0 and (step % log_every_ == 0)
             tensorboard_step = tb_every_ is not None and (step % tb_every_ == 0)
-            data_metrics: tuple[dict[str, Any], ...] = tuple({} for _ in self.constraints)
+            train_data_metrics: tuple[dict[str, Any], ...] = tuple(
+                {} for _ in self.constraints
+            )
+            eval_terms = jnp.zeros((0,), dtype=float)
+            eval_data_metrics: tuple[dict[str, Any], ...] = tuple(
+                {} for _ in self.eval_constraints
+            )
             terms_arr = jnp.zeros((0,), dtype=float)
             if log_constraints_ and (console_step or tensorboard_step):
                 terms_arr = jnp.asarray(
-                    terms_fn(cand_params, self, eval_key_shared, iter_, batches_tuple),
+                    terms_fn(
+                        cand_params,
+                        non_trainable,
+                        self,
+                        eval_key_shared,
+                        iter_,
+                        batches_tuple,
+                    ),
                     dtype=float,
                 )
-                data_metrics = _data_metrics_for_params(
+                train_data_metrics = _data_metrics_for_constraints(
                     cand_params,
+                    non_trainable,
                     self,
-                    eval_key_shared,
+                    self.constraints,
+                    jr.fold_in(eval_key_shared, 1),
+                    iter_,
+                )
+                eval_terms = _terms_for_constraints(
+                    cand_params,
+                    non_trainable,
+                    self,
+                    self.eval_constraints,
+                    jr.fold_in(eval_key_shared, 2),
+                    iter_,
+                )
+                eval_data_metrics = _data_metrics_for_constraints(
+                    cand_params,
+                    non_trainable,
+                    self,
+                    self.eval_constraints,
+                    jr.fold_in(eval_key_shared, 3),
                     iter_,
                 )
 
@@ -567,8 +758,24 @@ def _solve_evosax(
                     for i, (name, val) in enumerate(
                         zip(constraint_names, list(map(float, terms_arr)), strict=True)
                     ):
-                        suffix = _metric_suffix(data_metrics[i])
-                        print(f"  [{i}] {name}: {val:.6e}{suffix}", file=out_file)
+                        suffix = _metric_suffix(train_data_metrics[i])
+                        print(
+                            f"  [train {i}] {name}: {val:.6e}{suffix}",
+                            file=out_file,
+                        )
+                    eval_terms_arr = jnp.asarray(eval_terms, dtype=float)
+                    for i, (name, val) in enumerate(
+                        zip(
+                            eval_constraint_names,
+                            list(map(float, eval_terms_arr)),
+                            strict=True,
+                        )
+                    ):
+                        suffix = _metric_suffix(eval_data_metrics[i])
+                        print(
+                            f"  [eval {i}] {name}: {val:.6e}{suffix}",
+                            file=out_file,
+                        )
             if tensorboard_step and tb_writer is not None:
                 loss_f = float(cand_loss)
                 best_display = best_loss if keep_best else loss_f
@@ -578,13 +785,16 @@ def _solve_evosax(
                     loss=cand_loss,
                     best_loss=best_display,
                     iter_time_s=iter_time_s,
-                    constraint_names=constraint_names,
-                    terms=terms_arr,
-                    data_metrics=data_metrics,
+                    train_constraint_names=constraint_names,
+                    train_terms=terms_arr,
+                    train_data_metrics=train_data_metrics,
+                    eval_constraint_names=eval_constraint_names,
+                    eval_terms=eval_terms,
+                    eval_data_metrics=eval_data_metrics,
                     log_constraints=log_constraints_,
                 )
                 if step % tb_flush_every_ == 0:
                     tb_writer.flush()
 
-        functions = eqx.combine(best_params, static)
+        functions = combine_trainable(best_params, non_trainable)
         return eqx.tree_at(lambda s: s.functions, self, functions)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "polars>=1.40.1",
     "pyvista>=0.46.4",
     "quadax>=0.2.11",
+    "setuptools<81",
     "tensorboard>=2.20.0",
     "trimesh[easy]>=4.11.1",
 ]
@@ -93,4 +94,5 @@ max-line-length = 120
 filterwarnings = [
     "ignore::DeprecationWarning:ezdxf.queryparser:",
     "ignore::DeprecationWarning:build123d.objects_curve:",
+    "ignore:Setting `jax_pmap_shmap_merge` is deprecated in JAX v0\\.9\\.0.*:DeprecationWarning:jax\\._src\\.config:",
 ]

--- a/tests/integration/test_regression_trainers.py
+++ b/tests/integration/test_regression_trainers.py
@@ -2,7 +2,6 @@
 #  Copyright © 2026 PHYDRA, Inc. All rights reserved.
 #
 
-import equinox as eqx
 import jax.numpy as jnp
 import jax.random as jr
 import optax
@@ -73,7 +72,7 @@ def test_regression_2d_evosax():
     solver = _make_regression_solver(seed=1)
     init_loss = solver.loss(key=jr.key(0))
 
-    params, _ = eqx.partition(solver.functions, eqx.is_inexact_array)
+    params = solver.trainable_functions()
 
     algo_name = "Open_ES"
     algo_dict = vars(evo_algos)

--- a/tests/unit/constraints/test_ragged_time_series_constraint.py
+++ b/tests/unit/constraints/test_ragged_time_series_constraint.py
@@ -1,0 +1,141 @@
+#
+#  Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax.numpy as jnp
+import jax.random as jr
+
+from phydrax.constraints import RaggedTimeSeriesDataConstraint
+from phydrax.domain import ProductStructure, TrajectoryDatasetDomain
+
+
+def _make_domain_and_values():
+    inputs = jnp.asarray([[0.0], [1.0], [2.0]])
+    lengths = jnp.asarray([2, 4, 3])
+    domain = TrajectoryDatasetDomain(inputs, lengths, dt=0.5)
+    times = domain.start + domain.dt * jnp.arange(domain.max_length)
+    values = inputs[:, 0, None] + times[None, :]
+    return domain, values
+
+
+def test_ragged_time_series_data_constraint_matches_exact_observations():
+    domain, values = _make_domain_and_values()
+
+    @domain.Function("data", "t")
+    def exact(data, t):
+        return data[0] + t
+
+    constraint = RaggedTimeSeriesDataConstraint(
+        "u",
+        domain.component(),
+        values,
+        num_points=12,
+        structure=ProductStructure((("data", "t"),)),
+        sampling="observation_uniform",
+        label="trajectory_data",
+    )
+
+    loss = constraint.loss({"u": exact}, key=jr.key(0))
+    metrics = constraint.data_metrics({"u": exact}, key=jr.key(0))
+    assert jnp.allclose(loss, 0.0, atol=1e-12)
+    assert jnp.allclose(metrics["data_accuracy"], 1.0)
+    assert jnp.allclose(metrics["data_relative_l2_error"], 0.0)
+    assert jnp.allclose(metrics["data_rmse"], 0.0)
+
+
+def test_ragged_time_series_data_constraint_linear_interpolation():
+    domain, values = _make_domain_and_values()
+
+    @domain.Function("data", "t")
+    def exact(data, t):
+        return data[0] + t
+
+    constraint = RaggedTimeSeriesDataConstraint(
+        "u",
+        domain.component(),
+        values,
+        num_points=16,
+        structure=ProductStructure((("data", "t"),)),
+        sampling="case_time_uniform",
+        interpolation="linear",
+    )
+
+    loss = constraint.loss({"u": exact}, key=jr.key(1))
+    assert jnp.allclose(loss, 0.0, atol=1e-12)
+
+
+def test_ragged_time_series_data_constraint_vector_targets():
+    domain, scalar_values = _make_domain_and_values()
+    values = jnp.stack((scalar_values, 2.0 * scalar_values), axis=-1)
+
+    @domain.Function("data", "t")
+    def exact(data, t):
+        y = data[0] + t
+        return jnp.asarray([y, 2.0 * y])
+
+    constraint = RaggedTimeSeriesDataConstraint(
+        "u",
+        domain.component(),
+        values,
+        num_points=12,
+        sampling="observation_uniform",
+    )
+
+    loss = constraint.loss({"u": exact}, key=jr.key(2))
+    metrics = constraint.data_metrics({"u": exact}, key=jr.key(2))
+    assert jnp.allclose(loss, 0.0, atol=1e-12)
+    assert jnp.allclose(metrics["data_accuracy"], 1.0)
+
+
+def test_ragged_time_series_data_constraint_samples_only_case_subset():
+    domain, values = _make_domain_and_values()
+    allowed = jnp.asarray([1, 2], dtype=jnp.int32)
+    constraint = RaggedTimeSeriesDataConstraint(
+        "u",
+        domain.component(),
+        values,
+        num_points=24,
+        sampling="observation_uniform",
+        case_indices=allowed,
+    )
+
+    batch = constraint.sample(key=jr.key(9))
+    assert jnp.all(jnp.isin(batch.case_indices, allowed))
+
+
+def test_ragged_time_series_case_uniform_samples_only_case_subset():
+    domain, values = _make_domain_and_values()
+    allowed = jnp.asarray([2], dtype=jnp.int32)
+    constraint = RaggedTimeSeriesDataConstraint(
+        "u",
+        domain.component(),
+        values,
+        num_points=10,
+        sampling="case_uniform",
+        case_indices=allowed,
+    )
+
+    batch = constraint.sample(key=jr.key(10))
+    assert jnp.all(batch.case_indices == 2)
+
+
+def test_ragged_time_series_data_constraint_penalizes_wrong_function():
+    domain, values = _make_domain_and_values()
+
+    @domain.Function("data", "t")
+    def wrong(data, t):
+        del data, t
+        return 0.0
+
+    constraint = RaggedTimeSeriesDataConstraint(
+        "u",
+        domain.component(),
+        values,
+        num_points=12,
+        sampling="observation_uniform",
+    )
+
+    loss = constraint.loss({"u": wrong}, key=jr.key(3))
+    metrics = constraint.data_metrics({"u": wrong}, key=jr.key(3))
+    assert loss > 0.0
+    assert metrics["data_relative_l2_error"] > 0.0

--- a/tests/unit/constraints/test_ragged_time_series_enforced.py
+++ b/tests/unit/constraints/test_ragged_time_series_enforced.py
@@ -1,0 +1,189 @@
+#
+#  Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+from phydrax._frozendict import frozendict
+from phydrax.constraints import enforce_ragged_time_series, FunctionalConstraint
+from phydrax.domain import PointsBatch, ProductStructure, TrajectoryDatasetDomain
+from phydrax.operators.differential import partial_n, partial_t
+
+
+def _make_linear_problem():
+    inputs = jnp.asarray([[0.0], [1.0], [2.0]])
+    lengths = jnp.asarray([2, 4, 3])
+    domain = TrajectoryDatasetDomain(inputs, lengths, dt=0.25)
+    times = domain.start + domain.dt * jnp.arange(domain.max_length)
+    y0 = inputs[:, 0, None] + 2.0 * times[None, :]
+    y1 = 1.0 - inputs[:, 0, None] + 3.0 * times[None, :]
+    values = jnp.stack((y0, y1), axis=-1)
+    structure = ProductStructure((("data", "t"),))
+    return domain, values, structure
+
+
+def _all_observation_batch(domain, structure):
+    case_indices = domain.flat_case_indices
+    time_indices = domain.flat_time_indices
+    times = domain.observation_times(case_indices, time_indices)
+    return domain.points_from_case_time(
+        case_indices,
+        times,
+        structure=structure,
+        time_indices=time_indices,
+    )
+
+
+def test_enforce_ragged_time_series_matches_all_observed_nodes_exactly():
+    domain, values, structure = _make_linear_problem()
+
+    @domain.Function("data", "t")
+    def free(data, t):
+        del data, t
+        return jnp.asarray([10.0, -10.0])
+
+    hard = enforce_ragged_time_series(free, domain, values)
+    batch = _all_observation_batch(domain, structure)
+    pred = jnp.asarray(hard(batch, key=jr.key(0)).data)
+    case_indices = domain.flat_case_indices
+    time_indices = domain.flat_time_indices
+    target = values[case_indices, time_indices]
+    assert jnp.allclose(pred, target, atol=1e-12)
+
+
+def test_enforce_ragged_time_series_supports_first_time_derivative():
+    domain, values, structure = _make_linear_problem()
+
+    @domain.Function("data", "t")
+    def free(data, t):
+        return jnp.asarray([data[0] + 2.0 * t, 1.0 - data[0] + 3.0 * t])
+
+    hard = enforce_ragged_time_series(free, domain, values)
+    dt_hard = partial_t(hard, var="t")
+    batch = domain.component().sample(12, structure=structure, key=jr.key(1))
+    pred = jnp.asarray(dt_hard(batch, key=jr.key(2)).data)
+    expected = jnp.broadcast_to(jnp.asarray([2.0, 3.0]), pred.shape)
+    assert jnp.allclose(pred, expected, atol=1e-12)
+
+
+def test_enforce_ragged_time_series_supports_cubic_hermite_second_time_derivative():
+    domain, values, structure = _make_linear_problem()
+
+    @domain.Function("data", "t")
+    def free(data, t):
+        return jnp.asarray([data[0] + 2.0 * t, 1.0 - data[0] + 3.0 * t])
+
+    hard = enforce_ragged_time_series(
+        free,
+        domain,
+        values,
+        interpolation="cubic_hermite",
+        gate="sin4",
+    )
+    d2_hard = partial_n(hard, var="t", order=2)
+    batch = domain.component().sample(12, structure=structure, key=jr.key(5))
+    pred = jnp.asarray(d2_hard(batch, key=jr.key(6)).data)
+    assert jnp.allclose(pred, jnp.zeros_like(pred), atol=1e-10)
+
+
+def test_enforce_ragged_time_series_rejects_linear_second_time_derivative():
+    domain, values, _structure = _make_linear_problem()
+
+    @domain.Function("data", "t")
+    def free(data, t):
+        return jnp.asarray([data[0] + 2.0 * t, 1.0 - data[0] + 3.0 * t])
+
+    hard = enforce_ragged_time_series(free, domain, values, interpolation="linear")
+
+    with pytest.raises(ValueError, match="linear.*order 1"):
+        partial_n(hard, var="t", order=2)
+
+
+def test_enforce_ragged_time_series_can_enforce_selected_components():
+    domain, values, structure = _make_linear_problem()
+
+    @domain.Function("data", "t")
+    def free(data, t):
+        del data, t
+        return jnp.asarray([10.0, -5.0])
+
+    hard = enforce_ragged_time_series(free, domain, values, components=[0])
+    batch = _all_observation_batch(domain, structure)
+    pred = jnp.asarray(hard(batch, key=jr.key(7)).data)
+    case_indices = domain.flat_case_indices
+    time_indices = domain.flat_time_indices
+    target = values[case_indices, time_indices]
+    assert jnp.allclose(pred[:, 0], target[:, 0], atol=1e-12)
+    assert jnp.allclose(pred[:, 1], jnp.full_like(pred[:, 1], -5.0), atol=1e-12)
+
+
+def test_enforce_ragged_time_series_requires_trajectory_batch_indices():
+    domain, values, structure = _make_linear_problem()
+
+    @domain.Function("data", "t")
+    def free(data, t):
+        return jnp.asarray([data[0] + 2.0 * t, 1.0 - data[0] + 3.0 * t])
+
+    hard = enforce_ragged_time_series(free, domain, values)
+    batch = _all_observation_batch(domain, structure)
+    stripped = PointsBatch(
+        points=frozendict({"data": batch["data"], "t": batch["t"]}),
+        structure=batch.structure,
+    )
+
+    with pytest.raises(ValueError, match="internal field"):
+        hard(stripped, key=jr.key(4))
+
+
+def test_physics_only_constraint_can_use_hard_enforced_ragged_data():
+    domain, values, structure = _make_linear_problem()
+
+    @domain.Function("data", "t")
+    def free(data, t):
+        return jnp.asarray([data[0] + 2.0 * t, 1.0 - data[0] + 3.0 * t])
+
+    @domain.Function()
+    def rhs():
+        return jnp.asarray([2.0, 3.0])
+
+    hard = enforce_ragged_time_series(free, domain, values)
+    constraint = FunctionalConstraint.from_operator(
+        component=domain.component(),
+        operator=lambda u: partial_t(u, var="t") - rhs,
+        constraint_vars="u",
+        num_points=16,
+        structure=structure,
+        reduction="mean",
+    )
+
+    loss = constraint.loss({"u": hard}, key=jr.key(3))
+    assert jnp.allclose(loss, 0.0, atol=1e-12)
+
+
+def test_physics_only_constraint_can_use_second_derivative_hard_ragged_data():
+    domain, values, structure = _make_linear_problem()
+
+    @domain.Function("data", "t")
+    def free(data, t):
+        return jnp.asarray([data[0] + 2.0 * t, 1.0 - data[0] + 3.0 * t])
+
+    hard = enforce_ragged_time_series(
+        free,
+        domain,
+        values,
+        interpolation="cubic_hermite",
+        gate="sin4",
+    )
+    constraint = FunctionalConstraint.from_operator(
+        component=domain.component(),
+        operator=lambda u: partial_n(u, var="t", order=2),
+        constraint_vars="u",
+        num_points=16,
+        structure=structure,
+        reduction="mean",
+    )
+
+    loss = constraint.loss({"u": hard}, key=jr.key(8))
+    assert jnp.allclose(loss, 0.0, atol=1e-10)

--- a/tests/unit/constraints/test_supervised_dataset_constraint.py
+++ b/tests/unit/constraints/test_supervised_dataset_constraint.py
@@ -1,0 +1,145 @@
+#
+#  Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+from phydrax.constraints import SupervisedDatasetConstraint
+from phydrax.domain import DatasetDomain, ProductStructure
+
+
+def test_supervised_dataset_constraint_supervises_scalar_targets_exactly():
+    data = jnp.asarray([[0.0, 1.0], [1.0, 2.0], [2.0, 4.0]])
+    domain = DatasetDomain(data)
+    targets = data[:, 0] + 2.0 * data[:, 1]
+
+    @domain.Function("data")
+    def u(row):
+        return row[0] + 2.0 * row[1]
+
+    constraint = SupervisedDatasetConstraint(
+        "u",
+        domain.component(),
+        targets,
+        num_cases=12,
+        label="dataset_data",
+    )
+
+    loss = constraint.loss({"u": u}, key=jr.key(0))
+    metrics = constraint.data_metrics({"u": u}, key=jr.key(0))
+    assert jnp.allclose(loss, 0.0, atol=1e-12)
+    assert jnp.allclose(metrics["data_accuracy"], 1.0)
+    assert jnp.allclose(metrics["data_relative_l2_error"], 0.0)
+
+
+def test_supervised_dataset_constraint_supervises_vector_targets_exactly():
+    data = jnp.asarray([[0.0, 1.0], [1.0, 2.0], [2.0, 4.0]])
+    domain = DatasetDomain(data)
+    targets = jnp.stack((data[:, 0] + data[:, 1], data[:, 0] - data[:, 1]), axis=-1)
+
+    @domain.Function("data")
+    def theta(row):
+        return jnp.asarray([row[0] + row[1], row[0] - row[1]])
+
+    constraint = SupervisedDatasetConstraint(
+        "theta",
+        domain.component(),
+        targets,
+        num_cases=12,
+        reduction="sum",
+    )
+
+    loss = constraint.loss({"theta": theta}, key=jr.key(1))
+    metrics = constraint.data_metrics({"theta": theta}, key=jr.key(1))
+    assert jnp.allclose(loss, 0.0, atol=1e-12)
+    assert jnp.allclose(metrics["data_rmse"], 0.0)
+
+
+def test_supervised_dataset_constraint_aligns_sampled_indices_with_targets():
+    data = jnp.arange(10.0, dtype=float).reshape((5, 2))
+    domain = DatasetDomain(data)
+    targets = jnp.asarray([10.0, 20.0, 30.0, 40.0, 50.0])
+    constraint = SupervisedDatasetConstraint(
+        "u",
+        domain.component(),
+        targets,
+        num_cases=8,
+    )
+
+    batch = constraint.sample(key=jr.key(2))
+    assert batch.target.shape == (8,)
+    assert jnp.allclose(batch.target, targets[batch.indices])
+    assert jnp.allclose(batch.points["data"].data, data[batch.indices])
+
+
+def test_supervised_dataset_constraint_samples_only_index_subset():
+    data = jnp.arange(12.0, dtype=float).reshape((6, 2))
+    domain = DatasetDomain(data)
+    targets = data[:, 0]
+    allowed = jnp.asarray([1, 3, 5], dtype=jnp.int32)
+    constraint = SupervisedDatasetConstraint(
+        "u",
+        domain.component(),
+        targets,
+        num_cases=16,
+        indices=allowed,
+    )
+
+    batch = constraint.sample(key=jr.key(8))
+    assert jnp.all(jnp.isin(batch.indices, allowed))
+    assert jnp.allclose(batch.target, targets[batch.indices])
+
+
+def test_supervised_dataset_constraint_supports_pytree_rows():
+    rows = {
+        "a": jnp.asarray([[0.0], [1.0], [2.0]]),
+        "b": jnp.asarray([1.0, 2.0, 4.0]),
+    }
+    domain = DatasetDomain(rows)
+    targets = rows["a"][:, 0] + rows["b"]
+
+    @domain.Function("data")
+    def u(row):
+        return row["a"][0] + row["b"]
+
+    constraint = SupervisedDatasetConstraint(
+        "u",
+        domain.component(),
+        targets,
+        num_cases=12,
+        structure=ProductStructure((("data",),)),
+    )
+
+    loss = constraint.loss({"u": u}, key=jr.key(3))
+    assert jnp.allclose(loss, 0.0, atol=1e-12)
+
+
+def test_supervised_dataset_constraint_validates_targets_and_num_cases():
+    domain = DatasetDomain(jnp.zeros((3, 2), dtype=float))
+
+    with pytest.raises(ValueError, match="leading axis"):
+        SupervisedDatasetConstraint(
+            "u",
+            domain.component(),
+            jnp.zeros((4,), dtype=float),
+            num_cases=2,
+        )
+
+    with pytest.raises(ValueError, match="num_cases"):
+        SupervisedDatasetConstraint(
+            "u",
+            domain.component(),
+            jnp.zeros((3,), dtype=float),
+            num_cases=0,
+        )
+
+    with pytest.raises(ValueError, match="indices"):
+        SupervisedDatasetConstraint(
+            "u",
+            domain.component(),
+            jnp.zeros((3,), dtype=float),
+            num_cases=2,
+            indices=jnp.asarray([3], dtype=jnp.int32),
+        )

--- a/tests/unit/constraints/test_trajectory_data.py
+++ b/tests/unit/constraints/test_trajectory_data.py
@@ -1,0 +1,180 @@
+#
+#  Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+from phydrax.constraints import (
+    FunctionalConstraint,
+    TrajectoryCaseDataConstraint,
+    TrajectorySignal,
+)
+from phydrax.domain import ProductStructure, TrajectoryDatasetDomain
+from phydrax.operators.differential import partial_n, partial_t
+
+
+def _make_problem():
+    inputs = jnp.asarray([[0.0, 1.0], [1.0, 2.0], [2.0, 4.0]])
+    lengths = jnp.asarray([2, 4, 3])
+    domain = TrajectoryDatasetDomain(inputs, lengths, dt=0.5)
+    times = domain.start + domain.dt * jnp.arange(domain.max_length)
+    slopes = jnp.asarray([1.0, 2.0, 3.0, 4.0])
+    offsets = jnp.asarray([0.0, 10.0, 20.0, 30.0])
+    values = inputs[:, 0, None, None] + times[None, :, None] * slopes + offsets
+    structure = ProductStructure((("data", "t"),))
+    return domain, values, slopes, structure
+
+
+def _all_observation_batch(domain, structure):
+    case_indices = domain.flat_case_indices
+    time_indices = domain.flat_time_indices
+    times = domain.observation_times(case_indices, time_indices)
+    return domain.points_from_case_time(
+        case_indices,
+        times,
+        structure=structure,
+        time_indices=time_indices,
+    )
+
+
+def test_trajectory_signal_matches_vector_observed_nodes():
+    domain, values, _slopes, structure = _make_problem()
+    signal = TrajectorySignal(domain, values, interpolation="linear")
+
+    batch = _all_observation_batch(domain, structure)
+    pred = jnp.asarray(signal(batch, key=jr.key(0)).data)
+    target = values[domain.flat_case_indices, domain.flat_time_indices]
+    assert jnp.allclose(pred, target, atol=1e-12)
+
+
+def test_trajectory_signal_linear_interpolates_and_differentiates():
+    domain, values, slopes, structure = _make_problem()
+    signal = TrajectorySignal(domain, values, interpolation="linear")
+    dt_signal = partial_t(signal, var="t")
+
+    case_indices = jnp.asarray([0, 1, 2], dtype=jnp.int32)
+    times = jnp.asarray([0.25, 0.75, 0.5])
+    batch = domain.points_from_case_time(
+        case_indices,
+        times,
+        structure=structure,
+        time_indices=jnp.asarray([0, 1, 1], dtype=jnp.int32),
+    )
+
+    pred = jnp.asarray(signal(batch, key=jr.key(1)).data)
+    expected = values[case_indices, 0] + times[:, None] * slopes
+    assert jnp.allclose(pred, expected, atol=1e-12)
+
+    deriv = jnp.asarray(dt_signal(batch, key=jr.key(2)).data)
+    assert jnp.allclose(deriv, jnp.broadcast_to(slopes, deriv.shape), atol=1e-12)
+
+
+def test_trajectory_signal_nearest_rejects_time_derivative():
+    domain, values, _slopes, _structure = _make_problem()
+    signal = TrajectorySignal(domain, values, interpolation="nearest")
+
+    with pytest.raises(ValueError, match="nearest.*not differentiable"):
+        partial_t(signal, var="t")
+
+
+def test_trajectory_signal_cubic_hermite_supports_second_time_derivative():
+    domain, values, _slopes, structure = _make_problem()
+    signal = TrajectorySignal(domain, values, interpolation="cubic_hermite")
+    d2_signal = partial_n(signal, var="t", order=2)
+
+    batch = domain.component().sample(12, structure=structure, key=jr.key(6))
+    pred = jnp.asarray(d2_signal(batch, key=jr.key(7)).data)
+    assert jnp.allclose(pred, jnp.zeros_like(pred), atol=1e-10)
+
+
+def test_trajectory_case_data_constraint_supervises_case_only_vector_target():
+    domain, _values, _slopes, _structure = _make_problem()
+    inputs = domain.inputs
+    targets = jnp.stack(
+        (inputs[:, 0] + inputs[:, 1], inputs[:, 0] - inputs[:, 1]), axis=-1
+    )
+
+    @domain.Function("data")
+    def theta(data):
+        return jnp.asarray([data[0] + data[1], data[0] - data[1]])
+
+    constraint = TrajectoryCaseDataConstraint(
+        "theta",
+        domain.component(),
+        targets,
+        num_cases=12,
+        label="case_target",
+    )
+
+    loss = constraint.loss({"theta": theta}, key=jr.key(3))
+    metrics = constraint.data_metrics({"theta": theta}, key=jr.key(3))
+    assert jnp.allclose(loss, 0.0, atol=1e-12)
+    assert jnp.allclose(metrics["data_accuracy"], 1.0)
+    assert jnp.allclose(metrics["data_relative_l2_error"], 0.0)
+
+
+def test_trajectory_case_data_constraint_can_evaluate_at_case_end():
+    domain, _values, _slopes, _structure = _make_problem()
+    inputs = domain.inputs
+    targets = inputs[:, 0] + domain.end_times
+
+    @domain.Function("data", "t")
+    def final_value(data, t):
+        return data[0] + t
+
+    constraint = TrajectoryCaseDataConstraint(
+        "theta",
+        domain.component(),
+        targets,
+        num_cases=12,
+        case_time="end",
+    )
+
+    loss = constraint.loss({"theta": final_value}, key=jr.key(4))
+    assert jnp.allclose(loss, 0.0, atol=1e-12)
+
+
+def test_trajectory_case_data_constraint_samples_only_case_subset():
+    domain, _values, _slopes, _structure = _make_problem()
+    targets = domain.inputs[:, 0]
+    allowed = jnp.asarray([0, 2], dtype=jnp.int32)
+
+    constraint = TrajectoryCaseDataConstraint(
+        "theta",
+        domain.component(),
+        targets,
+        num_cases=16,
+        case_indices=allowed,
+    )
+
+    batch = constraint.sample(key=jr.key(8))
+    assert jnp.all(jnp.isin(batch.case_indices, allowed))
+    assert jnp.allclose(batch.target, targets[batch.case_indices])
+
+
+def test_physics_residual_can_use_fixed_trajectory_signal():
+    inputs = jnp.asarray([[0.0], [1.0], [2.0]])
+    lengths = jnp.asarray([2, 4, 3])
+    domain = TrajectoryDatasetDomain(inputs, lengths, dt=0.25)
+    structure = ProductStructure((("data", "t"),))
+    times = domain.start + domain.dt * jnp.arange(domain.max_length)
+    values = inputs[:, 0, None] + 2.0 * times[None, :]
+    signal = TrajectorySignal(domain, values, interpolation="linear")
+
+    @domain.Function("data", "t")
+    def u(data, t):
+        return data[0] + 2.0 * t
+
+    constraint = FunctionalConstraint.from_operator(
+        component=domain.component(),
+        operator=lambda u_fn, s_fn: partial_t(u_fn, var="t") - partial_t(s_fn, var="t"),
+        constraint_vars=("u", "s"),
+        num_points=16,
+        structure=structure,
+        reduction="mean",
+    )
+
+    loss = constraint.loss({"u": u, "s": signal}, key=jr.key(5))
+    assert jnp.allclose(loss, 0.0, atol=1e-12)

--- a/tests/unit/data_utils/test_splits.py
+++ b/tests/unit/data_utils/test_splits.py
@@ -1,0 +1,46 @@
+#
+#  Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+from phydrax.data_utils import kfold_indices, train_test_split_indices
+
+
+def test_train_test_split_indices_partition_cases():
+    train, test = train_test_split_indices(10, test_fraction=0.2, key=jr.key(0))
+
+    assert train.shape == (8,)
+    assert test.shape == (2,)
+    merged = jnp.sort(jnp.concatenate((train, test)))
+    assert jnp.all(merged == jnp.arange(10, dtype=jnp.int32))
+
+
+def test_train_test_split_indices_can_skip_shuffle():
+    train, test = train_test_split_indices(5, test_fraction=0.4, shuffle=False)
+
+    assert jnp.all(test == jnp.asarray([0, 1], dtype=jnp.int32))
+    assert jnp.all(train == jnp.asarray([2, 3, 4], dtype=jnp.int32))
+
+
+def test_kfold_indices_cover_each_case_once_as_validation():
+    folds = kfold_indices(7, 3, key=jr.key(1))
+
+    validation = jnp.concatenate([fold[1] for fold in folds])
+    assert jnp.all(jnp.sort(validation) == jnp.arange(7, dtype=jnp.int32))
+    for train, val in folds:
+        assert train.shape[0] + val.shape[0] == 7
+        assert not bool(jnp.any(jnp.isin(train, val)))
+
+
+def test_split_helpers_validate_arguments():
+    with pytest.raises(ValueError, match="at least 2"):
+        train_test_split_indices(1)
+
+    with pytest.raises(ValueError, match="strictly between"):
+        train_test_split_indices(4, test_fraction=1.0)
+
+    with pytest.raises(ValueError, match="cannot exceed"):
+        kfold_indices(3, 4)

--- a/tests/unit/domain/test_dataset_domain.py
+++ b/tests/unit/domain/test_dataset_domain.py
@@ -6,6 +6,7 @@ import jax.numpy as jnp
 import jax.random as jr
 
 from phydrax.domain import DatasetDomain, FourierAxisSpec, Interval1d, ProductStructure
+from phydrax.domain._dataset import DATASET_INDEX_KEY
 from phydrax.operators.integral import integral
 
 
@@ -22,6 +23,20 @@ def test_dataset_domain_samples_points_batch():
     field = batch["data"]
     assert field.dims == (axis, None)
     assert field.data.shape == (4, 1)
+
+
+def test_dataset_domain_points_from_indices_carries_internal_indices():
+    data = jnp.arange(10.0, dtype=float).reshape((5, 2))
+    dom = DatasetDomain(data)
+    structure = ProductStructure((("data",),))
+    indices = jnp.asarray([3, 1, 3], dtype=jnp.int32)
+
+    batch = dom.points_from_indices(indices, structure=structure)
+    axis = batch.structure.axis_for("data")
+    assert axis is not None
+    assert batch["data"].dims == (axis, None)
+    assert jnp.allclose(batch["data"].data, data[indices])
+    assert jnp.all(batch[DATASET_INDEX_KEY].data == indices)
 
 
 def test_dataset_domain_integral_probability_measure_is_average():

--- a/tests/unit/domain/test_trajectory_dataset_domain.py
+++ b/tests/unit/domain/test_trajectory_dataset_domain.py
@@ -1,0 +1,119 @@
+#
+#  Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+from phydrax.constraints import FunctionalConstraint
+from phydrax.domain import (
+    FixedEnd,
+    ProductStructure,
+    TrajectoryDatasetDomain,
+    UniformAxisSpec,
+)
+from phydrax.domain._trajectory_dataset import TRAJECTORY_CASE_INDEX_KEY
+from phydrax.operators.differential import partial_t
+from phydrax.operators.integral import integral
+
+
+def test_trajectory_dataset_domain_samples_coupled_data_time_points():
+    inputs = jnp.arange(3.0).reshape((3, 1))
+    domain = TrajectoryDatasetDomain(inputs, jnp.asarray([2, 4, 3]), dt=0.25)
+    component = domain.component()
+    structure = ProductStructure((("data", "t"),))
+
+    batch = component.sample(8, structure=structure, key=jr.key(0))
+    axis = batch.structure.axis_for("data")
+    assert axis is not None
+    assert batch.structure.axis_for("t") == axis
+    assert batch["data"].dims == (axis, None)
+    assert batch["t"].dims == (axis,)
+
+    case_indices = jnp.asarray(batch[TRAJECTORY_CASE_INDEX_KEY].data, dtype=jnp.int32)
+    assert jnp.allclose(batch["data"].data[:, 0], inputs[case_indices, 0])
+    assert jnp.all(batch["t"].data >= domain.start)
+    assert jnp.all(batch["t"].data <= domain.end_times[case_indices])
+
+
+def test_trajectory_dataset_probability_integral_of_constant_is_one():
+    inputs = jnp.zeros((3, 1))
+    domain = TrajectoryDatasetDomain(inputs, jnp.asarray([2, 4, 3]), dt=0.25)
+    component = domain.component()
+    structure = ProductStructure((("data", "t"),))
+    batch = component.sample(17, structure=structure, key=jr.key(1))
+
+    out = integral(1.0, batch, component=component)
+    assert jnp.allclose(jnp.asarray(out.data), 1.0)
+
+
+def test_trajectory_dataset_measure_modes():
+    inputs = jnp.zeros((3, 1))
+    avg = TrajectoryDatasetDomain(
+        inputs,
+        jnp.asarray([2, 4, 3]),
+        dt=0.25,
+        measure="time_integral_average",
+    )
+    summed = TrajectoryDatasetDomain(
+        inputs,
+        jnp.asarray([2, 4, 3]),
+        dt=0.25,
+        measure="time_integral_sum",
+    )
+
+    assert jnp.allclose(avg.component().measure(), jnp.mean(avg.durations))
+    assert jnp.allclose(summed.component().measure(), jnp.sum(summed.durations))
+
+
+def test_trajectory_dataset_fixed_end_is_row_specific():
+    inputs = jnp.arange(3.0).reshape((3, 1))
+    domain = TrajectoryDatasetDomain(inputs, jnp.asarray([2, 4, 3]), dt=0.25)
+    component = domain.component({"t": FixedEnd()})
+    structure = ProductStructure((("data", "t"),))
+
+    batch = component.sample(8, structure=structure, key=jr.key(2))
+    case_indices = jnp.asarray(batch[TRAJECTORY_CASE_INDEX_KEY].data, dtype=jnp.int32)
+    assert jnp.allclose(batch["t"].data, domain.end_times[case_indices])
+
+
+def test_trajectory_dataset_rejects_coord_separable_sampling():
+    inputs = jnp.arange(3.0).reshape((3, 1))
+    domain = TrajectoryDatasetDomain(inputs, jnp.asarray([2, 4, 3]), dt=0.25)
+
+    with pytest.raises(ValueError, match="paired data-time"):
+        domain.component().sample_coord_separable({"t": UniformAxisSpec(8)})
+
+
+def test_trajectory_dataset_equivalence_includes_ragged_lengths():
+    inputs = jnp.arange(3.0).reshape((3, 1))
+    first = TrajectoryDatasetDomain(inputs, jnp.asarray([2, 4, 3]), dt=0.25)
+    same = TrajectoryDatasetDomain(inputs, jnp.asarray([2, 4, 3]), dt=0.25)
+    different = TrajectoryDatasetDomain(inputs, jnp.asarray([4, 2, 3]), dt=0.25)
+
+    assert first.equivalent(same)
+    assert not first.equivalent(different)
+
+
+def test_trajectory_dataset_participates_in_time_residual_constraints():
+    inputs = jnp.arange(3.0).reshape((3, 1))
+    domain = TrajectoryDatasetDomain(inputs, jnp.asarray([2, 4, 3]), dt=0.25)
+    component = domain.component()
+    structure = ProductStructure((("data", "t"),))
+
+    @domain.Function("data", "t")
+    def exact(data, t):
+        return data[0] + t
+
+    constraint = FunctionalConstraint.from_operator(
+        component=component,
+        operator=lambda u: partial_t(u, var="t") - 1.0,
+        constraint_vars="u",
+        num_points=16,
+        structure=structure,
+        reduction="mean",
+    )
+
+    loss = constraint.loss({"u": exact}, key=jr.key(3))
+    assert jnp.allclose(loss, 0.0, atol=1e-12)

--- a/tests/unit/nn/test_models/test_neural_operator_models.py
+++ b/tests/unit/nn/test_models/test_neural_operator_models.py
@@ -13,7 +13,7 @@ from phydrax.domain import (
     ProductStructure,
     Square,
 )
-from phydrax.nn.models import DeepONet, FNO1d, FNO2d, MLP
+from phydrax.nn.models import DeepONet, FNO1d, FNO2d, MLP, SeparableMLP
 from phydrax.operators.differential import laplacian
 
 
@@ -193,3 +193,73 @@ def test_domain_model_structured_kwarg_allows_plain_callable_tuple_input():
     x_axis0, x_axis1 = batch.coord_axes_by_label["x"]
     assert out.dims == (data_axis, x_axis0, x_axis1)
     assert out.data.shape == (2, nx, ny)
+
+
+def test_separable_mlp_domain_model_defaults_to_flat_point_packing():
+    data = jnp.ones((3, 2), dtype=float)
+    data_dom = DatasetDomain(data)
+    geom = Interval1d(0.0, 1.0)
+    domain = data_dom @ geom
+
+    model = SeparableMLP(
+        in_size=3,
+        out_size=2,
+        width_size=8,
+        depth=2,
+        latent_size=4,
+        key=jr.key(0),
+    )
+    u = domain.Model("data", "x")(model)
+
+    batch = domain.component().sample(
+        5,
+        structure=ProductStructure((("data", "x"),)),
+        key=jr.key(1),
+    )
+    out = u(batch)
+
+    sample_axis = batch.structure.axis_for("data")
+    assert out.dims == (sample_axis, None)
+    assert out.data.shape == (5, 2)
+    assert jnp.all(jnp.isfinite(jnp.asarray(out.data)))
+
+
+def test_separable_mlp_domain_model_still_uses_structured_blockwise_grids():
+    geom = Square(center=(0.0, 0.0), side=1.0)
+    model = SeparableMLP(
+        in_size=2,
+        out_size=2,
+        width_size=8,
+        depth=2,
+        latent_size=4,
+        key=jr.key(2),
+    )
+    u = geom.Model("x")(model)
+
+    batch = geom.component().sample_coord_separable(
+        {"x": (FourierAxisSpec(5), FourierAxisSpec(4))},
+        key=jr.key(3),
+    )
+    out = u(batch)
+
+    x_axis0, x_axis1 = batch.coord_axes_by_label["x"]
+    assert out.dims == (x_axis0, x_axis1, None)
+    assert out.data.shape == (5, 4, 2)
+    assert jnp.all(jnp.isfinite(jnp.asarray(out.data)))
+
+
+def test_domain_model_input_mode_rejects_conflicting_structured_alias():
+    data = jnp.ones((3, 2), dtype=float)
+    domain = DatasetDomain(data) @ Interval1d(0.0, 1.0)
+
+    with pytest.raises(ValueError, match="either structured=True or input_mode"):
+        domain.Model("data", "x", structured=True, input_mode="flat")
+
+
+def test_domain_model_structured_input_mode_requires_structured_model():
+    data = jnp.ones((3, 2), dtype=float)
+    domain = DatasetDomain(data) @ Interval1d(0.0, 1.0)
+    model = MLP(in_size=3, out_size=1, width_size=8, depth=2, key=jr.key(0))
+
+    with pytest.raises(ValueError, match="requires a model that supports structured"):
+        domain.Model("data", "x", input_mode="structured")(model)

--- a/tests/unit/solver/test_solve_logging.py
+++ b/tests/unit/solver/test_solve_logging.py
@@ -7,8 +7,12 @@ import jax.random as jr
 import optax
 from tensorboard.backend.event_processing.event_accumulator import EventAccumulator
 
-from phydrax.constraints import DiscreteInteriorDataConstraint, DiscreteTimeDataConstraint
-from phydrax.domain import HyperRectangle, TimeInterval
+from phydrax.constraints import (
+    DiscreteInteriorDataConstraint,
+    DiscreteTimeDataConstraint,
+    SupervisedDatasetConstraint,
+)
+from phydrax.domain import DatasetDomain, HyperRectangle, TimeInterval
 from phydrax.nn import MLP
 from phydrax.solver import FunctionalSolver
 
@@ -33,6 +37,40 @@ def _make_supervised_solver(seed: int = 0) -> FunctionalSolver:
         label="data",
     )
     return FunctionalSolver(functions={"u": u}, constraints=[data])
+
+
+def _make_dataset_solver_with_eval(seed: int = 0) -> FunctionalSolver:
+    rows = jnp.linspace(0.0, 1.0, 6).reshape((-1, 1))
+    domain = DatasetDomain(rows)
+    targets = 1.0 + 2.0 * rows[:, 0]
+    model = MLP(
+        in_size=1,
+        out_size="scalar",
+        hidden_sizes=(),
+        key=jr.key(seed),
+    )
+    u = domain.Model("data")(model)
+    train = SupervisedDatasetConstraint(
+        "u",
+        domain.component(),
+        targets,
+        num_cases=8,
+        indices=jnp.asarray([0, 1, 2, 3], dtype=jnp.int32),
+        label="train_data",
+    )
+    eval_data = SupervisedDatasetConstraint(
+        "u",
+        domain.component(),
+        targets,
+        num_cases=8,
+        indices=jnp.asarray([4, 5], dtype=jnp.int32),
+        label="eval_data",
+    )
+    return FunctionalSolver(
+        functions={"u": u},
+        constraints=[train],
+        eval_constraints=[eval_data],
+    )
 
 
 def test_discrete_interior_data_constraint_reports_exact_data_metrics():
@@ -93,6 +131,54 @@ def test_solve_text_log_includes_discrete_data_metrics(tmp_path):
     assert "data_rmse=" in text
 
 
+def test_solve_text_log_includes_eval_constraints(tmp_path):
+    solver = _make_dataset_solver_with_eval()
+    log_path = tmp_path / "train_eval.log"
+
+    solver.solve(
+        num_iter=2,
+        optim=optax.adam(1e-2),
+        seed=0,
+        log_every=1,
+        log_path=log_path,
+    )
+
+    text = log_path.read_text(encoding="utf-8")
+    assert "[train 0] train_data:" in text
+    assert "[eval 0] eval_data:" in text
+    assert "data_accuracy=" in text
+
+
+def test_solver_loss_excludes_eval_constraints():
+    domain = DatasetDomain(jnp.asarray([[0.0], [1.0], [2.0]]))
+    train_targets = jnp.asarray([0.0, 1.0, 2.0])
+    eval_targets = jnp.asarray([10.0, 10.0, 10.0])
+
+    @domain.Function("data")
+    def u(data):
+        return data[0]
+
+    train = SupervisedDatasetConstraint(
+        "u",
+        domain.component(),
+        train_targets,
+        num_cases=8,
+    )
+    eval_data = SupervisedDatasetConstraint(
+        "u",
+        domain.component(),
+        eval_targets,
+        num_cases=8,
+    )
+    solver = FunctionalSolver(
+        functions={"u": u},
+        constraints=[train],
+        eval_constraints=[eval_data],
+    )
+
+    assert jnp.allclose(solver.loss(key=jr.key(4)), 0.0, atol=1e-12)
+
+
 def test_solve_tensorboard_log_includes_loss_and_data_metrics(tmp_path):
     solver = _make_supervised_solver()
     log_dir = tmp_path / "tb"
@@ -116,7 +202,33 @@ def test_solve_tensorboard_log_includes_loss_and_data_metrics(tmp_path):
     assert "train/loss" in scalar_tags
     assert "train/best_loss" in scalar_tags
     assert "train/iter_time_s" in scalar_tags
+    assert "train/constraints/000_data/loss" in scalar_tags
+    assert "train/constraints/000_data/data_accuracy" in scalar_tags
     assert "constraints/000_data/loss" in scalar_tags
     assert "constraints/000_data/data_accuracy" in scalar_tags
     assert "constraints/000_data/data_relative_l2_error" in scalar_tags
     assert "constraints/000_data/data_rmse" in scalar_tags
+
+
+def test_solve_tensorboard_log_includes_eval_metrics(tmp_path):
+    solver = _make_dataset_solver_with_eval()
+    log_dir = tmp_path / "tb_eval"
+
+    solver.solve(
+        num_iter=2,
+        optim=optax.adam(1e-2),
+        seed=0,
+        log_every=0,
+        tensorboard_log_dir=log_dir,
+        tensorboard_every=1,
+    )
+
+    accumulator = EventAccumulator(str(log_dir))
+    accumulator.Reload()
+    scalar_tags = set(accumulator.Tags()["scalars"])
+
+    assert "train/constraints/000_train_data/loss" in scalar_tags
+    assert "eval/constraints/000_eval_data/loss" in scalar_tags
+    assert "eval/constraints/000_eval_data/data_accuracy" in scalar_tags
+    assert "eval/constraints/000_eval_data/data_relative_l2_error" in scalar_tags
+    assert "eval/constraints/000_eval_data/data_rmse" in scalar_tags

--- a/tests/unit/solver/test_trainable_partition.py
+++ b/tests/unit/solver/test_trainable_partition.py
@@ -1,0 +1,110 @@
+#
+#  Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import warnings
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+
+from phydrax._trainable import partition_trainable
+from phydrax.constraints import enforce_ragged_time_series, TrajectorySignal
+from phydrax.domain import DomainFunction, Interval1d, TrajectoryDatasetDomain
+from phydrax.nn import MLP
+
+
+def _inexact_leaves(tree):
+    return tuple(
+        leaf for leaf in jax.tree_util.tree_leaves(tree) if eqx.is_inexact_array(leaf)
+    )
+
+
+def _array_leaves(tree):
+    return tuple(leaf for leaf in jax.tree_util.tree_leaves(tree) if eqx.is_array(leaf))
+
+
+def _make_trajectory_problem():
+    inputs = jnp.asarray([[0.0, 1.0], [1.0, 2.0], [2.0, 4.0]])
+    lengths = jnp.asarray([2, 4, 3])
+    domain = TrajectoryDatasetDomain(inputs, lengths, dt=0.5)
+    times = domain.start + domain.dt * jnp.arange(domain.max_length)
+    values = inputs[:, 0, None] + times[None, :]
+    return domain, inputs, values
+
+
+def test_trajectory_signal_construction_does_not_make_static_jax_arrays():
+    domain, _inputs, values = _make_trajectory_problem()
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        TrajectorySignal(domain, values, interpolation="linear")
+
+    messages = tuple(str(w.message) for w in caught)
+    assert not any("JAX array is being set as static" in message for message in messages)
+
+
+def test_trajectory_signal_values_are_not_trainable_solver_leaves():
+    domain, _inputs, values = _make_trajectory_problem()
+    signal = TrajectorySignal(domain, values, interpolation="linear")
+
+    params, non_trainable = partition_trainable({"forcing": signal})
+    assert _inexact_leaves(params) == ()
+    fixed_shapes = tuple(leaf.shape for leaf in _array_leaves(non_trainable))
+    assert values.shape in fixed_shapes
+
+
+def test_domain_parameter_stays_trainable_but_plain_constant_is_fixed():
+    domain = Interval1d(0.0, 1.0)
+    param = domain.Parameter(1.0)
+    const = DomainFunction(domain=domain, deps=(), func=jnp.asarray(2.0))
+
+    param_params, _param_fixed = partition_trainable({"lambda": param})
+    const_params, const_fixed = partition_trainable({"c": const})
+
+    assert len(_inexact_leaves(param_params)) == 1
+    assert _inexact_leaves(const_params) == ()
+    assert any(bool(jnp.allclose(leaf, 2.0)) for leaf in _inexact_leaves(const_fixed))
+
+
+def test_trajectory_domain_arrays_are_not_trainable_model_leaves():
+    domain, inputs, _values = _make_trajectory_problem()
+    model = MLP(
+        in_size=3,
+        out_size="scalar",
+        width_size=5,
+        depth=1,
+        key=jr.key(0),
+    )
+    u = domain.Model("data", "t")(model)
+
+    params, non_trainable = partition_trainable({"u": u})
+    param_shapes = tuple(leaf.shape for leaf in _inexact_leaves(params))
+    fixed_shapes = tuple(leaf.shape for leaf in _array_leaves(non_trainable))
+
+    assert param_shapes
+    assert inputs.shape not in param_shapes
+    assert inputs.shape in fixed_shapes
+    assert domain.lengths.shape in fixed_shapes
+
+
+def test_hard_ragged_table_is_fixed_but_free_model_stays_trainable():
+    domain, _inputs, values = _make_trajectory_problem()
+    model = MLP(
+        in_size=3,
+        out_size="scalar",
+        width_size=5,
+        depth=1,
+        key=jr.key(1),
+    )
+    free = domain.Model("data", "t")(model)
+    hard = enforce_ragged_time_series(free, domain, values)
+
+    params, non_trainable = partition_trainable({"u": hard})
+    param_shapes = tuple(leaf.shape for leaf in _inexact_leaves(params))
+    fixed_shapes = tuple(leaf.shape for leaf in _array_leaves(non_trainable))
+
+    assert param_shapes
+    assert values.shape not in param_shapes
+    assert values.shape in fixed_shapes


### PR DESCRIPTION
## Summary

- Add `TrajectoryDatasetDomain` plus ragged time-series and trajectory case data constraints.
- Add hard ragged time-series enforcement, trainable partition helpers, and eval-only solver constraints with TensorBoard namespaces.
- Add `SupervisedDatasetConstraint`, deterministic split helpers, and docs for dataset/ragged workflows.
- Update structured model/domain plumbing for flat and structured inputs.