### PR TITLE
Fix surface, boundary, and mesh calculus semantics

### DIFF
--- a/docs/api/constraints/continuous.md
+++ b/docs/api/constraints/continuous.md
@@ -20,6 +20,11 @@ multiplier or a pointwise `DomainFunction`.
 
 ## Integral constraints
 
+Boundary-integral helpers accept `var` to select the geometry label. When it is
+omitted, Phydrax infers the sole geometry label and raises on an ambiguous
+domain. In a product domain, only that factor is changed to `Boundary()`; the
+other factors retain their component defaults.
+
 ::: phydrax.constraints.ContinuousIntegralInteriorConstraint
 
 ---

--- a/docs/api/constraints/enforced.md
+++ b/docs/api/constraints/enforced.md
@@ -17,6 +17,14 @@ see [Enforced constraint pipelines](../solver/enforced_constraints.md).
       boundary normals and can be used in spectral/FNO-style or graph-batch
       evaluations.
 
+!!! warning
+    A `Boundary()` component restricted by `where` or `where_all` is not a
+    valid input to a direct geometry hard enforcer. Its signed-distance gate
+    vanishes on the full boundary and would enforce outside the requested
+    subset. Phydrax rejects this case. Construct each piece's ansatz against an
+    unfiltered `Boundary()` component, then associate those ansätze with the
+    filtered components passed to `enforce_blend`.
+
 ::: phydrax.constraints.enforce_dirichlet
 
 ---

--- a/docs/api/constraints/thermal.md
+++ b/docs/api/constraints/thermal.md
@@ -2,6 +2,11 @@
 
 ## Boundary conditions
 
+Heat-flux arguments use the physical outward convention
+\(q_n=-k\,\nabla T\cdot n\), where \(n\) is the outward unit normal. Thus
+`flux` and discrete `values` are prescribed \(q_n\), and convection enforces
+\(q_n=h(T-T_\infty)\). Continuous and discrete helpers use the same sign.
+
 ::: phydrax.constraints.ContinuousHeatFluxBoundaryConstraint
 
 ---

--- a/docs/api/domain/components.md
+++ b/docs/api/domain/components.md
@@ -48,6 +48,13 @@ fixed-time slices, etc.) and wrap these into `DomainComponent` objects.
 
 ## Domain components
 
+`DomainComponentUnion` is an additive collection of measure-disjoint
+components, not an arbitrary geometric set union. It requires at least one
+term, rejects duplicate terms, and requires every term to use the same
+compatible labeled domain. Measures and sample allocations add across terms;
+callers remain responsible for ensuring that separately filtered terms do not
+overlap.
+
 ::: phydrax.domain.DomainComponent
     options:
         members:

--- a/docs/api/domain/geometry3d.md
+++ b/docs/api/domain/geometry3d.md
@@ -2,6 +2,11 @@
 
 ## Mesh-based geometries
 
+`Geometry3DFromCAD` represents an enclosed solid. Input surface meshes must be
+finite, nondegenerate, consistently oriented, and watertight after
+sanitization; open or zero-volume surfaces are rejected before distance fields,
+sampling, or boundary normals are constructed.
+
 ### Boolean / CSG operations
 
 `Geometry3DFromCAD` supports boolean operations via operator overloading:

--- a/docs/api/nn/architectures.md
+++ b/docs/api/nn/architectures.md
@@ -294,6 +294,13 @@ fixed/aligned manifold basis. A target plan permits a pre-aligned
 cross-discretization, not arbitrary query coordinates or independently
 remeshed manifolds with unresolved eigenbasis alignment.
 
+`SpectralDiscretization.from_stiffness(K, M, ...)` uses the finite-element
+convention \(K\succeq0\), \(M\succ0\) and solves \(K v=\lambda M v\).
+`from_triangle_mesh(...)` assembles cotangent stiffness and lumped mass as
+sparse matrices and computes only the requested low modes for large meshes;
+small or nearly full spectra use a dense solve. Repeated eigenvalues are grouped
+as one eigenspace for basis-gauge-safe spectral mixing.
+
 ::: phydrax.nn.IFNO
     options:
         members:

--- a/docs/api/operators/differential.md
+++ b/docs/api/operators/differential.md
@@ -178,8 +178,8 @@ coordinate/covariant distinction and array-callable kernels.
 ## Riemannian differential operators
 
 These adapters apply Metrix geometry to labeled `DomainFunction` objects.
-`laplace_beltrami` accepts either a `RiemannianMetric` for intrinsic coordinate
-calculus or a `DomainComponent` for the existing normal-based surface calculus.
+`laplace_beltrami` requires a `RiemannianMetric` and performs intrinsic
+coordinate calculus. It does not dispatch on a boundary component.
 
 ::: phydrax.operators.riemannian_grad
 
@@ -199,7 +199,15 @@ calculus or a `DomainComponent` for the existing normal-based surface calculus.
 
 ::: phydrax.operators.covariant_derivative
 
+---
+
+::: phydrax.operators.laplace_beltrami
+
 ## Surface operators
+
+These operators use an embedded geometry's outward normal. The ambient Hessian
+trace is extension-dependent; it is not the intrinsic Laplace--Beltrami
+operator on a general curved surface.
 
 ::: phydrax.operators.surface_grad
 
@@ -221,11 +229,7 @@ calculus or a `DomainComponent` for the existing normal-based surface calculus.
 
 ---
 
-::: phydrax.operators.laplace_beltrami
-
----
-
-::: phydrax.operators.laplace_beltrami_divgrad
+::: phydrax.operators.ambient_surface_hessian_trace
 
 ## Fractional derivatives
 

--- a/docs/api/operators/graph.md
+++ b/docs/api/operators/graph.md
@@ -210,8 +210,10 @@ reach compiled execution.
 
 The functional DEC operators and their `GraphIR -> GraphIR` wrappers implement
 the exterior derivative, metric codifferential, split/full Hodge Laplacian, and
-metric harmonic projection. `CochainBoundaryPolicy("absolute" | "relative")`
-selects the active subcomplex. `reorient_cochain_complex` changes the oriented
+metric harmonic projection. `triangle_mesh_to_cochain_complex` always builds
+the complete oriented topology; boundary behavior belongs to the consuming
+operator. `CochainBoundaryPolicy("absolute" | "relative")` selects that
+operator's active subcomplex. `reorient_cochain_complex` changes the oriented
 cell basis without changing the represented physical complex; use
 `reorient_cochain` to transform signed coefficient arrays consistently.
 
@@ -362,7 +364,11 @@ interactions and hierarchy-aware graph neural operators.
 ## Mesh calculus
 
 Mesh-calculus helpers build geometry-aware `GraphIR` objects and executable
-cotangent operators for triangular surface meshes.
+cotangent operators for triangular surface meshes. `MeshCotangentLaplacian`
+requires an explicit sign: `"neighbor_minus_self"` approximates the
+negative-semidefinite differential Laplacian \(\Delta\), while
+`"self_minus_neighbor"` is the positive-semidefinite stiffness convention
+\(-\Delta\).
 
 ::: phydrax.graph.mesh_to_cotangent_graph
 

--- a/docs/cookbook/graph_physics.md
+++ b/docs/cookbook/graph_physics.md
@@ -1228,7 +1228,11 @@ preserving mesh metadata in the graph payload.
 
     def residual(f):
         return domain.GraphModel(
-            phx.graph.MeshCotangentLaplacian(input_key="u", output_key="lap_u"),
+            phx.graph.MeshCotangentLaplacian(
+                sign="neighbor_minus_self",
+                input_key="u",
+                output_key="lap_u",
+            ),
             input_fn=f,
             input_key="u",
             output_key="lap_u",

--- a/docs/guides_differential.md
+++ b/docs/guides_differential.md
@@ -224,48 +224,63 @@ This is the preferred mode for spectral operators and neural operators (FNO/Deep
 
 ## Surface differential operators
 
-Several operators act on fields restricted to a geometry boundary (surface/curve). These use the
-outward unit normal $n$ provided by the geometry and project ambient derivatives onto the tangent
-space.
+Here **surface** means one smooth boundary component of an embedded geometry.
+This is distinct from the additive face collection returned by a product domain's
+`boundary()` method and from signed simplicial/cochain boundary maps. Normal-based
+surface operators require a single `DomainComponent`, not a
+`DomainComponentUnion`.
 
-Let $\Gamma = \partial\Omega_x$ be a smooth boundary in $\mathbb{R}^d$ with unit normal
-$n(x)\in\mathbb{R}^d$. Define the tangential projector
-
-$$
-P(x) = I - n(x)\,n(x)^\top.
-$$
-
-For a scalar field $u$, the **surface gradient** is
+Let \(\Gamma=\partial\Omega_x\) be embedded in \(\mathbb{R}^d\), with outward
+unit normal \(n\) and tangent projector
 
 $$
-\nabla_\Gamma u = P\,\nabla u.
+P = I - n n^\top.
 $$
 
-For a (tangent) vector field $v$, the **surface divergence** is
+For an ambient scalar field \(u\) and vector field \(v\), Phydrax defines
 
 $$
-\nabla_\Gamma\cdot v = \text{tr}\!\left(P\,\nabla v\right).
+\nabla_\Gamma u = P\nabla u,
+\qquad
+\nabla_\Gamma\cdot v = \operatorname{tr}(P\nabla v).
 $$
 
-The **Laplace–Beltrami** operator is the surface analogue of the Laplacian:
+These are exposed as `surface_grad` and `surface_div`; use
+`tangential_component` to apply \(P\) directly to a vector field. In three
+ambient dimensions, the two surface-curl conventions are explicit:
 
 $$
-\Delta_\Gamma u = \nabla_\Gamma\cdot(\nabla_\Gamma u).
+\operatorname{curl}_\Gamma u = n\times\nabla_\Gamma u,
+\qquad
+\operatorname{curl}_\Gamma v = n\cdot(\nabla\times v),
 $$
 
-In Phydrax, these operators are exposed as `surface_grad`, `surface_div`, and
-`laplace_beltrami` (see [API → Operators → Differential](api/operators/differential.md)).
+implemented by `surface_curl_scalar` and `surface_curl_vector`.
 
-!!! note
-    Surface operators are intended to be evaluated on boundary components so that the geometry
-    can supply consistent normals.
+Operator composition follows the normal provider's autodiff contract. Analytic
+normal fields may contribute curvature derivatives; mesh-derived normals are
+intentionally nondifferentiable. Use metric-coordinate calculus whenever an
+exact curved-manifold identity is required.
 
-For a field already expressed in local coordinates with a
-`phydrax.metrix.RiemannianMetric`, pass the metric instead of a boundary
-component. That overload computes
-\(\Delta_g u=g^{ij}(\partial_i\partial_j u-\Gamma^k_{ij}\partial_k u)\)
-intrinsically and does not require ambient normals. See
-[API → Metrix → Connections and intrinsic operators](api/metrix/connections.md).
+`ambient_surface_hessian_trace(u, component)` computes
+\(\operatorname{tr}(P(\nabla^2u)P)\). This is an **ambient,
+extension-dependent contraction**. It equals the intrinsic
+Laplace--Beltrami operator only when the ambient extension is compatible with
+the surface, such as a closest-point extension or a flat surface.
+
+For a field expressed in local manifold coordinates, the intrinsic operator is
+
+$$
+\Delta_g u =
+\frac{1}{\sqrt{\lvert g\rvert}}
+\partial_i\left(\sqrt{\lvert g\rvert}\,g^{ij}\partial_j u\right).
+$$
+
+Call `laplace_beltrami(u, metric)` with a
+`phydrax.metrix.RiemannianMetric`. It does not accept a boundary component or
+use ambient normals. See
+[API → Metrix → Connections and intrinsic operators](api/metrix/connections.md)
+and [API → Operators → Differential](api/operators/differential.md).
 
 ## Fractional operators
 

--- a/docs/guides_domain.md
+++ b/docs/guides_domain.md
@@ -188,6 +188,12 @@ Components are created with `domain.component(...)`:
 component = domain.component({"t": phx.domain.FixedStart()})  # initial-time slice
 ```
 
+A product domain's `boundary()` method returns a `DomainComponentUnion`: one
+additive term for each codimension-one face. This collection models a
+measure-disjoint decomposition, so all terms share the same domain and exact
+duplicates are rejected. It is not a geometric Boolean union; overlapping
+filtered terms would be counted once per term.
+
 ### Filtering with `where` and `where_all`
 
 Sampling can be restricted by predicates:

--- a/phydrax/constraints/_bc_thermal.py
+++ b/phydrax/constraints/_bc_thermal.py
@@ -65,15 +65,15 @@ def ContinuousHeatFluxBoundaryConstraint(
 ) -> FunctionalConstraint:
     r"""Prescribed heat-flux (Neumann) boundary condition.
 
-    Enforces $k\,\partial T/\partial n = q$ on the boundary component, where
-    $q$ is the heat flux (default $0$).
+    Enforces the physical outward conductive heat flux
+    $-k\,\partial T/\partial n = q$ (default $q=0$).
 
     **Arguments:**
 
     - `temperature_var`: Name of the temperature field.
     - `component`: Boundary component.
     - `k`: Thermal conductivity.
-    - `flux`: Target flux $q$ (defaults to 0).
+    - `flux`: Target physical outward heat flux $q$ (defaults to 0).
     - `var`: Geometry variable used to compute normals.
     - `mode`: Differentiation mode (`"reverse"` or `"forward"`).
     - `num_points`: Number of boundary samples.
@@ -93,7 +93,7 @@ def ContinuousHeatFluxBoundaryConstraint(
 
     def operator(u: DomainFunction, /) -> DomainFunction:
         dd = directional_derivative(u, n, var=var, mode=mode)
-        return k * dd - target
+        return -k * dd - target
 
     return FunctionalConstraint.from_operator(
         component=component,
@@ -129,7 +129,7 @@ def ContinuousConvectionBoundaryConstraint(
 ) -> FunctionalConstraint:
     r"""Convection (Robin) boundary condition.
 
-    Enforces $k\,\partial T/\partial n = h\,(T - T_\infty)$ on the boundary
+    Enforces $-k\,\partial T/\partial n = h\,(T - T_\infty)$ on the boundary
     component, where $T_\infty$ is the ambient temperature (default $0$).
 
     **Arguments:**
@@ -158,7 +158,7 @@ def ContinuousConvectionBoundaryConstraint(
 
     def operator(u: DomainFunction, /) -> DomainFunction:
         dd = directional_derivative(u, n, var=var, mode=mode)
-        return k * dd - h * (u - ambient)
+        return -k * dd - h * (u - ambient)
 
     return FunctionalConstraint.from_operator(
         component=component,
@@ -230,7 +230,7 @@ def DiscreteHeatFluxBoundaryConstraint(
 ) -> PointSetConstraint:
     r"""Discrete heat-flux (Neumann-type) constraint at explicit anchor points.
 
-    Enforces $k\,\partial T/\partial n = q$ at the provided points.
+    Enforces the physical outward heat flux $-k\,\partial T/\partial n = q$.
     """
     n = _normal(component, var=var)
     target = _interp_target(component, points, values)
@@ -238,7 +238,7 @@ def DiscreteHeatFluxBoundaryConstraint(
     def residual(functions: Mapping[str, DomainFunction], /) -> DomainFunction:
         u = functions[temperature_var]
         dudn = directional_derivative(u, n, var=var, mode=mode)
-        return k * dudn - target
+        return -k * dudn - target
 
     return PointSetConstraint.from_points(
         component=component,
@@ -267,8 +267,8 @@ def DiscreteConvectionBoundaryConstraint(
 ) -> PointSetConstraint:
     r"""Discrete convection (Robin) constraint at explicit anchor points.
 
-    Enforces $k\,\partial T/\partial n = h\,(T - T_\infty)$ at the provided points,
-    where $T_\infty$ is given by `ambient_values` (interpolated when needed).
+    Enforces $-k\,\partial T/\partial n = h\,(T - T_\infty)$ at the provided
+    points, where $T_\infty$ is given by `ambient_values`.
     """
     n = _normal(component, var=var)
     ambient = _interp_target(component, points, ambient_values)
@@ -276,7 +276,7 @@ def DiscreteConvectionBoundaryConstraint(
     def residual(functions: Mapping[str, DomainFunction], /) -> DomainFunction:
         u = functions[temperature_var]
         dudn = directional_derivative(u, n, var=var, mode=mode)
-        return k * dudn - h * (u - ambient)
+        return -k * dudn - h * (u - ambient)
 
     return PointSetConstraint.from_points(
         component=component,

--- a/phydrax/constraints/_enforced.py
+++ b/phydrax/constraints/_enforced.py
@@ -336,6 +336,21 @@ def _enforced_constraint_weight_fn(
     return _weight_point
 
 
+def _reject_filtered_boundary(
+    component: DomainComponent,
+    /,
+    *,
+    var: str,
+    op_name: str,
+) -> None:
+    if component.where or component.where_all is not None:
+        raise ValueError(
+            f"{op_name} cannot directly enforce a filtered Boundary() component "
+            f"for {var!r}: its signed-distance gate vanishes on the full boundary. "
+            "Build one ansatz per boundary piece and combine them with enforce_blend."
+        )
+
+
 def enforce_dirichlet(
     u: DomainFunction,
     component: DomainComponent,
@@ -386,6 +401,11 @@ def enforce_dirichlet(
             raise ValueError(
                 "enforce_dirichlet for geometry vars requires component Boundary()."
             )
+        _reject_filtered_boundary(
+            component,
+            var=var,
+            op_name="enforce_dirichlet",
+        )
         phi = component.sdf(var=var)
         return blend_with_gate(value_fn, u, phi)
 
@@ -445,6 +465,7 @@ def enforce_neumann(
     comp = component.spec.component_for(var)
     if not isinstance(comp, Boundary):
         raise ValueError("enforce_neumann requires component Boundary() for var.")
+    _reject_filtered_boundary(component, var=var, op_name="enforce_neumann")
 
     phi = component.sdf(var=var)
     n = component.normal(var=var)
@@ -528,6 +549,7 @@ def enforce_traction(
     comp = component.spec.component_for(var)
     if not isinstance(comp, Boundary):
         raise ValueError("enforce_traction requires component Boundary() for var.")
+    _reject_filtered_boundary(component, var=var, op_name="enforce_traction")
 
     phi = component.sdf(var=var)
     n = component.normal(var=var)
@@ -616,6 +638,7 @@ def enforce_robin(
     comp = component.spec.component_for(var)
     if not isinstance(comp, Boundary):
         raise ValueError("enforce_robin requires component Boundary() for var.")
+    _reject_filtered_boundary(component, var=var, op_name="enforce_robin")
 
     g = 0.0 if target is None else _coerce_value(target, u)
     a = 1.0 if dirichlet_coeff is None else _coerce_value(dirichlet_coeff, u)
@@ -706,6 +729,7 @@ def enforce_sommerfeld(
     comp = component.spec.component_for(var)
     if not isinstance(comp, Boundary):
         raise ValueError("enforce_sommerfeld requires component Boundary() for var.")
+    _reject_filtered_boundary(component, var=var, op_name="enforce_sommerfeld")
 
     phi = component.sdf(var=var)
     n = component.normal(var=var)

--- a/phydrax/constraints/_integral.py
+++ b/phydrax/constraints/_integral.py
@@ -11,12 +11,14 @@ import jax.numpy as jnp
 from jaxtyping import Array, ArrayLike
 
 from .._callable import _ensure_special_kwonly_args
+from ..domain._base import _AbstractGeometry
 from ..domain._components import (
     Boundary,
     DomainComponent,
     DomainComponentUnion,
     FixedStart,
 )
+from ..domain._domain import RelabeledDomain
 from ..domain._function import DomainFunction
 from ..domain._structure import NumPoints, ProductStructure
 from ..operators.differential import cauchy_stress
@@ -58,6 +60,49 @@ def _normal(
     if isinstance(component, DomainComponentUnion):
         raise TypeError("Boundary normals require a single DomainComponent, not a union.")
     return component.normal(var=var)
+
+
+def _boundary_component(
+    domain,
+    /,
+    *,
+    var: str | None,
+    where: Mapping[str, Callable] | None,
+    where_all: DomainFunction | None,
+) -> tuple[str, DomainComponent]:
+    if var is None:
+        geometry_labels: list[str] = []
+        for label in domain.labels:
+            factor = domain.factor(label)
+            if isinstance(factor, RelabeledDomain):
+                factor = factor.base
+            if isinstance(factor, _AbstractGeometry):
+                geometry_labels.append(label)
+        if len(geometry_labels) != 1:
+            raise ValueError(
+                "Boundary integration requires var=... unless the domain has "
+                "exactly one geometry label."
+            )
+        resolved_var = geometry_labels[0]
+    else:
+        if var not in domain.labels:
+            raise KeyError(f"Label {var!r} not in domain {domain.labels}.")
+        resolved_var = var
+
+    factor = domain.factor(resolved_var)
+    if isinstance(factor, RelabeledDomain):
+        factor = factor.base
+    if not isinstance(factor, _AbstractGeometry):
+        raise TypeError(
+            f"Boundary integration requires a geometry label, got "
+            f"{type(factor).__name__} for {resolved_var!r}."
+        )
+    component = domain.component(
+        {resolved_var: Boundary()},
+        where=where,
+        where_all=where_all,
+    )
+    return resolved_var, component
 
 
 def _dot(a: DomainFunction, b: DomainFunction) -> DomainFunction:
@@ -145,6 +190,7 @@ def ContinuousIntegralBoundaryConstraint(
     operator: Callable[..., DomainFunction] | DomainFunction,
     /,
     *,
+    var: str | None = None,
     num_points: NumPoints | tuple[Any, ...],
     structure: ProductStructure | None = None,
     sampler: str = "latin_hypercube",
@@ -166,14 +212,17 @@ def ContinuousIntegralBoundaryConstraint(
     where `operator` receives the boundary normal field $n(x)$ as an additional
     argument.
     """
-    component = domain.component(
-        {domain.label: Boundary()}, where=where, where_all=where_all
+    resolved_var, component = _boundary_component(
+        domain,
+        var=var,
+        where=where,
+        where_all=where_all,
     )
     structure = _default_structure(component) if structure is None else structure
     op = _ensure_operator(operator)
 
     def operator_with_normals(*funcs: DomainFunction) -> DomainFunction:
-        return op(*funcs, _normal(component, var="x"))
+        return op(*funcs, _normal(component, var=resolved_var))
 
     return IntegralEqualityConstraint.from_operator(
         component=component,
@@ -239,7 +288,7 @@ def EMBoundaryChargeConstraint(
     /,
     *,
     total_free_charge: ArrayLike,
-    var: str = "x",
+    var: str | None = None,
     num_points: NumPoints | tuple[Any, ...],
     structure: ProductStructure | None = None,
     sampler: str = "latin_hypercube",
@@ -263,11 +312,14 @@ def EMBoundaryChargeConstraint(
     if q is None:
         raise ValueError("total_free_charge must be array-like.")
 
-    component = domain.component(
-        {domain.label: Boundary()}, where=where, where_all=where_all
+    resolved_var, component = _boundary_component(
+        domain,
+        var=var,
+        where=where,
+        where_all=where_all,
     )
     structure = _default_structure(component) if structure is None else structure
-    n = _normal(component, var=var)
+    n = _normal(component, var=resolved_var)
 
     def operator(u: DomainFunction, /) -> DomainFunction:
         return _dot(u, n)
@@ -291,7 +343,7 @@ def MagneticFluxZeroConstraint(
     domain,
     /,
     *,
-    var: str = "x",
+    var: str | None = None,
     num_points: NumPoints | tuple[Any, ...],
     structure: ProductStructure | None = None,
     sampler: str = "latin_hypercube",
@@ -309,11 +361,14 @@ def MagneticFluxZeroConstraint(
     \int_{\partial\Omega} B\cdot n\,dS = 0.
     $$
     """
-    component = domain.component(
-        {domain.label: Boundary()}, where=where, where_all=where_all
+    resolved_var, component = _boundary_component(
+        domain,
+        var=var,
+        where=where,
+        where_all=where_all,
     )
     structure = _default_structure(component) if structure is None else structure
-    n = _normal(component, var=var)
+    n = _normal(component, var=resolved_var)
 
     def operator(u: DomainFunction, /) -> DomainFunction:
         return _dot(u, n)
@@ -338,7 +393,7 @@ def CFDBoundaryFlowRateConstraint(
     /,
     *,
     flow_rate: ArrayLike,
-    var: str = "x",
+    var: str | None = None,
     num_points: NumPoints | tuple[Any, ...],
     structure: ProductStructure | None = None,
     sampler: str = "latin_hypercube",
@@ -362,11 +417,14 @@ def CFDBoundaryFlowRateConstraint(
     if target is None:
         raise ValueError("flow_rate must be array-like.")
 
-    component = domain.component(
-        {domain.label: Boundary()}, where=where, where_all=where_all
+    resolved_var, component = _boundary_component(
+        domain,
+        var=var,
+        where=where,
+        where_all=where_all,
     )
     structure = _default_structure(component) if structure is None else structure
-    n = _normal(component, var=var)
+    n = _normal(component, var=resolved_var)
 
     def operator(u: DomainFunction, /) -> DomainFunction:
         return _dot(u, n)
@@ -391,7 +449,7 @@ def CFDKineticEnergyFluxBoundaryConstraint(
     /,
     *,
     target_total_power: ArrayLike,
-    var: str = "x",
+    var: str | None = None,
     num_points: NumPoints | tuple[Any, ...],
     structure: ProductStructure | None = None,
     sampler: str = "latin_hypercube",
@@ -413,11 +471,14 @@ def CFDKineticEnergyFluxBoundaryConstraint(
     if target is None:
         raise ValueError("target_total_power must be array-like.")
 
-    component = domain.component(
-        {domain.label: Boundary()}, where=where, where_all=where_all
+    resolved_var, component = _boundary_component(
+        domain,
+        var=var,
+        where=where,
+        where_all=where_all,
     )
     structure = _default_structure(component) if structure is None else structure
-    n = _normal(component, var=var)
+    n = _normal(component, var=resolved_var)
 
     def operator(u: DomainFunction, /) -> DomainFunction:
         return 0.5 * _dot(u, u) * _dot(u, n)
@@ -444,7 +505,7 @@ def SolidTotalReactionBoundaryConstraint(
     lambda_: ArrayLike,
     mu: ArrayLike,
     target_reaction: ArrayLike,
-    var: str = "x",
+    var: str | None = None,
     num_points: NumPoints | tuple[Any, ...],
     structure: ProductStructure | None = None,
     sampler: str = "latin_hypercube",
@@ -467,16 +528,24 @@ def SolidTotalReactionBoundaryConstraint(
     if target is None:
         raise ValueError("target_reaction must be array-like.")
 
-    component = domain.component(
-        {domain.label: Boundary()}, where=where, where_all=where_all
+    resolved_var, component = _boundary_component(
+        domain,
+        var=var,
+        where=where,
+        where_all=where_all,
     )
     structure = _default_structure(component) if structure is None else structure
     lambda_fn = _as_domain_function(lambda_, domain, name="lambda_")
     mu_fn = _as_domain_function(mu, domain, name="mu")
-    n = _normal(component, var=var)
+    n = _normal(component, var=resolved_var)
 
     def operator(u: DomainFunction, /) -> DomainFunction:
-        sigma = cauchy_stress(u, lambda_=lambda_fn, mu=mu_fn, var=var)
+        sigma = cauchy_stress(
+            u,
+            lambda_=lambda_fn,
+            mu=mu_fn,
+            var=resolved_var,
+        )
         return _matvec(sigma, n)
 
     return IntegralEqualityConstraint.from_operator(
@@ -498,6 +567,7 @@ def AveragePressureBoundaryConstraint(
     domain,
     /,
     *,
+    var: str | None = None,
     mean_pressure: ArrayLike,
     num_points: NumPoints | tuple[Any, ...],
     structure: ProductStructure | None = None,
@@ -526,8 +596,11 @@ def AveragePressureBoundaryConstraint(
     def operator(p: DomainFunction, /) -> DomainFunction:
         return p
 
-    component = domain.component(
-        {domain.label: Boundary()}, where=where, where_all=where_all
+    _, component = _boundary_component(
+        domain,
+        var=var,
+        where=where,
+        where_all=where_all,
     )
     structure = _default_structure(component) if structure is None else structure
 
@@ -551,6 +624,7 @@ def EMPoyntingFluxBoundaryConstraint(
     domain,
     /,
     *,
+    var: str | None = None,
     target_total_power: ArrayLike,
     num_points: NumPoints | tuple[Any, ...],
     structure: ProductStructure | None = None,
@@ -573,11 +647,14 @@ def EMPoyntingFluxBoundaryConstraint(
     if target is None:
         raise ValueError("target_total_power must be array-like.")
 
-    component = domain.component(
-        {domain.label: Boundary()}, where=where, where_all=where_all
+    resolved_var, component = _boundary_component(
+        domain,
+        var=var,
+        where=where,
+        where_all=where_all,
     )
     structure = _default_structure(component) if structure is None else structure
-    n = _normal(component, var="x")
+    n = _normal(component, var=resolved_var)
 
     def operator(E: DomainFunction, H: DomainFunction, /) -> DomainFunction:
         s = _cross(E, H)

--- a/phydrax/domain/_components.py
+++ b/phydrax/domain/_components.py
@@ -6,6 +6,7 @@ from collections.abc import Callable, Mapping, Sequence
 from typing import Any, cast
 
 import coordax as cx
+import equinox as eqx
 import jax
 import jax.numpy as jnp
 import jax.random as jr
@@ -154,7 +155,7 @@ class _NormalCallable(StrictModule):
         n = jnp.asarray(self.geom._boundary_normals(pts), dtype=float)
         eps = jnp.finfo(float).eps
         nrm = jnp.linalg.norm(n, axis=-1, keepdims=True) + eps
-        n = jax.lax.stop_gradient(n / nrm)
+        n = n / nrm
         if pts_in.ndim == 0:
             return n.reshape(())
         return n.reshape(pts_in.shape)
@@ -417,7 +418,9 @@ class DomainComponent(StrictModule):
         if not graph_labels:
             return None
         if len(graph_labels) > 1:
-            raise ValueError("Sampling multiple GraphDomain factors is not supported yet.")
+            raise ValueError(
+                "Sampling multiple GraphDomain factors is not supported yet."
+            )
 
         graph_label = graph_labels[0]
         graph_factor = self.domain.factor(graph_label)
@@ -924,10 +927,7 @@ class DomainComponent(StrictModule):
 
                         coords_tuple = tuple(coords)
                         mask_arr = sdf_mask_from_adf(factor.adf, coords_tuple)
-                        if (
-                            isinstance(n_spec, GridSpec)
-                            and n_spec.cut_cell_order > 0
-                        ):
+                        if isinstance(n_spec, GridSpec) and n_spec.cut_cell_order > 0:
                             base_weights: list[Array] = []
                             for i, coord in enumerate(coords_tuple):
                                 axis_name = _axis_name_for_coord(lbl, i)
@@ -1095,12 +1095,8 @@ class DomainComponent(StrictModule):
             dense_structure=dense_structure_out,
             coord_axes_by_label=frozendict(coord_axes_by_label),
             coord_mask_by_label=frozendict(coord_mask_by_label),
-            coord_geometry_weight_by_label=frozendict(
-                coord_geometry_weight_by_label
-            ),
-            coord_geometry_order_by_label=frozendict(
-                coord_geometry_order_by_label
-            ),
+            coord_geometry_weight_by_label=frozendict(coord_geometry_weight_by_label),
+            coord_geometry_order_by_label=frozendict(coord_geometry_order_by_label),
             axis_discretization_by_axis=frozendict(axis_discretization_by_axis),
         )
 
@@ -1213,22 +1209,40 @@ class DomainComponent(StrictModule):
 
 
 class DomainComponentUnion(StrictModule):
-    r"""A finite union of `DomainComponent` terms.
+    r"""An additive collection of measure-disjoint domain components.
 
-    This is used to represent components that are naturally unions, e.g. for a time
-    interval $[t_0,t_1]$ the boundary is $\{t=t_0\}\cup\{t=t_1\}$.
+    This represents components that decompose naturally into disjoint terms, such
+    as the two endpoints of an interval or the codimension-one faces of a product
+    domain. All terms must use the same compatible labeled domain.
 
-    The total measure is the sum of term measures, and sampling allocates points
-    across terms.
+    Measures and sampling allocations are additive. Arbitrary filter overlap
+    cannot be detected, so callers must ensure distinct filtered terms are
+    measure-disjoint; intersections are otherwise counted once per term.
     """
 
     terms: tuple[DomainComponent, ...]
 
     def __init__(self, terms: tuple[DomainComponent, ...]):
-        """Create a union from non-empty `terms`."""
-        if not terms:
+        """Create an additive collection from non-empty compatible terms."""
+        resolved_terms = tuple(terms)
+        if not resolved_terms:
             raise ValueError("DomainComponentUnion.terms must be non-empty.")
-        self.terms = terms
+        if not all(isinstance(term, DomainComponent) for term in resolved_terms):
+            raise TypeError("DomainComponentUnion terms must be DomainComponent values.")
+
+        domain = resolved_terms[0].domain
+        for index, term in enumerate(resolved_terms):
+            if term.domain.labels != domain.labels or not domain.equivalent(term.domain):
+                raise ValueError(
+                    "DomainComponentUnion terms must share the same compatible "
+                    "labeled domain."
+                )
+            for previous in resolved_terms[:index]:
+                if bool(eqx.tree_equal(term, previous)):
+                    raise ValueError(
+                        "DomainComponentUnion terms must not contain duplicates."
+                    )
+        self.terms = resolved_terms
 
     @property
     def domain(self) -> _AbstractDomain:
@@ -1239,7 +1253,7 @@ class DomainComponentUnion(StrictModule):
         return self.domain.labels
 
     def measure(self) -> Array:
-        r"""Return the total measure $\mu(\cup_i \Omega_i)=\sum_i \mu(\Omega_i)$."""
+        r"""Return the sum of term measures $\sum_i \mu(\Omega_i)$."""
         m = jnp.array(0.0, dtype=float)
         for term in self.terms:
             m = m + term.measure()

--- a/phydrax/domain/geometry2d/_from_cad.py
+++ b/phydrax/domain/geometry2d/_from_cad.py
@@ -126,9 +126,7 @@ class Geometry2DFromCAD(_AbstractGeometry2D):
             edge_lengths,
             kind="segment",
         )
-        self.boundary_chart_atlas = CADChartAtlas(
-            self.boundary_measure_partition
-        )
+        self.boundary_chart_atlas = CADChartAtlas(self.boundary_measure_partition)
 
         self.adf = self.adf_blur(self.adf_orig, radius_fn=self.adf_orig)
 
@@ -721,11 +719,21 @@ class Geometry2DFromCAD(_AbstractGeometry2D):
         if pts.ndim != 2 or pts.shape[1] != 2:
             raise ValueError(f"Expected points with shape (N, 2), got {pts.shape}.")
 
-        zeros = jnp.zeros((pts.shape[0], 1), dtype=pts.dtype)
-        points_3d = jnp.concatenate([pts, zeros], axis=1)
+        z_mid = jnp.full(
+            (pts.shape[0], 1),
+            2.0 * self.diameter,
+            dtype=pts.dtype,
+        )
+        points_3d = jnp.concatenate([pts, z_mid], axis=1)
         normals_3d = self.geom_3d_extruded._boundary_normals(points_3d)
         normals_2d = normals_3d[:, :2]
-        nrm = jnp.linalg.norm(normals_2d, axis=1, keepdims=True) + jnp.finfo(float).eps
+        nrm = jnp.linalg.norm(normals_2d, axis=1, keepdims=True)
+        eps = jnp.finfo(pts.dtype).eps
+        normals_2d = eqx.error_if(
+            normals_2d,
+            (~jnp.all(jnp.isfinite(normals_2d))) | jnp.any(nrm <= 32.0 * eps),
+            "2D boundary normal projection produced a zero or non-finite vector.",
+        )
         normals_2d = normals_2d / nrm
 
         if squeeze:

--- a/phydrax/domain/geometry3d/_mesh.py
+++ b/phydrax/domain/geometry3d/_mesh.py
@@ -51,7 +51,6 @@ class Geometry3DFromCAD(_AbstractGeometry3D):
     volume_proportion: Array
     boundary_measure_partition: GeometryMeasurePartition
     boundary_chart_atlas: CADChartAtlas
-    immersed: bool
     adf: Callable[[Array], Array]
     _boundary_normals_field: Callable[[Array], Array]
 
@@ -60,7 +59,6 @@ class Geometry3DFromCAD(_AbstractGeometry3D):
         mesh: trimesh.Trimesh | meshio.Mesh | Path | str,
         *,
         recenter: bool = False,
-        immersed: bool = False,
     ):
         cleanup_path: Path | None = None
         if isinstance(mesh, (Path, str)):
@@ -87,16 +85,13 @@ class Geometry3DFromCAD(_AbstractGeometry3D):
             triangle_areas,
             kind="triangle",
         )
-        self.boundary_chart_atlas = CADChartAtlas(
-            self.boundary_measure_partition
-        )
+        self.boundary_chart_atlas = CADChartAtlas(self.boundary_measure_partition)
 
         min_bounds, max_bounds = self.mesh.bounds
         bounds = max_bounds - min_bounds
         self.volume_proportion = jnp.array(
             self.mesh.volume / np.prod(bounds), dtype=float
         )
-        self.immersed = immersed
 
         self.adf = self.adf_blur(self.adf_orig, radius_fn=self.adf_orig)
         from ._normals import make_smooth_mesh_normal_field
@@ -270,11 +265,7 @@ class Geometry3DFromCAD(_AbstractGeometry3D):
             raise ValueError(f"translate offset must have shape (3,), got {vec.shape!r}")
         mesh = self.mesh.copy()
         mesh.apply_translation(np.asarray(vec, dtype=float))
-        return Geometry3DFromCAD(
-            mesh,
-            recenter=False,
-            immersed=self.immersed,
-        )
+        return Geometry3DFromCAD(mesh, recenter=False)
 
     def scale(self, factor: ArrayLike) -> "Geometry3DFromCAD":
         r"""Return a uniformly scaled copy of the geometry.
@@ -289,11 +280,7 @@ class Geometry3DFromCAD(_AbstractGeometry3D):
         scale_val = float(factor_arr)
         mesh = self.mesh.copy()
         mesh.apply_scale(scale_val)
-        return Geometry3DFromCAD(
-            mesh,
-            recenter=False,
-            immersed=self.immersed,
-        )
+        return Geometry3DFromCAD(mesh, recenter=False)
 
     def _make_mesh_sdf(
         self, *, eps: float | None = None

--- a/phydrax/domain/geometry3d/_utils.py
+++ b/phydrax/domain/geometry3d/_utils.py
@@ -118,6 +118,50 @@ def _sanitize_meshio_mesh(
     return mesh
 
 
+def _validate_watertight_solid_mesh(mesh: trimesh.Trimesh, /) -> None:
+    vertices = np.asarray(mesh.vertices, dtype=float)
+    faces = np.asarray(mesh.faces)
+    if vertices.ndim != 2 or vertices.shape[1] != 3 or vertices.shape[0] < 4:
+        raise ValueError(
+            "Geometry3DFromCAD requires at least four finite 3D mesh vertices."
+        )
+    if not np.all(np.isfinite(vertices)):
+        raise ValueError("Geometry3DFromCAD mesh vertices must be finite.")
+    if (
+        faces.ndim != 2
+        or faces.shape[1] != 3
+        or faces.shape[0] < 4
+        or not np.issubdtype(faces.dtype, np.integer)
+    ):
+        raise ValueError(
+            "Geometry3DFromCAD requires at least four triangular mesh faces."
+        )
+
+    areas = np.asarray(mesh.area_faces, dtype=float)
+    if areas.shape != (faces.shape[0],) or np.any(~np.isfinite(areas)):
+        raise ValueError("Geometry3DFromCAD mesh face areas must be finite.")
+    if np.any(areas <= 0.0):
+        raise ValueError("Geometry3DFromCAD mesh faces must have positive area.")
+    if not bool(mesh.is_watertight):
+        raise ValueError("Geometry3DFromCAD requires a watertight surface mesh.")
+    if not bool(mesh.is_winding_consistent):
+        raise ValueError("Geometry3DFromCAD requires consistently wound mesh faces.")
+
+    volume = float(mesh.volume)
+    if not np.isfinite(volume) or volume <= 0.0:
+        raise ValueError(
+            "Geometry3DFromCAD requires a finite, strictly positive enclosed volume."
+        )
+    bounds = np.asarray(mesh.bounds, dtype=float)
+    if bounds.shape != (2, 3) or np.any(~np.isfinite(bounds)):
+        raise ValueError("Geometry3DFromCAD mesh bounds must be finite.")
+    bounding_volume = float(np.prod(bounds[1] - bounds[0]))
+    if not np.isfinite(bounding_volume) or bounding_volume <= 0.0:
+        raise ValueError(
+            "Geometry3DFromCAD requires a finite, strictly positive bounding-box volume."
+        )
+
+
 def _sanitize_mesh(
     mesh: trimesh.Trimesh | meshio.Mesh | Path | str,
     *,
@@ -128,16 +172,21 @@ def _sanitize_mesh(
         mesh = trimesh.load_mesh(mesh_path)
 
     if isinstance(mesh, meshio.Mesh):
-        mesh = _sanitize_meshio_mesh(mesh, output_type="trimesh", recenter=recenter)
+        mesh = _sanitize_meshio_mesh(mesh, output_type="trimesh", recenter=False)
 
-    assert isinstance(mesh, trimesh.Trimesh)
+    if not isinstance(mesh, trimesh.Trimesh):
+        raise TypeError(
+            "Geometry3DFromCAD requires a triangular trimesh.Trimesh or meshio.Mesh."
+        )
+    if not np.all(np.isfinite(np.asarray(mesh.vertices, dtype=float))):
+        raise ValueError("Geometry3DFromCAD mesh vertices must be finite.")
 
     mesh.remove_unreferenced_vertices()
     mesh.update_faces(mesh.unique_faces())
     mesh.update_faces(mesh.nondegenerate_faces())
-    mesh.remove_infinite_values()
-    mesh.fill_holes()
     mesh.fix_normals()
+    mesh.remove_unreferenced_vertices()
+    _validate_watertight_solid_mesh(mesh)
 
     if recenter:
         mesh.apply_translation(-mesh.center_mass)

--- a/phydrax/graph/_cochain.py
+++ b/phydrax/graph/_cochain.py
@@ -81,7 +81,6 @@ class CochainFieldSpec(StrictModule):
         )
 
 
-
 def _host_array(name: str, value: Any, /, *, dtype: Any | None = None) -> np.ndarray:
     array = np.asarray(value, dtype=dtype)
     if np.any(~np.isfinite(array)):
@@ -232,9 +231,13 @@ class HarmonicSubspace(StrictModule, NonTrainableState):
         basis_tuple = tuple(jnp.asarray(value) for value in bases)
         eigenvalue_tuple = tuple(jnp.asarray(value) for value in eigenvalues)
         rank_tuple = tuple(int(value) for value in ranks)
-        if len(basis_tuple) != len(rank_tuple) or len(eigenvalue_tuple) != len(rank_tuple):
+        if len(basis_tuple) != len(rank_tuple) or len(eigenvalue_tuple) != len(
+            rank_tuple
+        ):
             raise ValueError("Harmonic basis, eigenvalue, and rank counts must match.")
-        if int(max_modes) < 0 or any(rank < 0 or rank > int(max_modes) for rank in rank_tuple):
+        if int(max_modes) < 0 or any(
+            rank < 0 or rank > int(max_modes) for rank in rank_tuple
+        ):
             raise ValueError("Harmonic ranks must lie in [0, max_modes].")
         for basis, values, rank in zip(
             basis_tuple, eigenvalue_tuple, rank_tuple, strict=True
@@ -295,7 +298,9 @@ class CochainComplexIR(StrictModule, NonTrainableState):
         max_degree = len(counts) - 1
         incidence_tuple = tuple(incidences)
         if len(incidence_tuple) != max_degree:
-            raise ValueError("One incidence is required between every consecutive degree.")
+            raise ValueError(
+                "One incidence is required between every consecutive degree."
+            )
         for degree, incidence in enumerate(incidence_tuple, start=1):
             if not isinstance(incidence, CochainIncidence):
                 raise TypeError("incidences must contain CochainIncidence objects.")
@@ -304,7 +309,9 @@ class CochainComplexIR(StrictModule, NonTrainableState):
                 or incidence.lower_count != counts[degree - 1]
                 or incidence.upper_count != counts[degree]
             ):
-                raise ValueError("Incidence degrees and dimensions must match cell counts.")
+                raise ValueError(
+                    "Incidence degrees and dimensions must match cell counts."
+                )
 
         stars = self._degree_values("hodge_stars", hodge_stars, counts, positive=True)
         primal = self._degree_values(
@@ -317,7 +324,9 @@ class CochainComplexIR(StrictModule, NonTrainableState):
         )
         dual = self._degree_values(
             "dual_measures",
-            tuple(np.asarray(primal[k]) * np.asarray(stars[k]) for k in range(len(counts)))
+            tuple(
+                np.asarray(primal[k]) * np.asarray(stars[k]) for k in range(len(counts))
+            )
             if dual_measures is None
             else dual_measures,
             counts,
@@ -429,7 +438,9 @@ class CochainComplexIR(StrictModule, NonTrainableState):
             dimensions.add(int(array.shape[1]))
             points.append(jnp.asarray(array))
         if len(dimensions) > 1 or (dimensions and any(value is None for value in points)):
-            raise ValueError("Coordinates must be present with one common dimension at all degrees.")
+            raise ValueError(
+                "Coordinates must be present with one common dimension at all degrees."
+            )
         return tuple(points)
 
     @staticmethod
@@ -489,7 +500,10 @@ class CochainComplexIR(StrictModule, NonTrainableState):
 
     def _build_graph(self) -> GraphIR:
         degrees = np.concatenate(
-            [np.full((count,), degree, dtype=np.int32) for degree, count in enumerate(self.cell_counts)]
+            [
+                np.full((count,), degree, dtype=np.int32)
+                for degree, count in enumerate(self.cell_counts)
+            ]
         )
         local_indices = np.concatenate(
             [np.arange(count, dtype=np.int32) for count in self.cell_counts]
@@ -524,8 +538,13 @@ class CochainComplexIR(StrictModule, NonTrainableState):
         directions: list[np.ndarray] = []
         incidence_degrees: list[np.ndarray] = []
         for incidence in self.incidences:
-            lower = np.asarray(incidence.lower_indices) + self.cell_offsets[incidence.degree - 1]
-            upper = np.asarray(incidence.upper_indices) + self.cell_offsets[incidence.degree]
+            lower = (
+                np.asarray(incidence.lower_indices)
+                + self.cell_offsets[incidence.degree - 1]
+            )
+            upper = (
+                np.asarray(incidence.upper_indices) + self.cell_offsets[incidence.degree]
+            )
             coefficient = np.asarray(incidence.signs)
             count = lower.size
             senders.extend((lower, upper))
@@ -543,7 +562,9 @@ class CochainComplexIR(StrictModule, NonTrainableState):
                     np.full((count,), incidence.degree, dtype=np.int32),
                 )
             )
-        sender_array = np.concatenate(senders) if senders else np.zeros((0,), dtype=np.int32)
+        sender_array = (
+            np.concatenate(senders) if senders else np.zeros((0,), dtype=np.int32)
+        )
         receiver_array = (
             np.concatenate(receivers) if receivers else np.zeros((0,), dtype=np.int32)
         )
@@ -611,7 +632,9 @@ class CochainComplexIR(StrictModule, NonTrainableState):
                 np.asarray(incidence.lower_indices)
             ]
             if np.any(upper_boundary & ~lower_boundary):
-                raise ValueError("Boundary masks must define a closed boundary subcomplex.")
+                raise ValueError(
+                    "Boundary masks must define a closed boundary subcomplex."
+                )
 
 
 def cochain_complex_from_incidences(
@@ -647,7 +670,9 @@ def cochain_complex_from_simplicial(
     from ._simplicial import SimplicialComplexGraph
 
     if not isinstance(complex_graph, SimplicialComplexGraph):
-        raise TypeError("cochain_complex_from_simplicial requires SimplicialComplexGraph.")
+        raise TypeError(
+            "cochain_complex_from_simplicial requires SimplicialComplexGraph."
+        )
     edge_vertices = np.asarray(complex_graph.edge_vertices, dtype=np.int32)
     edge_ids = np.repeat(np.arange(edge_vertices.shape[0], dtype=np.int32), 2)
     b1 = CochainIncidence(
@@ -686,8 +711,6 @@ def triangle_mesh_to_cochain_complex(
     mesh_vertices: Any,
     mesh_faces: Any,
     /,
-    *,
-    boundary_policy: CochainBoundaryKind = "absolute",
 ) -> CochainComplexIR:
     """Build a positive barycentric metric cochain complex from a triangle mesh."""
     from ._simplicial import triangle_mesh_to_simplicial_graph
@@ -696,8 +719,10 @@ def triangle_mesh_to_cochain_complex(
     faces = np.asarray(mesh_faces)
     if vertices.ndim != 2 or vertices.shape[1] < 2:
         raise ValueError("mesh_vertices must have shape (vertices, embedding_dim >= 2).")
-    if faces.ndim != 2 or faces.shape[1] != 3 or not np.issubdtype(
-        faces.dtype, np.integer
+    if (
+        faces.ndim != 2
+        or faces.shape[1] != 3
+        or not np.issubdtype(faces.dtype, np.integer)
     ):
         raise ValueError("mesh_faces must have integer shape (faces, 3).")
     faces = faces.astype(np.int32, copy=False)
@@ -708,9 +733,7 @@ def triangle_mesh_to_cochain_complex(
         num_vertices=int(vertices.shape[0]),
     )
     edge_vertices = np.asarray(bundle.edge_vertices, dtype=np.int32)
-    edge_points = 0.5 * (
-        vertices[edge_vertices[:, 0]] + vertices[edge_vertices[:, 1]]
-    )
+    edge_points = 0.5 * (vertices[edge_vertices[:, 0]] + vertices[edge_vertices[:, 1]])
     face_points = np.mean(vertices[faces], axis=1)
     first = vertices[faces[:, 1]] - vertices[faces[:, 0]]
     second = vertices[faces[:, 2]] - vertices[faces[:, 0]]
@@ -742,7 +765,6 @@ def triangle_mesh_to_cochain_complex(
     boundary_vertex = np.zeros((vertices.shape[0],), dtype=bool)
     boundary_vertex[edge_vertices[boundary_edge].reshape((-1,))] = True
     boundary_face = np.zeros((faces.shape[0],), dtype=bool)
-    CochainBoundaryPolicy(boundary_policy)
     return cochain_complex_from_simplicial(
         bundle,
         (
@@ -808,23 +830,36 @@ def compute_harmonic_subspace(
         laplacian = sp.csr_matrix((active_count, active_count), dtype=float)
         if degree > 0:
             boundary = _restricted_boundary_matrix(complex_ir, degree, policy)
-            transformed = sqrt_metric @ boundary.T @ sp.diags(
-                1.0 / np.sqrt(
-                    np.asarray(complex_ir.hodge_stars[degree - 1])[
-                        np.asarray(complex_ir.active_mask(degree - 1, policy), dtype=bool)
-                    ]
+            transformed = (
+                sqrt_metric
+                @ boundary.T
+                @ sp.diags(
+                    1.0
+                    / np.sqrt(
+                        np.asarray(complex_ir.hodge_stars[degree - 1])[
+                            np.asarray(
+                                complex_ir.active_mask(degree - 1, policy), dtype=bool
+                            )
+                        ]
+                    )
                 )
             )
             laplacian = laplacian + transformed @ transformed.T
         if degree < complex_ir.max_degree:
             boundary = _restricted_boundary_matrix(complex_ir, degree + 1, policy)
-            transformed = sp.diags(
-                np.sqrt(
-                    np.asarray(complex_ir.hodge_stars[degree + 1])[
-                        np.asarray(complex_ir.active_mask(degree + 1, policy), dtype=bool)
-                    ]
+            transformed = (
+                sp.diags(
+                    np.sqrt(
+                        np.asarray(complex_ir.hodge_stars[degree + 1])[
+                            np.asarray(
+                                complex_ir.active_mask(degree + 1, policy), dtype=bool
+                            )
+                        ]
+                    )
                 )
-            ) @ boundary.T @ inverse_sqrt
+                @ boundary.T
+                @ inverse_sqrt
+            )
             laplacian = laplacian + transformed.T @ transformed
         laplacian = 0.5 * (laplacian + laplacian.T)
         scale = max(1.0, float(np.max(np.abs(laplacian.data), initial=0.0)))
@@ -914,9 +949,13 @@ def reorient_cochain_complex(
     signs = tuple(np.asarray(value, dtype=float) for value in orientation_signs)
     if len(signs) != len(complex_ir.cell_counts):
         raise ValueError("orientation_signs must provide one vector per degree.")
-    for degree, (value, count) in enumerate(zip(signs, complex_ir.cell_counts, strict=True)):
+    for degree, (value, count) in enumerate(
+        zip(signs, complex_ir.cell_counts, strict=True)
+    ):
         if value.shape != (count,) or np.any(np.abs(value) != 1.0):
-            raise ValueError(f"orientation_signs[{degree}] must contain {count} values ±1.")
+            raise ValueError(
+                f"orientation_signs[{degree}] must contain {count} values ±1."
+            )
     incidences = []
     for incidence in complex_ir.incidences:
         coefficient = (

--- a/phydrax/graph/_mesh.py
+++ b/phydrax/graph/_mesh.py
@@ -261,6 +261,7 @@ class MeshCotangentLaplacian(eqx.Module):
         self,
         /,
         *,
+        sign: MeshLaplacianSign,
         weight: Any = None,
         mass: Any = None,
         weight_key: str | None = "cotangent_weight",
@@ -268,7 +269,6 @@ class MeshCotangentLaplacian(eqx.Module):
         input_key: str | None = None,
         output_key: str | None = None,
         normalize_by_mass: bool = True,
-        sign: MeshLaplacianSign = "neighbor_minus_self",
     ):
         if sign not in ("neighbor_minus_self", "self_minus_neighbor"):
             raise ValueError(
@@ -329,7 +329,9 @@ class MeshCotangentLaplacian(eqx.Module):
     def __call__(self, graph: GraphIR) -> GraphIR:
         graph = ensure_graph(graph, validate=False)
         if graph.senders is None or graph.receivers is None:
-            raise ValueError("MeshCotangentLaplacian requires explicit senders/receivers.")
+            raise ValueError(
+                "MeshCotangentLaplacian requires explicit senders/receivers."
+            )
 
         nodes = self._node_field(graph)
         sent = _tree_index(nodes, graph.senders)

--- a/phydrax/nn/models/architectures/_manifold_spectral.py
+++ b/phydrax/nn/models/architectures/_manifold_spectral.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import hashlib
+import warnings
 from collections.abc import Callable
 from math import prod
 from typing import Any, Literal
@@ -15,6 +16,9 @@ import jax.numpy as jnp
 import jax.random as jr
 import numpy as np
 import opt_einsum as oe
+import scipy.linalg as scipy_linalg
+import scipy.sparse as scipy_sparse
+import scipy.sparse.linalg as scipy_sparse_linalg
 from jaxtyping import Array, Key
 
 from ...._doc import DOC_KEY0
@@ -46,6 +50,54 @@ def _canonicalize_eigenvector_signs(vectors: np.ndarray, /) -> np.ndarray:
         if result[pivot, mode] < 0.0:
             result[:, mode] *= -1.0
     return result
+
+
+_DENSE_GENERALIZED_EIGH_THRESHOLD = 256
+
+
+def _finite_symmetric_matrix(value: Any, /, *, name: str):
+    if scipy_sparse.issparse(value):
+        matrix = value.astype(float).tocsr(copy=True)
+        if matrix.ndim != 2 or matrix.shape[0] != matrix.shape[1]:
+            raise ValueError(f"{name} must be a square matrix.")
+        matrix.sum_duplicates()
+        matrix.sort_indices()
+        if np.any(~np.isfinite(matrix.data)):
+            raise ValueError(f"{name} must be finite.")
+        scale = max(
+            1.0,
+            float(np.max(np.abs(matrix.data))) if matrix.data.size else 0.0,
+        )
+        difference = matrix - matrix.T
+        error = float(np.max(np.abs(difference.data))) if difference.data.size else 0.0
+        if error > 1e-10 * scale:
+            raise ValueError(f"{name} must be symmetric.")
+        return ((matrix + matrix.T) * 0.5).tocsr()
+
+    matrix = np.asarray(value, dtype=float)
+    if matrix.ndim != 2 or matrix.shape[0] != matrix.shape[1]:
+        raise ValueError(f"{name} must be a square matrix.")
+    if np.any(~np.isfinite(matrix)):
+        raise ValueError(f"{name} must be finite.")
+    scale = max(1.0, float(np.max(np.abs(matrix))) if matrix.size else 0.0)
+    if not np.allclose(matrix, matrix.T, rtol=1e-10, atol=1e-10 * scale):
+        raise ValueError(f"{name} must be symmetric.")
+    return 0.5 * (matrix + matrix.T)
+
+
+def _update_matrix_digest(digest: Any, matrix: Any, /) -> None:
+    if scipy_sparse.issparse(matrix):
+        csr = matrix.tocsr(copy=True)
+        csr.sum_duplicates()
+        csr.sort_indices()
+        digest.update(b"csr")
+        digest.update(np.asarray(csr.shape, dtype=np.int64).tobytes())
+        digest.update(np.asarray(csr.indptr, dtype=np.int64).tobytes())
+        digest.update(np.asarray(csr.indices, dtype=np.int64).tobytes())
+        digest.update(np.asarray(csr.data, dtype=float).tobytes())
+        return
+    digest.update(b"dense")
+    digest.update(np.ascontiguousarray(np.asarray(matrix, dtype=float)).tobytes())
 
 
 class SpectralDiscretization(eqx.Module, NonTrainableState):
@@ -169,9 +221,9 @@ class SpectralDiscretization(eqx.Module, NonTrainableState):
         )
 
     @classmethod
-    def from_laplacian(
+    def from_stiffness(
         cls,
-        laplacian: Any,
+        stiffness: Any,
         mass: Any,
         /,
         *,
@@ -179,45 +231,188 @@ class SpectralDiscretization(eqx.Module, NonTrainableState):
         group_tolerance: float = 1e-7,
         basis_id: str | None = None,
     ) -> "SpectralDiscretization":
-        stiffness = np.asarray(laplacian, dtype=float)
-        if stiffness.ndim != 2 or stiffness.shape[0] != stiffness.shape[1]:
-            raise ValueError("Laplacian must be a square matrix.")
-        count = stiffness.shape[0]
-        mass_array = np.asarray(mass, dtype=float)
-        if mass_array.ndim == 1:
-            if mass_array.shape != (count,):
-                raise ValueError("Diagonal mass must have one entry per point.")
-            mass_matrix = np.diag(mass_array)
-            measure = mass_array
-        elif mass_array.shape == (count, count):
-            mass_matrix = mass_array
-            measure = np.diag(mass_array)
+        r"""Construct low modes of a positive-semidefinite stiffness operator.
+
+        Solves the generalized eigenproblem $K v = \lambda M v$, where $K$
+        represents the positive-semidefinite operator $-\Delta$ and $M$ is a
+        positive mass matrix. Sparse inputs use a sparse partial eigensolve.
+        """
+        stiffness_matrix = _finite_symmetric_matrix(stiffness, name="Stiffness")
+        count = int(stiffness_matrix.shape[0])
+        if count == 0:
+            raise ValueError("Stiffness must not be empty.")
+
+        diagonal_mass = False
+        if scipy_sparse.issparse(mass):
+            mass_matrix = _finite_symmetric_matrix(mass, name="Mass")
+            if mass_matrix.shape != (count, count):
+                raise ValueError("Mass matrix shape must match stiffness.")
+            measure = np.asarray(mass_matrix.diagonal(), dtype=float)
         else:
-            raise ValueError("Mass must be diagonal entries or a square matrix.")
+            mass_array = np.asarray(mass, dtype=float)
+            if mass_array.ndim == 1:
+                if mass_array.shape != (count,):
+                    raise ValueError("Diagonal mass must have one entry per point.")
+                if np.any(~np.isfinite(mass_array)):
+                    raise ValueError("Mass must be finite.")
+                measure = np.array(mass_array, dtype=float, copy=True)
+                mass_matrix = scipy_sparse.diags(measure, format="csr")
+                diagonal_mass = True
+            elif mass_array.shape == (count, count):
+                mass_matrix = _finite_symmetric_matrix(mass_array, name="Mass")
+                measure = np.asarray(np.diag(mass_matrix), dtype=float)
+            else:
+                raise ValueError("Mass must be diagonal entries or a square matrix.")
+
+        if np.any(~np.isfinite(measure)) or np.any(measure <= 0.0):
+            raise ValueError("Mass diagonal must be finite and strictly positive.")
+
         modes = int(n_modes)
         if modes <= 0 or modes > count:
             raise ValueError("n_modes must lie between one and the matrix size.")
-        stiffness = 0.5 * (stiffness + stiffness.T)
-        mass_matrix = 0.5 * (mass_matrix + mass_matrix.T)
-        cholesky = np.linalg.cholesky(mass_matrix)
-        inverse = np.linalg.solve(cholesky, np.eye(count))
-        transformed = inverse @ stiffness @ inverse.T
-        transformed = 0.5 * (transformed + transformed.T)
-        values, vectors = np.linalg.eigh(transformed)
-        order = np.argsort(values, kind="stable")[:modes]
-        values = values[order]
-        physical = inverse.T @ vectors[:, order]
+
+        if not diagonal_mass:
+            if scipy_sparse.issparse(mass_matrix):
+                if count == 1:
+                    smallest_mass = float(mass_matrix[0, 0])
+                else:
+                    smallest_mass = float(
+                        scipy_sparse_linalg.eigsh(
+                            mass_matrix,
+                            k=1,
+                            which="SA",
+                            return_eigenvectors=False,
+                        )[0]
+                    )
+                if not np.isfinite(smallest_mass) or smallest_mass <= 0.0:
+                    raise ValueError("Mass matrix must be positive definite.")
+            else:
+                try:
+                    scipy_linalg.cholesky(
+                        mass_matrix,
+                        lower=True,
+                        check_finite=False,
+                    )
+                except np.linalg.LinAlgError as exc:
+                    raise ValueError("Mass matrix must be positive definite.") from exc
+
+        use_dense = (
+            count <= _DENSE_GENERALIZED_EIGH_THRESHOLD
+            or 5 * modes >= count
+            or (
+                not scipy_sparse.issparse(stiffness_matrix)
+                and not scipy_sparse.issparse(mass_matrix)
+            )
+        )
+        if use_dense:
+            stiffness_dense = (
+                stiffness_matrix.toarray()
+                if scipy_sparse.issparse(stiffness_matrix)
+                else stiffness_matrix
+            )
+            mass_dense = (
+                mass_matrix.toarray()
+                if scipy_sparse.issparse(mass_matrix)
+                else mass_matrix
+            )
+            try:
+                values, physical = scipy_linalg.eigh(
+                    stiffness_dense,
+                    mass_dense,
+                    subset_by_index=(0, modes - 1),
+                    check_finite=False,
+                )
+            except np.linalg.LinAlgError as exc:
+                raise ValueError(
+                    "Generalized stiffness eigendecomposition failed; "
+                    "mass must be positive definite."
+                ) from exc
+        else:
+            stiffness_sparse = (
+                stiffness_matrix.tocsr()
+                if scipy_sparse.issparse(stiffness_matrix)
+                else scipy_sparse.csr_matrix(stiffness_matrix)
+            )
+            mass_sparse = (
+                mass_matrix.tocsr()
+                if scipy_sparse.issparse(mass_matrix)
+                else scipy_sparse.csr_matrix(mass_matrix)
+            )
+            rng = np.random.default_rng(0)
+            initial = rng.standard_normal((count, modes))
+            initial[:, 0] = 1.0
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", UserWarning)
+                values, physical = scipy_sparse_linalg.lobpcg(
+                    stiffness_sparse,
+                    initial,
+                    B=mass_sparse,
+                    largest=False,
+                    tol=1e-9,
+                    maxiter=500,
+                )
+
+            stiffness_times_physical = np.asarray(
+                stiffness_sparse @ physical,
+                dtype=float,
+            )
+            mass_times_physical = np.asarray(mass_sparse @ physical, dtype=float)
+            residual = (
+                stiffness_times_physical
+                - mass_times_physical * np.asarray(values)[None, :]
+            )
+            stiffness_scale = float(np.max(np.asarray(abs(stiffness_sparse).sum(axis=1))))
+            mass_scale = float(np.max(np.asarray(abs(mass_sparse).sum(axis=1))))
+            vector_norm = np.linalg.norm(physical, axis=0)
+            denominator = (
+                stiffness_scale + np.abs(np.asarray(values)) * mass_scale
+            ) * vector_norm
+            relative_residual = np.linalg.norm(residual, axis=0) / np.maximum(
+                denominator,
+                np.finfo(float).tiny,
+            )
+            if np.any(~np.isfinite(relative_residual)) or np.any(
+                relative_residual > 1e-7
+            ):
+                raise RuntimeError(
+                    "Sparse stiffness eigendecomposition failed to converge; "
+                    f"maximum relative residual is "
+                    f"{float(np.max(relative_residual))}."
+                )
+
+        order = np.argsort(values, kind="stable")
+        values = np.asarray(values[order], dtype=float)
+        physical = np.asarray(physical[:, order], dtype=float)
+        spectral_scale = max(
+            1.0,
+            float(np.max(np.abs(values))) if values.size else 0.0,
+        )
+        negative_tolerance = 1e-8 * spectral_scale
+        if np.any(values < -negative_tolerance):
+            raise ValueError(
+                "Stiffness must be positive semidefinite; "
+                f"smallest generalized eigenvalue is {float(values[0])}."
+            )
+        values = np.maximum(values, 0.0)
+
+        mass_times_physical = np.asarray(mass_matrix @ physical, dtype=float)
+        norms = np.sqrt(np.sum(physical * mass_times_physical, axis=0))
+        if np.any(~np.isfinite(norms)) or np.any(norms <= 0.0):
+            raise ValueError("Stiffness eigenvectors must have positive mass norm.")
+        physical = physical / norms[None, :]
         physical = _canonicalize_eigenvector_signs(physical)
+        mass_times_physical = np.asarray(mass_matrix @ physical, dtype=float)
         groups = _eigenspace_groups(values, float(group_tolerance))
+
         identifier = basis_id
         if identifier is None:
             digest = hashlib.sha256()
-            digest.update(np.ascontiguousarray(stiffness).tobytes())
-            digest.update(np.ascontiguousarray(mass_matrix).tobytes())
+            _update_matrix_digest(digest, stiffness_matrix)
+            _update_matrix_digest(digest, mass_matrix)
             digest.update(str(modes).encode("utf-8"))
             identifier = digest.hexdigest()
         return cls(
-            analysis=physical.T @ mass_matrix,
+            analysis=mass_times_physical.T,
             synthesis=physical,
             eigenvalues=values,
             group_ids=groups,
@@ -243,14 +438,20 @@ class SpectralDiscretization(eqx.Module, NonTrainableState):
 
         points = np.asarray(vertices, dtype=float)
         sender, receiver, edge_weight = mesh_cotangent_weights(vertices, faces)
-        sender_ = np.asarray(sender, dtype=int)
-        receiver_ = np.asarray(receiver, dtype=int)
+        sender_ = np.asarray(sender, dtype=np.int32)
+        receiver_ = np.asarray(receiver, dtype=np.int32)
         weights = np.asarray(edge_weight, dtype=float)
-        stiffness = np.zeros((points.shape[0], points.shape[0]), dtype=float)
-        np.add.at(stiffness, (sender_, sender_), weights)
-        np.add.at(stiffness, (sender_, receiver_), -weights)
+        rows = np.concatenate((sender_, sender_))
+        columns = np.concatenate((sender_, receiver_))
+        data = np.concatenate((weights, -weights))
+        stiffness = scipy_sparse.coo_matrix(
+            (data, (rows, columns)),
+            shape=(points.shape[0], points.shape[0]),
+            dtype=float,
+        ).tocsr()
+        stiffness.sum_duplicates()
         mass = np.asarray(mesh_lumped_vertex_areas(vertices, faces), dtype=float)
-        return cls.from_laplacian(
+        return cls.from_stiffness(
             stiffness,
             mass,
             n_modes=n_modes,

--- a/phydrax/operators/__init__.py
+++ b/phydrax/operators/__init__.py
@@ -47,6 +47,7 @@ from .delay import (  # noqa: F401
     delay as delay_operator,
 )
 from .differential import (  # noqa: F401
+    ambient_surface_hessian_trace,
     bilaplacian,
     caputo_time_fractional,
     caputo_time_fractional_dw,
@@ -78,7 +79,6 @@ from .differential import (  # noqa: F401
     hydrostatic_stress,
     kolmogorov_generator,
     laplace_beltrami,
-    laplace_beltrami_divgrad,
     laplacian,
     lie_bracket,
     linear_elastic_cauchy_stress_2d,
@@ -287,11 +287,11 @@ __all__ = [
     "stratonovich_to_ito_drift",
     "div_tensor",
     "navier_stokes_divergence",
+    "ambient_surface_hessian_trace",
     "laplace_beltrami",
     "riemannian_div",
     "riemannian_div_tensor",
     "riemannian_grad",
-    "laplace_beltrami_divgrad",
     "surface_curl_scalar",
     "surface_curl_vector",
     "surface_div",

--- a/phydrax/operators/differential/__init__.py
+++ b/phydrax/operators/differential/__init__.py
@@ -66,8 +66,8 @@ from ._stochastic_ops import (
     stratonovich_to_ito_drift,
 )
 from ._surface_ops import (
+    ambient_surface_hessian_trace,
     laplace_beltrami,
-    laplace_beltrami_divgrad,
     surface_curl_scalar,
     surface_curl_vector,
     surface_div,
@@ -133,8 +133,8 @@ __all__ = [
     "strain_rate_magnitude",
     "div_tensor",
     "navier_stokes_divergence",
+    "ambient_surface_hessian_trace",
     "laplace_beltrami",
-    "laplace_beltrami_divgrad",
     "surface_curl_scalar",
     "surface_curl_vector",
     "surface_div",

--- a/phydrax/operators/differential/_surface_ops.py
+++ b/phydrax/operators/differential/_surface_ops.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 from typing import Literal
 
-import jax
 import jax.numpy as jnp
 import opt_einsum as oe
 
@@ -63,7 +62,6 @@ def tangential_component(
     def _op(*args, key=None, **kwargs):
         wv = jnp.asarray(w2.func(*[args[i] for i in w_pos], key=key, **kwargs))
         nv = jnp.asarray(n2.func(*[args[i] for i in n_pos], key=key, **kwargs))
-        nv = jax.lax.stop_gradient(nv)
         dot = jnp.sum(wv * nv, axis=-1, keepdims=True)
         return wv - dot * nv
 
@@ -119,7 +117,6 @@ def surface_grad(
     def _op(*args, key=None, **kwargs):
         gv = jnp.asarray(g.func(*[args[i] for i in g_pos], key=key, **kwargs))
         nv = jnp.asarray(n2.func(*[args[i] for i in n_pos], key=key, **kwargs))
-        nv = jax.lax.stop_gradient(nv)
         P = tangent_projector_from_normal(nv)
 
         if gv.ndim == nv.ndim:
@@ -183,7 +180,6 @@ def surface_div(
     def _op(*args, key=None, **kwargs):
         Jv = jnp.asarray(J.func(*[args[i] for i in j_pos], key=key, **kwargs))
         nv = jnp.asarray(n2.func(*[args[i] for i in n_pos], key=key, **kwargs))
-        nv = jax.lax.stop_gradient(nv)
         P = tangent_projector_from_normal(nv)
         if Jv.ndim < 2 or P.ndim < 2:
             raise ValueError(
@@ -240,7 +236,6 @@ def surface_curl_scalar(
 
     def _op(*args, key=None, **kwargs):
         nv = jnp.asarray(n2.func(*[args[i] for i in n_pos], key=key, **kwargs))
-        nv = jax.lax.stop_gradient(nv)
         gv = jnp.asarray(sg2.func(*[args[i] for i in sg_pos], key=key, **kwargs))
         return jnp.cross(nv, gv)
 
@@ -292,60 +287,46 @@ def surface_curl_vector(
 
     def _op(*args, key=None, **kwargs):
         nv = jnp.asarray(n2.func(*[args[i] for i in n_pos], key=key, **kwargs))
-        nv = jax.lax.stop_gradient(nv)
         cv = jnp.asarray(c2.func(*[args[i] for i in c_pos], key=key, **kwargs))
         return jnp.sum(nv * cv, axis=-1)
 
     return DomainFunction(domain=joined, deps=deps, func=_op, metadata=v.metadata)
 
 
-def laplace_beltrami(
+def ambient_surface_hessian_trace(
     u: DomainFunction,
-    component: DomainComponent | RiemannianMetric,
+    component: DomainComponent,
     /,
     *,
     var: str | None = None,
-    curvature_aware: bool = False,
-    variant: Literal["contraction", "divgrad"] | None = None,
     mode: Literal["reverse", "forward"] = "reverse",
 ) -> DomainFunction:
-    r"""Laplace–Beltrami operator on a boundary component.
+    r"""Trace an ambient Hessian over a boundary tangent space.
 
-    The Laplace–Beltrami operator $\Delta_{\Gamma}$ is the surface analogue of the
-    Laplacian. Two common realizations are supported:
+    With outward unit normal $n$ and tangent projector $P=I-n\otimes n$, this
+    operator computes
 
-    - projection–contraction form (default): $\Delta_{\Gamma} u \approx \text{tr}(P\,\nabla^2 u\,P)$;
-    - divergence-of-surface-gradient (via `variant="divgrad"`): $\Delta_{\Gamma} u =
-      \nabla_{\Gamma}\cdot\nabla_{\Gamma}u$.
+    $$
+    \operatorname{tr}\left(P\,\nabla^2u\,P\right).
+    $$
 
-    The `curvature_aware=True` option selects the `divgrad` variant by default.
+    This is an ambient, extension-dependent contraction. It agrees with the
+    intrinsic Laplace--Beltrami operator only when the ambient extension of
+    $u$ is compatible with the surface, including flat surfaces and
+    closest-point extensions. Use `laplace_beltrami` with a
+    `RiemannianMetric` for intrinsic curved-manifold calculus.
 
     **Arguments:**
 
-    - `u`: Field to differentiate.
-    - `component`: Boundary `DomainComponent` used to supply the unit normal field.
+    - `u`: Ambient field to differentiate.
+    - `component`: Boundary component supplying the unit normal field.
     - `var`: Geometry label.
-    - `curvature_aware`: If `True`, defaults to `variant="divgrad"`.
-    - `variant`: `"contraction"` (projection–contraction) or `"divgrad"`.
-    - `mode`: Autodiff mode used by the underlying `grad`/`surface_grad`.
+    - `mode`: Autodiff mode used to construct the ambient Hessian.
 
     **Returns:**
 
-    - A `DomainFunction` representing $\Delta_\Gamma u$.
+    - A `DomainFunction` representing the tangent-space Hessian trace.
     """
-    if isinstance(component, RiemannianMetric):
-        if curvature_aware or variant is not None:
-            raise ValueError(
-                "curvature_aware and variant are only valid for boundary-component "
-                "Laplace-Beltrami operators."
-            )
-        from ._riemannian_ops import intrinsic_laplace_beltrami
-
-        return intrinsic_laplace_beltrami(u, component, var=var, mode=mode)
-
-    if variant == "divgrad" or (curvature_aware and variant is None):
-        return laplace_beltrami_divgrad(u, component, var=var, mode=mode)
-
     var = _resolve_var(u, var)
     _, var_dim = _factor_and_dim(u, var)
 
@@ -353,7 +334,6 @@ def laplace_beltrami(
     joined = u.domain.join(n.domain)
     u2 = u.promote(joined)
     n2 = n.promote(joined)
-
     H = grad(grad(u2, var=var, mode=mode), var=var, mode=mode)
 
     deps = tuple(lbl for lbl in joined.labels if (lbl in H.deps) or (lbl in n2.deps))
@@ -364,10 +344,10 @@ def laplace_beltrami(
     def _op(*args, key=None, **kwargs):
         Hv = jnp.asarray(H.func(*[args[i] for i in h_pos], key=key, **kwargs))
         nv = jnp.asarray(n2.func(*[args[i] for i in n_pos], key=key, **kwargs))
-        nv = jax.lax.stop_gradient(nv)
         if nv.shape[-1] != var_dim:
             raise ValueError(
-                f"laplace_beltrami expected normal last axis {var_dim}, got {nv.shape[-1]}."
+                "ambient_surface_hessian_trace expected normal last axis "
+                f"{var_dim}, got {nv.shape[-1]}."
             )
         P = tangent_projector_from_normal(nv)
         if Hv.ndim == P.ndim:
@@ -375,38 +355,40 @@ def laplace_beltrami(
         if Hv.ndim == P.ndim + 1:
             return oe.contract("...ij,...mjk,...ki->...m", P, Hv, P)
         raise ValueError(
-            f"laplace_beltrami got incompatible ranks: H.ndim={Hv.ndim}, P.ndim={P.ndim}."
+            "ambient_surface_hessian_trace got incompatible ranks: "
+            f"H.ndim={Hv.ndim}, P.ndim={P.ndim}."
         )
 
     return DomainFunction(domain=joined, deps=deps, func=_op, metadata=u.metadata)
 
 
-def laplace_beltrami_divgrad(
+def laplace_beltrami(
     u: DomainFunction,
-    component: DomainComponent,
+    metric: RiemannianMetric,
     /,
     *,
     var: str | None = None,
     mode: Literal["reverse", "forward"] = "reverse",
 ) -> DomainFunction:
-    r"""Laplace–Beltrami operator via surface divergence of the surface gradient.
+    r"""Apply the intrinsic Laplace--Beltrami operator.
 
-    Implements
+    For a scalar field $u$ and Riemannian metric $g$, this computes
 
     $$
-    \Delta_{\Gamma} u = \nabla_{\Gamma}\cdot(\nabla_{\Gamma}u).
+    \Delta_g u
+    = \frac{1}{\sqrt{\lvert g\rvert}}
+      \partial_i\left(\sqrt{\lvert g\rvert}\,g^{ij}\partial_j u\right).
     $$
 
-    **Arguments:**
-
-    - `u`: Field to differentiate.
-    - `component`: Boundary `DomainComponent`.
-    - `var`: Geometry label.
-    - `mode`: Autodiff mode used by `surface_grad`/`surface_div`.
-
-    **Returns:**
-
-    - A `DomainFunction` representing $\Delta_\Gamma u$.
+    Boundary-component normal projections are intentionally not accepted here;
+    use `ambient_surface_hessian_trace` for the extension-dependent ambient
+    contraction.
     """
-    g = surface_grad(u, component, var=var, mode=mode)
-    return surface_div(g, component, var=var, mode=mode)
+    if not isinstance(metric, RiemannianMetric):
+        raise TypeError(
+            "laplace_beltrami requires a RiemannianMetric; "
+            "use ambient_surface_hessian_trace for a boundary component."
+        )
+    from ._riemannian_ops import intrinsic_laplace_beltrami
+
+    return intrinsic_laplace_beltrami(u, metric, var=var, mode=mode)

--- a/tests/integration/enforced_pipeline/test_pipeline_additional_edges.py
+++ b/tests/integration/enforced_pipeline/test_pipeline_additional_edges.py
@@ -174,10 +174,11 @@ def test_identity_remainder_toggle_changes_output():
         return x[0] * 0.0 + 10.0
 
     left = geom.component({"x": Boundary()}, where={"x": lambda p: p[0] < 0.5})
+    full_boundary = geom.component({"x": Boundary()})
     left_constraint = SingleFieldEnforcedConstraint(
         "u",
         left,
-        lambda f: enforce_dirichlet(f, left, var="x", target=1.0),
+        lambda f: enforce_dirichlet(f, full_boundary, var="x", target=1.0),
     )
 
     pipes_no = EnforcedConstraintPipelines.build(

--- a/tests/integration/enforced_pipeline/test_pipeline_boundary_blend.py
+++ b/tests/integration/enforced_pipeline/test_pipeline_boundary_blend.py
@@ -37,16 +37,17 @@ def test_boundary_subset_blend_matches_pieces():
 
     left_component = geom.component({"x": Boundary()}, where={"x": left_where})
     right_component = geom.component({"x": Boundary()}, where={"x": right_where})
+    full_boundary = geom.component({"x": Boundary()})
 
     left_constraint = SingleFieldEnforcedConstraint(
         "u",
         left_component,
-        lambda f: enforce_dirichlet(f, left_component, var="x", target=1.0),
+        lambda f: enforce_dirichlet(f, full_boundary, var="x", target=1.0),
     )
     right_constraint = SingleFieldEnforcedConstraint(
         "u",
         right_component,
-        lambda f: enforce_dirichlet(f, right_component, var="x", target=2.0),
+        lambda f: enforce_dirichlet(f, full_boundary, var="x", target=2.0),
     )
 
     pipelines = EnforcedConstraintPipelines.build(

--- a/tests/integration/enforced_pipeline/test_pipeline_mixed_constraints_2d3d.py
+++ b/tests/integration/enforced_pipeline/test_pipeline_mixed_constraints_2d3d.py
@@ -55,18 +55,19 @@ def test_mixed_constraints_2d_transient():
 
     left = domain.component({"x": Boundary()}, where={"x": lambda p: p[0] < -0.9})
     right = domain.component({"x": Boundary()}, where={"x": lambda p: p[0] > 0.9})
+    full_boundary = domain.component({"x": Boundary()})
     initial = domain.component({"t": FixedStart()})
 
     constraints = [
         SingleFieldEnforcedConstraint(
             "u",
             left,
-            lambda f: enforce_dirichlet(f, left, var="x", target=1.0),
+            lambda f: enforce_dirichlet(f, full_boundary, var="x", target=1.0),
         ),
         SingleFieldEnforcedConstraint(
             "u",
             right,
-            lambda f: enforce_dirichlet(f, right, var="x", target=2.0),
+            lambda f: enforce_dirichlet(f, full_boundary, var="x", target=2.0),
         ),
         SingleFieldEnforcedConstraint(
             "u",
@@ -150,18 +151,19 @@ def test_mixed_constraints_3d_transient():
 
     left = domain.component({"x": Boundary()}, where={"x": lambda p: p[0] < -0.9})
     right = domain.component({"x": Boundary()}, where={"x": lambda p: p[0] > 0.9})
+    full_boundary = domain.component({"x": Boundary()})
     initial = domain.component({"t": FixedStart()})
 
     constraints = [
         SingleFieldEnforcedConstraint(
             "u",
             left,
-            lambda f: enforce_dirichlet(f, left, var="x", target=1.0),
+            lambda f: enforce_dirichlet(f, full_boundary, var="x", target=1.0),
         ),
         SingleFieldEnforcedConstraint(
             "u",
             right,
-            lambda f: enforce_dirichlet(f, right, var="x", target=2.0),
+            lambda f: enforce_dirichlet(f, full_boundary, var="x", target=2.0),
         ),
         SingleFieldEnforcedConstraint(
             "u",

--- a/tests/integration/enforced_pipeline/test_pipeline_mixed_constraints_steady.py
+++ b/tests/integration/enforced_pipeline/test_pipeline_mixed_constraints_steady.py
@@ -39,16 +39,17 @@ def test_mixed_constraints_steady_state():
     right_component = geom.component(
         {"x": Boundary()}, where={"x": lambda p: p[0] >= 0.5}
     )
+    full_boundary = geom.component({"x": Boundary()})
 
     left_constraint = SingleFieldEnforcedConstraint(
         "u",
         left_component,
-        lambda f: enforce_dirichlet(f, left_component, var="x", target=1.0),
+        lambda f: enforce_dirichlet(f, full_boundary, var="x", target=1.0),
     )
     right_constraint = SingleFieldEnforcedConstraint(
         "u",
         right_component,
-        lambda f: enforce_dirichlet(f, right_component, var="x", target=2.0),
+        lambda f: enforce_dirichlet(f, full_boundary, var="x", target=2.0),
     )
 
     anchors = {"x": jnp.array([[0.25], [0.75]], dtype=float)}

--- a/tests/integration/enforced_pipeline/test_pipeline_xp_xpt_domains.py
+++ b/tests/integration/enforced_pipeline/test_pipeline_xp_xpt_domains.py
@@ -72,17 +72,18 @@ def test_xp_steady_state_explicit_anchors():
 
     left = domain.component({"x": Boundary()}, where={"x": lambda p: p[0] < 0.5})
     right = domain.component({"x": Boundary()}, where={"x": lambda p: p[0] > 0.5})
+    full_boundary = domain.component({"x": Boundary()})
 
     constraints = [
         SingleFieldEnforcedConstraint(
             "u",
             left,
-            lambda f: enforce_dirichlet(f, left, var="x", target=1.0),
+            lambda f: enforce_dirichlet(f, full_boundary, var="x", target=1.0),
         ),
         SingleFieldEnforcedConstraint(
             "u",
             right,
-            lambda f: enforce_dirichlet(f, right, var="x", target=2.0),
+            lambda f: enforce_dirichlet(f, full_boundary, var="x", target=2.0),
         ),
     ]
 
@@ -154,17 +155,18 @@ def test_xpt_transient_explicit_anchors():
     left = domain.component({"x": Boundary()}, where={"x": lambda p: p[0] < 0.5})
     right = domain.component({"x": Boundary()}, where={"x": lambda p: p[0] > 0.5})
     initial = domain.component({"t": FixedStart()})
+    full_boundary = domain.component({"x": Boundary()})
 
     constraints = [
         SingleFieldEnforcedConstraint(
             "u",
             left,
-            lambda f: enforce_dirichlet(f, left, var="x", target=1.0),
+            lambda f: enforce_dirichlet(f, full_boundary, var="x", target=1.0),
         ),
         SingleFieldEnforcedConstraint(
             "u",
             right,
-            lambda f: enforce_dirichlet(f, right, var="x", target=2.0),
+            lambda f: enforce_dirichlet(f, full_boundary, var="x", target=2.0),
         ),
         SingleFieldEnforcedConstraint(
             "u",

--- a/tests/integration/test_constraint_negative_cases.py
+++ b/tests/integration/test_constraint_negative_cases.py
@@ -7,6 +7,7 @@ import pytest
 
 from phydrax.constraints import ContinuousInitialConstraint, FunctionalConstraint
 from phydrax.domain import (
+    Boundary,
     CoordSeparableBatch,
     DomainComponentUnion,
     Interior,
@@ -19,7 +20,7 @@ from phydrax.domain import (
 def test_coord_separable_rejects_component_union():
     geom = Interval1d(0.0, 1.0)
     c1 = geom.component({"x": Interior()})
-    c2 = geom.component({"x": Interior()})
+    c2 = geom.component({"x": Boundary()})
     union = DomainComponentUnion((c1, c2))
 
     with pytest.raises(ValueError, match="coord-separable sampling is not supported"):

--- a/tests/integration/test_constraints_catalog.py
+++ b/tests/integration/test_constraints_catalog.py
@@ -392,6 +392,65 @@ def test_thermal_constraints_continuous_and_discrete():
         _assert_zero_loss(constraint, functions)
 
 
+def test_thermal_constraints_use_physical_outward_flux_sign():
+    geom = Interval1d(0.0, 1.0)
+    component = geom.component({"x": Boundary()})
+    structure = ProductStructure((("x",),))
+    conductivity = 2.0
+    convection = 4.0
+
+    @geom.Function("x")
+    def temperature(x):
+        return x[0] ** 2
+
+    @geom.Function("x")
+    def outward_flux(x):
+        return -2.0 * conductivity * x[0]
+
+    @geom.Function("x")
+    def ambient_temperature(x):
+        return x[0] ** 2 + 2.0 * conductivity * x[0] / convection
+
+    points = {"x": jnp.array([[0.0], [1.0]], dtype=float)}
+    constraints = [
+        ContinuousHeatFluxBoundaryConstraint(
+            "T",
+            component,
+            k=conductivity,
+            flux=outward_flux,
+            num_points=8,
+            structure=structure,
+        ),
+        ContinuousConvectionBoundaryConstraint(
+            "T",
+            component,
+            h=convection,
+            k=conductivity,
+            ambient_temp=ambient_temperature,
+            num_points=8,
+            structure=structure,
+        ),
+        DiscreteHeatFluxBoundaryConstraint(
+            "T",
+            component,
+            points=points,
+            values=jnp.array([0.0, -2.0 * conductivity]),
+            k=conductivity,
+        ),
+        DiscreteConvectionBoundaryConstraint(
+            "T",
+            component,
+            points=points,
+            ambient_values=jnp.array([0.0, 1.0 + 2.0 * conductivity / convection]),
+            h=convection,
+            k=conductivity,
+        ),
+    ]
+
+    for constraint in constraints:
+        _assert_zero_loss(constraint, {"T": temperature})
+
+
 def test_em_constraints_continuous_and_discrete():
     geom = Cube(center=(0.0, 0.0, 0.0), side=2.0)
     component = geom.component({"x": Boundary()})

--- a/tests/integration/test_metrix_domain_functions.py
+++ b/tests/integration/test_metrix_domain_functions.py
@@ -1,6 +1,7 @@
 import coordax as cx
 import jax.numpy as jnp
 import jax.random as jr
+import pytest
 
 import phydrax as phx
 from phydrax._frozendict import frozendict
@@ -62,6 +63,37 @@ def test_domain_function_riemannian_operators_match_polar_identities():
     assert jnp.allclose(jnp.asarray(hessian(points).data)[..., 1, 1], 2.0 * radii**2)
     assert jnp.allclose(jnp.asarray(metric_derivative(points).data), 0.0, atol=1e-9)
     assert jnp.allclose(jnp.asarray(inverse_divergence(points).data), 0.0, atol=1e-9)
+
+
+def test_laplace_beltrami_matches_unit_sphere_eigenfunction():
+    chart = phx.metrix.CoordinateChart("sphere", ("theta", "phi"))
+    embedded = phx.metrix.EmbeddedChart(
+        chart,
+        lambda q: jnp.array(
+            [
+                jnp.sin(q[0]) * jnp.cos(q[1]),
+                jnp.sin(q[0]) * jnp.sin(q[1]),
+                jnp.cos(q[0]),
+            ]
+        ),
+        3,
+    )
+    metric = embedded.induced_metric()
+    domain = phx.domain.Square(center=(1.5, 0.0), side=2.0)
+    scalar = domain.Function("x")(lambda q: jnp.sin(q[0]) * jnp.cos(q[1]))
+    points = _points([[0.6, -0.7], [1.1, 0.4], [2.2, 0.8]])
+
+    laplacian = phx.operators.laplace_beltrami(scalar, metric, var="x")
+    values = jnp.asarray(laplacian(points).data)
+    expected = (
+        -2.0
+        * jnp.sin(jnp.asarray(points["x"].data)[:, 0])
+        * jnp.cos(jnp.asarray(points["x"].data)[:, 1])
+    )
+
+    assert jnp.allclose(values, expected, atol=1e-9)
+    with pytest.raises(TypeError, match="RiemannianMetric"):
+        phx.operators.laplace_beltrami(scalar, domain.component(), var="x")
 
 
 def test_riemannian_measure_multiplies_existing_component_weights():

--- a/tests/integration/test_ode_integral_constraints.py
+++ b/tests/integration/test_ode_integral_constraints.py
@@ -211,6 +211,29 @@ def test_integral_constraints_1d_zero_loss():
         assert _jit_loss(constraint, functions) < 1e-6
 
 
+def test_boundary_integral_resolves_relabeled_geometry_in_product_domain():
+    space = Interval1d(0.0, 1.0).relabel("space")
+    time = TimeInterval(0.0, 1.0)
+    domain = space @ time
+    structure = ProductStructure((("space",), ("t",)))
+
+    @domain.Function("space", "t")
+    def u(space_coordinate, time_coordinate):
+        del space_coordinate, time_coordinate
+        return 1.0
+
+    constraint = ContinuousIntegralBoundaryConstraint(
+        "u",
+        domain,
+        lambda value, normal: value,
+        num_points=(8, 8),
+        structure=structure,
+        equal_to=2.0,
+    )
+
+    assert _jit_loss(constraint, {"u": u}) < 1e-6
+
+
 def test_integral_initial_constraint_zero():
     geom = Interval1d(0.0, 1.0)
     time = TimeInterval(0.0, 1.0)

--- a/tests/integration/test_pde_toy_pipelines.py
+++ b/tests/integration/test_pde_toy_pipelines.py
@@ -35,16 +35,17 @@ def test_pde_toy_steady_pipeline_zero_loss():
 
     left = geom.component({"x": Boundary()}, where={"x": lambda p: p[0] < 0.5})
     right = geom.component({"x": Boundary()}, where={"x": lambda p: p[0] >= 0.5})
+    full_boundary = geom.component({"x": Boundary()})
 
     left_constraint = SingleFieldEnforcedConstraint(
         "u",
         left,
-        lambda f: enforce_dirichlet(f, left, var="x", target=1.0),
+        lambda f: enforce_dirichlet(f, full_boundary, var="x", target=1.0),
     )
     right_constraint = SingleFieldEnforcedConstraint(
         "u",
         right,
-        lambda f: enforce_dirichlet(f, right, var="x", target=1.0),
+        lambda f: enforce_dirichlet(f, full_boundary, var="x", target=1.0),
     )
 
     anchors = {"x": jnp.array([[0.25], [0.75]], dtype=float)}
@@ -111,16 +112,17 @@ def test_pde_toy_steady_pipeline_zero_loss_basis_backend_coord_separable():
 
     left = geom.component({"x": Boundary()}, where={"x": lambda p: p[0] < 0.5})
     right = geom.component({"x": Boundary()}, where={"x": lambda p: p[0] >= 0.5})
+    full_boundary = geom.component({"x": Boundary()})
 
     left_constraint = SingleFieldEnforcedConstraint(
         "u",
         left,
-        lambda f: enforce_dirichlet(f, left, var="x", target=1.0),
+        lambda f: enforce_dirichlet(f, full_boundary, var="x", target=1.0),
     )
     right_constraint = SingleFieldEnforcedConstraint(
         "u",
         right,
-        lambda f: enforce_dirichlet(f, right, var="x", target=1.0),
+        lambda f: enforce_dirichlet(f, full_boundary, var="x", target=1.0),
     )
 
     anchors = {"x": jnp.array([[0.25], [0.75]], dtype=float)}
@@ -195,17 +197,18 @@ def test_pde_toy_transient_pipeline_zero_loss():
     left = domain.component({"x": Boundary()}, where={"x": lambda p: p[0] < 0.5})
     right = domain.component({"x": Boundary()}, where={"x": lambda p: p[0] >= 0.5})
     initial = domain.component({"t": FixedStart()})
+    full_boundary = domain.component({"x": Boundary()})
 
     constraints = [
         SingleFieldEnforcedConstraint(
             "u",
             left,
-            lambda f: enforce_dirichlet(f, left, var="x", target=1.0),
+            lambda f: enforce_dirichlet(f, full_boundary, var="x", target=1.0),
         ),
         SingleFieldEnforcedConstraint(
             "u",
             right,
-            lambda f: enforce_dirichlet(f, right, var="x", target=1.0),
+            lambda f: enforce_dirichlet(f, full_boundary, var="x", target=1.0),
         ),
         SingleFieldEnforcedConstraint(
             "u",

--- a/tests/unit/constraints/test_enforced_helpers.py
+++ b/tests/unit/constraints/test_enforced_helpers.py
@@ -64,6 +64,52 @@ def test_enforce_dirichlet_enforces_values_on_boundary():
     assert jnp.allclose(out, 2.0)
 
 
+def test_direct_boundary_enforcers_reject_filtered_components():
+    geom = Interval1d(0.0, 1.0)
+    time = TimeInterval(0.0, 1.0)
+    domain = geom @ time
+    component = domain.component(
+        {"x": Boundary()},
+        where={"x": lambda x: x[0] < 0.5},
+    )
+
+    @domain.Function("x", "t")
+    def scalar(x, t):
+        return x[0] + t
+
+    @domain.Function("x", "t")
+    def vector(x, t):
+        return jnp.array([x[0] + t])
+
+    builders = (
+        lambda: enforce_dirichlet(scalar, component),
+        lambda: enforce_neumann(scalar, component),
+        lambda: enforce_robin(
+            scalar,
+            component,
+            dirichlet_coeff=1.0,
+            neumann_coeff=1.0,
+        ),
+        lambda: enforce_sommerfeld(scalar, component),
+        lambda: enforce_traction(
+            vector,
+            component,
+            lambda_=1.0,
+            mu=1.0,
+        ),
+    )
+    for build in builders:
+        with pytest.raises(ValueError, match="enforce_blend"):
+            build()
+
+    globally_filtered = domain.component(
+        {"x": Boundary()},
+        where_all=lambda x, t: x[0] < 0.5,
+    )
+    with pytest.raises(ValueError, match="enforce_blend"):
+        enforce_dirichlet(scalar, globally_filtered)
+
+
 def test_enforce_neumann_enforces_normal_derivative_on_boundary():
     geom = Interval1d(0.0, 1.0)
     component = geom.component({"x": Boundary()})
@@ -187,9 +233,10 @@ def test_enforce_blend_combines_subset_pieces_without_leakage():
     base = geom.Function()(0.0)
     left_component = geom.component({"x": Boundary()}, where={"x": left_where})
     right_component = geom.component({"x": Boundary()}, where={"x": right_where})
+    full_boundary = geom.component({"x": Boundary()})
 
-    left_piece = enforce_dirichlet(base, left_component, target=1.0)
-    right_piece = enforce_dirichlet(base, right_component, target=2.0)
+    left_piece = enforce_dirichlet(base, full_boundary, target=1.0)
+    right_piece = enforce_dirichlet(base, full_boundary, target=2.0)
 
     blended = enforce_blend(
         base,
@@ -218,9 +265,10 @@ def test_enforce_blend_coord_separable_spacetime_runs():
 
     left_component = domain.component({"x": Boundary()}, where={"x": left_where})
     right_component = domain.component({"x": Boundary()}, where={"x": right_where})
+    full_boundary = domain.component({"x": Boundary()})
 
-    left_piece = enforce_dirichlet(u, left_component, var="x", target=1.0)
-    right_piece = enforce_dirichlet(u, right_component, var="x", target=2.0)
+    left_piece = enforce_dirichlet(u, full_boundary, var="x", target=1.0)
+    right_piece = enforce_dirichlet(u, full_boundary, var="x", target=2.0)
 
     blended = enforce_blend(
         u,

--- a/tests/unit/domain/test_product_domain_sampling.py
+++ b/tests/unit/domain/test_product_domain_sampling.py
@@ -7,7 +7,9 @@ import pytest
 
 from phydrax.domain import (
     Boundary,
+    DomainComponentUnion,
     FixedStart,
+    Interior,
     Interval1d,
     ProductStructure,
     TimeInterval,
@@ -91,3 +93,26 @@ def test_coord_separable_sampling_rejects_boundary_component():
             dense_structure=dense_structure,
             key=jr.key(0),
         )
+
+
+def test_product_boundary_is_additive_component_collection():
+    domain = Interval1d(0.0, 1.0) @ TimeInterval(0.0, 1.0)
+    boundary = domain.boundary()
+
+    assert isinstance(boundary, DomainComponentUnion)
+    assert len(boundary.terms) == 3
+    assert all(term.domain.equivalent(domain) for term in boundary.terms)
+    assert float(boundary.measure()) == pytest.approx(4.0)
+
+
+def test_component_collection_rejects_invalid_terms():
+    domain = Interval1d(0.0, 1.0)
+    term = domain.component({"x": Interior()})
+    incompatible = Interval1d(0.0, 2.0).component({"x": Interior()})
+
+    with pytest.raises(ValueError, match="non-empty"):
+        DomainComponentUnion(())
+    with pytest.raises(ValueError, match="duplicates"):
+        DomainComponentUnion((term, term))
+    with pytest.raises(ValueError, match="compatible labeled domain"):
+        DomainComponentUnion((term, incompatible))

--- a/tests/unit/geometry/test_geometry_2d/test_from_cad_2d.py
+++ b/tests/unit/geometry/test_geometry_2d/test_from_cad_2d.py
@@ -10,6 +10,7 @@ import trimesh
 from jax import numpy as jnp
 from numpy.typing import ArrayLike
 
+from phydrax.domain import Circle
 from phydrax.domain.geometry2d import Geometry2DFromCAD
 
 
@@ -61,6 +62,21 @@ def test_measure_partitions_match_geometry_measures(geometry_from_square):
     assert points.shape == (8, 2)
     assert set(map(int, strata)) == {0, 1, 2, 3}
     assert np.isclose(float(jnp.sum(base_mass)), 1.0)
+
+
+def test_curved_boundary_normals_obey_divergence_theorem():
+    geom = Circle(center=(0.0, 0.0), radius=1.0)
+    quadrature = geom.boundary_chart_atlas.tensor_quadrature(3)
+    points = np.asarray(quadrature.points).reshape((-1, 2))
+    weights = np.asarray(quadrature.weights).reshape((-1,))
+    normals = np.asarray(geom._boundary_normals(points))
+
+    closure = np.sum(weights[:, None] * normals, axis=0)
+    position_flux = np.sum(weights * np.sum(points * normals, axis=-1))
+
+    assert np.allclose(np.linalg.norm(normals, axis=-1), 1.0, atol=1e-6)
+    assert np.allclose(closure, 0.0, atol=1e-6)
+    assert np.isclose(position_flux, 2.0 * float(geom.area), atol=1e-5)
 
 
 def test_boundary_chart_atlas_integrates_arclength_without_seam_duplication(

--- a/tests/unit/geometry/test_geometry_3d/test_from_cad_3d.py
+++ b/tests/unit/geometry/test_geometry_3d/test_from_cad_3d.py
@@ -30,6 +30,25 @@ def test_initialization(geometry_from_cube):
     assert geom.mesh_faces.shape[1] == 3
 
 
+def test_initialization_rejects_open_surface_mesh():
+    mesh = trimesh.creation.box(extents=(1.0, 1.0, 1.0))
+    mesh.update_faces(np.arange(mesh.faces.shape[0]) != 0)
+    mesh.remove_unreferenced_vertices()
+
+    with pytest.raises(ValueError, match="watertight"):
+        Geometry3DFromCAD(mesh=mesh, recenter=False)
+
+
+def test_initialization_rejects_nonfinite_vertices():
+    mesh = trimesh.creation.box(extents=(1.0, 1.0, 1.0))
+    vertices = np.asarray(mesh.vertices).copy()
+    vertices[0, 0] = np.nan
+    invalid = trimesh.Trimesh(vertices=vertices, faces=mesh.faces, process=False)
+
+    with pytest.raises(ValueError, match="finite"):
+        Geometry3DFromCAD(mesh=invalid, recenter=False)
+
+
 def test_volume_property(geometry_from_cube):
     geom = geometry_from_cube
     expected_volume = 1.0  # Cube with side length 1m

--- a/tests/unit/graph/test_cochain.py
+++ b/tests/unit/graph/test_cochain.py
@@ -10,27 +10,17 @@ import phydrax as phx
 
 
 def _square_complex():
-    vertices = np.asarray(
-        [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]]
-    )
+    vertices = np.asarray([[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]])
     faces = np.asarray([[0, 1, 2], [0, 2, 3]], dtype=np.int32)
     return phx.graph.triangle_mesh_to_cochain_complex(vertices, faces)
 
 
 def _annulus_complex():
-    outer = np.asarray(
-        [[-1.0, -1.0], [1.0, -1.0], [1.0, 1.0], [-1.0, 1.0]]
-    )
+    outer = np.asarray([[-1.0, -1.0], [1.0, -1.0], [1.0, 1.0], [-1.0, 1.0]])
     vertices = np.concatenate((outer, 0.4 * outer), axis=0)
     faces = np.asarray(
-        [
-            (index, (index + 1) % 4, 4 + (index + 1) % 4)
-            for index in range(4)
-        ]
-        + [
-            (index, 4 + (index + 1) % 4, 4 + index)
-            for index in range(4)
-        ],
+        [(index, (index + 1) % 4, 4 + (index + 1) % 4) for index in range(4)]
+        + [(index, 4 + (index + 1) % 4, 4 + index) for index in range(4)],
         dtype=np.int32,
     )
     return phx.graph.triangle_mesh_to_cochain_complex(vertices, faces)
@@ -80,12 +70,8 @@ def test_sparse_dec_operators_satisfy_exactness_adjointness_and_positive_energy(
     left_inner_product = jnp.sum(star * derivative * one_form)
     right_inner_product = jnp.sum(star * zero_form * codifferential)
 
-    lower = phx.graph.cochain_hodge_laplacian(
-        graph, one_form, 1, component="lower"
-    )
-    upper = phx.graph.cochain_hodge_laplacian(
-        graph, one_form, 1, component="upper"
-    )
+    lower = phx.graph.cochain_hodge_laplacian(graph, one_form, 1, component="lower")
+    upper = phx.graph.cochain_hodge_laplacian(graph, one_form, 1, component="upper")
     complete = phx.graph.cochain_hodge_laplacian(graph, one_form, 1)
     energy = jnp.sum(star * one_form * complete)
 
@@ -204,30 +190,22 @@ def test_orientation_changes_conjugate_exterior_codifferential_and_laplacian():
         phx.graph.reorient_cochain(one_form, signs[1]),
     )
 
-    derivative = phx.graph.cochain_exterior_derivative(
-        complex_ir.graph, packed_zero, 0
-    )
+    derivative = phx.graph.cochain_exterior_derivative(complex_ir.graph, packed_zero, 0)
     transformed_derivative = phx.graph.cochain_exterior_derivative(
         reoriented.graph, reoriented_zero, 0
     )
-    codifferential = phx.graph.cochain_codifferential(
-        complex_ir.graph, packed_one, 1
-    )
+    codifferential = phx.graph.cochain_codifferential(complex_ir.graph, packed_one, 1)
     transformed_codifferential = phx.graph.cochain_codifferential(
         reoriented.graph, reoriented_one, 1
     )
-    laplacian = phx.graph.cochain_hodge_laplacian(
-        complex_ir.graph, packed_one, 1
-    )
+    laplacian = phx.graph.cochain_hodge_laplacian(complex_ir.graph, packed_one, 1)
     transformed_laplacian = phx.graph.cochain_hodge_laplacian(
         reoriented.graph, reoriented_one, 1
     )
 
     assert jnp.allclose(
         transformed_derivative[_degree_slice(reoriented, 1)],
-        phx.graph.reorient_cochain(
-            derivative[_degree_slice(complex_ir, 1)], signs[1]
-        ),
+        phx.graph.reorient_cochain(derivative[_degree_slice(complex_ir, 1)], signs[1]),
         atol=1e-12,
     )
     assert jnp.allclose(
@@ -239,9 +217,7 @@ def test_orientation_changes_conjugate_exterior_codifferential_and_laplacian():
     )
     assert jnp.allclose(
         transformed_laplacian[_degree_slice(reoriented, 1)],
-        phx.graph.reorient_cochain(
-            laplacian[_degree_slice(complex_ir, 1)], signs[1]
-        ),
+        phx.graph.reorient_cochain(laplacian[_degree_slice(complex_ir, 1)], signs[1]),
         atol=1e-12,
     )
 
@@ -310,9 +286,7 @@ def test_cochain_cells_select_degree_boundary_and_padded_dataset_offsets():
     )
 
     base_dataset = phx.domain.GraphDatasetDomain((small.graph, large.graph))
-    dataset = base_dataset.with_layout(
-        base_dataset.layout_for_batch_size(2, multiple=4)
-    )
+    dataset = base_dataset.with_layout(base_dataset.layout_for_batch_size(2, multiple=4))
     dataset_batch = dataset.points_from_indices(
         [0, 1],
         component=phx.domain.CochainCells(0, region="interior"),

--- a/tests/unit/graph/test_mesh_calculus.py
+++ b/tests/unit/graph/test_mesh_calculus.py
@@ -77,7 +77,9 @@ def test_mesh_cotangent_laplacian_zero_for_constant_field():
         validate=False,
     )
 
-    out = phx.graph.MeshCotangentLaplacian(input_key="u", output_key="lap_u")(graph)
+    out = phx.graph.MeshCotangentLaplacian(
+        sign="neighbor_minus_self", input_key="u", output_key="lap_u"
+    )(graph)
 
     assert jnp.allclose(out.nodes["lap_u"], jnp.zeros((3,)))
 
@@ -90,7 +92,9 @@ def test_mesh_cotangent_laplacian_known_linear_field_on_open_triangle():
         validate=False,
     )
 
-    out = phx.graph.MeshCotangentLaplacian(input_key="u", output_key="lap_u")(graph)
+    out = phx.graph.MeshCotangentLaplacian(
+        sign="neighbor_minus_self", input_key="u", output_key="lap_u"
+    )(graph)
 
     assert jnp.allclose(out.nodes["lap_u"], jnp.array([3.0, -3.0, 0.0]))
 
@@ -109,7 +113,9 @@ def test_mesh_cotangent_laplacian_integrates_with_graph_model_keys():
 
     def residual(f):
         return domain.GraphModel(
-            phx.graph.MeshCotangentLaplacian(input_key="u", output_key="lap_u"),
+            phx.graph.MeshCotangentLaplacian(
+                sign="neighbor_minus_self", input_key="u", output_key="lap_u"
+            ),
             input_fn=f,
             input_key="u",
             output_key="lap_u",

--- a/tests/unit/nn/test_operator_foundation_architectures.py
+++ b/tests/unit/nn/test_operator_foundation_architectures.py
@@ -9,6 +9,7 @@ import jax.random as jr
 import numpy as np
 import opt_einsum as oe
 import pytest
+import trimesh
 
 import phydrax as phx
 
@@ -241,7 +242,7 @@ def test_manifold_spectral_operator_runs_valid_small_laplacian_plan():
             [-1.0, 0.0, -1.0, 2.0],
         ]
     )
-    plan = phx.nn.SpectralDiscretization.from_laplacian(
+    plan = phx.nn.SpectralDiscretization.from_stiffness(
         laplacian, np.ones((4,)), n_modes=4, basis_id="cycle-4"
     )
     coordinates = jnp.array([[1.0, 0.0], [0.0, 1.0], [-1.0, 0.0], [0.0, -1.0]])
@@ -279,6 +280,46 @@ def test_manifold_spectral_operator_runs_valid_small_laplacian_plan():
     assert jnp.allclose(compiled, eager)
     assert jnp.array_equal(eager[2:], jnp.zeros((2,)))
     _assert_finite_model_gradient(model, lambda item: jnp.sum(item(batch) ** 2))
+
+
+def test_stiffness_plan_rejects_negative_semidefinite_operator():
+    differential_laplacian = np.array(
+        [
+            [-2.0, 1.0, 0.0, 1.0],
+            [1.0, -2.0, 1.0, 0.0],
+            [0.0, 1.0, -2.0, 1.0],
+            [1.0, 0.0, 1.0, -2.0],
+        ]
+    )
+
+    with pytest.raises(ValueError, match="positive semidefinite"):
+        phx.nn.SpectralDiscretization.from_stiffness(
+            differential_laplacian,
+            np.ones((4,)),
+            n_modes=4,
+        )
+
+
+def test_triangle_mesh_plan_preserves_sparse_sphere_eigenspace_multiplicities():
+    mesh = trimesh.creation.icosphere(subdivisions=3, radius=1.0)
+    plan = phx.nn.SpectralDiscretization.from_triangle_mesh(
+        np.asarray(mesh.vertices),
+        np.asarray(mesh.faces),
+        n_modes=9,
+    )
+    eigenvalues = np.asarray(plan.eigenvalues)
+
+    assert plan.analysis.shape == (9, mesh.vertices.shape[0])
+    assert plan.synthesis.shape == (mesh.vertices.shape[0], 9)
+    assert np.allclose(plan.analysis @ plan.synthesis, np.eye(9), atol=1e-6)
+    assert np.isclose(eigenvalues[0], 0.0, atol=1e-8)
+    assert np.allclose(eigenvalues[1:4], 2.0, rtol=0.02)
+    assert np.allclose(eigenvalues[4:9], 6.0, rtol=0.02)
+    assert np.array_equal(
+        np.bincount(np.asarray(plan.group_ids)),
+        np.array([1, 3, 5]),
+    )
+    assert np.ptp(np.asarray(plan.synthesis)[:, 0]) < 1e-8
 
 
 def test_upt_and_abupt_preserve_case_and_source_query_masks():

--- a/tests/unit/operators/test_surface_ops.py
+++ b/tests/unit/operators/test_surface_ops.py
@@ -6,13 +6,27 @@ import coordax as cx
 import jax.numpy as jnp
 
 from phydrax._frozendict import frozendict
-from phydrax.domain import Boundary, Square
+from phydrax.domain import Boundary, Cube, Square
 from phydrax.operators.differential import (
-    laplace_beltrami,
+    ambient_surface_hessian_trace,
+    surface_curl_scalar,
+    surface_curl_vector,
     surface_div,
     surface_grad,
     tangential_component,
 )
+
+
+class _RadialNormalComponent:
+    def __init__(self, domain):
+        self.domain = domain
+
+    def normal(self, *, var):
+        @self.domain.Function(var)
+        def radial(point):
+            return point / jnp.linalg.norm(point)
+
+        return radial
 
 
 def test_surface_grad_scalar_flat_edge_projection():
@@ -50,7 +64,7 @@ def test_surface_div_vector_flat_edge():
     assert jnp.allclose(val, jnp.ones_like(x), atol=1e-6)
 
 
-def test_laplace_beltrami_scalar_flat_edge():
+def test_ambient_surface_hessian_trace_flat_edge():
     geom = Square(center=(0.0, 0.0), side=2.0)
     component = geom.component({"x": Boundary()})
 
@@ -61,13 +75,74 @@ def test_laplace_beltrami_scalar_flat_edge():
     def u(p):
         return p[0] ** 2 + p[1] ** 2
 
-    lb = laplace_beltrami(u, component)
-    val = jnp.asarray(lb(frozendict({"x": cx.Field(pts, dims=("n", None))})).data)
+    trace = ambient_surface_hessian_trace(u, component)
+    val = jnp.asarray(trace(frozendict({"x": cx.Field(pts, dims=("n", None))})).data)
     assert jnp.allclose(val, 2.0 * jnp.ones_like(x), atol=1e-5)
 
-    lb2 = laplace_beltrami(u, component, curvature_aware=True)
-    val2 = jnp.asarray(lb2(frozendict({"x": cx.Field(pts, dims=("n", None))})).data)
-    assert jnp.allclose(val2, 2.0 * jnp.ones_like(x), atol=1e-5)
+
+def test_surface_curl_scalar_on_flat_face():
+    geom = Cube(center=(0.0, 0.0, 0.0), side=2.0)
+    component = geom.component({"x": Boundary()})
+    points = jnp.array([[0.2, 0.3, 1.0], [-0.4, 0.1, 1.0]])
+
+    @geom.Function("x")
+    def scalar(point):
+        return point[0] ** 2 + point[1]
+
+    result = surface_curl_scalar(scalar, component)
+    values = jnp.asarray(
+        result(frozendict({"x": cx.Field(points, dims=("n", None))})).data
+    )
+    expected = jnp.stack(
+        (
+            -jnp.ones((points.shape[0],)),
+            2.0 * points[:, 0],
+            jnp.zeros((points.shape[0],)),
+        ),
+        axis=-1,
+    )
+
+    assert jnp.allclose(values, expected, atol=1e-6)
+
+
+def test_surface_curl_vector_on_flat_face():
+    geom = Cube(center=(0.0, 0.0, 0.0), side=2.0)
+    component = geom.component({"x": Boundary()})
+    points = jnp.array([[0.2, 0.3, 1.0], [-0.4, 0.1, 1.0]])
+
+    @geom.Function("x")
+    def vector(point):
+        return jnp.array([-0.5 * point[1], 0.5 * point[0], 0.0])
+
+    result = surface_curl_vector(vector, component)
+    values = jnp.asarray(
+        result(frozendict({"x": cx.Field(points, dims=("n", None))})).data
+    )
+
+    assert jnp.allclose(values, jnp.ones((points.shape[0],)), atol=1e-6)
+
+
+def test_surface_div_grad_uses_differentiable_normal_provider():
+    geom = Cube(center=(0.0, 0.0, 0.0), side=2.0)
+    component = _RadialNormalComponent(geom)
+    points = jnp.array(
+        [
+            [1.0, 0.0, 0.0],
+            [0.6, 0.8, 0.0],
+            [-0.5, 0.5, jnp.sqrt(0.5)],
+        ]
+    )
+
+    @geom.Function("x")
+    def scalar(point):
+        return point[0]
+
+    result = surface_div(surface_grad(scalar, component), component)
+    values = jnp.asarray(
+        result(frozendict({"x": cx.Field(points, dims=("n", None))})).data
+    )
+
+    assert jnp.allclose(values, -2.0 * points[:, 0], atol=1e-6)
 
 
 def test_tangential_component_projection():


### PR DESCRIPTION
## Summary

This PR applies the corrective actions from a repository-wide audit of PhydraX surface differential operators, geometric/topological boundaries, boundary constraints, and discrete mesh calculus.

The central change is a clean semantic split:

- **ambient surface calculus** uses an embedded geometry's outward unit normal and tangent projector;
- **intrinsic Riemannian calculus** uses a metric and chart coordinates;
- **topological boundary data** stays in the simplicial/cochain layer;
- **domain boundary collections** are additive, measure-disjoint collections rather than Boolean geometric unions.

The cutover intentionally removes ambiguous or ignored API paths instead of retaining compatibility shims.

## Why

The audit found several independent conventions sharing surface/boundary terminology but disagreeing in behavior:

1. `laplace_beltrami` accepted both a metric and a boundary component even though those paths compute different objects. The normal-based path was the tangent trace of an ambient Hessian and therefore extension-dependent, while the metric path is intrinsic.
2. Cotangent mesh operators hid a Laplacian/stiffness sign choice, and spectral construction accepted a field named “laplacian” while requiring positive-semidefinite stiffness semantics.
3. Thermal boundary helpers disagreed about whether the target was outward conductive flux or the normal temperature derivative.
4. Boundary-integral helpers hard-coded the geometry label `"x"`, breaking relabeled/product domains.
5. Filtered `Boundary()` components were accepted by direct hard enforcement even though their signed-distance gate vanishes on the entire boundary and cannot localize the ansatz.
6. `DomainComponentUnion` behaved additively but did not enforce the compatible-domain and no-duplicate invariants implied by that behavior.
7. 2D CAD normals queried an extrusion end cap instead of the sidewall, while 3D CAD construction accepted open or invalid meshes despite modeling an enclosed solid.
8. The large-mesh spectral path used a single-vector sparse solve that could miss repeated eigenspace multiplicities.

## Changes

### Boundary geometry and normals

- Query extruded 2D boundary normals at the extrusion midplane so the 3D provider returns sidewall normals before projection.
- Reject projected 2D normals that are non-finite or have zero length instead of silently normalizing invalid vectors.
- Require `Geometry3DFromCAD` inputs to be finite, nondegenerate, consistently oriented, watertight, and positive-volume after mesh sanitization.
- Remove the unused `immersed` constructor option.
- Preserve the normal provider's autodiff contract: analytic providers may expose curvature derivatives; mesh-derived normals remain intentionally nondifferentiable.

### Continuous surface calculus

- Keep `surface_grad`, `surface_div`, `surface_curl_scalar`, `surface_curl_vector`, and `tangential_component` as ambient, normal-based operators.
- Add `ambient_surface_hessian_trace(u, component)` as the explicit name for the extension-dependent contraction
  \(P^{ij}\partial_i\partial_j u\).
- Make `laplace_beltrami(u, metric)` exclusively intrinsic Riemannian calculus.
- Remove the ambiguous boundary-component overload, `laplace_beltrami_divgrad`, and the `curvature_aware` / `variant` switches.
- Update exports, callers, tests, and documentation to the new names and contracts.

### Discrete mesh and spectral calculus

- Require `MeshCotangentLaplacian(sign=...)` with explicit choices:
  - `neighbor_minus_self`: differential \(\Delta\), negative semidefinite;
  - `self_minus_neighbor`: stiffness \(-\Delta\), positive semidefinite.
- Rename `SpectralDiscretization.from_laplacian(...)` to `from_stiffness(...)` and validate \(K\succeq0\), \(M\succ0\).
- Assemble sparse cotangent stiffness and lumped mass matrices for triangle meshes.
- Use block LOBPCG for requested low modes on large meshes; retain a dense generalized eigensolve for small or nearly full spectra.
- Mass-orthonormalize eigenvectors, canonicalize signs, group repeated eigenvalues, and validate residuals.
- Remove the ignored `boundary_policy` argument from `triangle_mesh_to_cochain_complex`; boundary policy remains on consuming DEC operators.

### Boundary constraints and integrals

- Standardize continuous and discrete thermal constraints on physical outward conductive flux:
  \[
  q_n=-k\,\nabla T\cdot n,\qquad q_n=h(T-T_\infty).
  \]
- Add `var` support to boundary-integral helpers and infer the sole geometry label when unambiguous, including relabeled product domains.
- Reject filtered `Boundary()` components in direct hard-enforcement helpers. Piecewise enforcement now constructs each ansatz against an unfiltered boundary and associates it with filtered components only in `enforce_blend`.

### Domain-component semantics

- Document `DomainComponentUnion` as an additive collection of measure-disjoint components, not a Boolean geometric union.
- Require nonempty terms from compatible labeled domains.
- Reject duplicate terms to prevent deterministic double counting.
- Keep product-domain boundaries as additive codimension-one face decompositions.

### Regression coverage and documentation

- Add or update regressions for:
  - 2D normal unit length and the divergence theorem;
  - open/invalid 3D meshes;
  - flat and curved surface differential identities;
  - intrinsic unit-sphere \(\Delta_\Gamma x_i=-2x_i\);
  - cotangent sign semantics and sparse sphere multiplicities \(1,3,5\);
  - physical thermal-flux orientation;
  - relabeled product-domain boundary integrals;
  - filtered hard-enforcement rejection and `enforce_blend` usage;
  - component collection compatibility and duplicate rejection.
- Update API guides and cookbook examples for every clean-cutover API change.

## Breaking API migrations

| Previous API or behavior | Replacement |
| --- | --- |
| `laplace_beltrami(u, component)` | `ambient_surface_hessian_trace(u, component)` for the ambient contraction, or `laplace_beltrami(u, metric)` for intrinsic calculus |
| `laplace_beltrami_divgrad(...)` | Compose the explicit surface operators, or use intrinsic `laplace_beltrami` with a metric |
| `curvature_aware=` / `variant=` surface switches | Select the explicit ambient or intrinsic API |
| `SpectralDiscretization.from_laplacian(...)` | `SpectralDiscretization.from_stiffness(...)` |
| Implicit `MeshCotangentLaplacian` sign | Pass `sign="neighbor_minus_self"` or `sign="self_minus_neighbor"` |
| `triangle_mesh_to_cochain_complex(..., boundary_policy=...)` | Pass boundary policy to the consuming DEC operator |
| `Geometry3DFromCAD(..., immersed=...)` | Remove the unused argument |
| Direct hard enforcement on a filtered boundary | Build against the unfiltered boundary, then combine filtered pieces with `enforce_blend` |

## Verification

- Focused affected regression suite: **142 passed** after intended callsite migrations.
- Full incremental test run: **1,652 passed, 5 skipped**; it exposed 10 stale clean-cutover callsites, all migrated.
- Rerun of the migrated affected files: **14 passed**.
- Final global `pytest -q -n auto --testmon`: no pending affected tests.
- `uv run --extra docs mkdocs build --strict`: passed.
- Ruff checks and formatting: passed.
- Direct mathematical smoke checks exercised normal closure, the divergence theorem, physical flux orientation, component invariants, and sparse sphere eigenvalue multiplicities.

## Intentional limitations

- CAD/mesh normals do not become smooth curvature providers. Exact curved-manifold identities should use an analytic metric or differentiable normal provider.
- Existing CAD approximate-distance-field accuracy and scale covariance are unchanged.
- Arbitrary overlap between separately filtered `DomainComponentUnion` terms cannot be detected; overlapping terms are still counted additively and remain the caller's responsibility.
- Strict solid-mesh validation intentionally rejects previously accepted open, degenerate, inconsistent, or zero-volume inputs.

## Suggested review order

1. `phydrax/operators/differential/_surface_ops.py` and the operator exports.
2. `phydrax/domain/geometry2d/_from_cad.py` plus `geometry3d/_utils.py` / `_mesh.py`.
3. `phydrax/graph/_mesh.py` and `phydrax/nn/models/architectures/_manifold_spectral.py`.
4. Constraint and component changes.
5. Regression tests and documentation migrations.
