### PR TITLE
feat: add domain-aware adaptive integration

### DIFF
--- a/docs/api/objectives.md
+++ b/docs/api/objectives.md
@@ -8,3 +8,5 @@ not impose squared-residual semantics or nonnegativity.
 ::: phydrax.objectives.AbstractSamplingObjectiveTerm
 
 ::: phydrax.objectives.IntegralFunctional
+
+::: phydrax.objectives.AdaptiveIntegralFunctional

--- a/docs/api/operators/integral.md
+++ b/docs/api/operators/integral.md
@@ -18,6 +18,22 @@
 
 ---
 
+::: phydrax.operators.AdaptiveQuadratureConfig
+
+---
+
+::: phydrax.operators.adaptive_integral
+
+---
+
+::: phydrax.operators.AdaptiveIntegralResult
+
+---
+
+::: phydrax.operators.AdaptiveSubintervals
+
+---
+
 ::: phydrax.operators.integral._batch_ops.integral
 
 ---

--- a/docs/guides_integrals.md
+++ b/docs/guides_integrals.md
@@ -78,6 +78,55 @@ $$
 
 For coord-separable batches, `over="x"` integrates over the coord-separable axes for that label.
 
+## One-dimensional adaptive quadrature
+
+`adaptive_integral` uses Quadax's globally adaptive Gauss–Kronrod,
+Clenshaw–Curtis, or tanh–sinh rules when the required accuracy matters more than
+a fixed sample budget. It does not consume a sampled batch. Instead, the selected
+component must have exactly one `Interior()` label backed by `ScalarInterval` or
+`Interval1d`; every other product-domain label must be fixed. Fixed factors retain
+their unit-mass Dirac semantics.
+
+`component.where`, `component.where_all`, and `component.weight_all` are evaluated
+at every adaptive node. Supply known discontinuities or singular locations as
+strictly increasing `breakpoints`; this initializes separate subintervals on each
+side of the difficult point.
+
+```python
+import phydrax as phx
+
+time = phx.domain.ScalarInterval(0.0, 1.0, label="t")
+
+@time.Function("t")
+def cubic(t):
+    return t**3
+
+quadrature = phx.operators.AdaptiveQuadratureConfig(
+    method="gauss_kronrod",
+    absolute_tolerance=1e-10,
+    relative_tolerance=1e-10,
+    collect_subintervals=True,
+)
+result = phx.operators.adaptive_integral(
+    cubic,
+    component=time.component(),
+    quadrature=quadrature,
+)
+value = result.value
+```
+
+`AdaptiveIntegralResult` reports the estimated error, function-evaluation count,
+status bitmask, and optional padded subinterval arrays plus their active count.
+The default `throw=True` turns any nonzero Quadax status into a JIT-safe error;
+use `throw=False` only when the caller explicitly handles `result.successful`.
+`AdaptiveIntegralFunctional` always rejects a failed quadrature before
+contributing its raw signed scalar to `FunctionalSolver`.
+
+The operator is JIT-compatible and differentiable through the selected adaptive
+execution. A stochastic integrand receives the same key at every node so one
+quadrature call estimates a deterministic realization rather than mixing
+independent noise into its local error estimates.
+
 ## Examples
 
 !!! example

--- a/phydrax/objectives/__init__.py
+++ b/phydrax/objectives/__init__.py
@@ -5,10 +5,12 @@
 """Raw scalar objective terms for functional optimization."""
 
 from .._objective import AbstractObjectiveTerm, AbstractSamplingObjectiveTerm
+from ._adaptive_integral import AdaptiveIntegralFunctional
 from ._integral import IntegralFunctional
 
 
 __all__ = [
+    "AdaptiveIntegralFunctional",
     "AbstractObjectiveTerm",
     "AbstractSamplingObjectiveTerm",
     "IntegralFunctional",

--- a/phydrax/objectives/_adaptive_integral.py
+++ b/phydrax/objectives/_adaptive_integral.py
@@ -1,0 +1,150 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any
+
+import coordax as cx
+import equinox as eqx
+import jax.numpy as jnp
+from jaxtyping import Array, ArrayLike, Key
+
+from .._doc import DOC_KEY0
+from .._objective import AbstractObjectiveTerm
+from ..domain._components import DomainComponent
+from ..domain._function import DomainFunction
+from ..operators.integral._adaptive import (
+    adaptive_integral,
+    AdaptiveQuadratureConfig,
+)
+
+
+class AdaptiveIntegralFunctional(AbstractObjectiveTerm):
+    """A raw signed objective evaluated by one-dimensional adaptive quadrature."""
+
+    objective_vars: tuple[str, ...]
+    component: DomainComponent
+    integrand: Callable[[Mapping[str, DomainFunction]], DomainFunction] | DomainFunction
+    quadrature: AdaptiveQuadratureConfig
+    weight: Array
+    variable: str | None
+    label: str | None
+
+    def __init__(
+        self,
+        *,
+        component: DomainComponent,
+        integrand: Callable[[Mapping[str, DomainFunction]], DomainFunction]
+        | DomainFunction,
+        objective_vars: Sequence[str] | None = None,
+        quadrature: AdaptiveQuadratureConfig | None = None,
+        weight: ArrayLike = 1.0,
+        variable: str | None = None,
+        label: str | None = None,
+    ):
+        if not isinstance(component, DomainComponent):
+            raise TypeError("component must be a DomainComponent.")
+        if not isinstance(integrand, DomainFunction) and not callable(integrand):
+            raise TypeError("integrand must be a DomainFunction or callable.")
+        if quadrature is not None and not isinstance(
+            quadrature, AdaptiveQuadratureConfig
+        ):
+            raise TypeError("quadrature must be an AdaptiveQuadratureConfig or None.")
+
+        self.objective_vars = () if objective_vars is None else tuple(objective_vars)
+        self.component = component
+        self.integrand = integrand
+        self.quadrature = AdaptiveQuadratureConfig() if quadrature is None else quadrature
+        self.weight = jnp.asarray(weight, dtype=float).reshape(())
+        self.variable = None if variable is None else str(variable)
+        self.label = None if label is None else str(label)
+
+    @classmethod
+    def from_operator(
+        cls,
+        *,
+        component: DomainComponent,
+        operator: Callable[..., DomainFunction],
+        objective_vars: str | Sequence[str],
+        quadrature: AdaptiveQuadratureConfig | None = None,
+        weight: ArrayLike = 1.0,
+        variable: str | None = None,
+        label: str | None = None,
+    ) -> "AdaptiveIntegralFunctional":
+        """Build an adaptive functional from an operator on named solver fields."""
+        vars_tuple = (
+            (objective_vars,)
+            if isinstance(objective_vars, str)
+            else tuple(objective_vars)
+        )
+
+        def integrand(functions: Mapping[str, DomainFunction], /) -> DomainFunction:
+            return operator(*(functions[name] for name in vars_tuple))
+
+        return cls(
+            component=component,
+            integrand=integrand,
+            objective_vars=vars_tuple,
+            quadrature=quadrature,
+            weight=weight,
+            variable=variable,
+            label=label,
+        )
+
+    def _integrand_function(
+        self,
+        functions: Mapping[str, DomainFunction],
+        /,
+    ) -> DomainFunction:
+        value = self.integrand
+        integrand = value if isinstance(value, DomainFunction) else value(functions)
+        if not isinstance(integrand, DomainFunction):
+            raise TypeError(
+                "AdaptiveIntegralFunctional integrand must produce a DomainFunction; "
+                f"got {type(integrand).__name__}."
+            )
+        return integrand
+
+    def loss(
+        self,
+        functions: Mapping[str, DomainFunction],
+        /,
+        *,
+        key: Key[Array, ""] = DOC_KEY0,
+        **kwargs: Any,
+    ) -> Array:
+        """Evaluate and return the raw signed adaptive integral."""
+        result = adaptive_integral(
+            self._integrand_function(functions),
+            component=self.component,
+            variable=self.variable,
+            quadrature=self.quadrature,
+            key=key,
+            **kwargs,
+        )
+        if not isinstance(result.value, cx.Field):
+            raise TypeError("Expected adaptive_integral to return a coordax.Field value.")
+        if result.value.dims != ():
+            raise ValueError(
+                "AdaptiveIntegralFunctional requires a scalar integral; "
+                f"got dims={result.value.dims}."
+            )
+
+        value = jnp.asarray(result.value.data).reshape(())
+        if jnp.iscomplexobj(value):
+            raise TypeError(
+                "AdaptiveIntegralFunctional requires a real scalar integrand; "
+                "use real_part(...) to select an explicitly real objective."
+            )
+        value = eqx.error_if(
+            value,
+            result.status != 0,
+            "AdaptiveIntegralFunctional quadrature did not converge.",
+        )
+        return self.weight * value
+
+
+__all__ = ["AdaptiveIntegralFunctional"]

--- a/phydrax/operators/__init__.py
+++ b/phydrax/operators/__init__.py
@@ -139,6 +139,11 @@ from .graph import (  # noqa: F401
     neighbor_aggregate,
 )
 from .integral import (  # noqa: F401
+    adaptive_integral,
+    AdaptiveIntegralResult,
+    AdaptiveQuadratureConfig,
+    AdaptiveQuadratureMethod,
+    AdaptiveSubintervals,
     build_ball_quadrature,
     build_quadrature,
     integral,
@@ -297,6 +302,11 @@ __all__ = [
     "caputo_time_fractional",
     "caputo_time_fractional_dw",
     # integral exports
+    "AdaptiveIntegralResult",
+    "AdaptiveQuadratureConfig",
+    "AdaptiveQuadratureMethod",
+    "AdaptiveSubintervals",
+    "adaptive_integral",
     "build_ball_quadrature",
     "build_quadrature",
     "integrate_boundary",

--- a/phydrax/operators/integral/__init__.py
+++ b/phydrax/operators/integral/__init__.py
@@ -2,6 +2,13 @@
 #  Copyright © 2026 PHYDRA, Inc. All rights reserved.
 #
 
+from ._adaptive import (
+    adaptive_integral,
+    AdaptiveIntegralResult,
+    AdaptiveQuadratureConfig,
+    AdaptiveQuadratureMethod,
+    AdaptiveSubintervals,
+)
 from ._batch_ops import (
     build_quadrature,
     integral,
@@ -22,6 +29,11 @@ from ._time_convolution import time_convolution
 
 
 __all__ = [
+    "AdaptiveIntegralResult",
+    "AdaptiveQuadratureConfig",
+    "AdaptiveQuadratureMethod",
+    "AdaptiveSubintervals",
+    "adaptive_integral",
     "build_ball_quadrature",
     "build_quadrature",
     "integrate_boundary",

--- a/phydrax/operators/integral/_adaptive.py
+++ b/phydrax/operators/integral/_adaptive.py
@@ -1,0 +1,449 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import math
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any, Literal
+
+import coordax as cx
+import equinox as eqx
+import jax.numpy as jnp
+import quadax
+from jaxtyping import Array, ArrayLike, Key
+
+from ..._doc import DOC_KEY0
+from ..._frozendict import frozendict
+from ..._strict import StrictModule
+from ...domain._base import _AbstractGeometry
+from ...domain._components import (
+    Boundary,
+    DomainComponent,
+    Fixed,
+    FixedEnd,
+    FixedStart,
+    Interior,
+)
+from ...domain._domain import RelabeledDomain
+from ...domain._function import DomainFunction
+from ...domain._scalar import _AbstractScalarDomain, ScalarInterval
+from ...domain._structure import PointsBatch, ProductStructure
+from ...domain.geometry1d._primitives import Interval1d
+from ._batch_ops import _sum_over, _weight_product, _where_product
+
+
+AdaptiveQuadratureMethod = Literal[
+    "gauss_kronrod",
+    "clenshaw_curtis",
+    "tanh_sinh",
+]
+
+_DEFAULT_ORDERS: dict[AdaptiveQuadratureMethod, int] = {
+    "gauss_kronrod": 21,
+    "clenshaw_curtis": 32,
+    "tanh_sinh": 61,
+}
+_ALLOWED_ORDERS: dict[AdaptiveQuadratureMethod, frozenset[int]] = {
+    "gauss_kronrod": frozenset((15, 21, 31, 41, 51, 61)),
+    "clenshaw_curtis": frozenset((8, 16, 32, 64, 128, 256)),
+    "tanh_sinh": frozenset((41, 61, 81, 101)),
+}
+
+
+class AdaptiveQuadratureConfig(StrictModule):
+    """Static controls for one-dimensional globally adaptive quadrature."""
+
+    method: AdaptiveQuadratureMethod = eqx.field(static=True)
+    absolute_tolerance: float | None = eqx.field(static=True)
+    relative_tolerance: float | None = eqx.field(static=True)
+    max_intervals: int = eqx.field(static=True)
+    order: int = eqx.field(static=True)
+    norm: float | int | Callable[[Array], Array] = eqx.field(static=True)
+    breakpoints: tuple[float, ...] = eqx.field(static=True)
+    collect_subintervals: bool = eqx.field(static=True)
+    throw: bool = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        method: AdaptiveQuadratureMethod = "gauss_kronrod",
+        absolute_tolerance: float | None = None,
+        relative_tolerance: float | None = None,
+        max_intervals: int = 50,
+        order: int | None = None,
+        norm: float | int | Callable[[Array], Array] = math.inf,
+        breakpoints: Sequence[float] = (),
+        collect_subintervals: bool = False,
+        throw: bool = True,
+    ):
+        method_ = str(method)
+        if method_ not in _DEFAULT_ORDERS:
+            raise ValueError(
+                "method must be 'gauss_kronrod', 'clenshaw_curtis', or 'tanh_sinh'."
+            )
+        method_typed: AdaptiveQuadratureMethod = method_  # type: ignore[assignment]
+
+        order_ = _DEFAULT_ORDERS[method_typed] if order is None else int(order)
+        if order_ not in _ALLOWED_ORDERS[method_typed]:
+            allowed = tuple(sorted(_ALLOWED_ORDERS[method_typed]))
+            raise ValueError(f"order for {method_!r} must be one of {allowed}.")
+
+        max_intervals_ = int(max_intervals)
+        if max_intervals_ <= 0:
+            raise ValueError("max_intervals must be positive.")
+
+        absolute_tolerance_ = _validate_tolerance(
+            absolute_tolerance,
+            "absolute_tolerance",
+        )
+        relative_tolerance_ = _validate_tolerance(
+            relative_tolerance,
+            "relative_tolerance",
+        )
+
+        breakpoints_ = tuple(float(point) for point in breakpoints)
+        if any(not math.isfinite(point) for point in breakpoints_):
+            raise ValueError("breakpoints must be finite.")
+        if any(
+            right <= left
+            for left, right in zip(breakpoints_[:-1], breakpoints_[1:], strict=True)
+        ):
+            raise ValueError("breakpoints must be strictly increasing and unique.")
+        if max_intervals_ < len(breakpoints_) + 1:
+            raise ValueError(
+                "max_intervals must be at least the number of initial intervals."
+            )
+
+        if callable(norm):
+            norm_ = norm
+        else:
+            norm_ = float(norm)
+            if norm_ <= 0.0 or math.isnan(norm_):
+                raise ValueError("norm must be positive or callable.")
+
+        self.method = method_typed
+        self.absolute_tolerance = absolute_tolerance_
+        self.relative_tolerance = relative_tolerance_
+        self.max_intervals = max_intervals_
+        self.order = order_
+        self.norm = norm_
+        self.breakpoints = breakpoints_
+        self.collect_subintervals = bool(collect_subintervals)
+        self.throw = bool(throw)
+
+
+def _validate_tolerance(value: float | None, name: str, /) -> float | None:
+    if value is None:
+        return None
+    value_ = float(value)
+    if not math.isfinite(value_) or value_ < 0.0:
+        raise ValueError(f"{name} must be finite and non-negative.")
+    return value_
+
+
+class AdaptiveSubintervals(StrictModule):
+    """Padded accepted-subinterval diagnostics from Quadax."""
+
+    count: Array
+    lower_bounds: Array
+    upper_bounds: Array
+    integral_estimates: Array
+    estimated_errors: Array
+
+
+class AdaptiveIntegralResult(StrictModule):
+    """Adaptive integral value and JAX-compatible convergence diagnostics."""
+
+    value: cx.Field
+    estimated_error: Array
+    num_evaluations: Array
+    status: Array
+    subintervals: AdaptiveSubintervals | None
+    method: AdaptiveQuadratureMethod = eqx.field(static=True)
+
+    @property
+    def successful(self) -> Array:
+        """Whether Quadax terminated without a numerical failure status."""
+        return self.status == 0
+
+
+def _unwrap_factor(factor: Any, /) -> Any:
+    return factor.base if isinstance(factor, RelabeledDomain) else factor
+
+
+def _fixed_field(factor: Any, component: Any, /) -> cx.Field:
+    factor = _unwrap_factor(factor)
+    if isinstance(factor, _AbstractScalarDomain):
+        if isinstance(component, FixedStart):
+            value = factor.fixed("start")
+        elif isinstance(component, FixedEnd):
+            value = factor.fixed("end")
+        elif isinstance(component, Fixed):
+            value = component.value
+        else:
+            raise TypeError(
+                "Non-integrated scalar factors must use Fixed, FixedStart, or FixedEnd."
+            )
+        return cx.Field(jnp.asarray(value, dtype=float).reshape(()), dims=())
+
+    if isinstance(factor, _AbstractGeometry) and isinstance(component, Fixed):
+        value = jnp.asarray(component.value, dtype=float).reshape((factor.var_dim,))
+        return cx.Field(value, dims=(None,))
+
+    raise TypeError(
+        "Non-integrated factors must be fixed scalar domains or fixed geometries."
+    )
+
+
+class _DomainAdaptiveIntegrand(StrictModule):
+    integrand: DomainFunction
+    component: DomainComponent
+    fixed_points: frozendict[str, cx.Field]
+    structure: ProductStructure
+    key: Key[Array, ""]
+    kwargs: frozendict[str, Any]
+    variable: str = eqx.field(static=True)
+    axis: str = eqx.field(static=True)
+    geometry_variable: bool = eqx.field(static=True)
+    cache_token: tuple[int, int, int, str, str, bool] = eqx.field(static=True)
+
+    def __hash__(self) -> int:
+        return hash((type(self), self.cache_token))
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, _DomainAdaptiveIntegrand) and (
+            self.cache_token == other.cache_token
+        )
+
+    def __call__(self, coordinate: Array, /) -> Array:
+        coordinate_ = jnp.asarray(coordinate, dtype=float)
+        if self.geometry_variable:
+            variable_field = cx.Field(
+                coordinate_.reshape((1, 1)),
+                dims=(self.axis, None),
+            )
+        else:
+            variable_field = cx.Field(coordinate_.reshape((1,)), dims=(self.axis,))
+
+        points = dict(self.fixed_points.items())
+        points[self.variable] = variable_field
+        ordered_points = frozendict(
+            {label: points[label] for label in self.component.domain.labels}
+        )
+        batch = PointsBatch(ordered_points, self.structure)
+
+        value = self.integrand(batch, key=self.key, **self.kwargs)
+        if not isinstance(value, cx.Field):
+            raise TypeError("integrand must evaluate to a coordax.Field.")
+        mask = _where_product(
+            self.component,
+            batch,
+            key=self.key,
+            **self.kwargs,
+        )
+        weight = _weight_product(
+            self.component,
+            batch,
+            key=self.key,
+            **self.kwargs,
+        )
+        value = value * mask * weight
+
+        unexpected_axes = tuple(name for name in value.named_dims if name != self.axis)
+        if unexpected_axes:
+            raise ValueError(
+                "Adaptive integration produced unexpected named output axes "
+                f"{unexpected_axes!r}."
+            )
+        if self.axis in value.named_dims:
+            value = _sum_over(value, self.axis)
+        return jnp.asarray(value.data)
+
+
+def _resolve_adaptive_domain(
+    component: DomainComponent,
+    variable: str | None,
+    /,
+) -> tuple[str, ScalarInterval | Interval1d, ProductStructure, frozendict[str, cx.Field]]:
+    if not isinstance(component, DomainComponent):
+        raise TypeError("component must be a DomainComponent.")
+
+    labels = component.domain.labels
+    if variable is None:
+        free_labels = tuple(
+            label
+            for label in labels
+            if isinstance(component.spec.component_for(label), Interior)
+        )
+        if len(free_labels) != 1:
+            raise ValueError(
+                "Adaptive integration requires exactly one interior label; "
+                "specify all other labels as fixed."
+            )
+        variable_ = free_labels[0]
+    else:
+        variable_ = str(variable)
+        if variable_ not in labels:
+            raise ValueError(
+                f"Unknown integration variable {variable_!r}; expected one of {labels!r}."
+            )
+
+    if not isinstance(component.spec.component_for(variable_), Interior):
+        raise ValueError("The adaptive integration variable must select Interior().")
+
+    factor = _unwrap_factor(component.domain.factor(variable_))
+    if not isinstance(factor, (ScalarInterval, Interval1d)):
+        raise TypeError(
+            "Adaptive integration currently supports ScalarInterval and Interval1d "
+            "integration factors."
+        )
+
+    fixed_points: dict[str, cx.Field] = {}
+    fixed_labels: set[str] = set()
+    for label in labels:
+        if label == variable_:
+            continue
+        selector = component.spec.component_for(label)
+        if isinstance(selector, (Interior, Boundary)):
+            raise ValueError(
+                "Adaptive integration supports one free label; all other labels "
+                "must be fixed."
+            )
+        fixed_points[label] = _fixed_field(
+            component.domain.factor(label),
+            selector,
+        )
+        fixed_labels.add(label)
+
+    structure = ProductStructure(((variable_,),)).canonicalize(
+        labels,
+        fixed_labels=frozenset(fixed_labels),
+    )
+    return variable_, factor, structure, frozendict(fixed_points)
+
+
+def adaptive_integral(
+    integrand: DomainFunction | ArrayLike,
+    /,
+    *,
+    component: DomainComponent,
+    variable: str | None = None,
+    quadrature: AdaptiveQuadratureConfig | None = None,
+    key: Key[Array, ""] = DOC_KEY0,
+    **kwargs: Any,
+) -> AdaptiveIntegralResult:
+    """Adaptively integrate over one interval label of a domain component.
+
+    Exactly one component label may select ``Interior``. Other product-domain
+    labels must be fixed, and therefore contribute unit-mass Dirac factors. Domain
+    filters and ``weight_all`` are evaluated at every adaptive node.
+    """
+    config = AdaptiveQuadratureConfig() if quadrature is None else quadrature
+    if not isinstance(config, AdaptiveQuadratureConfig):
+        raise TypeError("quadrature must be an AdaptiveQuadratureConfig or None.")
+
+    variable_, factor, structure, fixed_points = _resolve_adaptive_domain(
+        component,
+        variable,
+    )
+    function = (
+        integrand
+        if isinstance(integrand, DomainFunction)
+        else DomainFunction(domain=component.domain, deps=(), func=integrand)
+    )
+    missing_labels = tuple(
+        label for label in function.domain.labels if label not in component.domain.labels
+    )
+    if missing_labels:
+        raise ValueError(
+            f"Integrand domain labels {missing_labels!r} are absent from the component."
+        )
+
+    axis = structure.axis_for(variable_)
+    if axis is None:
+        raise RuntimeError("Adaptive integration variable has no sampling axis.")
+    callback_kwargs = frozendict(kwargs)
+    callback = _DomainAdaptiveIntegrand(
+        integrand=function,
+        component=component,
+        fixed_points=fixed_points,
+        structure=structure,
+        key=key,
+        kwargs=callback_kwargs,
+        variable=variable_,
+        axis=axis,
+        geometry_variable=isinstance(factor, Interval1d),
+        cache_token=(
+            id(function),
+            id(component),
+            0 if not kwargs else id(callback_kwargs),
+            variable_,
+            axis,
+            isinstance(factor, Interval1d),
+        ),
+    )
+
+    interval = jnp.asarray(
+        (factor.start, *config.breakpoints, factor.end),
+        dtype=float,
+    )
+    interval = eqx.error_if(
+        interval,
+        jnp.any(jnp.diff(interval) <= 0.0),
+        "Adaptive quadrature breakpoints must lie strictly inside the interval.",
+    )
+    backend = {
+        "gauss_kronrod": quadax.quadgk,
+        "clenshaw_curtis": quadax.quadcc,
+        "tanh_sinh": quadax.quadts,
+    }[config.method]
+    value, info = backend(
+        callback,
+        interval,
+        full_output=config.collect_subintervals,
+        epsabs=config.absolute_tolerance,
+        epsrel=config.relative_tolerance,
+        max_ninter=config.max_intervals,
+        order=config.order,
+        norm=config.norm,
+    )
+
+    value_array = jnp.asarray(value)
+    status = jnp.asarray(info.status, dtype=jnp.int32)
+    if config.throw:
+        value_array = eqx.error_if(
+            value_array,
+            status != 0,
+            "Adaptive quadrature failed to meet its numerical contract.",
+        )
+
+    subintervals = None
+    if config.collect_subintervals:
+        backend_info: Mapping[str, Any] = info.info
+        subintervals = AdaptiveSubintervals(
+            count=jnp.asarray(backend_info["ninter"], dtype=jnp.int32),
+            lower_bounds=jnp.asarray(backend_info["a_arr"]),
+            upper_bounds=jnp.asarray(backend_info["b_arr"]),
+            integral_estimates=jnp.asarray(backend_info["r_arr"]),
+            estimated_errors=jnp.asarray(backend_info["e_arr"]),
+        )
+
+    return AdaptiveIntegralResult(
+        value=cx.Field(value_array, dims=(None,) * value_array.ndim),
+        estimated_error=jnp.asarray(info.err),
+        num_evaluations=jnp.asarray(info.neval, dtype=jnp.int32),
+        status=status,
+        subintervals=subintervals,
+        method=config.method,
+    )
+
+
+__all__ = [
+    "AdaptiveIntegralResult",
+    "AdaptiveQuadratureConfig",
+    "AdaptiveQuadratureMethod",
+    "AdaptiveSubintervals",
+    "adaptive_integral",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "orthax>=0.2.7",
     "polars>=1.40.1",
     "pyvista>=0.46.4",
-    "quadax>=0.2.11",
+    "quadax>=0.2.13,<0.3",
     "scipy>=1.14",
     "setuptools<81",
     "shapely>=2.0",

--- a/tests/unit/operators/test_adaptive_integral.py
+++ b/tests/unit/operators/test_adaptive_integral.py
@@ -1,0 +1,166 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+import phydrax as phx
+
+
+@pytest.mark.parametrize(
+    "method",
+    ("gauss_kronrod", "clenshaw_curtis", "tanh_sinh"),
+)
+def test_adaptive_methods_integrate_scalar_interval_polynomial(method):
+    time = phx.domain.ScalarInterval(-1.0, 2.0, label="t")
+
+    @time.Function("t")
+    def polynomial(t):
+        return t**3 - 2.0 * t + 1.0
+
+    result = phx.operators.adaptive_integral(
+        polynomial,
+        component=time.component(),
+        quadrature=phx.operators.AdaptiveQuadratureConfig(method=method),
+    )
+
+    assert bool(result.successful)
+    assert result.value.dims == ()
+    assert jnp.allclose(result.value.data, 3.75, rtol=1e-9, atol=1e-11)
+    assert result.num_evaluations > 0
+    assert result.estimated_error >= 0.0
+
+
+def test_adaptive_integral_preserves_fixed_slice_masks_weights_and_breakpoints():
+    space = phx.domain.Interval1d(0.0, 1.0)
+    time = phx.domain.ScalarInterval(0.0, 2.0, label="t")
+    domain = space @ time
+    component = domain.component(
+        {"t": phx.domain.Fixed(0.25)},
+        where={"x": lambda x: x[0] <= 0.5},
+        weight_all=lambda x, t: 2.0,
+    )
+
+    @domain.Function("x", "t")
+    def field(x, t):
+        return x[0] + t
+
+    config = phx.operators.AdaptiveQuadratureConfig(breakpoints=(0.5,))
+    run = jax.jit(
+        lambda scale: phx.operators.adaptive_integral(
+            scale * field,
+            component=component,
+            variable="x",
+            quadrature=config,
+        )
+    )
+    result = run(1.0)
+
+    assert bool(result.successful)
+    assert jnp.allclose(result.value.data, 0.5, rtol=1e-9, atol=1e-11)
+
+
+def test_adaptive_integral_supports_vector_outputs_and_subinterval_diagnostics():
+    time = phx.domain.ScalarInterval(0.0, 1.0, label="t")
+
+    @time.Function("t")
+    def moments(t):
+        return jnp.asarray((t, t**2))
+
+    config = phx.operators.AdaptiveQuadratureConfig(collect_subintervals=True)
+    result = phx.operators.adaptive_integral(
+        moments,
+        component=time.component(),
+        quadrature=config,
+    )
+
+    assert result.value.dims == (None,)
+    assert jnp.allclose(result.value.data, jnp.asarray((0.5, 1.0 / 3.0)), atol=1e-11)
+    assert result.subintervals is not None
+    assert int(result.subintervals.count) >= 1
+    assert result.subintervals.lower_bounds.shape == (config.max_intervals,)
+    assert result.subintervals.upper_bounds.shape == (config.max_intervals,)
+    assert result.subintervals.integral_estimates.shape == (
+        config.max_intervals,
+        2,
+    )
+
+
+def test_adaptive_integral_is_jittable_and_differentiable():
+    time = phx.domain.ScalarInterval(0.0, 1.0, label="t")
+
+    def integral_value(scale):
+        @time.Function("t")
+        def density(t):
+            return scale * t**2
+
+        return phx.operators.adaptive_integral(
+            density,
+            component=time.component(),
+        ).value.data
+
+    compiled_value = jax.jit(integral_value)(jnp.asarray(2.0))
+    derivative = jax.grad(integral_value)(jnp.asarray(2.0))
+
+    assert jnp.allclose(compiled_value, 2.0 / 3.0, rtol=1e-9, atol=1e-11)
+    assert jnp.allclose(derivative, 1.0 / 3.0, rtol=1e-9, atol=1e-11)
+
+
+def test_adaptive_integral_reports_numerical_failure_without_throwing():
+    time = phx.domain.ScalarInterval(0.0, 1.0, label="t")
+
+    @time.Function("t")
+    def discontinuity(t):
+        return jnp.where(t < 0.123, 1.0, 0.0)
+
+    result = phx.operators.adaptive_integral(
+        discontinuity,
+        component=time.component(),
+        quadrature=phx.operators.AdaptiveQuadratureConfig(
+            absolute_tolerance=1e-14,
+            relative_tolerance=1e-14,
+            max_intervals=1,
+            throw=False,
+        ),
+    )
+
+    assert not bool(result.successful)
+    assert int(result.status) != 0
+    assert result.estimated_error > 1e-14
+
+
+def test_adaptive_integral_rejects_unsupported_domain_structure():
+    space = phx.domain.Interval1d(0.0, 1.0)
+    time = phx.domain.ScalarInterval(0.0, 1.0, label="t")
+    product = space @ time
+
+    @product.Function("x", "t")
+    def field(x, t):
+        return x[0] + t
+
+    with pytest.raises(ValueError, match="exactly one interior label"):
+        phx.operators.adaptive_integral(
+            field,
+            component=product.component(),
+        )
+
+    square = phx.domain.Square(center=(0.0, 0.0), side=1.0)
+    with pytest.raises(TypeError, match="ScalarInterval and Interval1d"):
+        phx.operators.adaptive_integral(
+            1.0,
+            component=square.component(),
+        )
+
+
+def test_adaptive_quadrature_config_validates_backend_contracts():
+    with pytest.raises(ValueError, match="order"):
+        phx.operators.AdaptiveQuadratureConfig(method="gauss_kronrod", order=32)
+    with pytest.raises(ValueError, match="strictly increasing"):
+        phx.operators.AdaptiveQuadratureConfig(breakpoints=(0.5, 0.5))
+    with pytest.raises(ValueError, match="initial intervals"):
+        phx.operators.AdaptiveQuadratureConfig(
+            breakpoints=(0.25, 0.5),
+            max_intervals=2,
+        )

--- a/tests/unit/solver/test_adaptive_integral_functional.py
+++ b/tests/unit/solver/test_adaptive_integral_functional.py
@@ -1,0 +1,113 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import optax
+import pytest
+
+import phydrax as phx
+
+
+def test_adaptive_integral_functional_returns_raw_signed_value():
+    time = phx.domain.ScalarInterval(0.0, 1.0, label="t")
+    density = time.Function()(-2.0)
+    objective = phx.objectives.AdaptiveIntegralFunctional(
+        component=time.component(),
+        integrand=density,
+        label="negative_energy",
+    )
+    solver = phx.solver.FunctionalSolver(
+        functions={"density": density},
+        constraints=(),
+        objectives=(objective,),
+    )
+
+    assert jnp.allclose(solver.loss(), -2.0, atol=1e-12)
+
+
+def test_adaptive_integral_functional_from_operator_trains_parameter():
+    time = phx.domain.ScalarInterval(0.0, 1.0, label="t")
+    parameter = time.Parameter(2.0)
+    objective = phx.objectives.AdaptiveIntegralFunctional.from_operator(
+        component=time.component(),
+        operator=lambda value: (value - 1.0) ** 2,
+        objective_vars="u",
+    )
+    solver = phx.solver.FunctionalSolver(
+        functions={"u": parameter},
+        constraints=(),
+        objectives=(objective,),
+    )
+
+    initial_loss = solver.loss()
+    trained = solver.solve(
+        num_iter=2,
+        optim=optax.sgd(0.1),
+        keep_best=False,
+        jit=True,
+        log_every=0,
+    )
+
+    assert jnp.allclose(initial_loss, 1.0, atol=1e-12)
+    assert trained.loss() < initial_loss
+    assert jnp.allclose(trained.loss(), 0.4096, rtol=1e-8, atol=1e-10)
+
+
+def test_adaptive_integral_functional_gradient_matches_analytic_value():
+    time = phx.domain.ScalarInterval(0.0, 1.0, label="t")
+
+    def loss(scale):
+        @time.Function("t")
+        def density(t):
+            return scale * t**2
+
+        objective = phx.objectives.AdaptiveIntegralFunctional(
+            component=time.component(),
+            integrand=density,
+        )
+        return objective.loss({"density": density})
+
+    assert jnp.allclose(jax.grad(loss)(2.0), 1.0 / 3.0, rtol=1e-9, atol=1e-11)
+    scales = jnp.asarray((1.0, 2.0, 3.0))
+    batched = jax.jit(jax.vmap(loss))(scales)
+    assert jnp.allclose(batched, scales / 3.0, rtol=1e-9, atol=1e-11)
+
+
+def test_adaptive_integral_functional_rejects_complex_result():
+    time = phx.domain.ScalarInterval(0.0, 1.0, label="t")
+    density = time.Function()(1.0 + 2.0j)
+    objective = phx.objectives.AdaptiveIntegralFunctional(
+        component=time.component(),
+        integrand=density,
+    )
+
+    with pytest.raises(TypeError, match="requires a real scalar integrand"):
+        objective.loss({"density": density})
+
+
+def test_adaptive_integral_functional_never_accepts_failed_quadrature():
+    time = phx.domain.ScalarInterval(0.0, 1.0, label="t")
+
+    @time.Function("t")
+    def discontinuity(t):
+        return jnp.where(t < 0.123, 1.0, 0.0)
+
+    objective = phx.objectives.AdaptiveIntegralFunctional(
+        component=time.component(),
+        integrand=discontinuity,
+        quadrature=phx.operators.AdaptiveQuadratureConfig(
+            absolute_tolerance=1e-14,
+            relative_tolerance=1e-14,
+            max_intervals=1,
+            throw=False,
+        ),
+    )
+
+    with pytest.raises(
+        (ValueError, eqx.EquinoxRuntimeError),
+        match="did not converge",
+    ):
+        jax.block_until_ready(objective.loss({"density": discontinuity}))


### PR DESCRIPTION
## Summary

This PR adds a narrow, domain-aware one-dimensional adaptive integration path backed by Quadax, together with a raw scalar objective for `FunctionalSolver`.

The public surface consists of:

- `phydrax.operators.adaptive_integral`
- `phydrax.operators.AdaptiveQuadratureConfig`
- `phydrax.operators.AdaptiveIntegralResult`
- `phydrax.operators.AdaptiveSubintervals`
- `phydrax.objectives.AdaptiveIntegralFunctional`

The implementation adapts Phydrax `DomainFunction` and `DomainComponent` semantics to Quadax's array-callable interval contract while preserving fixed product-domain factors, masks, weights, JAX transformations, and explicit numerical failure handling.

## Motivation

Phydrax's existing integration operators consume pre-sampled dense or coordinate-separable batches. That is the correct path for fixed-budget training and tensor quadrature, but it cannot allocate work dynamically around localized singularities, discontinuities, sharp layers, or difficult weighted regions.

Quadax provides JAX-native globally adaptive quadrature, but its native interface operates on a plain numeric callable over an interval. Calling it directly would bypass Phydrax invariants:

- domain labels and scalar-versus-geometric coordinate shapes,
- fixed product-domain factors and their unit-mass semantics,
- component filters and weights,
- `DomainFunction` evaluation and solver rebinding,
- Coordax field dimensions,
- JIT-safe convergence reporting.

This PR supplies that boundary adaptation without introducing a generic quadrature backend hierarchy.

## Detailed changes

### 1. Adaptive quadrature configuration

Adds `AdaptiveQuadratureConfig`, containing static controls for:

- method selection,
- absolute and relative tolerances,
- local rule order,
- maximum subinterval count,
- vector-output error norm,
- known breakpoints,
- optional subinterval diagnostics,
- throw-versus-status failure handling.

Supported Quadax rules are:

- globally adaptive Gauss–Kronrod,
- globally adaptive Clenshaw–Curtis,
- globally adaptive tanh–sinh.

Method-specific orders are validated before tracing. Breakpoints must be finite, strictly increasing, unique, inside the integration interval, and compatible with the interval budget.

### 2. Domain-aware operator

`adaptive_integral` accepts a `DomainFunction` or constant-like value plus a `DomainComponent`.

The supported domain contract is intentionally narrow:

- exactly one component label selects `Interior`,
- the adaptive factor is a `ScalarInterval` or `Interval1d`,
- every other product-domain label is fixed,
- fixed scalar and geometric factors retain their existing Dirac semantics.

At every adaptive node the adapter reconstructs a one-point `PointsBatch`, evaluates the integrand through the normal `DomainFunction` path, and applies:

- per-label component filters,
- cross-label filters,
- component weights.

The selected adaptive axis is reduced while unnamed output dimensions are preserved, enabling scalar and array-valued integrands.

### 3. JAX and compilation behavior

The operator remains compatible with JIT, VMAP, and differentiation through Quadax's selected adaptive execution.

The callback carries dynamic integrand leaves, points, keys, and weights through the Equinox/JAX PyTree path. A stable identity token avoids recursive hashing through Phydrax domain objects and allows repeated direct calls with the same function and component to reuse the compiled Quadax executable.

Stochastic integrands receive the same key at every adaptive node. One quadrature invocation therefore estimates one deterministic realization rather than contaminating local error estimates with independent node noise.

### 4. Result and convergence contract

`AdaptiveIntegralResult` returns:

- the integral as a `coordax.Field`,
- the global estimated error,
- the reported function-evaluation count,
- the Quadax status bitmask,
- the selected method,
- optional padded subinterval diagnostics.

`successful` is JAX-compatible and reports whether the status is zero.

With the default `throw=True`, a nonzero numerical status becomes a JIT-safe error. `throw=False` is available for callers that explicitly branch on or inspect the returned status.

When requested, `AdaptiveSubintervals` exposes the terminal padded partition: active count, lower and upper bounds, local integral estimates, and local estimated errors. The fixed-size representation preserves JAX output-shape requirements.

### 5. Adaptive integral objective

Adds `AdaptiveIntegralFunctional`, a raw signed scalar objective compatible with `FunctionalSolver`.

It supports:

- a directly supplied `DomainFunction`,
- a callable that rebinds current solver functions,
- `from_operator` construction over named objective variables,
- scalar objective weights,
- explicit variable selection and labels.

The objective requires a real scalar result. Complex results must be projected explicitly, and non-converged quadrature is always rejected before contributing to the solver loss even when the underlying operator configuration uses `throw=False`.

### 6. Dependency and public exports

Updates the Quadax dependency to `>=0.2.13,<0.3`, the first compatible release used by this adapter, and exports the new operator and objective surfaces through the existing integral, operator, and objective namespaces.

### 7. Documentation

Documents:

- when adaptive quadrature is preferable to sampled-batch integration,
- the one-free-label domain contract,
- fixed-factor, filter, and weight behavior,
- breakpoint usage,
- result diagnostics and failure semantics,
- differentiability and stochastic-key behavior,
- the adaptive functional API.

## Public API sketch

```python
import phydrax as phx

space = phx.domain.ScalarInterval(0.0, 1.0, label="x")

@space.Function("x")
def density(x):
    return x**3

config = phx.operators.AdaptiveQuadratureConfig(
    method="gauss_kronrod",
    absolute_tolerance=1e-10,
    relative_tolerance=1e-10,
    breakpoints=(),
)

result = phx.operators.adaptive_integral(
    density,
    component=space.component(),
    quadrature=config,
)

objective = phx.objectives.AdaptiveIntegralFunctional(
    component=space.component(),
    integrand=density,
    quadrature=config,
)
```

## Design decisions and invariants

- **One-dimensional scope:** this is interval quadrature, not an implicit multidimensional cubature API.
- **Domain semantics first:** fixed factors, filters, and weights are evaluated through existing component contracts rather than duplicated numerical conventions.
- **No sampled-batch ambiguity:** adaptive integration owns its nodes and therefore does not accept a pre-sampled batch.
- **Explicit difficult points:** known discontinuities and singularities are represented as breakpoints rather than left for blind refinement.
- **Static result structure:** optional local diagnostics are padded to the configured interval budget.
- **Failure is data or an error, never silent success:** direct callers choose throw-versus-status; solver objectives always require convergence.
- **No backend abstraction layer:** the adapter targets the declared Quadax contract directly.
- **No implicit complex projection:** scalar optimization objectives remain explicitly real.

## Compatibility notes

- Existing fixed-grid and sampled-batch integral APIs are unchanged.
- Existing `IntegralFunctional` behavior is unchanged.
- Adaptive integration is additive and selected explicitly.
- Product-domain callers must fix all non-integrated labels.
- Unsupported geometries and multiple free labels fail at the domain boundary.

## Intentional scope boundaries

This PR does not add:

- multidimensional adaptive cubature,
- automatic nesting over several free labels,
- adaptive sampling of arbitrary mesh or graph domains,
- a generic integration-backend registry,
- automatic breakpoint discovery,
- stochastic resampling at each quadrature node.

## Suggested review order

1. `phydrax/operators/integral/_adaptive.py`
2. `phydrax/objectives/_adaptive_integral.py`
3. namespace exports and dependency change
4. adaptive operator and objective contracts
5. integral documentation
