### PR TITLE
feat: add optimizer evaluation parameter lifecycle

### DIFF
--- a/docs/api/nn/architectures.md
+++ b/docs/api/nn/architectures.md
@@ -1477,6 +1477,15 @@ output pipeline. `OperatorFitResult.execution_model` and
 and all callable schedules require stable identities for exact-resume
 compatibility.
 
+Optimizers with distinct training and evaluation iterates can supply
+`evaluation_parameters(optimizer_state, training_parameters)`. Validation,
+best-model selection, `execution_model`, and `last_execution_model` then use that
+evaluation view; gradients and updates continue to use raw training parameters.
+Checkpointed runs must also supply a stable `evaluation_parameters_id`. The
+identifier is part of the exact-resume contract, so changing or omitting it rejects
+resume before training continues. With the default `None` lifecycle, existing
+checkpoint fingerprints are unchanged.
+
 ---
 
 ::: phydrax.nn.fit_operator

--- a/docs/api/solver/functional_solver.md
+++ b/docs/api/solver/functional_solver.md
@@ -15,6 +15,9 @@ For a conceptual overview (loss evaluation, enforced pipelines, training loop be
       are added directly and are not squared.
     - `partition_functions()` exposes the trainable/non-trainable state split used by `solve(...)`.
     - `solve(...)` updates parameters inside `functions` using Optax or evosax optimizers.
+    - `solve(..., evaluation_parameters=...)` keeps optimizer updates on raw training
+      parameters while using the optimizer-prescribed view for diagnostics, selection,
+      and returned functions.
     - `solve(..., train_constraint_sample_size=k)` trains on an unbiased subset of constraints per Optax step.
     - `solve(..., tensorboard_log_dir=...)` writes TensorBoard scalar logs.
     - `save_onnx("u", ...)` exports one named ansatz function for deployment.

--- a/docs/guides_solver.md
+++ b/docs/guides_solver.md
@@ -168,6 +168,28 @@ shape.
 - an Optax `GradientTransformationExtraArgs` (line-search style optimizers),
 - an evosax algorithm instance (evolutionary strategies).
 
+### Optimizer evaluation parameters
+
+Some Optax transformations update raw training parameters but prescribe a different
+parameter view for validation and model selection. Pass that transformation as
+`evaluation_parameters(state, training_parameters)`. Gradients and optimizer updates
+continue to use the raw parameters; diagnostics, best-state selection, and returned
+functions use the transformed view. The transform must preserve the parameter PyTree,
+leaf shapes, and dtypes.
+
+```py
+import optax
+
+optimizer = optax.contrib.schedule_free(optax.sgd(1e-3), 1e-3)
+solver = solver.solve(
+    num_iter=1000,
+    optim=optimizer,
+    evaluation_parameters=optax.contrib.schedule_free_eval_params,
+)
+```
+
+This contract is available for Optax optimizers, not evosax algorithms.
+
 ### Iteration counter (`iter_`)
 
 During training, the current epoch index is passed to each constraint loss as `iter_` (as a JAX

--- a/phydrax/_training.py
+++ b/phydrax/_training.py
@@ -7,17 +7,51 @@ from __future__ import annotations
 import signal
 import threading
 import time
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, Literal, Protocol
 
+import equinox as eqx
+import jax
 import jax.numpy as jnp
 import jax.random as jr
 from jaxtyping import Array, Key
 
 
 SelectionMode = Literal["min", "max"]
+EvaluationParametersFn = Callable[[Any, Any], Any]
+
+
+def resolve_evaluation_parameters(
+    transform: EvaluationParametersFn | None,
+    optimizer_state: Any,
+    training_parameters: Any,
+    /,
+) -> Any:
+    """Return the optimizer-prescribed evaluation view of training parameters."""
+
+    if transform is None:
+        return training_parameters
+    evaluation_parameters = transform(optimizer_state, training_parameters)
+    expected_structure = jax.tree_util.tree_structure(training_parameters)
+    actual_structure = jax.tree_util.tree_structure(evaluation_parameters)
+    if actual_structure != expected_structure:
+        raise ValueError(
+            "evaluation_parameters must preserve the training-parameter PyTree structure."
+        )
+    expected_leaves = jax.tree_util.tree_leaves(training_parameters)
+    actual_leaves = jax.tree_util.tree_leaves(evaluation_parameters)
+    for expected, actual in zip(expected_leaves, actual_leaves, strict=True):
+        if eqx.is_array(expected) != eqx.is_array(actual) or (
+            eqx.is_array(expected)
+            and (expected.shape != actual.shape or expected.dtype != actual.dtype)
+        ):
+            raise ValueError(
+                "evaluation_parameters must preserve every training-parameter "
+                "leaf shape and dtype."
+            )
+    return evaluation_parameters
 
 
 @dataclass(frozen=True, slots=True)
@@ -321,6 +355,7 @@ def log_training_signal_stop(
 
 
 __all__ = [
+    "EvaluationParametersFn",
     "SelectionMode",
     "TensorBoardLogger",
     "TrainingCallback",
@@ -328,6 +363,7 @@ __all__ = [
     "TrainingEvent",
     "TrainingProgress",
     "TrainingSignalGuard",
+    "resolve_evaluation_parameters",
     "log_training_signal_stop",
     "tensorboard_every",
     "training_key",

--- a/phydrax/nn/operator_training/_fit.py
+++ b/phydrax/nn/operator_training/_fit.py
@@ -23,6 +23,8 @@ import optax
 from ..._frozendict import frozendict
 from ..._trainable import combine_trainable, partition_trainable
 from ..._training import (
+    EvaluationParametersFn,
+    resolve_evaluation_parameters,
     TensorBoardLogger,
     TrainingCallback,
     TrainingController,
@@ -408,6 +410,8 @@ def fit_operator(
     include_model_losses: bool = True,
     optimizer: optax.GradientTransformation | optax.GradientTransformationExtraArgs | None = None,
     optimizer_id: str | None = None,
+    evaluation_parameters: EvaluationParametersFn | None = None,
+    evaluation_parameters_id: str | None = None,
     learning_rate: float = 1e-3,
     epochs: int = 1,
     steps: int | None = None,
@@ -436,7 +440,13 @@ def fit_operator(
     artifact_id: str = "",
     provenance: dict[str, Any] | None = None,
 ) -> OperatorFitResult:
-    """Fit a neural operator through one deterministic production control plane."""
+    """Fit a neural operator through one deterministic production control plane.
+
+    ``evaluation_parameters`` maps ``(optimizer_state, training_parameters)`` to
+    the parameter view used for validation, best-model selection, and returned
+    execution models. Checkpointed fits require ``evaluation_parameters_id`` so
+    resume cannot silently change that lifecycle contract.
+    """
     if not isinstance(model, _AbstractOperatorModel):
         raise TypeError("fit_operator requires a PhydraX operator model.")
     if int(epochs) < 0:
@@ -449,6 +459,23 @@ def fit_operator(
         raise ValueError("checkpoint_every must be positive.")
     if int(tensorboard_every) <= 0:
         raise ValueError("tensorboard_every must be positive.")
+    if evaluation_parameters is None:
+        if evaluation_parameters_id is not None:
+            raise ValueError("evaluation_parameters_id requires evaluation_parameters.")
+        resolved_evaluation_parameters_id = None
+    else:
+        if not callable(evaluation_parameters):
+            raise TypeError("evaluation_parameters must be callable.")
+        resolved_evaluation_parameters_id = (
+            None
+            if evaluation_parameters_id is None
+            else str(evaluation_parameters_id).strip()
+        )
+        if checkpoint_path is not None and not resolved_evaluation_parameters_id:
+            raise ValueError(
+                "Checkpointed fits with evaluation_parameters require a stable "
+                "evaluation_parameters_id."
+            )
     if task is not None and not isinstance(task, OperatorTask):
         raise TypeError("task must be an OperatorTask.")
     if task is None and training_evidence is not None:
@@ -667,6 +694,12 @@ def fit_operator(
 
     parameters, fixed = partition_trainable(model)
     optimizer_state = optimizer.init(parameters)
+    evaluated_parameters = resolve_evaluation_parameters(
+        evaluation_parameters,
+        optimizer_state,
+        parameters,
+    )
+    evaluation_model = combine_trainable(evaluated_parameters, fixed)
     gradient_accumulator = _tree_zeros(parameters)
     accumulated_cases = 0.0
     accumulated_microsteps = 0
@@ -839,7 +872,7 @@ def fit_operator(
             else ()
         ),
     )
-    best_model = model
+    best_model = evaluation_model
     train_steps: list[int] = []
     train_history: list[dict[str, float]] = []
     validation_steps: list[int] = []
@@ -848,58 +881,53 @@ def fit_operator(
     resumed_from_step = 0
     prior_training_seconds = 0.0
 
-    fit_contract = _canonical_json(
-        {
-            "model_contract": operator_contract_fingerprint(model.operator_contract),
-            "task_fingerprint": None if task is None else task.fingerprint,
-            "output_field_map": resolved_output_map,
-            "loss_terms": [term.fingerprint for term in terms],
-            "include_model_losses": bool(include_model_losses),
-            "optimizer_id": resolved_optimizer_id,
-            "gradient_accumulation": int(gradient_accumulation),
-            "normalization": (
-                None
-                if resolved_normalization is None
-                else resolved_normalization.to_dict()
-            ),
-            "fixed_query_fingerprints": fixed_query_fingerprints,
-            "dtype_policy": resolved_dtype.to_dict(),
-            "mixed_precision": (
-                None if mixed_precision is None else asdict(mixed_precision)
-            ),
-            "output_pipeline": (
-                None if output_pipeline is None else output_pipeline.fingerprint
-            ),
-            "validation_policy": (
-                None if validation_config is None else asdict(validation_config)
-            ),
-            "train_loader": raw_train_loader.configuration(),
-            "validation_loader": (
-                None
-                if raw_validation_loader is None
-                else raw_validation_loader.configuration()
-            ),
-            "train_provenance": _source_provenance_fingerprint(
-                raw_train_loader.source
-            ),
-            "validation_provenance": (
-                None
-                if raw_validation_loader is None
-                else _source_provenance_fingerprint(raw_validation_loader.source)
-            ),
-            "sharding": (
-                None
-                if sharding_policy is None
-                else {
-                    "mesh_axis": sharding_policy.mesh_axis,
-                    "case_axis": sharding_policy.case_axis,
-                    "mesh_shape": list(sharding_policy.mesh.devices.shape),
-                    "device_count": int(sharding_policy.mesh.devices.size),
-                }
-            ),
-            "configuration": {} if configuration is None else dict(configuration),
-        }
-    )
+    fit_contract_data = {
+        "model_contract": operator_contract_fingerprint(model.operator_contract),
+        "task_fingerprint": None if task is None else task.fingerprint,
+        "output_field_map": resolved_output_map,
+        "loss_terms": [term.fingerprint for term in terms],
+        "include_model_losses": bool(include_model_losses),
+        "optimizer_id": resolved_optimizer_id,
+        "gradient_accumulation": int(gradient_accumulation),
+        "normalization": (
+            None if resolved_normalization is None else resolved_normalization.to_dict()
+        ),
+        "fixed_query_fingerprints": fixed_query_fingerprints,
+        "dtype_policy": resolved_dtype.to_dict(),
+        "mixed_precision": (None if mixed_precision is None else asdict(mixed_precision)),
+        "output_pipeline": (
+            None if output_pipeline is None else output_pipeline.fingerprint
+        ),
+        "validation_policy": (
+            None if validation_config is None else asdict(validation_config)
+        ),
+        "train_loader": raw_train_loader.configuration(),
+        "validation_loader": (
+            None
+            if raw_validation_loader is None
+            else raw_validation_loader.configuration()
+        ),
+        "train_provenance": _source_provenance_fingerprint(raw_train_loader.source),
+        "validation_provenance": (
+            None
+            if raw_validation_loader is None
+            else _source_provenance_fingerprint(raw_validation_loader.source)
+        ),
+        "sharding": (
+            None
+            if sharding_policy is None
+            else {
+                "mesh_axis": sharding_policy.mesh_axis,
+                "case_axis": sharding_policy.case_axis,
+                "mesh_shape": list(sharding_policy.mesh.devices.shape),
+                "device_count": int(sharding_policy.mesh.devices.size),
+            }
+        ),
+        "configuration": {} if configuration is None else dict(configuration),
+    }
+    if resolved_evaluation_parameters_id is not None:
+        fit_contract_data["evaluation_parameters_id"] = resolved_evaluation_parameters_id
+    fit_contract = _canonical_json(fit_contract_data)
     schema = {
         "batch": operator_batch_schema(first.batch, target=first.targets),
     }
@@ -962,10 +990,20 @@ def fit_operator(
         prior_training_seconds = float(metadata["training_seconds"])
         resumed_from_step = progress.update_step
         parameters, fixed = partition_trainable(model)
+        evaluated_parameters = resolve_evaluation_parameters(
+            evaluation_parameters,
+            optimizer_state,
+            parameters,
+        )
+        evaluation_model = combine_trainable(evaluated_parameters, fixed)
     else:
-        initial_metrics = evaluate(model, raw_train_loader, 0)
+        initial_metrics = evaluate(evaluation_model, raw_train_loader, 0)
         if raw_validation_loader is not None:
-            validation_metrics = evaluate(model, raw_validation_loader, 0)
+            validation_metrics = evaluate(
+                evaluation_model,
+                raw_validation_loader,
+                0,
+            )
             validation_steps.append(0)
             validation_history.append(validation_metrics)
             assert validation_config is not None
@@ -978,7 +1016,7 @@ def fit_operator(
                 best_value=validation_metrics[validation_config.monitor],
                 best_step=0,
             )
-            control.best_payload = model
+            control.best_payload = evaluation_model
 
     def save_progress(training_seconds: float) -> None:
         if checkpoint is None:
@@ -1025,7 +1063,11 @@ def fit_operator(
             )
         control.emit("checkpoint", metrics={"step": control.progress.update_step})
 
-    def consider_validation(metrics: Mapping[str, float]) -> None:
+    def consider_validation(
+        metrics: Mapping[str, float],
+        current_evaluation_model: _AbstractOperatorModel,
+        /,
+    ) -> None:
         nonlocal best_model
         assert validation_config is not None
         score = float(metrics[validation_config.monitor])
@@ -1048,17 +1090,20 @@ def fit_operator(
             else score > previous + required
         )
         if strict_better:
-            best_model = model
-            control.best_payload = model
+            best_model = current_evaluation_model
+            control.best_payload = current_evaluation_model
         stale = 0 if meaningful else control.progress.stale_validations + 1
-        stopped = (
-            validation_config.patience is not None
-            and stale >= int(validation_config.patience)
+        stopped = validation_config.patience is not None and stale >= int(
+            validation_config.patience
         )
         control.progress = replace(
             control.progress,
             best_value=score if strict_better else previous,
-            best_step=(control.progress.update_step if strict_better else control.progress.best_step),
+            best_step=(
+                control.progress.update_step
+                if strict_better
+                else control.progress.best_step
+            ),
             stale_validations=stale,
             stopped_early=stopped,
         )
@@ -1197,8 +1242,17 @@ def fit_operator(
                         and validation_config is not None
                         and update_step % int(validation_config.every) == 0
                     ):
+                        evaluated_parameters = resolve_evaluation_parameters(
+                            evaluation_parameters,
+                            optimizer_state,
+                            parameters,
+                        )
+                        evaluation_model = combine_trainable(
+                            evaluated_parameters,
+                            fixed,
+                        )
                         validation_metrics = evaluate(
-                            model,
+                            evaluation_model,
                             raw_validation_loader,
                             update_step,
                         )
@@ -1208,7 +1262,7 @@ def fit_operator(
                             raise KeyError(
                                 f"Unknown validation monitor {validation_config.monitor!r}."
                             )
-                        consider_validation(validation_metrics)
+                        consider_validation(validation_metrics, evaluation_model)
                         control.emit("validation_end", metrics=validation_metrics)
                         if tensorboard is not None:
                             for name, value in validation_metrics.items():
@@ -1233,6 +1287,12 @@ def fit_operator(
         stopped_by_signal = signal_guard.stop_requested
 
     training_seconds = prior_training_seconds + time.perf_counter() - started
+    evaluated_parameters = resolve_evaluation_parameters(
+        evaluation_parameters,
+        optimizer_state,
+        parameters,
+    )
+    evaluation_model = combine_trainable(evaluated_parameters, fixed)
     if (
         raw_validation_loader is not None
         and validation_config is not None
@@ -1242,18 +1302,18 @@ def fit_operator(
         )
     ):
         validation_metrics = evaluate(
-            model,
+            evaluation_model,
             raw_validation_loader,
             control.progress.update_step,
         )
         validation_steps.append(control.progress.update_step)
         validation_history.append(validation_metrics)
-        consider_validation(validation_metrics)
+        consider_validation(validation_metrics, evaluation_model)
     save_progress(training_seconds)
     selected_model = (
         best_model
         if validation_config is not None and validation_config.select_best
-        else model
+        else evaluation_model
     )
     final_metrics = evaluate(
         selected_model,
@@ -1289,7 +1349,7 @@ def fit_operator(
     )
     return OperatorFitResult(
         execution_model=selected_model,
-        last_execution_model=model,
+        last_execution_model=evaluation_model,
         trained_operator=trained,
         output_field_map=frozendict(resolved_output_map),
         output_pipeline=output_pipeline,

--- a/phydrax/solver/_functional_solver.py
+++ b/phydrax/solver/_functional_solver.py
@@ -17,6 +17,7 @@ from .._doc import DOC_KEY0
 from .._frozendict import frozendict
 from .._objective import AbstractObjectiveTerm
 from .._strict import StrictModule
+from .._training import EvaluationParametersFn
 from ..constraints._base import AbstractConstraint
 from ..constraints._functional import FunctionalConstraint
 from ..domain._function import DomainFunction
@@ -296,6 +297,7 @@ class FunctionalSolver(StrictModule):
         | optax.GradientTransformationExtraArgs
         | Any
         | None = None,
+        evaluation_parameters: EvaluationParametersFn | None = None,
         seed: int = 0,
         jit: bool = True,
         keep_best: bool = True,
@@ -316,6 +318,10 @@ class FunctionalSolver(StrictModule):
         - If `optim` is an Optax `GradientTransformation`, a standard gradient step is used.
         - If `optim` is an Optax `GradientTransformationExtraArgs`, a line-search style update is used.
         - Otherwise, `optim` is treated as an evosax algorithm instance.
+        - `evaluation_parameters`, when provided, maps optimizer state and raw training
+          parameters to the parameter view used for diagnostics, model selection, and
+          the returned solver. This supports optimizers such as Optax schedule-free
+          transformations without changing the gradient/update parameter lifecycle.
 
         During training, each constraint loss receives an `iter_` keyword argument (the
         1-based iteration index as a JAX scalar) to enable schedules.
@@ -347,6 +353,7 @@ class FunctionalSolver(StrictModule):
             self,
             num_iter=num_iter,
             optim=optim,
+            evaluation_parameters=evaluation_parameters,
             seed=seed,
             jit=jit,
             keep_best=keep_best,

--- a/phydrax/solver/_functional_train.py
+++ b/phydrax/solver/_functional_train.py
@@ -22,7 +22,9 @@ from .._frozendict import frozendict
 from .._objective import AbstractSamplingObjectiveTerm
 from .._trainable import combine_trainable, partition_trainable
 from .._training import (
+    EvaluationParametersFn,
     log_training_signal_stop as _log_training_signal_stop,
+    resolve_evaluation_parameters,
     tensorboard_every as _tensorboard_every,
     TensorBoardLogger as _TensorBoardLogger,
     TrainingController,
@@ -217,6 +219,7 @@ def _log_tensorboard_scalars(
     step: int,
     loss: Any,
     best_loss: float,
+    evaluation_loss: Any | None,
     iter_time_s: float,
     train_constraint_names: tuple[str, ...],
     train_terms: Any,
@@ -232,6 +235,8 @@ def _log_tensorboard_scalars(
 ) -> None:
     writer.scalar("train/loss", loss, step)
     writer.scalar("train/best_loss", best_loss, step)
+    if evaluation_loss is not None:
+        writer.scalar("eval/loss", evaluation_loss, step)
     writer.scalar("train/iter_time_s", iter_time_s, step)
 
     if not log_constraints:
@@ -440,6 +445,7 @@ def solve(
     optim: optax.GradientTransformation
     | optax.GradientTransformationExtraArgs
     | Any = optax.rprop(1e-3),
+    evaluation_parameters: EvaluationParametersFn | None = None,
     seed: int = 0,
     jit: bool = True,
     keep_best: bool = True,
@@ -469,6 +475,10 @@ def solve(
     elif isinstance(optim, optax.GradientTransformation):
         _opt_standard = optim
     else:
+        if evaluation_parameters is not None:
+            raise ValueError(
+                "evaluation_parameters is supported only for Optax optimizers."
+            )
         return _solve_evosax(
             self,
             num_iter=num_iter,
@@ -730,17 +740,27 @@ def solve(
 
         if jit and not is_linesearch:
             solve_step_constraints = eqx.filter_jit(solve_step_constraints)
+        selection_loss_fn = (
+            eqx.filter_jit(_loss_wrt_params)
+            if jit and evaluation_parameters is not None
+            else _loss_wrt_params
+        )
 
         opt = _opt_linesearch if is_linesearch else _opt_standard
         if opt is None:
             raise ValueError("Optimizer is not configured.")
         opt_state = opt.init(params)
+        current_evaluation_params = resolve_evaluation_parameters(
+            evaluation_parameters,
+            opt_state,
+            params,
+        )
         control = TrainingController(
             total_steps=int(num_iter),
             key=jr.key(seed),
             progress=TrainingProgress(best_value=float("inf")),
         )
-        control.best_payload = params
+        control.best_payload = current_evaluation_params
         collocation = self.collocation
         out_file = log_fp if log_fp is not None else None
         refresh_wall_time = 0.0
@@ -784,6 +804,7 @@ def solve(
                 active_collocation = tuple(
                     collocation[index] for index in active_constraint_indices
                 )
+                pre_update_params = params
                 params, opt_state, loss_val, terms = solve_step_constraints(
                     params,
                     non_trainable,
@@ -820,8 +841,36 @@ def solve(
                 ]
                 step = epoch + 1
                 control.complete_update(step)
+                current_evaluation_params = resolve_evaluation_parameters(
+                    evaluation_parameters,
+                    opt_state,
+                    params,
+                )
+                evaluation_loss = None
                 if keep_best:
-                    control.select(float(loss_val), params, step=step)
+                    if evaluation_parameters is None:
+                        selection_parameters = (
+                            params if is_linesearch else pre_update_params
+                        )
+                        selection_loss = loss_val
+                    else:
+                        evaluation_loss, _ = selection_loss_fn(
+                            current_evaluation_params,
+                            non_trainable,
+                            self,
+                            active_constraints,
+                            constraint_scale,
+                            subkey,
+                            iter_,
+                            active_collocation,
+                        )
+                        selection_parameters = current_evaluation_params
+                        selection_loss = evaluation_loss
+                    control.select(
+                        float(selection_loss),
+                        selection_parameters,
+                        step=step,
+                    )
                 iter_time_s = time.perf_counter() - iter_start
                 if signal_guard.stop_requested:
                     _log_training_signal_stop(
@@ -843,7 +892,7 @@ def solve(
                 )
                 if log_constraints_ and (console_step or tensorboard_step):
                     train_data_metrics = _data_metrics_wrt_constraints(
-                        params,
+                        current_evaluation_params,
                         non_trainable,
                         self,
                         self.constraints,
@@ -863,7 +912,7 @@ def solve(
                         )
                     )
                     eval_terms = _terms_wrt_constraints(
-                        params,
+                        current_evaluation_params,
                         non_trainable,
                         self,
                         self.eval_constraints,
@@ -871,7 +920,7 @@ def solve(
                         iter_,
                     )
                     eval_data_metrics = _data_metrics_wrt_constraints(
-                        params,
+                        current_evaluation_params,
                         non_trainable,
                         self,
                         self.eval_constraints,
@@ -886,10 +935,15 @@ def solve(
                         loss_f,
                         keep_best=keep_best,
                     )
+                    evaluation_suffix = (
+                        ""
+                        if evaluation_loss is None
+                        else f" eval_loss={float(evaluation_loss):.6e}"
+                    )
                     print(
                         f"[phydrax][optax] iter {step}/{int(num_iter)} "
-                        f"loss={loss_f:.6e} best={best_display:.6e} "
-                        f"iter_time={iter_time_s:.3f}s",
+                        f"loss={loss_f:.6e}{evaluation_suffix} "
+                        f"best={best_display:.6e} iter_time={iter_time_s:.3f}s",
                         file=out_file,
                     )
                     if log_constraints_:
@@ -952,6 +1006,7 @@ def solve(
                         step=step,
                         loss=loss_val,
                         best_loss=best_display,
+                        evaluation_loss=evaluation_loss,
                         iter_time_s=iter_time_s,
                         train_constraint_names=constraint_names,
                         train_terms=train_constraint_terms,
@@ -978,7 +1033,16 @@ def solve(
                 )
                 break
 
-        chosen = control.selected(params) if keep_best else params
+        current_evaluation_params = resolve_evaluation_parameters(
+            evaluation_parameters,
+            opt_state,
+            params,
+        )
+        chosen = (
+            control.selected(current_evaluation_params)
+            if keep_best
+            else current_evaluation_params
+        )
         functions = combine_trainable(chosen, non_trainable)
         settle_started = time.perf_counter() if profile_adaptive else 0.0
         collocation = _settle_collocation(
@@ -1519,6 +1583,7 @@ def _solve_evosax(
                         step=step,
                         loss=cand_loss,
                         best_loss=best_display,
+                        evaluation_loss=None,
                         iter_time_s=iter_time_s,
                         train_constraint_names=constraint_names,
                         train_terms=train_constraint_terms,

--- a/tests/unit/nn/test_operator_evaluation_parameters.py
+++ b/tests/unit/nn/test_operator_evaluation_parameters.py
@@ -1,0 +1,197 @@
+#
+#  Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import optax
+import pytest
+
+import phydrax as phx
+from phydrax._trainable import combine_trainable, partition_trainable
+
+
+def _dataset():
+    axis = phx.nn.OperatorAxis(
+        "x",
+        jnp.linspace(0.0, 1.0, 4),
+        quadrature_weights=jnp.full((4,), 0.25),
+    )
+    values = jnp.stack((axis.nodes, axis.nodes + 1.0))
+    return phx.nn.operator_dataset_from_arrays(
+        {"state": values},
+        {"solution": 2.0 * values},
+        source_axes={"state": (axis,)},
+        query_axes=(axis,),
+    )
+
+
+def _model():
+    return phx.nn.FNO(
+        in_channels="scalar",
+        out_channels="scalar",
+        width=2,
+        depth=1,
+        n_modes=(2,),
+        key=jr.key(0),
+    )
+
+
+def _schedule_free():
+    return optax.contrib.schedule_free(optax.sgd(1e-3), 1e-3)
+
+
+def _schedule_free_fit(model, dataset, **kwargs):
+    return phx.nn.fit_operator(
+        model,
+        dataset,
+        optimizer=_schedule_free(),
+        optimizer_id="tests.schedule_free_sgd.v1",
+        evaluation_parameters=optax.contrib.schedule_free_eval_params,
+        evaluation_parameters_id="optax.schedule_free_eval_params.v1",
+        batch_size=2,
+        seed=11,
+        jit=False,
+        **kwargs,
+    )
+
+
+def _assert_array_trees_equal(left, right):
+    left_leaves = jax.tree_util.tree_leaves(left)
+    right_leaves = jax.tree_util.tree_leaves(right)
+    for left_leaf, right_leaf in zip(left_leaves, right_leaves, strict=True):
+        if isinstance(left_leaf, jax.Array):
+            assert jnp.array_equal(left_leaf, right_leaf)
+
+
+def test_fit_operator_returns_and_validates_on_evaluation_model():
+    dataset = _dataset()
+    model = _model()
+
+    def shifted(_state, parameters):
+        return jax.tree.map(lambda value: value + 1.0, parameters)
+
+    baseline = phx.nn.fit_operator(
+        model,
+        dataset,
+        validation=dataset,
+        steps=0,
+        jit=False,
+    )
+    evaluated = phx.nn.fit_operator(
+        model,
+        dataset,
+        validation=dataset,
+        steps=0,
+        evaluation_parameters=shifted,
+        jit=False,
+    )
+    parameters, fixed = partition_trainable(baseline.last_execution_model)
+    expected = combine_trainable(
+        jax.tree.map(lambda value: value + 1.0, parameters),
+        fixed,
+    )
+
+    assert bool(eqx.tree_equal(evaluated.last_execution_model, expected))
+    assert evaluated.history.validation_metrics[-1]["loss"] == evaluated.final_loss
+    assert evaluated.final_loss != baseline.final_loss
+
+
+def test_schedule_free_checkpoint_resume_matches_uninterrupted_training(tmp_path):
+    dataset = _dataset()
+    model = _model()
+    uninterrupted = _schedule_free_fit(
+        model,
+        dataset,
+        epochs=2,
+        steps=2,
+    )
+    checkpoint = tmp_path / "schedule-free-fit"
+    _schedule_free_fit(
+        model,
+        dataset,
+        epochs=1,
+        steps=1,
+        checkpoint_path=checkpoint,
+        checkpoint_every=1,
+    )
+    resumed = _schedule_free_fit(
+        model,
+        dataset,
+        epochs=2,
+        steps=2,
+        checkpoint_path=checkpoint,
+        checkpoint_every=1,
+        resume=True,
+    )
+
+    _assert_array_trees_equal(
+        uninterrupted.last_execution_model,
+        resumed.last_execution_model,
+    )
+    assert resumed.resumed_from_step == 1
+    assert resumed.history == uninterrupted.history
+
+
+@pytest.mark.parametrize("resume_id", ["changed-evaluator", None])
+def test_schedule_free_resume_rejects_changed_or_missing_evaluator_id(
+    tmp_path,
+    resume_id,
+):
+    dataset = _dataset()
+    model = _model()
+    checkpoint = tmp_path / "schedule-free-contract"
+    _schedule_free_fit(
+        model,
+        dataset,
+        epochs=1,
+        steps=1,
+        checkpoint_path=checkpoint,
+        checkpoint_every=1,
+    )
+
+    kwargs = {
+        "optimizer": _schedule_free(),
+        "optimizer_id": "tests.schedule_free_sgd.v1",
+        "batch_size": 2,
+        "seed": 11,
+        "jit": False,
+        "epochs": 2,
+        "steps": 2,
+        "checkpoint_path": checkpoint,
+        "checkpoint_every": 1,
+        "resume": True,
+    }
+    if resume_id is not None:
+        kwargs["evaluation_parameters"] = optax.contrib.schedule_free_eval_params
+        kwargs["evaluation_parameters_id"] = resume_id
+
+    with pytest.raises(ValueError, match="checkpoint contract mismatch"):
+        phx.nn.fit_operator(model, dataset, **kwargs)
+
+
+def test_checkpointed_evaluation_transform_requires_stable_id(tmp_path):
+    with pytest.raises(ValueError, match="stable evaluation_parameters_id"):
+        phx.nn.fit_operator(
+            _model(),
+            _dataset(),
+            steps=0,
+            checkpoint_path=tmp_path / "fit",
+            evaluation_parameters=optax.contrib.schedule_free_eval_params,
+            optimizer=_schedule_free(),
+            optimizer_id="tests.schedule_free_sgd.v1",
+            jit=False,
+        )
+
+
+def test_operator_evaluation_transform_must_preserve_parameter_structure():
+    with pytest.raises(ValueError, match="PyTree structure"):
+        phx.nn.fit_operator(
+            _model(),
+            _dataset(),
+            steps=0,
+            evaluation_parameters=lambda _state, parameters: (parameters,),
+            jit=False,
+        )

--- a/tests/unit/solver/test_evaluation_parameters.py
+++ b/tests/unit/solver/test_evaluation_parameters.py
@@ -1,0 +1,126 @@
+#
+#  Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax
+import jax.numpy as jnp
+import optax
+import pytest
+
+import phydrax as phx
+
+
+def _scalar_solver(initial: float, *, target: float = 0.0, integrand=None):
+    domain = phx.domain.Interval1d(0.0, 1.0)
+    field = domain.Parameter(initial)
+    density = (
+        (lambda functions: (functions["u"] - target) ** 2)
+        if integrand is None
+        else integrand
+    )
+    objective = phx.objectives.IntegralFunctional(
+        component=domain.component(),
+        integrand=density,
+        num_points={"x": phx.domain.LegendreAxisSpec(8)},
+        structure=phx.domain.ProductStructure((("x",),)),
+        sampling_mode="fixed",
+    )
+    return phx.solver.FunctionalSolver(
+        functions={"u": field},
+        constraints=(),
+        objectives=(objective,),
+    )
+
+
+def _parameter_value(solver):
+    return jnp.asarray(solver["u"].func()).reshape(())
+
+
+def test_standard_optimizer_best_score_keeps_its_preupdate_parameters():
+    base_optimizer = optax.sgd(1.0)
+    optimizer = optax.GradientTransformation(
+        base_optimizer.init,
+        base_optimizer.update,
+    )
+    trained = _scalar_solver(1.0).solve(
+        num_iter=1,
+        optim=optimizer,
+        keep_best=True,
+        jit=False,
+        log_every=0,
+    )
+
+    assert jnp.allclose(_parameter_value(trained), 1.0)
+
+
+def test_schedule_free_returns_the_optimizer_evaluation_parameters():
+    optimizer = optax.contrib.schedule_free(optax.sgd(0.1), 0.1)
+    initial = jnp.asarray(2.0)
+    state = optimizer.init(initial)
+    updates, state = optimizer.update(jnp.asarray(2.0), state, initial)
+    raw_parameters = optax.apply_updates(initial, updates)
+    expected = optax.contrib.schedule_free_eval_params(state, raw_parameters)
+
+    trained = _scalar_solver(2.0, target=1.0).solve(
+        num_iter=1,
+        optim=optimizer,
+        evaluation_parameters=optax.contrib.schedule_free_eval_params,
+        keep_best=False,
+        jit=True,
+        log_every=0,
+    )
+
+    assert jnp.allclose(_parameter_value(trained), expected)
+
+
+def test_evaluation_transform_controls_selection_and_returned_functions():
+    def shifted(_state, parameters):
+        return jax.tree.map(lambda value: value + 5.0, parameters)
+
+    trained = _scalar_solver(2.0, target=1.0).solve(
+        num_iter=1,
+        optim=optax.sgd(0.1),
+        evaluation_parameters=shifted,
+        keep_best=True,
+        jit=False,
+        log_every=0,
+    )
+
+    assert jnp.allclose(_parameter_value(trained), 6.8)
+    assert jnp.allclose(trained.loss(), 5.8**2)
+
+
+def test_identity_lifecycle_adds_no_objective_evaluations():
+    calls = 0
+
+    def counting_integrand(functions):
+        nonlocal calls
+        calls += 1
+        return functions["u"] ** 2
+
+    base_optimizer = optax.sgd(0.1)
+    optimizer = optax.GradientTransformation(
+        base_optimizer.init,
+        base_optimizer.update,
+    )
+
+    _scalar_solver(1.0, integrand=counting_integrand).solve(
+        num_iter=3,
+        optim=optimizer,
+        keep_best=True,
+        jit=False,
+        log_every=0,
+    )
+
+    assert calls == 3
+
+
+def test_evaluation_transform_must_preserve_parameter_structure():
+    with pytest.raises(ValueError, match="PyTree structure"):
+        _scalar_solver(1.0).solve(
+            num_iter=1,
+            optim=optax.sgd(0.1),
+            evaluation_parameters=lambda _state, parameters: (parameters,),
+            jit=False,
+            log_every=0,
+        )


### PR DESCRIPTION
## Summary

This PR adds an explicit optimizer evaluation-parameter lifecycle to both `FunctionalSolver.solve` and `phydrax.nn.fit_operator`.

Optimizers whose training iterate differs from their evaluation iterate—most notably schedule-free optimizers—can now provide:

```python
evaluation_parameters(optimizer_state, training_parameters)
```

Training gradients and optimizer updates continue to use the raw training parameters. Loss reporting, validation, best-model selection, and returned execution models use the transformed evaluation parameters.

## Motivation

Phydrax previously assumed that the optimizer's update parameters were also the parameters that should be validated and returned. That invariant does not hold for optimizers that maintain distinct training and evaluation iterates.

Using the raw iterate in those cases causes several coupled correctness problems:

- validation scores the wrong model,
- best-model selection associates a score with the wrong parameter state,
- returned functions or execution models are not the optimizer-prescribed inference model,
- checkpoint resume cannot verify the identity of the evaluation transformation.

The new lifecycle makes the distinction explicit without changing the gradient/update parameter path or introducing optimizer-specific branches.

## Detailed changes

### 1. Shared evaluation-parameter resolver

Adds a shared `EvaluationParametersFn` contract and `resolve_evaluation_parameters` helper in `phydrax._training`.

The resolver:

- returns training parameters unchanged when no transform is supplied,
- calls the optimizer-aware transform when configured,
- verifies that the transformed result has the same PyTree structure,
- verifies corresponding array leaves retain their expected shapes and dtypes.

This keeps transformation validation identical across scalar functional training and neural-operator training.

### 2. FunctionalSolver lifecycle

`FunctionalSolver.solve` now accepts `evaluation_parameters` for Optax optimizers.

The solve loop preserves two distinct meanings:

- **training parameters:** consumed by gradient evaluation and optimizer updates;
- **evaluation parameters:** consumed by validation, loss-based selection, best-state capture, final model construction, and the returned solver.

The identity lifecycle remains the default. Non-Optax optimizer paths reject an evaluation transform rather than silently ignoring it.

The best-model bookkeeping is also aligned with the parameter state that produced the score: a pre-update loss can no longer be paired with post-update parameters.

### 3. Operator-training lifecycle

`phydrax.nn.fit_operator` gains:

- `evaluation_parameters`,
- `evaluation_parameters_id`.

Evaluation models are reconstructed from transformed trainable parameters plus the original non-trainable partition. Initial validation, periodic validation, best-model selection, final validation, `execution_model`, and `last_execution_model` consistently use that model.

Training batches and updates continue to use the raw optimizer iterate.

### 4. Exact-resume checkpoint contract

Checkpointed operator training requires a stable `evaluation_parameters_id` whenever an evaluation transform is supplied.

The identifier is included in the fit-contract fingerprint. Resume is rejected before training continues when the evaluator identity is changed or omitted. With the default identity lifecycle, the existing checkpoint fingerprint remains unchanged.

### 5. Schedule-free interoperability

The API directly supports Optax schedule-free optimizers:

```python
optimizer = optax.contrib.schedule_free(optax.sgd(1e-3), 1e-3)

result = phx.nn.fit_operator(
    model,
    dataset,
    optimizer=optimizer,
    evaluation_parameters=optax.contrib.schedule_free_eval_params,
    evaluation_parameters_id="optax.schedule_free_eval_params.v1",
)
```

The same transform can be passed to `FunctionalSolver.solve` when checkpoint identity is not required.

### 6. Documentation

Updates the functional-solver guide and API references to document:

- training-versus-evaluation parameter semantics,
- schedule-free usage,
- validation and best-model behavior,
- operator checkpoint identity requirements.

## Design decisions and invariants

- **One explicit hook:** optimizer-specific evaluation behavior stays in the supplied transform, not in solver dispatch logic.
- **No lifecycle ambiguity:** training parameters are never replaced before gradient or update computation.
- **Selection consistency:** each score is paired with the exact evaluation parameters that produced it.
- **Strict structural compatibility:** transforms may change values, but not the parameter PyTree contract, array shapes, or dtypes.
- **Exact resume:** checkpointed evaluator identity is explicit and fingerprinted.
- **Identity compatibility:** callers that omit the hook retain the existing training and checkpoint behavior.
- **Clean failure for unsupported paths:** non-Optax optimizers cannot accept a hook they cannot honor.

## Compatibility notes

- Existing `FunctionalSolver.solve` and `fit_operator` calls require no changes.
- Existing checkpoint fingerprints are unchanged when `evaluation_parameters` is `None`.
- Schedule-free users should provide the optimizer's evaluation transform explicitly.
- Checkpointed operator runs using a transform must assign it a stable `evaluation_parameters_id`.

## Suggested review order

1. `phydrax/_training.py`
2. `phydrax/solver/_functional_solver.py` and `_functional_train.py`
3. `phydrax/nn/operator_training/_fit.py`
4. lifecycle contract coverage
5. solver and operator-training documentation
