### PR TITLE
Add model-level loss terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ Most workflows are composing a few primitives:
 - **DomainFunction**: a field $u :\Omega\to\mathbb{R}^m$ with explicit label dependencies.
 - **Operators**: maps $u\mapsto r$ like $\nabla u$, $\Delta u$, $\partial_t u$, integrals, etc.
 - **Constraints**: scalar loss terms built from residuals on components.
-- **FunctionalSolver**: sums constraints into a differentiable scalar objective and runs optimization.
+- **Model losses**: optional parameter-space penalties attached directly to models.
+- **FunctionalSolver**: sums constraints and model losses into a differentiable scalar objective and runs optimization.
 
 Optional (but central in many PDE problems):
 

--- a/docs/all-of-phydrax.md
+++ b/docs/all-of-phydrax.md
@@ -29,7 +29,7 @@ At a practical level, most workflows look like:
 2) define one or more **fields** \(u_\theta:\Omega\to\mathbb{R}^m\) as `DomainFunction`s,  
 3) build **residual operators** \(r=\mathcal{N}(u_\theta,\dots)\) using `phydrax.operators`,  
 4) turn residuals into **constraint terms** \(\ell_i\) via sampling + reduction (mean/integral),  
-5) sum terms into a **functional** \(L=\sum_i \ell_i\) and optimize with `FunctionalSolver`.
+5) sum constraint terms and optional model losses into a **functional** and optimize with `FunctionalSolver`.
 
 Two design choices make this interoperable:
 

--- a/docs/api/nn/index.md
+++ b/docs/api/nn/index.md
@@ -9,5 +9,7 @@ support for structured inputs used in product-domain factorization.
     - Most models are pointwise: use `jax.vmap` for batching.
     - `out_size="scalar"` indicates scalar outputs (typically shape `()`).
     - Structured models accept tuple inputs like `(x1, x2, ..., xd)`.
+    - Models may contribute parameter-space penalties through `model.add_model_loss(...)`
+      or a custom `__loss__` method; `FunctionalSolver` adds these to the train objective.
     - Neural operator architectures (DeepONet/FNO) are intentionally minimal reference
       implementations; extend them for production features and scaling needs.

--- a/docs/api/solver/functional_solver.md
+++ b/docs/api/solver/functional_solver.md
@@ -1,7 +1,7 @@
 # Functional solver
 
-`FunctionalSolver` is the main entry point for turning a set of fields and constraints
-into a differentiable objective.
+`FunctionalSolver` is the main entry point for turning a set of fields, constraints,
+and attached model losses into a differentiable objective.
 
 For a conceptual overview (loss evaluation, enforced pipelines, training loop behavior), see
 [Guides → Solvers and training](../../guides_solver.md).

--- a/docs/api/solver/index.md
+++ b/docs/api/solver/index.md
@@ -9,5 +9,5 @@ For a conceptual overview (loss evaluation, enforced pipelines, training loop be
 !!! note
     Key notes:
 
-    - Use `FunctionalSolver` to sum constraint losses into $L=\sum_i \ell_i$.
+    - Use `FunctionalSolver` to sum constraint losses and attached model losses.
     - Use enforced constraint pipelines to enforce conditions by construction (no penalty term).

--- a/docs/guides_solver.md
+++ b/docs/guides_solver.md
@@ -8,14 +8,16 @@ A `FunctionalSolver` is a lightweight orchestrator that holds:
 
 - `functions`: a mapping `{name: DomainFunction}` of the current fields,
 - `constraints`: a list/tuple of constraint objects, each producing a scalar loss,
+- model-level losses attached to models with `model.add_model_loss(...)` or a custom
+  model `__loss__` hook,
 - `eval_constraints`: optional constraints used only for diagnostics/logging,
 - optional `constraint_pipelines`: enforced-constraint pipelines that replace raw fields with ansatz
   functions satisfying selected conditions exactly.
 
-The total objective is the sum of constraint losses:
+The training objective is the sum of constraint losses plus any attached model losses:
 
 $$
-L = \sum_i \ell_i.
+L = \sum_i \ell_i + \sum_j r_j.
 $$
 
 `eval_constraints` are evaluated against the same current ansatz functions, but
@@ -31,8 +33,60 @@ When you call `solver.loss(key=...)`:
    *ansatz functions* via `solver.ansatz_functions()`.
 2) The provided PRNG key is split into one subkey per constraint.
 3) Each constraint loss is evaluated and summed.
+4) Model-level losses attached to the raw trainable models are evaluated and added.
 
 Additional keyword arguments are forwarded to each constraint's `.loss(...)` method.
+The `iter_` keyword, when present, is also forwarded to model losses.
+
+## Model losses
+
+Use model losses for parameter-space penalties that are not residuals over a domain,
+such as spectral penalties, norm targets, sparsity penalties, or architecture-specific
+regularization. These losses are evaluated once per distinct raw model in
+`solver.functions`; if two fields share the same model object, its model loss is not
+double-counted.
+
+For existing Phydrax models, attach a scalar penalty with `add_model_loss(...)`:
+
+```python
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import phydrax as phx
+
+model = phx.nn.MLP(
+    in_size=2,
+    out_size="scalar",
+    width_size=32,
+    depth=2,
+    key=jr.key(0),
+).add_model_loss(
+    lambda m: (jnp.linalg.norm(m.layers[0].weight) - 1.0) ** 2,
+    weight=1e-4,
+    label="unit_weight_norm",
+)
+```
+
+The penalty callable receives the wrapped model as its first argument and may accept
+keyword-only `key` and `iter_` arguments.
+
+Custom model classes can instead implement `__loss__`:
+
+```python
+class MyModel(eqx.Module):
+    weight: jax.Array
+
+    def __call__(self, x, *, key=None):
+        return self.weight @ x
+
+    def __loss__(self, *, key=None, iter_=None):
+        return 1e-4 * jnp.sum(self.weight**2)
+```
+
+During `solve(...)`, model losses contribute to gradients, optimizer state, and
+best-model selection. When `log_constraints=True`, text logs print them as
+`[model i] ...`, and TensorBoard writes them under `train/model_losses/...`.
 
 ## Enforced-constraint pipelines
 
@@ -93,7 +147,7 @@ scalar), so constraints can implement schedules (annealing, curriculum weights, 
 of those outputs.
 
 - `log_every`: console/file logging cadence. Use `0` to disable text progress logs.
-- `log_constraints`: include per-constraint losses in text logs and TensorBoard.
+- `log_constraints`: include per-constraint and per-model-loss terms in text logs and TensorBoard.
 - `log_path`: write text logs to a file instead of stdout.
 - `tensorboard_log_dir`: write TensorBoard event files.
 - `tensorboard_every`: TensorBoard scalar cadence. By default it follows `log_every`

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,8 @@ Most workflows are composing a few primitives:
 - **DomainFunction**: a field \(u:\Omega\to\mathbb{R}^m\) with explicit label dependencies.
 - **Operators**: maps \(u\mapsto r\) like \(\nabla u\), \(\Delta u\), \(\partial_t u\), integrals, etc.
 - **Constraints**: scalar loss terms built from residuals on components.
-- **FunctionalSolver**: sums constraints into a differentiable scalar objective and runs optimization.
+- **Model losses**: optional parameter-space penalties attached directly to models.
+- **FunctionalSolver**: sums constraints and model losses into a differentiable scalar objective and runs optimization.
 
 Optional (but central in many PDE problems):
 

--- a/phydrax/domain/_model_function.py
+++ b/phydrax/domain/_model_function.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import inspect
 import warnings
 from collections.abc import Callable
 from typing import Any
@@ -12,7 +13,8 @@ import jax.numpy as jnp
 
 from .._callable import _ensure_special_kwonly_args
 from .._strict import StrictModule
-from ..nn.models.core._base import _AbstractBaseModel, DomainInputMode
+from ..nn.models.core._base import DomainInputMode
+from ..nn.models.core._loss import model_domain_metadata
 
 
 class StructuredCallable(StrictModule):
@@ -34,11 +36,13 @@ def structured(func: Callable, /) -> StructuredCallable:
 
 class _ConcatenatedModelCallable(StrictModule):
     raw_model: Any
-    model: Callable
     input_mode: DomainInputMode
     supports_structured_input: bool
     supports_blockwise_input: bool
     warn_on_auto_fallback: bool
+    _call_has_var_kwargs: bool
+    _call_has_key: bool
+    _call_has_iter: bool
 
     def __init__(
         self,
@@ -54,11 +58,14 @@ class _ConcatenatedModelCallable(StrictModule):
         inferred_mode: DomainInputMode = (
             "structured" if supports_structured_input else "flat"
         )
-        if isinstance(model, _AbstractBaseModel):
-            inferred_mode = model.domain_input_mode()
-            supports_structured_input = model.supports_structured_input()
-            supports_blockwise_input = model.supports_blockwise_input()
-            warn_on_auto_fallback = model.warn_on_auto_fallback()
+        metadata = model_domain_metadata(model)
+        if metadata is not None:
+            (
+                inferred_mode,
+                supports_structured_input,
+                supports_blockwise_input,
+                warn_on_auto_fallback,
+            ) = metadata
         mode = inferred_mode if input_mode is None else input_mode
         if mode not in ("flat", "structured"):
             raise ValueError("input_mode must be either 'flat' or 'structured'.")
@@ -71,11 +78,35 @@ class _ConcatenatedModelCallable(StrictModule):
         self.supports_structured_input = bool(supports_structured_input)
         self.supports_blockwise_input = bool(supports_blockwise_input)
         self.warn_on_auto_fallback = bool(warn_on_auto_fallback)
-        self.model = _ensure_special_kwonly_args(model)
+        sig = inspect.signature(model)
+        params = sig.parameters
+        has_var_kwargs = any(
+            p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
+        )
+        has_key = "key" in params
+        has_iter = "iter_" in params
+        if has_key and params["key"].kind != inspect.Parameter.KEYWORD_ONLY:
+            raise TypeError("`key` must be a keyword-only argument for model calls.")
+        if has_iter and params["iter_"].kind != inspect.Parameter.KEYWORD_ONLY:
+            raise TypeError("`iter_` must be a keyword-only argument for model calls.")
+        self._call_has_var_kwargs = bool(has_var_kwargs)
+        self._call_has_key = bool(has_key)
+        self._call_has_iter = bool(has_iter)
 
     def emit_auto_fallback_warning(self, message: str, /) -> None:
         if self.warn_on_auto_fallback:
             warnings.warn(message, UserWarning, stacklevel=3)
+
+    def _call_model(self, x: Any, /, *, key=None, iter_=None, **kwargs: Any):
+        out_kwargs = kwargs
+        if self._call_has_key or self._call_has_var_kwargs:
+            out_kwargs = dict(out_kwargs)
+            out_kwargs["key"] = key
+        if iter_ is not None and (self._call_has_iter or self._call_has_var_kwargs):
+            if out_kwargs is kwargs:
+                out_kwargs = dict(out_kwargs)
+            out_kwargs["iter_"] = iter_
+        return self.raw_model(x, **out_kwargs)
 
     def __call__(self, *args: Any, key=None, iter_=None, **kwargs: Any):
         if not args:
@@ -109,7 +140,7 @@ class _ConcatenatedModelCallable(StrictModule):
                     else:
                         packed.append(jnp.asarray(value))
                 x_in = tuple(packed)
-            return self.model(x_in, key=key, iter_=iter_, **kwargs)
+            return self._call_model(x_in, key=key, iter_=iter_, **kwargs)
 
         arrays: list[Any] = []
         for value in args:
@@ -122,7 +153,7 @@ class _ConcatenatedModelCallable(StrictModule):
 
         if len(arrays) == 1:
             x_in = arrays[0]
-            return self.model(x_in, key=key, iter_=iter_, **kwargs)
+            return self._call_model(x_in, key=key, iter_=iter_, **kwargs)
 
         leading_shape: tuple[int, ...] | None = None
         for arr in arrays:
@@ -141,7 +172,7 @@ class _ConcatenatedModelCallable(StrictModule):
         if leading_shape is None:
             parts = [arr.reshape((-1,)) for arr in arrays]
             x_in = jnp.concatenate(parts, axis=0)
-            return self.model(x_in, key=key, iter_=iter_, **kwargs)
+            return self._call_model(x_in, key=key, iter_=iter_, **kwargs)
 
         parts = []
         for arr in arrays:
@@ -158,4 +189,4 @@ class _ConcatenatedModelCallable(StrictModule):
                 )
             parts.append(part)
         x_in = jnp.concatenate(parts, axis=-1)
-        return self.model(x_in, key=key, iter_=iter_, **kwargs)
+        return self._call_model(x_in, key=key, iter_=iter_, **kwargs)

--- a/phydrax/nn/__init__.py
+++ b/phydrax/nn/__init__.py
@@ -36,6 +36,7 @@ from .activations import (  # noqa: F401
     Stan,
 )
 from .models import (  # noqa: F401
+    add_model_loss,
     ComplexOutputModel,
     ConcatenatedModel,
     DeepONet,
@@ -50,6 +51,7 @@ from .models import (  # noqa: F401
     Linear,
     MagnitudeDirectionModel,
     MLP,
+    ModelWithLoss,
     RandomFourierFeatureEmbeddings,
     Separable,
     SeparableFeynmaNN,
@@ -78,6 +80,7 @@ __all__ = [
     "KAN",
     "Linear",
     "MLP",
+    "ModelWithLoss",
     "FeynmaNN",
     "DeepONet",
     "FNO1d",
@@ -87,4 +90,5 @@ __all__ = [
     "LatentContractionModel",
     "Separable",
     "SeparableFeynmaNN",
+    "add_model_loss",
 ]

--- a/phydrax/nn/models/__init__.py
+++ b/phydrax/nn/models/__init__.py
@@ -10,6 +10,7 @@ from .architectures._mlp import MLP
 from .architectures._separable_feynmann import SeparableFeynmaNN
 from .architectures._separable_kan import SeparableKAN
 from .architectures._separable_mlp import SeparableMLP
+from .core._loss import add_model_loss, ModelWithLoss
 from .embeddings._fourier import (
     RandomFourierFeatureEmbeddings,
 )
@@ -39,6 +40,7 @@ __all__ = [
     "KAN",
     "Linear",
     "MLP",
+    "ModelWithLoss",
     "ConcatenatedModel",
     "MagnitudeDirectionModel",
     "DeepONet",
@@ -52,4 +54,5 @@ __all__ = [
     "LatentExecutionPolicy",
     "LatentContractionModel",
     "Separable",
+    "add_model_loss",
 ]

--- a/phydrax/nn/models/core/_base.py
+++ b/phydrax/nn/models/core/_base.py
@@ -3,8 +3,10 @@
 #
 
 from abc import abstractmethod
-from typing import ClassVar, Literal, TypeAlias
+from collections.abc import Callable
+from typing import Any, ClassVar, Literal, TypeAlias
 
+import jax.numpy as jnp
 from jaxtyping import Array
 
 from ...._doc import DOC_KEY0
@@ -50,6 +52,28 @@ class _AbstractBaseModel(StrictModule):
     @classmethod
     def domain_input_mode(cls) -> DomainInputMode:
         return cls._domain_input_mode
+
+    def __loss__(
+        self,
+        *,
+        key: EvalKey = DOC_KEY0,
+        iter_: Array | None = None,
+    ) -> Array:
+        del key, iter_
+        return jnp.array(0.0, dtype=float)
+
+    def add_model_loss(
+        self,
+        penalty: Callable[..., Any],
+        /,
+        *,
+        weight: Any = 1.0,
+        label: str | None = None,
+    ) -> Any:
+        """Return a model wrapper that contributes an extra scalar objective term."""
+        from ._loss import add_model_loss
+
+        return add_model_loss(self, penalty, weight=weight, label=label)
 
 
 class _AbstractStructuredInputModel(_AbstractBaseModel):

--- a/phydrax/nn/models/core/_loss.py
+++ b/phydrax/nn/models/core/_loss.py
@@ -1,0 +1,347 @@
+#
+#  Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import dataclasses
+import inspect
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any
+
+import jax.numpy as jnp
+import jax.random as jr
+from jaxtyping import Array, Key
+
+from ...._callable import _ensure_special_kwonly_args
+from ...._doc import DOC_KEY0
+from ...._strict import StrictModule
+from ...._trainable import NonTrainableState
+from ._base import _AbstractBaseModel, DomainInputMode, EvalKey
+
+
+class ModelLossTerm(StrictModule, NonTrainableState):
+    """A fixed scalar penalty attached to a model."""
+
+    penalty: Callable
+    weight: Array
+    label: str | None
+
+    def __init__(
+        self,
+        penalty: Callable[..., Any],
+        /,
+        *,
+        weight: Any = 1.0,
+        label: str | None = None,
+    ):
+        if not callable(penalty):
+            raise TypeError("Model loss penalty must be callable.")
+        self.penalty = _ensure_special_kwonly_args(penalty)
+        self.weight = jnp.asarray(weight, dtype=float)
+        self.label = None if label is None else str(label)
+
+    def __call__(
+        self,
+        model: Any,
+        /,
+        *,
+        key: EvalKey = DOC_KEY0,
+        iter_: Array | None = None,
+    ) -> Array:
+        value = self.penalty(model, key=key, iter_=iter_)
+        return self.weight * jnp.asarray(value, dtype=float).reshape(())
+
+
+class ModelWithLoss(StrictModule):
+    """Callable model wrapper carrying additional scalar objective terms."""
+
+    model: Any
+    loss_terms: tuple[ModelLossTerm, ...]
+    loss_identity: int
+    in_size: Any
+    out_size: Any
+    _call_has_var_kwargs: bool
+    _call_has_key: bool
+    _call_has_iter: bool
+
+    def __init__(
+        self,
+        model: Any,
+        /,
+        *,
+        loss_terms: Sequence[ModelLossTerm] = (),
+        loss_identity: int | None = None,
+    ):
+        if not callable(model):
+            raise TypeError("ModelWithLoss requires a callable model.")
+        terms = tuple(loss_terms)
+        bad = tuple(t for t in terms if not isinstance(t, ModelLossTerm))
+        if bad:
+            raise TypeError(
+                "loss_terms must contain ModelLossTerm instances; got "
+                f"{tuple(type(t).__name__ for t in bad)!r}."
+            )
+        self.model = model
+        self.loss_terms = terms
+        self.loss_identity = int(id(terms) if loss_identity is None else loss_identity)
+        self.in_size = getattr(model, "in_size", None)
+        self.out_size = getattr(model, "out_size", None)
+        sig = inspect.signature(model)
+        params = sig.parameters
+        self._call_has_var_kwargs = any(
+            p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
+        )
+        self._call_has_key = "key" in params
+        self._call_has_iter = "iter_" in params
+        if self._call_has_key and params["key"].kind != inspect.Parameter.KEYWORD_ONLY:
+            raise TypeError("`key` must be a keyword-only argument for model calls.")
+        if (
+            self._call_has_iter
+            and params["iter_"].kind != inspect.Parameter.KEYWORD_ONLY
+        ):
+            raise TypeError("`iter_` must be a keyword-only argument for model calls.")
+
+    def __call__(
+        self,
+        x: Any,
+        /,
+        *,
+        key: EvalKey = DOC_KEY0,
+        iter_: Array | None = None,
+        **kwargs: Any,
+    ) -> Array:
+        out_kwargs = kwargs
+        if self._call_has_key or self._call_has_var_kwargs:
+            out_kwargs = dict(out_kwargs)
+            out_kwargs["key"] = key
+        if iter_ is not None and (self._call_has_iter or self._call_has_var_kwargs):
+            if out_kwargs is kwargs:
+                out_kwargs = dict(out_kwargs)
+            out_kwargs["iter_"] = iter_
+        return self.model(x, **out_kwargs)
+
+    def add_model_loss(
+        self,
+        penalty: Callable[..., Any],
+        /,
+        *,
+        weight: Any = 1.0,
+        label: str | None = None,
+    ) -> "ModelWithLoss":
+        term = ModelLossTerm(penalty, weight=weight, label=label)
+        return ModelWithLoss(self.model, loss_terms=self.loss_terms + (term,))
+
+    def supports_structured_input(self) -> bool:
+        return _supports_structured_input(self.model)
+
+    def supports_blockwise_input(self) -> bool:
+        return _supports_blockwise_input(self.model)
+
+    def warn_on_auto_fallback(self) -> bool:
+        method = getattr(self.model, "warn_on_auto_fallback", None)
+        if callable(method):
+            return bool(method())
+        return bool(getattr(self.model, "_warn_on_auto_fallback", False))
+
+    def domain_input_mode(self) -> DomainInputMode:
+        return _domain_input_mode(self.model)
+
+
+def add_model_loss(
+    model: Any,
+    penalty: Callable[..., Any],
+    /,
+    *,
+    weight: Any = 1.0,
+    label: str | None = None,
+) -> ModelWithLoss:
+    """Return `model` wrapped with an additional scalar objective term.
+
+    `penalty` is called as `penalty(model, key=..., iter_=...)` and must return a
+    scalar JAX-compatible value.
+    """
+    term = ModelLossTerm(penalty, weight=weight, label=label)
+    if isinstance(model, ModelWithLoss):
+        return ModelWithLoss(model.model, loss_terms=model.loss_terms + (term,))
+    return ModelWithLoss(model, loss_terms=(term,))
+
+
+def _supports_structured_input(model: Any, /) -> bool:
+    method = getattr(model, "supports_structured_input", None)
+    if callable(method):
+        return bool(method())
+    return bool(getattr(model, "_supports_structured_input", False))
+
+
+def _supports_blockwise_input(model: Any, /) -> bool:
+    method = getattr(model, "supports_blockwise_input", None)
+    if callable(method):
+        return bool(method())
+    return bool(getattr(model, "_supports_blockwise_input", False))
+
+
+def _domain_input_mode(model: Any, /) -> DomainInputMode:
+    method = getattr(model, "domain_input_mode", None)
+    if callable(method):
+        mode = method()
+    else:
+        mode = getattr(model, "_domain_input_mode", "flat")
+    if mode not in ("flat", "structured"):
+        raise ValueError("Model domain input mode must be either 'flat' or 'structured'.")
+    return mode
+
+
+def model_domain_metadata(
+    model: Any,
+    /,
+) -> tuple[DomainInputMode, bool, bool, bool] | None:
+    """Return domain-call metadata for Phydrax model-like objects."""
+    if isinstance(model, (_AbstractBaseModel, ModelWithLoss)):
+        return (
+            _domain_input_mode(model),
+            _supports_structured_input(model),
+            _supports_blockwise_input(model),
+            bool(
+                model.warn_on_auto_fallback()
+                if callable(getattr(model, "warn_on_auto_fallback", None))
+                else getattr(model, "_warn_on_auto_fallback", False)
+            ),
+        )
+    return None
+
+
+def model_loss_labels(model: Any, /) -> tuple[str, ...]:
+    """Return static labels for all objective terms attached to `model`."""
+    return _model_loss_labels(model, seen=set())
+
+
+def model_loss_values(
+    model: Any,
+    /,
+    *,
+    key: Key[Array, ""] = DOC_KEY0,
+    iter_: Array | None = None,
+) -> tuple[Array, ...]:
+    """Evaluate all scalar objective terms attached to `model`."""
+    counter = [0]
+    return _model_loss_values(model, key=key, iter_=iter_, seen=set(), counter=counter)
+
+
+def _model_loss_labels(model: Any, /, *, seen: set[int]) -> tuple[str, ...]:
+    obj_id = _model_loss_seen_key(model)
+    if obj_id in seen:
+        return ()
+    seen.add(obj_id)
+
+    if isinstance(model, ModelWithLoss):
+        labels = list(_model_loss_labels(model.model, seen=seen))
+        for i, term in enumerate(model.loss_terms):
+            labels.append(
+                term.label
+                if term.label is not None
+                else f"{type(model.model).__name__}.model_loss_{i}"
+            )
+        return tuple(labels)
+
+    labels: list[str] = []
+    if _has_custom_model_loss(model):
+        labels.append(f"{type(model).__name__}.__loss__")
+
+    for child in _iter_children(model):
+        labels.extend(_model_loss_labels(child, seen=seen))
+    return tuple(labels)
+
+
+def _model_loss_values(
+    model: Any,
+    /,
+    *,
+    key: Key[Array, ""],
+    iter_: Array | None,
+    seen: set[int],
+    counter: list[int],
+) -> tuple[Array, ...]:
+    obj_id = _model_loss_seen_key(model)
+    if obj_id in seen:
+        return ()
+    seen.add(obj_id)
+
+    if isinstance(model, ModelWithLoss):
+        values = list(
+            _model_loss_values(
+                model.model,
+                key=key,
+                iter_=iter_,
+                seen=seen,
+                counter=counter,
+            )
+        )
+        for term in model.loss_terms:
+            term_key = jr.fold_in(key, counter[0])
+            counter[0] += 1
+            values.append(jnp.asarray(term(model.model, key=term_key, iter_=iter_)))
+        return tuple(values)
+
+    values: list[Array] = []
+    if _has_custom_model_loss(model):
+        loss_fn = _ensure_special_kwonly_args(getattr(model, "__loss__"))
+        term_key = jr.fold_in(key, counter[0])
+        counter[0] += 1
+        value = loss_fn(key=term_key, iter_=iter_)
+        values.append(jnp.asarray(value, dtype=float).reshape(()))
+
+    for child in _iter_children(model):
+        values.extend(
+            _model_loss_values(
+                child,
+                key=key,
+                iter_=iter_,
+                seen=seen,
+                counter=counter,
+            )
+        )
+    return tuple(values)
+
+
+def _has_custom_model_loss(model: Any, /) -> bool:
+    if isinstance(model, ModelWithLoss):
+        return False
+    loss_attr = getattr(type(model), "__loss__", None)
+    if loss_attr is None:
+        return callable(getattr(model, "__loss__", None))
+    return loss_attr is not _AbstractBaseModel.__loss__
+
+
+def _model_loss_seen_key(model: Any, /) -> int:
+    if isinstance(model, ModelWithLoss):
+        return model.loss_identity
+    return id(model)
+
+
+def _iter_children(value: Any, /):
+    if value is None or isinstance(value, (str, bytes, int, float, complex, bool)):
+        return
+    if isinstance(value, ModelWithLoss):
+        return
+    if dataclasses.is_dataclass(value):
+        for field in dataclasses.fields(value):
+            if field.name == "_strict_initialized":
+                continue
+            yield getattr(value, field.name)
+        return
+    if isinstance(value, Mapping):
+        yield from value.values()
+        return
+    if isinstance(value, tuple | list):
+        yield from value
+
+
+__all__ = [
+    "ModelLossTerm",
+    "ModelWithLoss",
+    "add_model_loss",
+    "model_domain_metadata",
+    "model_loss_labels",
+    "model_loss_values",
+]

--- a/phydrax/solver/__init__.py
+++ b/phydrax/solver/__init__.py
@@ -5,8 +5,9 @@
 """
 # Solver
 
-Solvers assemble constraints and data into a loss and provide utilities for
-training or evaluation. The main entry point is `FunctionalSolver`.
+Solvers assemble constraints, data, and attached model losses into a loss and
+provide utilities for training or evaluation. The main entry point is
+`FunctionalSolver`.
 
 ## Enforced constraints
 

--- a/phydrax/solver/_functional_solver.py
+++ b/phydrax/solver/_functional_solver.py
@@ -25,6 +25,7 @@ from ._enforced_constraint_pipeline import (
     MultiFieldEnforcedConstraint,
     SingleFieldEnforcedConstraint,
 )
+from ._model_losses import function_model_loss_values
 
 
 def _constraints_tuple(
@@ -47,18 +48,19 @@ def _constraints_tuple(
 
 
 class FunctionalSolver(StrictModule):
-    r"""Assemble constraints into a differentiable scalar loss.
+    r"""Assemble constraints and model losses into a differentiable scalar loss.
 
     A `FunctionalSolver` holds:
 
     - a mapping of named fields (as `DomainFunction`s), e.g. $u_\theta$;
     - a collection of constraints $\ell_i$ producing scalar penalties.
+    - optional model-level losses attached to the trainable models.
     - optional eval-only constraints for validation diagnostics.
 
     The solver loss is the (weighted) sum
 
     $$
-    L = \sum_i \ell_i.
+    L = \sum_i \ell_i + \sum_j r_j.
     $$
 
     Optionally, *enforced constraint pipelines* can be applied to replace the raw fields
@@ -68,8 +70,8 @@ class FunctionalSolver(StrictModule):
 
     - `ansatz_functions()` applies any enforced pipelines and returns the effective field
       mapping used by constraints.
-    - `loss(key=...)` splits the provided PRNG key into one subkey per constraint and
-      sums the resulting scalar losses.
+    - `loss(key=...)` splits the provided PRNG key into one subkey per constraint,
+      evaluates any attached model losses, and sums the resulting scalar losses.
 
     **Training**
 
@@ -188,25 +190,31 @@ class FunctionalSolver(StrictModule):
         key: Key[Array, ""] = DOC_KEY0,
         **kwargs: Any,
     ) -> Array:
-        r"""Evaluate the total loss $L=\sum_i \ell_i$ over all configured constraints.
+        r"""Evaluate the total loss over constraints and attached model losses.
 
         This:
 
         1) applies enforced pipelines (if configured),
         2) splits `key` into one subkey per constraint,
-        3) sums `constraint.loss(...)` over all constraints.
+        3) sums `constraint.loss(...)` over all constraints,
+        4) adds scalar model losses attached via `model.add_model_loss(...)` or
+           model `__loss__` hooks.
 
         Any additional keyword arguments are forwarded to each constraint.
         """
-        if not self.constraints:
-            return jnp.array(0.0, dtype=float)
-
         functions = self.ansatz_functions()
         keys = jr.split(key, len(self.constraints))
         total = jnp.array(0.0, dtype=float)
         with derivative_runtime_context():
             for c, k in zip(self.constraints, keys, strict=True):
                 total = total + c.loss(functions, key=k, **kwargs)
+            iter_ = kwargs.get("iter_", None)
+            for term in function_model_loss_values(
+                self.functions,
+                key=jr.fold_in(key, len(self.constraints)),
+                iter_=iter_,
+            ):
+                total = total + term
         return total
 
     def solve(

--- a/phydrax/solver/_functional_train.py
+++ b/phydrax/solver/_functional_train.py
@@ -19,6 +19,7 @@ from jax import core as jcore
 
 from .._trainable import combine_trainable, partition_trainable
 from ..operators.differential._runtime import derivative_runtime_context
+from ._model_losses import function_model_loss_labels, function_model_loss_values
 
 
 if TYPE_CHECKING:
@@ -98,6 +99,10 @@ def _constraint_tag(index: int, name: str, /) -> str:
     return f"constraints/{index:03d}_{_clean_tag_part(name)}"
 
 
+def _model_loss_tag(index: int, name: str, /) -> str:
+    return f"model_losses/{index:03d}_{_clean_tag_part(name)}"
+
+
 def _metric_suffix(metrics: dict[str, Any], /) -> str:
     if not metrics:
         return ""
@@ -151,6 +156,20 @@ def _write_constraint_tensorboard_scalars(
                 writer.scalar(f"{base}/{metric_name}", metric_value, step)
 
 
+def _write_model_loss_tensorboard_scalars(
+    writer: _TensorBoardLogger,
+    *,
+    step: int,
+    model_loss_names: tuple[str, ...],
+    terms: Any,
+) -> None:
+    terms_arr = jnp.asarray(terms, dtype=float)
+    for i, (name, val) in enumerate(
+        zip(model_loss_names, list(map(float, terms_arr)), strict=True)
+    ):
+        writer.scalar(f"train/{_model_loss_tag(i, name)}/loss", val, step)
+
+
 def _log_tensorboard_scalars(
     writer: _TensorBoardLogger,
     *,
@@ -161,6 +180,8 @@ def _log_tensorboard_scalars(
     train_constraint_names: tuple[str, ...],
     train_terms: Any,
     train_data_metrics: tuple[dict[str, Any], ...],
+    train_model_loss_names: tuple[str, ...],
+    train_model_loss_terms: Any,
     eval_constraint_names: tuple[str, ...],
     eval_terms: Any,
     eval_data_metrics: tuple[dict[str, Any], ...],
@@ -181,6 +202,12 @@ def _log_tensorboard_scalars(
         terms=train_terms,
         data_metrics=train_data_metrics,
         write_legacy=True,
+    )
+    _write_model_loss_tensorboard_scalars(
+        writer,
+        step=step,
+        model_loss_names=train_model_loss_names,
+        terms=train_model_loss_terms,
     )
     _write_constraint_tensorboard_scalars(
         writer,
@@ -268,6 +295,7 @@ def solve(
             raise ValueError("tensorboard_flush_every must be positive.")
         log_constraints_ = bool(log_constraints)
         constraint_names = tuple(_constraint_label(c) for c in self.constraints)
+        model_loss_names = function_model_loss_labels(self.functions)
         eval_constraint_names = tuple(_constraint_label(c) for c in self.eval_constraints)
 
         def _loss_wrt_params(params_, non_trainable_, solver, key, iter_):
@@ -283,11 +311,25 @@ def solve(
                     for c, k in zip(solver.constraints, keys, strict=True):
                         term = c.loss(enforced, key=k, iter_=iter_)
                         total = total + jnp.asarray(term, dtype=float).reshape(())
+                    for term in function_model_loss_values(
+                        functions,
+                        key=jr.fold_in(key, len(solver.constraints)),
+                        iter_=iter_,
+                    ):
+                        total = total + jnp.asarray(term, dtype=float).reshape(())
                     return total, jnp.zeros((0,), dtype=float)
 
                 terms: list[jax.Array] = []
                 for c, k in zip(solver.constraints, keys, strict=True):
                     term = c.loss(enforced, key=k, iter_=iter_)
+                    term = jnp.asarray(term, dtype=float).reshape(())
+                    terms.append(term)
+                    total = total + term
+                for term in function_model_loss_values(
+                    functions,
+                    key=jr.fold_in(key, len(solver.constraints)),
+                    iter_=iter_,
+                ):
                     term = jnp.asarray(term, dtype=float).reshape(())
                     terms.append(term)
                     total = total + term
@@ -405,6 +447,9 @@ def solve(
             params, opt_state, loss_val, terms = solve_step(
                 params, non_trainable, opt_state, self, subkey, iter_
             )
+            terms_arr = jnp.asarray(terms, dtype=float)
+            train_constraint_terms = terms_arr[: len(constraint_names)]
+            train_model_loss_terms = terms_arr[len(constraint_names) :]
             if keep_best:
                 loss_f = float(loss_val)
                 if loss_f < best_loss:
@@ -457,13 +502,27 @@ def solve(
                     file=out_file,
                 )
                 if log_constraints_:
-                    terms_arr = jnp.asarray(terms, dtype=float)
                     for i, (name, val) in enumerate(
-                        zip(constraint_names, list(map(float, terms_arr)), strict=True)
+                        zip(
+                            constraint_names,
+                            list(map(float, train_constraint_terms)),
+                            strict=True,
+                        )
                     ):
                         suffix = _metric_suffix(train_data_metrics[i])
                         print(
                             f"  [train {i}] {name}: {val:.6e}{suffix}",
+                            file=out_file,
+                        )
+                    for i, (name, val) in enumerate(
+                        zip(
+                            model_loss_names,
+                            list(map(float, train_model_loss_terms)),
+                            strict=True,
+                        )
+                    ):
+                        print(
+                            f"  [model {i}] {name}: {val:.6e}",
                             file=out_file,
                         )
                     eval_terms_arr = jnp.asarray(eval_terms, dtype=float)
@@ -489,8 +548,10 @@ def solve(
                     best_loss=best_display,
                     iter_time_s=iter_time_s,
                     train_constraint_names=constraint_names,
-                    train_terms=terms,
+                    train_terms=train_constraint_terms,
                     train_data_metrics=train_data_metrics,
+                    train_model_loss_names=model_loss_names,
+                    train_model_loss_terms=train_model_loss_terms,
                     eval_constraint_names=eval_constraint_names,
                     eval_terms=eval_terms,
                     eval_data_metrics=eval_data_metrics,
@@ -536,6 +597,7 @@ def _solve_evosax(
         raise ValueError("tensorboard_flush_every must be positive.")
     log_constraints_ = bool(log_constraints)
     constraint_names = tuple(_constraint_label(c) for c in self.constraints)
+    model_loss_names = function_model_loss_labels(self.functions)
     eval_constraint_names = tuple(_constraint_label(c) for c in self.eval_constraints)
 
     algo_params = algo.default_params
@@ -554,6 +616,12 @@ def _solve_evosax(
                     total = total + c.loss(enforced, key=k, iter_=iter_)
                 else:
                     total = total + c.loss(enforced, key=k, iter_=iter_, batch=b)
+            for term in function_model_loss_values(
+                functions,
+                key=jr.fold_in(key, len(solver.constraints)),
+                iter_=iter_,
+            ):
+                total = total + jnp.asarray(term, dtype=float).reshape(())
         return total
 
     def _terms_for_params(p, non_trainable_, solver, key, iter_, batches):
@@ -570,6 +638,12 @@ def _solve_evosax(
                     term = c.loss(enforced, key=k, iter_=iter_)
                 else:
                     term = c.loss(enforced, key=k, iter_=iter_, batch=b)
+                terms.append(jnp.asarray(term, dtype=float).reshape(()))
+            for term in function_model_loss_values(
+                functions,
+                key=jr.fold_in(key, len(solver.constraints)),
+                iter_=iter_,
+            ):
                 terms.append(jnp.asarray(term, dtype=float).reshape(()))
         if terms:
             return jnp.stack(terms, axis=0)
@@ -708,6 +782,8 @@ def _solve_evosax(
                 {} for _ in self.eval_constraints
             )
             terms_arr = jnp.zeros((0,), dtype=float)
+            train_constraint_terms = terms_arr[: len(constraint_names)]
+            train_model_loss_terms = terms_arr[len(constraint_names) :]
             if log_constraints_ and (console_step or tensorboard_step):
                 terms_arr = jnp.asarray(
                     terms_fn(
@@ -720,6 +796,8 @@ def _solve_evosax(
                     ),
                     dtype=float,
                 )
+                train_constraint_terms = terms_arr[: len(constraint_names)]
+                train_model_loss_terms = terms_arr[len(constraint_names) :]
                 train_data_metrics = _data_metrics_for_constraints(
                     cand_params,
                     non_trainable,
@@ -756,11 +834,26 @@ def _solve_evosax(
                 )
                 if log_constraints_:
                     for i, (name, val) in enumerate(
-                        zip(constraint_names, list(map(float, terms_arr)), strict=True)
+                        zip(
+                            constraint_names,
+                            list(map(float, train_constraint_terms)),
+                            strict=True,
+                        )
                     ):
                         suffix = _metric_suffix(train_data_metrics[i])
                         print(
                             f"  [train {i}] {name}: {val:.6e}{suffix}",
+                            file=out_file,
+                        )
+                    for i, (name, val) in enumerate(
+                        zip(
+                            model_loss_names,
+                            list(map(float, train_model_loss_terms)),
+                            strict=True,
+                        )
+                    ):
+                        print(
+                            f"  [model {i}] {name}: {val:.6e}",
                             file=out_file,
                         )
                     eval_terms_arr = jnp.asarray(eval_terms, dtype=float)
@@ -786,8 +879,10 @@ def _solve_evosax(
                     best_loss=best_display,
                     iter_time_s=iter_time_s,
                     train_constraint_names=constraint_names,
-                    train_terms=terms_arr,
+                    train_terms=train_constraint_terms,
                     train_data_metrics=train_data_metrics,
+                    train_model_loss_names=model_loss_names,
+                    train_model_loss_terms=train_model_loss_terms,
                     eval_constraint_names=eval_constraint_names,
                     eval_terms=eval_terms,
                     eval_data_metrics=eval_data_metrics,

--- a/phydrax/solver/_model_losses.py
+++ b/phydrax/solver/_model_losses.py
@@ -1,0 +1,97 @@
+#
+#  Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import Mapping
+from typing import Any
+
+import jax.numpy as jnp
+from jaxtyping import Array, Key
+
+from .._doc import DOC_KEY0
+from ..domain._model_function import _ConcatenatedModelCallable
+from ..nn.models.core._base import _AbstractBaseModel
+from ..nn.models.core._loss import (
+    _has_custom_model_loss,
+    _model_loss_labels,
+    _model_loss_values,
+    ModelWithLoss,
+)
+
+
+def function_model_loss_labels(functions: Any, /) -> tuple[str, ...]:
+    """Return static labels for all model objective terms in a function tree."""
+    labels: list[str] = []
+    seen_models: set[int] = set()
+    for model in _iter_model_roots(functions, seen_nodes=set()):
+        labels.extend(_model_loss_labels(model, seen=seen_models))
+    return tuple(labels)
+
+
+def function_model_loss_values(
+    functions: Any,
+    /,
+    *,
+    key: Key[Array, ""] = DOC_KEY0,
+    iter_: Array | None = None,
+) -> tuple[Array, ...]:
+    """Evaluate all model objective terms in a function tree."""
+    values: list[Array] = []
+    seen_models: set[int] = set()
+    counter = [0]
+    for model in _iter_model_roots(functions, seen_nodes=set()):
+        values.extend(
+            _model_loss_values(
+                model,
+                key=key,
+                iter_=iter_,
+                seen=seen_models,
+                counter=counter,
+            )
+        )
+    return tuple(jnp.asarray(v, dtype=float).reshape(()) for v in values)
+
+
+def _iter_model_roots(value: Any, /, *, seen_nodes: set[int]):
+    node_id = id(value)
+    if node_id in seen_nodes:
+        return
+    seen_nodes.add(node_id)
+
+    if isinstance(value, _ConcatenatedModelCallable):
+        yield value.raw_model
+        return
+
+    if isinstance(value, (ModelWithLoss, _AbstractBaseModel)) or _has_custom_model_loss(
+        value
+    ):
+        yield value
+        return
+
+    if value is None or isinstance(value, (str, bytes, int, float, complex, bool)):
+        return
+
+    if dataclasses.is_dataclass(value):
+        for field in dataclasses.fields(value):
+            if field.name == "_strict_initialized":
+                continue
+            yield from _iter_model_roots(getattr(value, field.name), seen_nodes=seen_nodes)
+        return
+
+    if isinstance(value, Mapping):
+        for item in value.values():
+            yield from _iter_model_roots(item, seen_nodes=seen_nodes)
+        return
+
+    if isinstance(value, tuple | list):
+        for item in value:
+            yield from _iter_model_roots(item, seen_nodes=seen_nodes)
+
+
+__all__ = [
+    "function_model_loss_labels",
+    "function_model_loss_values",
+]

--- a/tests/unit/nn/test_model_losses.py
+++ b/tests/unit/nn/test_model_losses.py
@@ -1,0 +1,221 @@
+#
+#  Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from typing import Literal
+
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import optax
+from tensorboard.backend.event_processing.event_accumulator import EventAccumulator
+
+from phydrax.constraints import DiscreteInteriorDataConstraint
+from phydrax.constraints._pointset import points_batch_from_points
+from phydrax.domain import Interval1d
+from phydrax.nn import add_model_loss, MLP, SeparableMLP
+from phydrax.nn.models.core._base import _AbstractBaseModel
+from phydrax.solver import FunctionalSolver
+
+
+def _domain_model_solver(model) -> FunctionalSolver:
+    domain = Interval1d(0.0, 1.0)
+    u = domain.Model("x")(model)
+    return FunctionalSolver(functions={"u": u}, constraints=[])
+
+
+def test_add_model_loss_contributes_to_solver_loss_without_constraints():
+    model = MLP(
+        in_size=1,
+        out_size="scalar",
+        hidden_sizes=(),
+        key=jr.key(0),
+    ).add_model_loss(lambda m: 2.0, weight=3.0, label="constant")
+
+    solver = _domain_model_solver(model)
+
+    assert jnp.allclose(solver.loss(key=jr.key(0)), 6.0)
+
+
+def test_standalone_add_model_loss_helper_matches_method_api():
+    base = MLP(
+        in_size=1,
+        out_size="scalar",
+        hidden_sizes=(),
+        key=jr.key(1),
+    )
+    model = add_model_loss(base, lambda m: 4.0, weight=0.5, label="constant")
+
+    solver = _domain_model_solver(model)
+
+    assert jnp.allclose(solver.loss(key=jr.key(0)), 2.0)
+
+
+def test_model_with_loss_preserves_wrapped_forward_call():
+    base = MLP(
+        in_size=1,
+        out_size="scalar",
+        hidden_sizes=(),
+        key=jr.key(6),
+    )
+    model = base.add_model_loss(lambda m: 0.0)
+    x = jnp.asarray([0.25])
+
+    assert jnp.allclose(model(x, key=jr.key(0)), base(x, key=jr.key(0)))
+
+
+def test_model_loss_is_optimized_by_solve():
+    model = MLP(
+        in_size=1,
+        out_size="scalar",
+        hidden_sizes=(),
+        key=jr.key(2),
+    ).add_model_loss(
+        lambda m: (jnp.linalg.norm(m.layers[0].weight) - 1.0) ** 2,
+        label="unit_weight_norm",
+    )
+    solver = _domain_model_solver(model)
+    init_loss = solver.loss(key=jr.key(0))
+
+    trained = solver.solve(
+        num_iter=80,
+        optim=optax.adam(5e-2),
+        seed=0,
+        log_every=0,
+    )
+    final_loss = trained.loss(key=jr.key(0))
+
+    assert final_loss < init_loss
+
+
+class CustomLossModel(_AbstractBaseModel):
+    weight: jax.Array
+    in_size: Literal["scalar"]
+    out_size: Literal["scalar"]
+
+    def __init__(self, init: float = 0.0):
+        self.weight = jnp.asarray(init, dtype=float)
+        self.in_size = "scalar"
+        self.out_size = "scalar"
+
+    def __call__(self, x, /, *, key=None):
+        del key
+        return self.weight * jnp.asarray(x)
+
+    def __loss__(self, *, key=None, iter_=None):
+        del key, iter_
+        return (self.weight - 2.0) ** 2
+
+
+class ScaleModel(_AbstractBaseModel):
+    weight: jax.Array
+    in_size: Literal["scalar"]
+    out_size: Literal["scalar"]
+
+    def __init__(self, init: float = 0.0):
+        self.weight = jnp.asarray(init, dtype=float)
+        self.in_size = "scalar"
+        self.out_size = "scalar"
+
+    def __call__(self, x, /, *, key=None):
+        del key
+        return self.weight * jnp.asarray(x)
+
+
+def test_custom_model_dunder_loss_contributes_to_solver_loss():
+    solver = _domain_model_solver(CustomLossModel(init=0.5))
+
+    assert jnp.allclose(solver.loss(key=jr.key(0)), 2.25)
+
+
+def test_model_loss_regularizes_domain_model_forward_weights():
+    domain = Interval1d(0.0, 1.0)
+    model = ScaleModel(init=1.0).add_model_loss(
+        lambda m: m.weight**2,
+        label="l2",
+    )
+    u = domain.Model("x")(model)
+    data = DiscreteInteriorDataConstraint(
+        "u",
+        domain,
+        points={"x": jnp.asarray([[1.0]])},
+        values=jnp.asarray([1.0]),
+        label="data",
+    )
+    tx = optax.sgd(0.1)
+    solver = FunctionalSolver(functions={"u": u}, constraints=[data])
+
+    trained = solver.solve(
+        num_iter=1,
+        optim=optax.GradientTransformation(tx.init, tx.update),
+        keep_best=False,
+        log_every=0,
+    )
+
+    batch = points_batch_from_points(domain.component(), {"x": jnp.asarray([[1.0]])})
+    pred = jnp.asarray(trained.functions["u"](batch).data).reshape(())
+    assert jnp.allclose(pred, 0.8, atol=1e-6)
+
+
+def test_model_loss_is_deduped_for_shared_model_aliases():
+    domain = Interval1d(0.0, 1.0)
+    model = MLP(
+        in_size=1,
+        out_size="scalar",
+        hidden_sizes=(),
+        key=jr.key(3),
+    ).add_model_loss(lambda m: 2.0, label="shared")
+    u = domain.Model("x")(model)
+    v = domain.Model("x")(model)
+
+    solver = FunctionalSolver(functions={"u": u, "v": v}, constraints=[])
+
+    assert jnp.allclose(solver.loss(key=jr.key(0)), 2.0)
+
+
+def test_loss_wrapper_preserves_domain_model_metadata():
+    domain = Interval1d(0.0, 1.0)
+    model = SeparableMLP(
+        in_size=2,
+        out_size="scalar",
+        latent_size=2,
+        width_size=None,
+        depth=None,
+        hidden_sizes=(),
+        key=jr.key(4),
+    ).add_model_loss(lambda m: 0.0)
+
+    u = domain.Model("x")(model)
+
+    assert u.func.input_mode == "flat"
+    assert u.func.supports_blockwise_input
+
+
+def test_solver_logs_model_losses_to_text_and_tensorboard(tmp_path):
+    model = MLP(
+        in_size=1,
+        out_size="scalar",
+        hidden_sizes=(),
+        key=jr.key(5),
+    ).add_model_loss(lambda m: 1.0, label="unit_penalty")
+    solver = _domain_model_solver(model)
+    log_path = tmp_path / "model_loss.log"
+    log_dir = tmp_path / "tb"
+
+    solver.solve(
+        num_iter=1,
+        optim=optax.adam(1e-2),
+        seed=0,
+        log_every=1,
+        log_path=log_path,
+        tensorboard_log_dir=log_dir,
+        tensorboard_every=1,
+    )
+
+    text = log_path.read_text(encoding="utf-8")
+    assert "[model 0] unit_penalty:" in text
+
+    accumulator = EventAccumulator(str(log_dir))
+    accumulator.Reload()
+    scalar_tags = set(accumulator.Tags()["scalars"])
+    assert "train/model_losses/000_unit_penalty/loss" in scalar_tags


### PR DESCRIPTION
## Summary
- add model-level loss hooks via optional model __loss__ methods and model.add_model_loss(...)
- include model losses in solver objectives, Optax/evosax training, console logs, and TensorBoard scalars
- keep Domain.Model forward calls and model-loss traversal on the same raw model object
- document model-loss usage and add focused regression coverage
