### PR TITLE
Add a unified JAX-native sparse execution substrate

### DIFF
--- a/docs/all-of-phydrax.md
+++ b/docs/all-of-phydrax.md
@@ -48,13 +48,15 @@ Phydrax supports two complementary evaluation regimes:
 - `CoordSeparableBatch` (axis/grid sampling): spectral/basis operators and neural operators (FNO/DeepONet). See [Guides → Differential operators](guides_differential.md).
 
 Sampling owns sites and measure metadata; interpolation owns deterministic
-reconstruction of stored values at query sites. They share typed axis and batch
-metadata without collapsing into one operation. Temporal nearest/linear/Hermite
-maps, inverse-distance reconstruction, rectilinear warps, parity-correct Fourier
-transfer to aligned or shifted grids, arbitrary-point periodic Fourier
-evaluation, and sparse Smolyak interpolation use a common private numerical
-substrate while retaining their distinct boundary, support, and derivative
-contracts. See [API → Operators → Interpolation](api/operators/interpolation.md).
+reconstruction of stored values at query sites. Low-level source-to-target
+execution is shared through `phydrax.sparse`: arbitrary edge relations,
+fixed-width case-local rows, robust masked routing, target reduction, and
+weighted forward/transpose/adjoint actions. Interpolation stencils,
+`QueryNeighborhood`, `GraphIR`, and cochain incidences retain their own
+geometry, topology, support, and measure semantics above that substrate.
+Fourier evaluation, sparse Smolyak approximation, sparse Gaussian processes,
+and stochastic estimators remain specialized methods rather than sparse
+storage types. See [API → Operators → Interpolation](api/operators/interpolation.md).
 
 ### Differentiation: AD / jets / FD / basis
 
@@ -424,6 +426,7 @@ Below are the common SciML regimes expressed in Phydrax’s primitives.
 - [API reference](api/phydrax.md)
 - `phydrax.domain` for geometry, time, and sampling.
 - `phydrax.sampling` for typed reference designs and capability inspection.
+- `phydrax.sparse` for JAX-native relations, routing kernels, and sparse linear actions.
 - `phydrax.metrix` for charts, tensors, metrics, curvature, and stochastic geometry.
 - `phydrax.data_utils` for CSV loading, array scaling, and case-index splits.
 - `phydrax.constraints` for loss terms and enforced constraints.

--- a/docs/api/phydrax.md
+++ b/docs/api/phydrax.md
@@ -10,11 +10,46 @@ Top-level package namespace. Most functionality lives in subpackages:
 - `phydrax.constraints`: residual and data penalty terms
 - `phydrax.objectives`: raw signed scalar objectives and integral functionals
 - `phydrax.nn`: neural network components and structured models
+- `phydrax.sparse`: JAX-native sparse relations, routing, reductions, and linear actions
 - `phydrax.solver`: functional solvers and direct ODE/SDE, jump, hybrid, and
   semidiscrete SPDE integration
 - `phydrax.stochastic`: global Wiener/Poisson/composite realizations, random
   fields, process laws, and explicit path coupling
 - `phydrax.export`: deployment helpers for learned inference functions
+
+## Sparse execution substrate
+
+`phydrax.sparse` factors out the gather–message–reduce mechanics shared by
+fixed interpolation stencils, case-local neighborhoods, graph edges, and
+cochain incidence maps. `EdgeRelation` represents arbitrary source-to-target
+routes; `RowRelation` represents fixed-width target rows with explicit case
+boundaries. Invalid capacity slots are numerically inert under routing and
+reduction, including when their stored payloads are non-finite.
+
+`SparseLinearMap` attaches scalar route coefficients and exposes forward,
+transpose, and conjugate-adjoint actions while preserving trailing payload
+dimensions. Dense and SciPy conversions are explicit interoperability
+operations, not execution fallbacks. Sparse-grid quadrature, sparse Gaussian
+process approximations, stochastic probes, and generic matrix-free callables
+remain in their semantic subsystems.
+
+::: phydrax.sparse.EdgeRelation
+
+---
+
+::: phydrax.sparse.RowRelation
+
+---
+
+::: phydrax.sparse.SparseLinearMap
+
+---
+
+::: phydrax.sparse.gather_routes
+
+---
+
+::: phydrax.sparse.route_reduce
 
 ## Stochastic realizations and fields
 

--- a/phydrax/__init__.py
+++ b/phydrax/__init__.py
@@ -22,6 +22,7 @@ from . import (
     operators,
     sampling,
     solver,
+    sparse,
     stochastic,
     uq,
 )
@@ -41,6 +42,7 @@ __all__ = [
     "nn",
     "operators",
     "sampling",
+    "sparse",
     "solver",
     "stochastic",
     "uq",

--- a/phydrax/_interpolation/_inverse_distance.py
+++ b/phydrax/_interpolation/_inverse_distance.py
@@ -55,6 +55,7 @@ def inverse_distance_stencil(
     /,
     *,
     source_size: int,
+    case_shape: tuple[int, ...] = (),
     valid: ArrayLike | None = None,
     power: ArrayLike = 2.0,
     regularization: ArrayLike = 0.0,
@@ -190,6 +191,7 @@ def inverse_distance_stencil(
         source_size=source_size,
         valid=valid_,
         support=map_support,
+        case_shape=case_shape,
     )
 
 

--- a/phydrax/_interpolation/_stencil.py
+++ b/phydrax/_interpolation/_stencil.py
@@ -9,17 +9,16 @@ import jax.numpy as jnp
 from jaxtyping import Array, ArrayLike
 
 from .._strict import StrictModule
+from ..sparse import gather_routes, route_reduce, RowRelation
 from ._types import InterpolationResult, MaskMode
 
 
 class GatherStencil(StrictModule):
     """A fixed-capacity sparse linear map from source sites to query sites."""
 
-    indices: Array
+    relation: RowRelation
     weights: Array
-    valid: Array
     support: Array
-    source_size: int = eqx.field(static=True)
 
     def __init__(
         self,
@@ -29,47 +28,49 @@ class GatherStencil(StrictModule):
         source_size: int,
         valid: ArrayLike | None = None,
         support: ArrayLike | None = None,
+        case_shape: tuple[int, ...] = (),
     ):
-        indices_ = jnp.asarray(indices)
-        if not jnp.issubdtype(indices_.dtype, jnp.integer):
-            raise TypeError("GatherStencil indices must have an integer dtype.")
-        if indices_.ndim < 1 or int(indices_.shape[-1]) <= 0:
-            raise ValueError(
-                "GatherStencil indices must end in a non-empty stencil axis."
-            )
-
+        relation = RowRelation(
+            indices,
+            source_size=source_size,
+            valid=valid,
+            case_shape=case_shape,
+        )
         weights_ = jnp.asarray(weights)
         if not jnp.issubdtype(weights_.dtype, jnp.inexact):
             weights_ = weights_.astype(float)
-        if weights_.shape != indices_.shape:
+        if weights_.shape != relation.route_shape:
             raise ValueError("GatherStencil weights must match indices shape.")
 
-        source_size_ = int(source_size)
-        if source_size_ <= 0:
-            raise ValueError("GatherStencil source_size must be positive.")
-
-        valid_ = (
-            jnp.ones(indices_.shape, dtype=bool)
-            if valid is None
-            else jnp.asarray(valid, dtype=bool)
-        )
-        if valid_.shape != indices_.shape:
-            raise ValueError("GatherStencil valid must match indices shape.")
-
-        query_shape = indices_.shape[:-1]
         support_ = (
-            jnp.any(valid_, axis=-1)
+            jnp.any(relation.valid, axis=-1)
             if support is None
             else jnp.asarray(support, dtype=bool)
         )
-        if support_.shape != query_shape:
-            raise ValueError("GatherStencil support must match the indices query shape.")
+        if support_.shape != relation.output_shape:
+            raise ValueError(
+                "GatherStencil support must match the relation output shape."
+            )
 
-        self.indices = indices_
+        self.relation = relation
         self.weights = weights_
-        self.valid = valid_
         self.support = support_
-        self.source_size = source_size_
+
+    @property
+    def indices(self) -> Array:
+        return self.relation.source_indices
+
+    @property
+    def valid(self) -> Array:
+        return self.relation.valid
+
+    @property
+    def source_size(self) -> int:
+        return self.relation.source_size
+
+    @property
+    def case_shape(self) -> tuple[int, ...]:
+        return self.relation.case_shape
 
 
 def gather_patches(
@@ -79,22 +80,18 @@ def gather_patches(
 ) -> tuple[Array, Array]:
     """Gather source payloads with invalid indices made numerically inert."""
     array = jnp.asarray(values)
-    if array.ndim < 1 or int(array.shape[0]) != stencil.source_size:
+    expected = stencil.relation.input_shape
+    if (
+        array.ndim < len(expected)
+        or tuple(int(size) for size in array.shape[: len(expected)]) != expected
+    ):
         raise ValueError(
-            "Gather source values must have one leading entry per source site."
+            f"Gather source values must begin with source shape {expected}; "
+            f"got {array.shape}."
         )
     if not jnp.issubdtype(array.dtype, jnp.inexact):
         array = array.astype(float)
-
-    in_bounds = (stencil.indices >= 0) & (stencil.indices < stencil.source_size)
-    array = eqx.error_if(
-        array,
-        jnp.any(stencil.valid & ~in_bounds),
-        "A valid gather stencil index is outside the source array.",
-    )
-    valid = stencil.valid & in_bounds
-    safe_indices = jnp.where(valid, stencil.indices, 0)
-    return array[safe_indices], valid
+    return gather_routes(stencil.relation, array), stencil.valid
 
 
 def apply_gather_stencil(
@@ -112,9 +109,10 @@ def apply_gather_stencil(
     patches, valid = gather_patches(values, stencil)
     if source_mask is not None:
         mask = jnp.asarray(source_mask, dtype=bool)
-        if mask.shape != (stencil.source_size,):
+        if mask.shape != stencil.relation.input_shape:
             raise ValueError(
-                f"source_mask must have shape {(stencil.source_size,)}, got {mask.shape}."
+                "source_mask must have shape "
+                f"{stencil.relation.input_shape}, got {mask.shape}."
             )
         if mask_mode == "reject":
             patches = eqx.error_if(
@@ -123,9 +121,7 @@ def apply_gather_stencil(
                 "Gather interpolation in reject mode does not permit source holes.",
             )
         else:
-            safe_indices = jnp.where(valid, stencil.indices, 0)
-            valid = valid & mask[safe_indices]
-
+            valid = valid & gather_routes(stencil.relation, mask)
     weights = jnp.where(valid, stencil.weights, 0)
     scale = jnp.maximum(1.0, jnp.max(jnp.abs(stencil.weights)))
     tolerance = jnp.finfo(stencil.weights.real.dtype).eps * scale
@@ -138,7 +134,7 @@ def apply_gather_stencil(
         material = jnp.abs(stencil.weights) > tolerance
         support = stencil.support & jnp.all(valid | ~material, axis=-1)
 
-    payload_ndim = patches.ndim - weights.ndim
+    payload_ndim = patches.ndim - len(stencil.relation.route_shape)
     expanded_valid = valid.reshape(valid.shape + (1,) * payload_ndim)
     safe_patches = jnp.where(
         expanded_valid,
@@ -146,10 +142,8 @@ def apply_gather_stencil(
         jnp.zeros((), dtype=patches.dtype),
     )
     expanded_weights = weights.reshape(weights.shape + (1,) * payload_ndim)
-    output = jnp.sum(
-        safe_patches * expanded_weights.astype(patches.dtype),
-        axis=-1 - payload_ndim,
-    )
+    messages = safe_patches * expanded_weights.astype(patches.dtype)
+    output = route_reduce(stencil.relation, messages)
     support_expanded = support.reshape(support.shape + (1,) * payload_ndim)
     output = jnp.where(support_expanded, output, jnp.zeros((), dtype=output.dtype))
     return InterpolationResult(output, support)

--- a/phydrax/graph/_cochain.py
+++ b/phydrax/graph/_cochain.py
@@ -19,6 +19,7 @@ from scipy.sparse.linalg import eigsh
 
 from .._strict import StrictModule
 from .._trainable import NonTrainableState
+from ..sparse import EdgeRelation, SparseLinearMap
 from ._ir import GraphIR
 
 
@@ -195,6 +196,26 @@ class CochainIncidence(StrictModule, NonTrainableState):
             upper,
             dense[lower, upper],
         )
+
+    def exterior_derivative_map(self) -> SparseLinearMap:
+        """Return ``B_degree.T`` as a lower-to-upper sparse linear action."""
+        relation = EdgeRelation(
+            self.lower_indices,
+            self.upper_indices,
+            source_size=self.lower_count,
+            target_size=self.upper_count,
+        )
+        return SparseLinearMap(relation, self.signs)
+
+    def boundary_map(self) -> SparseLinearMap:
+        """Return ``B_degree`` as an upper-to-lower sparse linear action."""
+        relation = EdgeRelation(
+            self.upper_indices,
+            self.lower_indices,
+            source_size=self.upper_count,
+            target_size=self.lower_count,
+        )
+        return SparseLinearMap(relation, self.signs)
 
     def scipy_matrix(self) -> sp.csr_matrix:
         """Return the host-side sparse boundary matrix."""

--- a/phydrax/graph/_cochain_ops.py
+++ b/phydrax/graph/_cochain_ops.py
@@ -15,6 +15,7 @@ from jax import core as jax_core
 from jaxtyping import Array
 
 from .._strict import StrictModule
+from ..sparse import EdgeRelation, linear_apply
 from ._cochain import CochainBoundaryKind, CochainBoundaryPolicy
 from ._ir import GraphIR
 from ._kernels import segment_sum
@@ -88,6 +89,15 @@ def _forward_incidence_mask(
     return mask
 
 
+def _incidence_relation(
+    graph: GraphIR,
+    node_count: int,
+    valid: Array,
+    /,
+) -> EdgeRelation:
+    return graph.edge_relation(node_count=node_count).with_valid(valid)
+
+
 def _validate_values(values: Any, node_count: int, /) -> Array:
     array = jnp.asarray(values)
     if array.ndim == 0 or int(array.shape[0]) != node_count:
@@ -115,15 +125,11 @@ def cochain_exterior_derivative(
     source_active = _active_nodes(graph, nodes, source_degree, policy)
     target_active = _active_nodes(graph, nodes, source_degree + 1, policy)
     route_active = source_active | target_active
-    mask = _forward_incidence_mask(
-        graph, edges, source_degree + 1, route_active
-    )
-    assert graph.senders is not None
-    assert graph.receivers is not None
+    mask = _forward_incidence_mask(graph, edges, source_degree + 1, route_active)
+    node_count = _node_count(graph, nodes)
+    relation = _incidence_relation(graph, node_count, mask)
     signs = jnp.asarray(edges["incidence_sign"], dtype=array.dtype)
-    coefficient = _reshape_coefficient(signs * mask.astype(array.dtype), array)
-    messages = coefficient * array[graph.senders]
-    output = segment_sum(messages, graph.receivers, _node_count(graph, nodes))
+    output = linear_apply(relation, signs, array)
     target_shape = (target_active.shape[0],) + (1,) * (array.ndim - 1)
     return jnp.where(target_active.reshape(target_shape), output, 0)
 
@@ -147,13 +153,12 @@ def cochain_codifferential(
     upper_active = _active_nodes(graph, nodes, source_degree, policy)
     route_active = lower_active | upper_active
     mask = _forward_incidence_mask(graph, edges, source_degree, route_active)
-    assert graph.senders is not None
-    assert graph.receivers is not None
+    node_count = _node_count(graph, nodes)
+    relation = _incidence_relation(graph, node_count, mask)
     signs = jnp.asarray(edges["incidence_sign"], dtype=array.dtype)
     star = jnp.asarray(nodes["hodge_star"], dtype=array.dtype)
-    coefficient = signs * mask.astype(array.dtype) * star[graph.receivers]
-    messages = _reshape_coefficient(coefficient, array) * array[graph.receivers]
-    accumulated = segment_sum(messages, graph.senders, _node_count(graph, nodes))
+    weighted = array * _reshape_coefficient(star, array)
+    accumulated = linear_apply(relation.transpose(), signs, weighted)
     inverse_star = jnp.where(star > 0, 1.0 / star, 0.0)
     output = accumulated * inverse_star.reshape(
         (inverse_star.shape[0],) + (1,) * (array.ndim - 1)
@@ -173,7 +178,9 @@ def cochain_hodge_laplacian(
 ) -> Array:
     """Apply a lower, upper, or complete metric Hodge Laplacian."""
     if component not in ("lower", "upper", "complete"):
-        raise ValueError("Hodge Laplacian component must be 'lower', 'upper', or 'complete'.")
+        raise ValueError(
+            "Hodge Laplacian component must be 'lower', 'upper', or 'complete'."
+        )
     nodes, _ = _cochain_payload(graph)
     resolved_degree = int(degree)
     if resolved_degree < 0:
@@ -221,7 +228,10 @@ def cochain_harmonic_projection(
     nodes, _ = _cochain_payload(graph)
     if "harmonic_basis" not in nodes or not isinstance(graph.globals, Mapping):
         raise ValueError("GraphIR has no precomputed harmonic subspace.")
-    if "harmonic_rank" not in graph.globals or "harmonic_boundary_policy" not in graph.globals:
+    if (
+        "harmonic_rank" not in graph.globals
+        or "harmonic_boundary_policy" not in graph.globals
+    ):
         raise ValueError("GraphIR harmonic metadata is incomplete.")
     policy = CochainBoundaryPolicy(boundary_policy)
     boundary_code = jnp.asarray(graph.globals["harmonic_boundary_policy"])

--- a/phydrax/graph/_ir.py
+++ b/phydrax/graph/_ir.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import importlib
 import importlib.util
 from collections.abc import Sequence
-from typing import Any
+from typing import Any, Literal
 
 import equinox as eqx
 import jax.core as jcore
@@ -12,6 +12,7 @@ import jax.tree_util as jtu
 import numpy as np
 
 from .._trainable import NonTrainableState
+from ..sparse import EdgeRelation
 
 
 _MISSING = object()
@@ -163,6 +164,45 @@ class GraphIR(eqx.Module, NonTrainableState):
             return jnp.zeros((2, 0), dtype=jnp.int32)
         return jnp.stack([self.senders, self.receivers], axis=0)
 
+    def edge_relation(
+        self,
+        /,
+        *,
+        node_count: int | None = None,
+        flow: Literal["source_to_target", "target_to_source"] = "source_to_target",
+    ) -> EdgeRelation:
+        """Return the graph routes as a sparse relation without copying payloads."""
+        if self.senders is None or self.receivers is None:
+            raise ValueError("GraphIR has no explicit edge relation.")
+        if flow == "source_to_target":
+            source, target = self.senders, self.receivers
+        elif flow == "target_to_source":
+            source, target = self.receivers, self.senders
+        else:
+            raise ValueError("flow must be 'source_to_target' or 'target_to_source'.")
+
+        if node_count is not None:
+            count = int(node_count)
+        elif self.node_mask is not None:
+            count = int(self.node_mask.shape[0])
+        else:
+            payload_count = _leaf_leading_size(self.nodes)
+            if payload_count is not None:
+                count = payload_count
+            elif _contains_tracer(self.n_node):
+                raise ValueError(
+                    "node_count is required for a payload-free traced GraphIR."
+                )
+            else:
+                count = int(np.asarray(self.n_node).sum())
+        return EdgeRelation(
+            source,
+            target,
+            source_size=count,
+            target_size=count,
+            valid=self.edge_mask,
+        )
+
     def validate(self, *, strict: bool = True) -> None:
         if self.n_node.shape != self.n_edge.shape:
             raise ValueError("`n_node` and `n_edge` must have identical shapes.")
@@ -270,8 +310,7 @@ class GraphIR(eqx.Module, NonTrainableState):
                     ):
                         graph_endpoints = endpoints[edge_start:edge_end]
                         offending = np.flatnonzero(
-                            (graph_endpoints < node_start)
-                            | (graph_endpoints >= node_end)
+                            (graph_endpoints < node_start) | (graph_endpoints >= node_end)
                         )
                         if offending.size:
                             local_edge = int(offending[0])

--- a/phydrax/graph/_mesh.py
+++ b/phydrax/graph/_mesh.py
@@ -8,6 +8,7 @@ import jax.numpy as jnp
 import jax.tree_util as jtu
 import numpy as np
 
+from ..sparse import gather_routes, mask_routes, route_reduce
 from ._geometry import (
     _face_geometry,
     _triangle_adjacency,
@@ -18,7 +19,6 @@ from ._geometry import (
 )
 from ._graph import ensure_graph
 from ._ir import GraphIR
-from ._kernels import segment_sum
 
 
 MeshLaplacianSign = Literal["neighbor_minus_self", "self_minus_neighbor"]
@@ -29,10 +29,6 @@ def _tree_leading_size(tree: Any) -> int:
     if not leaves:
         raise ValueError("Feature tree must contain at least one array leaf.")
     return int(jnp.asarray(leaves[0]).shape[0])
-
-
-def _tree_index(tree: Any, index: jnp.ndarray, /) -> Any:
-    return jtu.tree_map(lambda x: x[index], tree)
 
 
 def _multiply_leaf(value: Any, weight: Any, /) -> jnp.ndarray:
@@ -64,14 +60,13 @@ def _multiply_tree(tree: Any, weight: Any, /) -> Any:
 def _mask_tree(tree: Any, mask: jnp.ndarray | None, /) -> Any:
     if mask is None:
         return tree
-    return jtu.tree_map(
-        lambda x: _multiply_leaf(x, mask.astype(x.dtype)),
-        tree,
-    )
 
+    def mask_leaf(value: Any, /) -> jnp.ndarray:
+        array = jnp.asarray(value)
+        expanded = mask.reshape(mask.shape + (1,) * (array.ndim - mask.ndim))
+        return jnp.where(expanded, array, jnp.zeros((), dtype=array.dtype))
 
-def _tree_segment_sum(tree: Any, segment_ids: jnp.ndarray, num_segments: int, /) -> Any:
-    return jtu.tree_map(lambda x: segment_sum(x, segment_ids, num_segments), tree)
+    return jtu.tree_map(mask_leaf, tree)
 
 
 def _num_nodes(graph: GraphIR, nodes: Any, /) -> int:
@@ -334,16 +329,18 @@ class MeshCotangentLaplacian(eqx.Module):
             )
 
         nodes = self._node_field(graph)
-        sent = _tree_index(nodes, graph.senders)
-        recv = _tree_index(nodes, graph.receivers)
+        node_count = _num_nodes(graph, nodes)
+        relation = graph.edge_relation(node_count=node_count)
+        sent = gather_routes(relation, nodes)
+        recv = gather_routes(relation.transpose(), nodes)
         if self.sign == "neighbor_minus_self":
             messages = jtu.tree_map(lambda s, r: s - r, sent, recv)
         else:
             messages = jtu.tree_map(lambda s, r: r - s, sent, recv)
 
         messages = _multiply_tree(messages, self._edge_weight(graph))
-        messages = _mask_tree(messages, graph.edge_mask)
-        out = _tree_segment_sum(messages, graph.receivers, _num_nodes(graph, nodes))
+        messages = mask_routes(relation, messages)
+        out = route_reduce(relation, messages)
 
         if self.normalize_by_mass:
             mass = jnp.asarray(self._mass(graph))

--- a/phydrax/graph/_neural_operators.py
+++ b/phydrax/graph/_neural_operators.py
@@ -7,6 +7,7 @@ import equinox as eqx
 import jax.numpy as jnp
 import jax.tree_util as jtu
 
+from ..sparse import gather_routes, mask_routes, route_reduce
 from ._graph import ensure_graph
 from ._ir import GraphIR
 from ._kernels import segment_softmax, segment_sum
@@ -22,10 +23,6 @@ def _tree_leading_size(tree: ArrayTree) -> int:
     if not leaves:
         raise ValueError("Feature tree must contain at least one array leaf.")
     return int(jnp.asarray(leaves[0]).shape[0])
-
-
-def _tree_index(tree: ArrayTree, index: jnp.ndarray) -> ArrayTree:
-    return jtu.tree_map(lambda x: x[index], tree)
 
 
 def _multiply_leaf(value: Any, weight: Any, /) -> jnp.ndarray:
@@ -57,19 +54,13 @@ def _multiply_tree(tree: ArrayTree, weight: Any, /) -> ArrayTree:
 def _mask_tree(tree: ArrayTree, mask: jnp.ndarray | None, /) -> ArrayTree:
     if mask is None:
         return tree
-    return jtu.tree_map(
-        lambda x: _multiply_leaf(x, mask.astype(x.dtype)),
-        tree,
-    )
 
+    def mask_leaf(value: Any, /) -> jnp.ndarray:
+        array = jnp.asarray(value)
+        expanded = mask.reshape(mask.shape + (1,) * (array.ndim - mask.ndim))
+        return jnp.where(expanded, array, jnp.zeros((), dtype=array.dtype))
 
-def _tree_segment_sum(
-    tree: ArrayTree,
-    segment_ids: jnp.ndarray,
-    num_segments: int,
-    /,
-) -> ArrayTree:
-    return jtu.tree_map(lambda x: segment_sum(x, segment_ids, num_segments), tree)
+    return jtu.tree_map(mask_leaf, tree)
 
 
 def _pad_tree_leading(tree: ArrayTree, target: int, /) -> ArrayTree:
@@ -242,13 +233,10 @@ def _finite_volume_divergence(
     normalize_by_volume: bool,
     sign: FiniteVolumeSign,
 ) -> jnp.ndarray:
-    if graph.senders is None or graph.receivers is None:
-        raise ValueError("Finite-volume graph operators require explicit senders/receivers.")
     n_node = _num_graph_nodes(graph)
-    if graph.edge_mask is not None:
-        flux = _multiply_leaf(flux, graph.edge_mask.astype(flux.dtype))
-    incoming = segment_sum(flux, graph.receivers, n_node)
-    outgoing = segment_sum(flux, graph.senders, n_node)
+    relation = graph.edge_relation(node_count=n_node)
+    incoming = route_reduce(relation, flux)
+    outgoing = route_reduce(relation.transpose(), flux)
     if sign == "in_minus_out":
         out = incoming - outgoing
     elif sign == "out_minus_in":
@@ -273,7 +261,9 @@ def _edge_bias(graph: GraphIR, edge_bias_key: str | None, /) -> jnp.ndarray | No
     if bias.ndim == 2 and int(bias.shape[1]) == 1:
         return bias[:, 0]
     if bias.ndim not in (1, 2):
-        raise ValueError("edge attention bias must have shape (n_edge,), (n_edge, 1), or (n_edge, n_head).")
+        raise ValueError(
+            "edge attention bias must have shape (n_edge,), (n_edge, 1), or (n_edge, n_head)."
+        )
     return bias
 
 
@@ -359,14 +349,15 @@ class GraphKernelIntegral(eqx.Module):
             raise ValueError("GraphKernelIntegral requires explicit senders/receivers.")
 
         nodes = graph.nodes
+        num_nodes = _num_nodes(graph, nodes)
+        relation = graph.edge_relation(node_count=num_nodes)
         source = nodes if self.source_fn is None else self.source_fn(nodes)
-        sent_source = _tree_index(source, graph.senders)
-        sent_nodes = _tree_index(nodes, graph.senders)
-        recv_nodes = _tree_index(nodes, graph.receivers)
+        sent_source = gather_routes(relation, source)
+        sent_nodes = gather_routes(relation, nodes)
+        recv_nodes = gather_routes(relation.transpose(), nodes)
         num_edges = _num_edges(graph)
         glob_edge = _repeat_globals_for_entities(graph.globals, graph.n_edge, num_edges)
 
-        num_nodes = _num_nodes(graph, nodes)
         edge_measure = None
         if self.source_measure_key is not None or self.source_measure is not None:
             node_measure = _node_measure(
@@ -375,7 +366,7 @@ class GraphKernelIntegral(eqx.Module):
                 self.source_measure,
                 n_node=num_nodes,
             )
-            edge_measure = node_measure[graph.senders]
+            edge_measure = node_measure[relation.source_indices]
         messages = sent_source
         if self.kernel_fn is not None:
             weight = self.kernel_fn(graph.edges, sent_nodes, recv_nodes, glob_edge)
@@ -383,9 +374,9 @@ class GraphKernelIntegral(eqx.Module):
         if edge_measure is not None:
             messages = _multiply_tree(messages, edge_measure)
 
-        messages = _mask_tree(messages, graph.edge_mask)
+        messages = mask_routes(relation, messages)
         aggregated = jtu.tree_map(
-            lambda x: self.aggregate_fn(x, graph.receivers, num_nodes),
+            lambda x: self.aggregate_fn(x, relation.target_indices, num_nodes),
             messages,
         )
 
@@ -394,9 +385,7 @@ class GraphKernelIntegral(eqx.Module):
                 normalizer = jnp.ones((num_edges,), dtype=float)
             else:
                 normalizer = edge_measure
-            if graph.edge_mask is not None:
-                normalizer = normalizer * graph.edge_mask.astype(normalizer.dtype)
-            degree = segment_sum(normalizer, graph.receivers, num_nodes)
+            degree = route_reduce(relation, normalizer)
             scale = jnp.where(degree > 0, 1.0 / degree, 0.0)
             aggregated = _multiply_tree(aggregated, scale)
 
@@ -423,7 +412,9 @@ class GraphDiffusion(eqx.Module):
         sign: str = "in_minus_out",
     ):
         if sign not in ("in_minus_out", "out_minus_in"):
-            raise ValueError("GraphDiffusion sign must be 'in_minus_out' or 'out_minus_in'.")
+            raise ValueError(
+                "GraphDiffusion sign must be 'in_minus_out' or 'out_minus_in'."
+            )
         self.conductivity_fn = conductivity_fn
         self.update_node_fn = update_node_fn
         self.sign = sign
@@ -436,19 +427,20 @@ class GraphDiffusion(eqx.Module):
             raise ValueError("GraphDiffusion requires explicit senders/receivers.")
 
         nodes = graph.nodes
-        sent = _tree_index(nodes, graph.senders)
-        recv = _tree_index(nodes, graph.receivers)
+        num_nodes = _num_nodes(graph, nodes)
+        relation = graph.edge_relation(node_count=num_nodes)
+        sent = gather_routes(relation, nodes)
+        recv = gather_routes(relation.transpose(), nodes)
         gradient = jtu.tree_map(lambda r, s: r - s, recv, sent)
         num_edges = _num_edges(graph)
         glob_edge = _repeat_globals_for_entities(graph.globals, graph.n_edge, num_edges)
         if self.conductivity_fn is not None:
             conductivity = self.conductivity_fn(graph.edges, sent, recv, glob_edge)
             gradient = _multiply_tree(gradient, conductivity)
-        gradient = _mask_tree(gradient, graph.edge_mask)
+        gradient = mask_routes(relation, gradient)
 
-        num_nodes = _num_nodes(graph, nodes)
-        incoming = _tree_segment_sum(gradient, graph.receivers, num_nodes)
-        outgoing = _tree_segment_sum(gradient, graph.senders, num_nodes)
+        incoming = route_reduce(relation, gradient)
+        outgoing = route_reduce(relation.transpose(), gradient)
         if self.sign == "in_minus_out":
             diffused = jtu.tree_map(lambda inc, out: inc - out, incoming, outgoing)
         else:
@@ -511,7 +503,9 @@ class GraphNeuralOperator(eqx.Module):
         self.source_measure = source_measure
         self.normalize = bool(normalize)
         self.node_type_key = str(node_type_key)
-        self.target_node_type = None if target_node_type is None else int(target_node_type)
+        self.target_node_type = (
+            None if target_node_type is None else int(target_node_type)
+        )
 
     def __call__(self, graph: GraphIR) -> GraphIR:
         graph = ensure_graph(graph, validate=False)
@@ -519,10 +513,12 @@ class GraphNeuralOperator(eqx.Module):
             raise ValueError("GraphNeuralOperator requires explicit senders/receivers.")
 
         nodes = _node_field(graph, self.input_key, name="GraphNeuralOperator")
+        num_nodes = _num_nodes(graph, nodes)
+        relation = graph.edge_relation(node_count=num_nodes)
         source = nodes if self.source_fn is None else self.source_fn(nodes)
-        sent_source = _tree_index(source, graph.senders)
-        sent_nodes = _tree_index(nodes, graph.senders)
-        recv_nodes = _tree_index(nodes, graph.receivers)
+        sent_source = gather_routes(relation, source)
+        sent_nodes = gather_routes(relation, nodes)
+        recv_nodes = gather_routes(relation.transpose(), nodes)
         num_edges = _num_edges(graph)
         glob_edge = _repeat_globals_for_entities(graph.globals, graph.n_edge, num_edges)
 
@@ -531,7 +527,6 @@ class GraphNeuralOperator(eqx.Module):
             kernel = self.kernel_fn(graph.edges, sent_nodes, recv_nodes, glob_edge)
             messages = _multiply_tree(messages, kernel)
 
-        num_nodes = _num_nodes(graph, nodes)
         edge_measure = None
         if self.source_measure_key is not None or self.source_measure is not None:
             node_measure = _node_measure(
@@ -540,16 +535,16 @@ class GraphNeuralOperator(eqx.Module):
                 self.source_measure,
                 n_node=num_nodes,
             )
-            edge_measure = node_measure[graph.senders]
+            edge_measure = node_measure[relation.source_indices]
         edge_weight = _edge_weight(graph, self.edge_weight_key)
         if edge_weight is not None:
             messages = _multiply_tree(messages, edge_weight)
         if edge_measure is not None:
             messages = _multiply_tree(messages, edge_measure)
-        messages = _mask_tree(messages, graph.edge_mask)
+        messages = mask_routes(relation, messages)
 
         aggregated = jtu.tree_map(
-            lambda x: self.aggregate_fn(x, graph.receivers, num_nodes),
+            lambda x: self.aggregate_fn(x, relation.target_indices, num_nodes),
             messages,
         )
         if self.normalize:
@@ -558,9 +553,7 @@ class GraphNeuralOperator(eqx.Module):
                 normalizer = normalizer * edge_weight
             if edge_measure is not None:
                 normalizer = normalizer * edge_measure
-            if graph.edge_mask is not None:
-                normalizer = normalizer * graph.edge_mask.astype(normalizer.dtype)
-            degree = segment_sum(normalizer, graph.receivers, num_nodes)
+            degree = route_reduce(relation, normalizer)
             scale = jnp.where(degree > 0, 1.0 / degree, 0.0)
             aggregated = _multiply_tree(aggregated, scale)
 
@@ -646,11 +639,15 @@ class GraphAttentionOperator(eqx.Module):
         self.temperature = 0.0 if temperature is None else float(temperature)
         self.head_reduction = head_reduction
         self.node_type_key = str(node_type_key)
-        self.target_node_type = None if target_node_type is None else int(target_node_type)
+        self.target_node_type = (
+            None if target_node_type is None else int(target_node_type)
+        )
 
     def _oriented_edges(self, graph: GraphIR, /) -> tuple[jnp.ndarray, jnp.ndarray]:
         if graph.senders is None or graph.receivers is None:
-            raise ValueError("GraphAttentionOperator requires explicit senders/receivers.")
+            raise ValueError(
+                "GraphAttentionOperator requires explicit senders/receivers."
+            )
         if self.flow == "source_to_target":
             return graph.senders, graph.receivers
         return graph.receivers, graph.senders
@@ -693,9 +690,19 @@ class GraphAttentionOperator(eqx.Module):
     def __call__(self, graph: GraphIR) -> GraphIR:
         graph = ensure_graph(graph, validate=False)
         nodes = _node_array(graph, self.input_key, name="GraphAttentionOperator")
-        queries = nodes if self.query_fn is None else jnp.asarray(self.query_fn(nodes), dtype=float)
-        keys = nodes if self.key_fn is None else jnp.asarray(self.key_fn(nodes), dtype=float)
-        values = nodes if self.value_fn is None else jnp.asarray(self.value_fn(nodes), dtype=float)
+        queries = (
+            nodes
+            if self.query_fn is None
+            else jnp.asarray(self.query_fn(nodes), dtype=float)
+        )
+        keys = (
+            nodes if self.key_fn is None else jnp.asarray(self.key_fn(nodes), dtype=float)
+        )
+        values = (
+            nodes
+            if self.value_fn is None
+            else jnp.asarray(self.value_fn(nodes), dtype=float)
+        )
         if queries.ndim != 2 or keys.ndim != 2 or values.ndim != 2:
             raise ValueError("query_fn, key_fn, and value_fn must return rank-2 arrays.")
         if queries.shape != keys.shape:
@@ -746,7 +753,9 @@ class GraphAttentionOperator(eqx.Module):
             else:
                 out = headed.reshape((headed.shape[0], headed.shape[1] * headed.shape[2]))
 
-        glob_node = _repeat_globals_for_entities(graph.globals, graph.n_node, int(nodes.shape[0]))
+        glob_node = _repeat_globals_for_entities(
+            graph.globals, graph.n_node, int(nodes.shape[0])
+        )
         if self.update_node_fn is not None:
             out = self.update_node_fn(nodes, out, glob_node)
         out = _mask_node_type(
@@ -756,7 +765,9 @@ class GraphAttentionOperator(eqx.Module):
             node_type_key=self.node_type_key,
         )
         out = _mask_tree(out, graph.node_mask)
-        return graph.replace(nodes=_with_node_output(graph, out, self.output_key), validate=False)
+        return graph.replace(
+            nodes=_with_node_output(graph, out, self.output_key), validate=False
+        )
 
 
 class GraphFiniteVolumeDivergence(eqx.Module):
@@ -800,7 +811,9 @@ class GraphFiniteVolumeDivergence(eqx.Module):
             normalize_by_volume=self.normalize_by_volume,
             sign=self.sign,
         )
-        return graph.replace(nodes=_with_node_output(graph, out, self.output_key), validate=False)
+        return graph.replace(
+            nodes=_with_node_output(graph, out, self.output_key), validate=False
+        )
 
 
 class GraphFiniteVolumeDiffusion(eqx.Module):
@@ -859,7 +872,9 @@ class GraphFiniteVolumeDiffusion(eqx.Module):
     def __call__(self, graph: GraphIR) -> GraphIR:
         graph = ensure_graph(graph, validate=False)
         if graph.senders is None or graph.receivers is None:
-            raise ValueError("GraphFiniteVolumeDiffusion requires explicit senders/receivers.")
+            raise ValueError(
+                "GraphFiniteVolumeDiffusion requires explicit senders/receivers."
+            )
         nodes = _node_array(graph, self.input_key, name="GraphFiniteVolumeDiffusion")
         sent = nodes[graph.senders]
         recv = nodes[graph.receivers]
@@ -886,7 +901,9 @@ class GraphFiniteVolumeDiffusion(eqx.Module):
             normalize_by_volume=self.normalize_by_volume,
             sign=self.sign,
         )
-        return graph.replace(nodes=_with_node_output(graph, out, self.output_key), validate=False)
+        return graph.replace(
+            nodes=_with_node_output(graph, out, self.output_key), validate=False
+        )
 
 
 class GraphProcessor(eqx.Module):

--- a/phydrax/graph/_query_batch.py
+++ b/phydrax/graph/_query_batch.py
@@ -10,6 +10,7 @@ from typing import Any, Sequence
 import equinox as eqx
 import jax.numpy as jnp
 
+from ..sparse import gather_routes, RowRelation
 from ._geometry import mollified_kernel_weight, MollifierKind, QueryGraph
 from ._ir import GraphIR
 
@@ -17,12 +18,70 @@ from ._ir import GraphIR
 class QueryNeighborhood(eqx.Module):
     """Fixed-capacity, case-local source neighborhoods for target points."""
 
-    indices: jnp.ndarray
+    relation: RowRelation
     relative: jnp.ndarray
     distance: jnp.ndarray
     distance_squared: jnp.ndarray
-    mask: jnp.ndarray
     count: jnp.ndarray
+
+    def __init__(
+        self,
+        *,
+        indices: Any,
+        relative: Any,
+        distance: Any,
+        distance_squared: Any,
+        mask: Any,
+        count: Any,
+        source_size: int,
+    ):
+        index_array = jnp.asarray(indices)
+        if index_array.ndim != 3:
+            raise ValueError(
+                "QueryNeighborhood indices must have shape (case, target, neighbor)."
+            )
+        relation = RowRelation(
+            index_array,
+            source_size=source_size,
+            valid=mask,
+            case_shape=(int(index_array.shape[0]),),
+        )
+        relative_array = jnp.asarray(relative)
+        distance_array = jnp.asarray(distance)
+        distance_squared_array = jnp.asarray(distance_squared)
+        count_array = jnp.asarray(count, dtype=jnp.int32)
+        if relative_array.shape[:-1] != relation.route_shape:
+            raise ValueError(
+                "QueryNeighborhood relative vectors must align with its routes."
+            )
+        if (
+            distance_array.shape != relation.route_shape
+            or distance_squared_array.shape != relation.route_shape
+        ):
+            raise ValueError("QueryNeighborhood distances must align with its routes.")
+        if count_array.shape != relation.output_shape:
+            raise ValueError("QueryNeighborhood count must match its target shape.")
+        self.relation = relation
+        self.relative = relative_array
+        self.distance = distance_array
+        self.distance_squared = distance_squared_array
+        self.count = count_array
+
+    @property
+    def indices(self) -> jnp.ndarray:
+        return self.relation.source_indices
+
+    @property
+    def mask(self) -> jnp.ndarray:
+        return self.relation.valid
+
+    @property
+    def source_size(self) -> int:
+        return self.relation.source_size
+
+    def gather(self, source_values: Any, /) -> Any:
+        """Gather case-local source values without source-target replication."""
+        return gather_routes(self.relation, source_values)
 
 
 def _case_shape(
@@ -209,6 +268,7 @@ def _query_neighbors_block(
         distance_squared=selected_distance_squared,
         mask=selected_mask,
         count=jnp.sum(selected_mask, axis=-1, dtype=jnp.int32),
+        source_size=int(source.shape[1]),
     )
 
 
@@ -280,6 +340,7 @@ def query_neighbors(
         ),
         mask=jnp.concatenate([block.mask for block in blocks], axis=1),
         count=jnp.concatenate([block.count for block in blocks], axis=1),
+        source_size=source_count,
     )
 
 

--- a/phydrax/graph/_spectral.py
+++ b/phydrax/graph/_spectral.py
@@ -7,9 +7,9 @@ import equinox as eqx
 import jax.numpy as jnp
 import jax.tree_util as jtu
 
+from ..sparse import linear_apply, route_reduce
 from ._graph import ensure_graph
 from ._ir import GraphIR
-from ._kernels import segment_sum
 
 
 GraphFilterOperator = Literal["laplacian", "adjacency"]
@@ -55,7 +55,13 @@ def _multiply_tree(tree: Any, weight: Any, /) -> Any:
 def _mask_tree(tree: Any, mask: jnp.ndarray | None, /) -> Any:
     if mask is None:
         return tree
-    return jtu.tree_map(lambda x: _multiply_leaf(x, mask.astype(x.dtype)), tree)
+
+    def mask_leaf(value: Any, /) -> jnp.ndarray:
+        array = jnp.asarray(value)
+        expanded = mask.reshape(mask.shape + (1,) * (array.ndim - mask.ndim))
+        return jnp.where(expanded, array, jnp.zeros((), dtype=array.dtype))
+
+    return jtu.tree_map(mask_leaf, tree)
 
 
 def _tree_add(a: Any, b: Any, /) -> Any:
@@ -68,10 +74,6 @@ def _tree_sub(a: Any, b: Any, /) -> Any:
 
 def _tree_zeros_like(tree: Any, /) -> Any:
     return jtu.tree_map(jnp.zeros_like, tree)
-
-
-def _tree_index(tree: Any, index: jnp.ndarray, /) -> Any:
-    return jtu.tree_map(lambda x: x[index], tree)
 
 
 def _as_feature_mapping(value: Any, /) -> dict[str, Any]:
@@ -124,22 +126,12 @@ def _edge_weight(
     if out.ndim == 2 and int(out.shape[1]) == 1:
         out = out[:, 0]
     if out.ndim != 1:
-        raise ValueError("Graph spectral edge weights must have shape (n_edge,) or (n_edge, 1).")
+        raise ValueError(
+            "Graph spectral edge weights must have shape (n_edge,) or (n_edge, 1)."
+        )
     if int(out.shape[0]) != int(graph.senders.shape[0]):
         raise ValueError("Graph spectral edge weights must match edge count.")
-    if graph.edge_mask is not None:
-        out = out * graph.edge_mask.astype(out.dtype)
     return out
-
-
-def _oriented_edges(graph: GraphIR, flow: GraphFlow, /) -> tuple[jnp.ndarray, jnp.ndarray]:
-    if graph.senders is None or graph.receivers is None:
-        raise ValueError("Spectral graph operators require explicit senders/receivers.")
-    if flow == "source_to_target":
-        return graph.senders, graph.receivers
-    if flow == "target_to_source":
-        return graph.receivers, graph.senders
-    raise ValueError("flow must be 'source_to_target' or 'target_to_source'.")
 
 
 def graph_adjacency_apply(
@@ -159,21 +151,23 @@ def graph_adjacency_apply(
     x = graph.nodes if nodes is None else nodes
     if x is None:
         raise ValueError("graph_adjacency_apply requires node features.")
-    source, target = _oriented_edges(graph, flow)
     n = _num_nodes(graph, x)
+    relation = graph.edge_relation(node_count=n, flow=flow)
     edge_weight = _edge_weight(graph, weight=weight, weight_key=weight_key)
-    degree = segment_sum(edge_weight, target, n)
-    messages = _tree_index(x, source)
+    degree = route_reduce(relation, edge_weight)
 
     if normalization == "random_walk":
         inv_degree = jnp.where(degree > 0, 1.0 / degree, 0.0)
-        edge_weight = edge_weight * inv_degree[target]
+        edge_weight = edge_weight * inv_degree[relation.target_indices]
     elif normalization == "symmetric":
         inv_sqrt = jnp.where(degree > 0, jax_lax_rsqrt(degree), 0.0)
-        edge_weight = edge_weight * inv_sqrt[source] * inv_sqrt[target]
+        edge_weight = (
+            edge_weight
+            * inv_sqrt[relation.source_indices]
+            * inv_sqrt[relation.target_indices]
+        )
 
-    messages = _multiply_tree(messages, edge_weight)
-    out = jtu.tree_map(lambda y: segment_sum(y, target, n), messages)
+    out = linear_apply(relation, edge_weight, x)
     return _mask_tree(out, graph.node_mask)
 
 
@@ -198,10 +192,10 @@ def graph_laplacian_apply(
     x = graph.nodes if nodes is None else nodes
     if x is None:
         raise ValueError("graph_laplacian_apply requires node features.")
-    source, target = _oriented_edges(graph, flow)
     n = _num_nodes(graph, x)
+    relation = graph.edge_relation(node_count=n, flow=flow)
     edge_weight = _edge_weight(graph, weight=weight, weight_key=weight_key)
-    degree = segment_sum(edge_weight, target, n)
+    degree = route_reduce(relation, edge_weight)
 
     if normalization == "none":
         adjacency = graph_adjacency_apply(
@@ -327,7 +321,9 @@ class GraphLaplacianOperator(eqx.Module):
             flow=self.flow,
             normalization=self.normalization,
         )
-        return graph.replace(nodes=_with_node_output(graph, out, self.output_key), validate=False)
+        return graph.replace(
+            nodes=_with_node_output(graph, out, self.output_key), validate=False
+        )
 
 
 class GraphPolynomialFilter(eqx.Module):
@@ -388,9 +384,13 @@ class GraphPolynomialFilter(eqx.Module):
                 flow=self.flow,
                 normalization=self.normalization,
             )
-            out = _tree_add(out, _apply_coefficient(term, _coeff_at(self.coefficients, k)))
+            out = _tree_add(
+                out, _apply_coefficient(term, _coeff_at(self.coefficients, k))
+            )
         out = _mask_tree(out, graph.node_mask)
-        return graph.replace(nodes=_with_node_output(graph, out, self.output_key), validate=False)
+        return graph.replace(
+            nodes=_with_node_output(graph, out, self.output_key), validate=False
+        )
 
 
 class GraphChebyshevFilter(eqx.Module):
@@ -459,14 +459,18 @@ class GraphChebyshevFilter(eqx.Module):
             out = _tree_add(out, _apply_coefficient(t1, _coeff_at(self.coefficients, 1)))
             prev, current = t0, t1
             for k in range(2, self.order + 1):
-                next_term = _tree_sub(_multiply_tree(self._scaled_laplacian(graph, current), 2.0), prev)
+                next_term = _tree_sub(
+                    _multiply_tree(self._scaled_laplacian(graph, current), 2.0), prev
+                )
                 out = _tree_add(
                     out,
                     _apply_coefficient(next_term, _coeff_at(self.coefficients, k)),
                 )
                 prev, current = current, next_term
         out = _mask_tree(out, graph.node_mask)
-        return graph.replace(nodes=_with_node_output(graph, out, self.output_key), validate=False)
+        return graph.replace(
+            nodes=_with_node_output(graph, out, self.output_key), validate=False
+        )
 
 
 __all__ = [

--- a/phydrax/nn/models/architectures/_geometry_operator.py
+++ b/phydrax/nn/models/architectures/_geometry_operator.py
@@ -587,23 +587,20 @@ class _GeometryOperatorCore(eqx.Module):
             target_chunk_size=256,
         )
         case_count = prod(case_shape) if case_shape else 1
-        case_offsets = (jnp.arange(case_count, dtype=jnp.int32) * source_count).reshape(
-            (case_count, 1, 1)
-        )
-        indices = neighborhood.indices + case_offsets
         tolerance = jnp.sqrt(jnp.finfo(source_values.dtype).eps)
         stencil = inverse_distance_stencil(
-            indices,
+            neighborhood.indices,
             neighborhood.distance_squared,
-            source_size=case_count * source_count,
+            source_size=source_count,
             valid=neighborhood.mask,
+            case_shape=(case_count,),
             power=1.0,
             snap_tolerance_squared=tolerance * tolerance,
             snap_policy="average",
             snap_inclusive=True,
         )
         interpolation = apply_gather_stencil(
-            source_values.reshape((-1,)),
+            source_values.reshape((case_count, source_count)),
             stencil,
         )
         interpolated = interpolation.values.reshape(latent_coordinates.shape[:-1])

--- a/phydrax/nn/models/architectures/_local_operator.py
+++ b/phydrax/nn/models/architectures/_local_operator.py
@@ -94,7 +94,6 @@ def _neighbor_data(
     radius: float | None,
     max_neighbors: int | None,
 ) -> tuple[Array, Array, Array, Array, Array, Array]:
-    cases, query_count = int(query.shape[0]), int(query.shape[1])
     source_count = int(source_coordinates.shape[1])
     neighbor_count = (
         source_count if max_neighbors is None else min(int(max_neighbors), source_count)
@@ -106,30 +105,9 @@ def _neighbor_data(
         max_neighbors=neighbor_count,
         radius=radius,
     )
-    indices = neighborhood.indices
-    expanded_values = jnp.broadcast_to(
-        source_values[:, None, :, :],
-        (cases, query_count, source_count, source_values.shape[-1]),
-    )
-    expanded_coordinates = jnp.broadcast_to(
-        source_coordinates[:, None, :, :],
-        (cases, query_count, source_count, source_coordinates.shape[-1]),
-    )
-    expanded_weights = jnp.broadcast_to(
-        source_weights[:, None, :],
-        (cases, query_count, source_count),
-    )
-    source_data = jnp.take_along_axis(
-        expanded_values,
-        indices[..., None],
-        axis=2,
-    )
-    source_position = jnp.take_along_axis(
-        expanded_coordinates,
-        indices[..., None],
-        axis=2,
-    )
-    selected_weights = jnp.take_along_axis(expanded_weights, indices, axis=2)
+    source_data = neighborhood.gather(source_values)
+    source_position = neighborhood.gather(source_coordinates)
+    selected_weights = neighborhood.gather(source_weights)
     query_position = jnp.broadcast_to(
         query[:, :, None, :],
         source_position.shape,

--- a/phydrax/nn/models/layers/_graph_transfer.py
+++ b/phydrax/nn/models/layers/_graph_transfer.py
@@ -527,13 +527,7 @@ class GeometryMomentEmbedding(eqx.Module):
             raise ValueError(
                 "GeometryMomentEmbedding source_measure must have shape (case, source)."
             )
-        cases, targets, neighbors = neighborhood.indices.shape
-        expanded = jnp.broadcast_to(
-            measure[:, None, :],
-            (cases, targets, int(measure.shape[-1])),
-        )
-        selected = jnp.take_along_axis(expanded, neighborhood.indices, axis=2)
-        selected = selected * neighborhood.mask.astype(selected.dtype)
+        selected = neighborhood.gather(measure)
         mass = jnp.sum(selected, axis=-1, keepdims=True)
         normalized = jnp.where(mass > 0.0, selected / mass, jnp.zeros_like(selected))
         relative = neighborhood.relative / self.radius

--- a/phydrax/sparse/__init__.py
+++ b/phydrax/sparse/__init__.py
@@ -1,0 +1,33 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+"""JAX-native sparse relations, routing kernels, and linear actions."""
+
+from ._linear import LinearAction, SparseLinearMap
+from ._ops import (
+    gather_routes,
+    linear_adjoint_apply,
+    linear_apply,
+    linear_transpose_apply,
+    mask_routes,
+    route_reduce,
+    RouteReduction,
+)
+from ._relation import EdgeRelation, RowRelation, SparseRelation
+
+
+__all__ = [
+    "EdgeRelation",
+    "LinearAction",
+    "RouteReduction",
+    "RowRelation",
+    "SparseLinearMap",
+    "SparseRelation",
+    "gather_routes",
+    "linear_adjoint_apply",
+    "linear_apply",
+    "linear_transpose_apply",
+    "mask_routes",
+    "route_reduce",
+]

--- a/phydrax/sparse/_linear.py
+++ b/phydrax/sparse/_linear.py
@@ -1,0 +1,127 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from math import prod
+from typing import Any, Protocol
+
+import jax.numpy as jnp
+import numpy as np
+from jaxtyping import Array, ArrayLike
+
+from .._strict import StrictModule
+from ._ops import linear_adjoint_apply, linear_apply, linear_transpose_apply
+from ._relation import EdgeRelation, RowRelation, SparseRelation
+
+
+class LinearAction(Protocol):
+    """Minimal structured linear action accepted by matrix-free consumers."""
+
+    @property
+    def input_shape(self) -> tuple[int, ...]: ...
+
+    @property
+    def output_shape(self) -> tuple[int, ...]: ...
+
+    def mv(self, vector: Any, /) -> Any: ...
+
+    def transpose_mv(self, vector: Any, /) -> Any: ...
+
+    def adjoint_mv(self, vector: Any, /) -> Any: ...
+
+
+class SparseLinearMap(StrictModule):
+    """Scalar-coefficient linear action over one immutable sparse relation."""
+
+    relation: SparseRelation
+    coefficients: Array
+
+    def __init__(
+        self,
+        relation: SparseRelation,
+        coefficients: ArrayLike,
+        /,
+    ):
+        if not isinstance(relation, (EdgeRelation, RowRelation)):
+            raise TypeError("relation must be an EdgeRelation or RowRelation.")
+        values = jnp.asarray(coefficients)
+        if values.shape != relation.route_shape:
+            raise ValueError(
+                f"Sparse coefficients must have route shape {relation.route_shape}; "
+                f"got {values.shape}."
+            )
+        if not jnp.issubdtype(values.dtype, jnp.inexact):
+            values = values.astype(float)
+        self.relation = relation
+        self.coefficients = values
+
+    @property
+    def input_shape(self) -> tuple[int, ...]:
+        return self.relation.input_shape
+
+    @property
+    def output_shape(self) -> tuple[int, ...]:
+        return self.relation.output_shape
+
+    @property
+    def input_size(self) -> int:
+        return prod(self.input_shape) if self.input_shape else 1
+
+    @property
+    def output_size(self) -> int:
+        return prod(self.output_shape) if self.output_shape else 1
+
+    def mv(self, vector: Any, /) -> Any:
+        """Apply the sparse map while preserving trailing payload dimensions."""
+        return linear_apply(self.relation, self.coefficients, vector)
+
+    def transpose_mv(self, vector: Any, /) -> Any:
+        """Apply the algebraic transpose without conjugating coefficients."""
+        return linear_transpose_apply(self.relation, self.coefficients, vector)
+
+    def adjoint_mv(self, vector: Any, /) -> Any:
+        """Apply the conjugate adjoint."""
+        return linear_adjoint_apply(self.relation, self.coefficients, vector)
+
+    def __call__(self, vector: Any, /) -> Any:
+        return self.mv(vector)
+
+    def _edge_form(self) -> tuple[EdgeRelation, Array]:
+        if isinstance(self.relation, EdgeRelation):
+            return self.relation, self.coefficients
+        return self.relation.as_edge_relation(), self.coefficients.reshape((-1,))
+
+    def as_dense(self) -> Array:
+        """Materialize a two-dimensional matrix over flattened source and target spaces."""
+        relation, coefficients = self._edge_form()
+        safe_source = jnp.where(relation.valid, relation.source_indices, 0)
+        safe_target = jnp.where(relation.valid, relation.target_indices, 0)
+        values = jnp.where(
+            relation.valid,
+            coefficients,
+            jnp.zeros((), dtype=coefficients.dtype),
+        )
+        matrix = jnp.zeros(
+            (relation.target_size, relation.source_size),
+            dtype=coefficients.dtype,
+        )
+        return matrix.at[safe_target, safe_source].add(values)
+
+    def to_scipy(self):
+        """Return a host-side CSR matrix, coalescing duplicate linear routes."""
+        import scipy.sparse as sp
+
+        relation, coefficients = self._edge_form()
+        valid = np.asarray(relation.valid, dtype=bool)
+        source = np.asarray(relation.source_indices)[valid]
+        target = np.asarray(relation.target_indices)[valid]
+        values = np.asarray(coefficients)[valid]
+        return sp.coo_matrix(
+            (values, (target, source)),
+            shape=(relation.target_size, relation.source_size),
+        ).tocsr()
+
+
+__all__ = ["LinearAction", "SparseLinearMap"]

--- a/phydrax/sparse/_ops.py
+++ b/phydrax/sparse/_ops.py
@@ -1,0 +1,311 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from typing import Any, Literal, TypeAlias
+
+import jax
+import jax.numpy as jnp
+import jax.tree_util as jtu
+from jaxtyping import Array, ArrayLike
+
+from ._relation import EdgeRelation, RowRelation, SparseRelation
+
+
+RouteReduction: TypeAlias = Literal["sum", "mean", "max", "min"]
+
+
+def _require_prefix(
+    name: str,
+    array: Array,
+    prefix: tuple[int, ...],
+    /,
+) -> tuple[int, ...]:
+    if (
+        array.ndim < len(prefix)
+        or tuple(int(size) for size in array.shape[: len(prefix)]) != prefix
+    ):
+        raise ValueError(f"{name} must begin with shape {prefix}; got {array.shape}.")
+    return tuple(int(size) for size in array.shape[len(prefix) :])
+
+
+def _expanded_mask(valid: Array, payload_ndim: int, /) -> Array:
+    return valid.reshape(valid.shape + (1,) * int(payload_ndim))
+
+
+def mask_routes(relation: SparseRelation, values: Any, /) -> Any:
+    """Make invalid route payloads numerically inert without changing their layout."""
+    route_shape = relation.route_shape
+
+    def mask_leaf(value: Any, /) -> Array:
+        array = jnp.asarray(value)
+        payload_shape = _require_prefix("Route values", array, route_shape)
+        valid = _expanded_mask(relation.valid, len(payload_shape))
+        return jnp.where(valid, array, jnp.zeros((), dtype=array.dtype))
+
+    return jtu.tree_map(mask_leaf, values)
+
+
+def _gather_edge_leaf(relation: EdgeRelation, value: Any, /) -> Array:
+    array = jnp.asarray(value)
+    payload_shape = _require_prefix("Edge source values", array, relation.input_shape)
+    safe = jnp.where(relation.valid, relation.source_indices, 0)
+    gathered = array[safe]
+    valid = _expanded_mask(relation.valid, len(payload_shape))
+    return jnp.where(valid, gathered, jnp.zeros((), dtype=gathered.dtype))
+
+
+def _gather_row_leaf(relation: RowRelation, value: Any, /) -> Array:
+    array = jnp.asarray(value)
+    payload_shape = _require_prefix("Row source values", array, relation.input_shape)
+    cases = relation.num_cases
+    targets = relation.targets_per_case
+    width = relation.width
+    flattened = array.reshape((cases, relation.source_size) + payload_shape)
+    safe = jnp.where(relation.valid, relation.source_indices, 0).reshape(
+        (cases, targets, width)
+    )
+    case_indices = jnp.arange(cases, dtype=jnp.int32).reshape((cases, 1, 1))
+    gathered = flattened[case_indices, safe].reshape(relation.route_shape + payload_shape)
+    valid = _expanded_mask(relation.valid, len(payload_shape))
+    return jnp.where(valid, gathered, jnp.zeros((), dtype=gathered.dtype))
+
+
+def gather_routes(relation: SparseRelation, values: Any, /) -> Any:
+    """Gather source payloads onto routes using the relation's canonical source axis."""
+    if isinstance(relation, EdgeRelation):
+        return jtu.tree_map(lambda value: _gather_edge_leaf(relation, value), values)
+    if isinstance(relation, RowRelation):
+        return jtu.tree_map(lambda value: _gather_row_leaf(relation, value), values)
+    raise TypeError("relation must be an EdgeRelation or RowRelation.")
+
+
+def _extreme_fill(dtype: jnp.dtype, reduction: RouteReduction, /) -> Array:
+    if jnp.issubdtype(dtype, jnp.complexfloating):
+        raise TypeError(f"Route reduction {reduction!r} does not support complex values.")
+    if jnp.issubdtype(dtype, jnp.bool_):
+        return jnp.asarray(reduction == "min", dtype=dtype)
+    if jnp.issubdtype(dtype, jnp.inexact):
+        value = -jnp.inf if reduction == "max" else jnp.inf
+        return jnp.asarray(value, dtype=dtype)
+    limits = jnp.iinfo(dtype)
+    value = limits.min if reduction == "max" else limits.max
+    return jnp.asarray(value, dtype=dtype)
+
+
+def _finalize_reduction(
+    reduced: Array,
+    counts: Array,
+    payload_ndim: int,
+    reduction: RouteReduction,
+    /,
+) -> Array:
+    expanded_counts = counts.reshape(counts.shape + (1,) * payload_ndim)
+    if reduction == "mean":
+        denominator = jnp.maximum(expanded_counts, 1).astype(reduced.dtype)
+        return reduced / denominator
+    if reduction in ("max", "min"):
+        return jnp.where(expanded_counts > 0, reduced, jnp.zeros_like(reduced))
+    return reduced
+
+
+def _reduce_edge_leaf(
+    relation: EdgeRelation,
+    value: Any,
+    reduction: RouteReduction,
+    /,
+) -> Array:
+    array = jnp.asarray(value)
+    payload_shape = _require_prefix("Edge route values", array, relation.route_shape)
+    payload_ndim = len(payload_shape)
+    valid = _expanded_mask(relation.valid, payload_ndim)
+    safe_target = jnp.where(relation.valid, relation.target_indices, 0)
+    counts = jax.ops.segment_sum(
+        relation.valid.astype(jnp.int32),
+        safe_target,
+        relation.target_size,
+    )
+    if reduction in ("sum", "mean"):
+        material = jnp.where(valid, array, jnp.zeros((), dtype=array.dtype))
+        reduced = jax.ops.segment_sum(material, safe_target, relation.target_size)
+    elif reduction == "max":
+        material = jnp.where(valid, array, _extreme_fill(array.dtype, reduction))
+        reduced = jax.ops.segment_max(material, safe_target, relation.target_size)
+    else:
+        material = jnp.where(valid, array, _extreme_fill(array.dtype, reduction))
+        reduced = jax.ops.segment_min(material, safe_target, relation.target_size)
+    return _finalize_reduction(reduced, counts, payload_ndim, reduction)
+
+
+def _reduce_row_leaf(
+    relation: RowRelation,
+    value: Any,
+    reduction: RouteReduction,
+    /,
+) -> Array:
+    array = jnp.asarray(value)
+    payload_shape = _require_prefix("Row route values", array, relation.route_shape)
+    payload_ndim = len(payload_shape)
+    valid = _expanded_mask(relation.valid, payload_ndim)
+    route_axis = len(relation.route_shape) - 1
+    counts = jnp.sum(relation.valid, axis=-1, dtype=jnp.int32)
+    if reduction in ("sum", "mean"):
+        material = jnp.where(valid, array, jnp.zeros((), dtype=array.dtype))
+        reduced = jnp.sum(material, axis=route_axis)
+    elif reduction == "max":
+        material = jnp.where(valid, array, _extreme_fill(array.dtype, reduction))
+        reduced = jnp.max(material, axis=route_axis)
+    else:
+        material = jnp.where(valid, array, _extreme_fill(array.dtype, reduction))
+        reduced = jnp.min(material, axis=route_axis)
+    return _finalize_reduction(reduced, counts, payload_ndim, reduction)
+
+
+def route_reduce(
+    relation: SparseRelation,
+    values: Any,
+    /,
+    *,
+    reduction: RouteReduction = "sum",
+) -> Any:
+    """Reduce route payloads only onto the relation's declared target axis."""
+    if reduction not in ("sum", "mean", "max", "min"):
+        raise ValueError("reduction must be 'sum', 'mean', 'max', or 'min'.")
+    if isinstance(relation, EdgeRelation):
+        return jtu.tree_map(
+            lambda value: _reduce_edge_leaf(relation, value, reduction), values
+        )
+    if isinstance(relation, RowRelation):
+        return jtu.tree_map(
+            lambda value: _reduce_row_leaf(relation, value, reduction), values
+        )
+    raise TypeError("relation must be an EdgeRelation or RowRelation.")
+
+
+def _coefficient_array(
+    relation: SparseRelation,
+    coefficients: ArrayLike,
+    /,
+) -> Array:
+    values = jnp.asarray(coefficients)
+    if values.shape != relation.route_shape:
+        raise ValueError(
+            f"Sparse coefficients must have route shape {relation.route_shape}; "
+            f"got {values.shape}."
+        )
+    if not jnp.issubdtype(values.dtype, jnp.inexact):
+        values = values.astype(float)
+    return jnp.where(relation.valid, values, jnp.zeros((), dtype=values.dtype))
+
+
+def linear_apply(
+    relation: SparseRelation,
+    coefficients: ArrayLike,
+    values: Any,
+    /,
+) -> Any:
+    """Apply a scalar-coefficient sparse linear map to source payloads."""
+    weights = _coefficient_array(relation, coefficients)
+    gathered = gather_routes(relation, values)
+
+    def weight_leaf(value: Any, /) -> Array:
+        array = jnp.asarray(value)
+        payload_ndim = array.ndim - len(relation.route_shape)
+        expanded = weights.reshape(weights.shape + (1,) * payload_ndim)
+        return array * expanded
+
+    messages = jtu.tree_map(weight_leaf, gathered)
+    return route_reduce(relation, messages)
+
+
+def _flatten_row_targets(relation: RowRelation, values: Any, /) -> Any:
+    def flatten_leaf(value: Any, /) -> Array:
+        array = jnp.asarray(value)
+        payload_shape = _require_prefix("Row target values", array, relation.output_shape)
+        return array.reshape(
+            (relation.num_cases * relation.targets_per_case,) + payload_shape
+        )
+
+    return jtu.tree_map(flatten_leaf, values)
+
+
+def _restore_row_sources(relation: RowRelation, values: Any, /) -> Any:
+    def restore_leaf(value: Any, /) -> Array:
+        array = jnp.asarray(value)
+        payload_shape = _require_prefix(
+            "Flattened row source values",
+            array,
+            (relation.num_cases * relation.source_size,),
+        )
+        return array.reshape(relation.input_shape + payload_shape)
+
+    return jtu.tree_map(restore_leaf, values)
+
+
+def _linear_reverse_apply(
+    relation: SparseRelation,
+    coefficients: ArrayLike,
+    values: Any,
+    /,
+    *,
+    conjugate: bool,
+) -> Any:
+    weights = _coefficient_array(relation, coefficients)
+    if conjugate:
+        weights = jnp.conj(weights)
+    if isinstance(relation, EdgeRelation):
+        return linear_apply(relation.transpose(), weights, values)
+    if isinstance(relation, RowRelation):
+        edge_relation = relation.as_edge_relation()
+        flattened_targets = _flatten_row_targets(relation, values)
+        flattened_weights = weights.reshape((-1,))
+        sources = linear_apply(
+            edge_relation.transpose(),
+            flattened_weights,
+            flattened_targets,
+        )
+        return _restore_row_sources(relation, sources)
+    raise TypeError("relation must be an EdgeRelation or RowRelation.")
+
+
+def linear_transpose_apply(
+    relation: SparseRelation,
+    coefficients: ArrayLike,
+    values: Any,
+    /,
+) -> Any:
+    """Apply the algebraic transpose of a sparse linear map."""
+    return _linear_reverse_apply(
+        relation,
+        coefficients,
+        values,
+        conjugate=False,
+    )
+
+
+def linear_adjoint_apply(
+    relation: SparseRelation,
+    coefficients: ArrayLike,
+    values: Any,
+    /,
+) -> Any:
+    """Apply the conjugate adjoint of a sparse linear map."""
+    return _linear_reverse_apply(
+        relation,
+        coefficients,
+        values,
+        conjugate=True,
+    )
+
+
+__all__ = [
+    "RouteReduction",
+    "gather_routes",
+    "linear_adjoint_apply",
+    "linear_apply",
+    "linear_transpose_apply",
+    "mask_routes",
+    "route_reduce",
+]

--- a/phydrax/sparse/_relation.py
+++ b/phydrax/sparse/_relation.py
@@ -1,0 +1,252 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from math import prod
+from typing import TypeAlias
+
+import equinox as eqx
+import jax.numpy as jnp
+from jaxtyping import Array, ArrayLike
+
+from .._strict import StrictModule
+from .._trainable import NonTrainableState
+
+
+def _integer_indices(name: str, value: ArrayLike, /) -> Array:
+    indices = jnp.asarray(value)
+    if not jnp.issubdtype(indices.dtype, jnp.integer):
+        raise TypeError(f"{name} must have an integer dtype.")
+    return indices.astype(jnp.int32)
+
+
+def _valid_mask(value: ArrayLike | None, shape: tuple[int, ...], /) -> Array:
+    if value is None:
+        return jnp.ones(shape, dtype=bool)
+    valid = jnp.asarray(value, dtype=bool)
+    if valid.shape != shape:
+        raise ValueError(f"valid must have shape {shape}; got {valid.shape}.")
+    return valid
+
+
+def _check_bounds(
+    name: str,
+    indices: Array,
+    valid: Array,
+    size: int,
+    /,
+) -> Array:
+    if int(indices.size) == 0:
+        return indices
+    return eqx.error_if(
+        indices,
+        jnp.any(valid & ((indices < 0) | (indices >= int(size)))),
+        f"A valid {name} lies outside [0, {int(size)}).",
+    )
+
+
+class EdgeRelation(StrictModule, NonTrainableState):
+    """Fixed-capacity source-to-target routes in edge-list form."""
+
+    source_indices: Array
+    target_indices: Array
+    valid: Array
+    source_size: int = eqx.field(static=True)
+    target_size: int = eqx.field(static=True)
+
+    def __init__(
+        self,
+        source_indices: ArrayLike,
+        target_indices: ArrayLike,
+        /,
+        *,
+        source_size: int,
+        target_size: int,
+        valid: ArrayLike | None = None,
+    ):
+        source_count = int(source_size)
+        target_count = int(target_size)
+        if source_count < 0 or target_count < 0:
+            raise ValueError(
+                "Edge relation source and target sizes must be non-negative."
+            )
+
+        source = _integer_indices("source_indices", source_indices)
+        target = _integer_indices("target_indices", target_indices)
+        if source.ndim != 1 or target.ndim != 1:
+            raise ValueError("Edge relation indices must be rank-1.")
+        if source.shape != target.shape:
+            raise ValueError("Edge relation source and target indices must match.")
+        if int(source.size) > 0 and (source_count == 0 or target_count == 0):
+            raise ValueError(
+                "A non-empty edge relation requires non-empty source and target spaces."
+            )
+
+        route_valid = _valid_mask(valid, tuple(int(size) for size in source.shape))
+        self.source_indices = _check_bounds(
+            "edge source index", source, route_valid, source_count
+        )
+        self.target_indices = _check_bounds(
+            "edge target index", target, route_valid, target_count
+        )
+        self.valid = route_valid
+        self.source_size = source_count
+        self.target_size = target_count
+
+    @property
+    def route_shape(self) -> tuple[int, ...]:
+        return (int(self.source_indices.shape[0]),)
+
+    @property
+    def capacity(self) -> int:
+        return int(self.source_indices.shape[0])
+
+    @property
+    def input_shape(self) -> tuple[int, ...]:
+        return (self.source_size,)
+
+    @property
+    def output_shape(self) -> tuple[int, ...]:
+        return (self.target_size,)
+
+    def transpose(self) -> "EdgeRelation":
+        """Swap source and target spaces without reordering routes."""
+        return EdgeRelation(
+            self.target_indices,
+            self.source_indices,
+            source_size=self.target_size,
+            target_size=self.source_size,
+            valid=self.valid,
+        )
+
+    def with_valid(self, valid: ArrayLike, /) -> "EdgeRelation":
+        """Return this relation with an additional route-validity condition."""
+        extra = _valid_mask(valid, self.route_shape)
+        return EdgeRelation(
+            self.source_indices,
+            self.target_indices,
+            source_size=self.source_size,
+            target_size=self.target_size,
+            valid=self.valid & extra,
+        )
+
+
+class RowRelation(StrictModule, NonTrainableState):
+    """Fixed-width, case-local source routes grouped by target rows."""
+
+    source_indices: Array
+    valid: Array
+    source_size: int = eqx.field(static=True)
+    case_shape: tuple[int, ...] = eqx.field(static=True)
+
+    def __init__(
+        self,
+        source_indices: ArrayLike,
+        /,
+        *,
+        source_size: int,
+        valid: ArrayLike | None = None,
+        case_shape: tuple[int, ...] = (),
+    ):
+        source_count = int(source_size)
+        if source_count <= 0:
+            raise ValueError("Row relation source_size must be positive.")
+        cases = tuple(int(size) for size in case_shape)
+        if any(size <= 0 for size in cases):
+            raise ValueError("Row relation case dimensions must be positive.")
+
+        source = _integer_indices("source_indices", source_indices)
+        if source.ndim <= len(cases):
+            raise ValueError(
+                "Row relation indices must contain target rows and a route-width axis."
+            )
+        if tuple(int(size) for size in source.shape[: len(cases)]) != cases:
+            raise ValueError(
+                f"Row relation indices must begin with case_shape {cases}; "
+                f"got {source.shape}."
+            )
+        if int(source.shape[-1]) <= 0:
+            raise ValueError("Row relation route width must be positive.")
+
+        route_valid = _valid_mask(valid, tuple(int(size) for size in source.shape))
+        self.source_indices = _check_bounds(
+            "row source index", source, route_valid, source_count
+        )
+        self.valid = route_valid
+        self.source_size = source_count
+        self.case_shape = cases
+
+    @property
+    def route_shape(self) -> tuple[int, ...]:
+        return tuple(int(size) for size in self.source_indices.shape)
+
+    @property
+    def target_shape(self) -> tuple[int, ...]:
+        return self.route_shape[len(self.case_shape) : -1]
+
+    @property
+    def width(self) -> int:
+        return int(self.source_indices.shape[-1])
+
+    @property
+    def num_cases(self) -> int:
+        return prod(self.case_shape) if self.case_shape else 1
+
+    @property
+    def targets_per_case(self) -> int:
+        return prod(self.target_shape) if self.target_shape else 1
+
+    @property
+    def capacity(self) -> int:
+        return int(self.source_indices.size)
+
+    @property
+    def input_shape(self) -> tuple[int, ...]:
+        return self.case_shape + (self.source_size,)
+
+    @property
+    def output_shape(self) -> tuple[int, ...]:
+        return self.case_shape + self.target_shape
+
+    def with_valid(self, valid: ArrayLike, /) -> "RowRelation":
+        """Return this relation with an additional route-validity condition."""
+        extra = _valid_mask(valid, self.route_shape)
+        return RowRelation(
+            self.source_indices,
+            source_size=self.source_size,
+            valid=self.valid & extra,
+            case_shape=self.case_shape,
+        )
+
+    def as_edge_relation(self) -> EdgeRelation:
+        """Flatten cases and target rows into one disconnected edge relation."""
+        cases = self.num_cases
+        targets = self.targets_per_case
+        width = self.width
+        local_source = self.source_indices.reshape((cases, targets, width))
+        source_offsets = (jnp.arange(cases, dtype=jnp.int32) * self.source_size).reshape(
+            (cases, 1, 1)
+        )
+        source = local_source + source_offsets
+        target = jnp.broadcast_to(
+            (
+                jnp.arange(cases, dtype=jnp.int32)[:, None] * targets
+                + jnp.arange(targets, dtype=jnp.int32)[None, :]
+            )[..., None],
+            (cases, targets, width),
+        )
+        return EdgeRelation(
+            source.reshape((-1,)),
+            target.reshape((-1,)),
+            source_size=cases * self.source_size,
+            target_size=cases * targets,
+            valid=self.valid.reshape((-1,)),
+        )
+
+
+SparseRelation: TypeAlias = EdgeRelation | RowRelation
+
+
+__all__ = ["EdgeRelation", "RowRelation", "SparseRelation"]

--- a/tests/unit/test_sparse_substrate.py
+++ b/tests/unit/test_sparse_substrate.py
@@ -1,0 +1,127 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax
+import jax.numpy as jnp
+
+import phydrax as phx
+
+
+def test_edge_linear_map_matches_dense_forward_transpose_and_adjoint():
+    relation = phx.sparse.EdgeRelation(
+        jnp.asarray([0, 1, 2, 0], dtype=jnp.int32),
+        jnp.asarray([0, 0, 1, 1], dtype=jnp.int32),
+        source_size=3,
+        target_size=2,
+        valid=jnp.asarray([True, False, True, True]),
+    )
+    coefficients = jnp.asarray([2.0 + 1.0j, jnp.nan + 0.0j, -1.0j, 4.0])
+    action = phx.sparse.SparseLinearMap(relation, coefficients)
+    source = jnp.asarray([1.0 - 1.0j, jnp.nan + 0.0j, 2.0 + 0.5j])
+    target = jnp.asarray([3.0 + 2.0j, -1.0 + 0.5j])
+    dense = action.as_dense()
+
+    forward = jax.jit(lambda values: action.mv(values))(source)
+    transpose = jax.jit(lambda values: action.transpose_mv(values))(target)
+    adjoint = jax.jit(lambda values: action.adjoint_mv(values))(target)
+
+    assert jnp.all(jnp.isfinite(forward))
+    assert jnp.allclose(forward, dense @ source.at[1].set(0.0))
+    assert jnp.allclose(transpose, dense.T @ target)
+    assert jnp.allclose(adjoint, jnp.conj(dense).T @ target)
+
+
+def test_row_linear_map_preserves_cases_payloads_and_dense_adjoint():
+    relation = phx.sparse.RowRelation(
+        jnp.asarray(
+            [
+                [[0, 2], [1, 0]],
+                [[2, 1], [0, 2]],
+            ],
+            dtype=jnp.int32,
+        ),
+        source_size=3,
+        valid=jnp.asarray(
+            [
+                [[True, True], [True, False]],
+                [[True, False], [True, True]],
+            ]
+        ),
+        case_shape=(2,),
+    )
+    coefficients = jnp.asarray(
+        [
+            [[0.25, 0.75], [2.0, jnp.nan]],
+            [[-1.0, jnp.nan], [0.5, 0.5]],
+        ]
+    )
+    action = phx.sparse.SparseLinearMap(relation, coefficients)
+    source = jnp.asarray(
+        [
+            [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]],
+            [[7.0, 8.0], [jnp.nan, jnp.nan], [9.0, 10.0]],
+        ]
+    )
+    target = jnp.asarray(
+        [
+            [[1.0, -1.0], [2.0, 3.0]],
+            [[-2.0, 0.5], [4.0, -3.0]],
+        ]
+    )
+    dense = action.as_dense()
+
+    forward = action.mv(source)
+    adjoint = action.adjoint_mv(target)
+    safe_source = source.at[1, 1].set(0.0)
+
+    assert forward.shape == (2, 2, 2)
+    assert adjoint.shape == (2, 3, 2)
+    assert jnp.all(jnp.isfinite(forward))
+    assert jnp.allclose(
+        forward.reshape((4, 2)),
+        dense @ safe_source.reshape((6, 2)),
+    )
+    assert jnp.allclose(
+        adjoint.reshape((6, 2)),
+        jnp.conj(dense).T @ target.reshape((4, 2)),
+    )
+
+
+def test_route_reductions_keep_invalid_nan_routes_inert_and_empty_targets_zero():
+    relation = phx.sparse.EdgeRelation(
+        jnp.asarray([0, 1, 2], dtype=jnp.int32),
+        jnp.asarray([0, 0, 1], dtype=jnp.int32),
+        source_size=3,
+        target_size=3,
+        valid=jnp.asarray([True, False, True]),
+    )
+    route_values = jnp.asarray([[2.0, 4.0], [jnp.nan, jnp.nan], [-1.0, 5.0]])
+
+    summed = phx.sparse.route_reduce(relation, route_values)
+    maximum = phx.sparse.route_reduce(relation, route_values, reduction="max")
+
+    expected = jnp.asarray([[2.0, 4.0], [-1.0, 5.0], [0.0, 0.0]])
+    assert jnp.array_equal(summed, expected)
+    assert jnp.array_equal(maximum, expected)
+
+
+def test_cochain_incidence_exposes_sparse_boundary_and_derivative_actions():
+    boundary = jnp.asarray(
+        [
+            [-1.0, 0.0],
+            [1.0, -1.0],
+            [0.0, 1.0],
+        ]
+    )
+    incidence = phx.graph.CochainIncidence.from_dense(1, boundary)
+    lower = jnp.asarray([2.0, 3.0, 5.0])
+    upper = jnp.asarray([7.0, 11.0])
+
+    derivative_action = incidence.exterior_derivative_map()
+    boundary_action = incidence.boundary_map()
+
+    assert jnp.allclose(derivative_action(lower), boundary.T @ lower)
+    assert jnp.allclose(boundary_action(upper), boundary @ upper)
+    assert jnp.array_equal(derivative_action.as_dense(), boundary.T)
+    assert jnp.array_equal(boundary_action.as_dense(), boundary)


### PR DESCRIPTION
## Summary

Introduce `phydrax.sparse`, a small JAX-native execution substrate for the gather–message–reduce structure already shared by interpolation stencils, local neighborhoods, graph operators, and cochain incidence maps.

The substrate unifies sparse routing and weighted linear actions without flattening the semantic layers above it. Geometry, topology, interpolation support, physical measures, graph batching, cochain orientation, and boundary policy remain owned by their existing objects.

## Motivation

Phydrax previously had several mature sparse execution paths with the same underlying mechanics but separate implementations:

- fixed-capacity interpolation stencils;
- case-local source neighborhoods;
- `GraphIR` edge gathers and segment reductions;
- graph adjacency, Laplacian, diffusion, integral, and finite-volume operators;
- signed cochain incidence actions;
- local and geometry-aware neural-operator gathers.

Those paths repeatedly implemented index validation, batch-local offsets, masked gathering, payload broadcasting, segment reduction, and transpose-like actions. This made numerical edge cases and JAX behavior subsystem-specific and prevented sparse operators from participating in one explicit linear-action contract.

This change factors out that common execution layer while retaining the specialized APIs that carry scientific meaning.

## Architecture

### Two explicit relation layouts

The new substrate deliberately supports two physical layouts instead of forcing all sparse work into one universal container:

- `EdgeRelation` stores arbitrary source-to-target routes in edge-list form. It supports irregular degree, multiedges, graph partitions, arbitrary route ordering, and transpose by exchanging source and target spaces.
- `RowRelation` stores fixed-width routes grouped by target rows, with explicit case dimensions. It preserves query shape and case-local indexing without materializing global batch offsets during normal gather/reduce execution.

Both relations declare source capacity, target layout, route capacity, and validity independently. Valid routes are bounds-checked; invalid capacity slots are allowed to contain arbitrary placeholder indices because they are made inert before indexing or reduction.

### Shared routing kernels

`phydrax.sparse` exposes:

- `gather_routes` for source-to-route gathering;
- `mask_routes` for robust route masking;
- `route_reduce` for sum, mean, maximum, and minimum reductions onto declared targets;
- `linear_apply` for weighted forward application;
- `linear_transpose_apply` for algebraic transpose application;
- `linear_adjoint_apply` for conjugate-adjoint application.

The kernels preserve arbitrary trailing payload dimensions and PyTree structure. Masking uses conditional selection rather than multiplication, so invalid routes remain numerically inert even when placeholder payloads or coefficients are non-finite. Empty targets reduce to zero, and duplicate routes remain distinct execution routes.

### Sparse linear actions

`SparseLinearMap` attaches scalar route coefficients to either relation layout and provides:

- callable and `mv` forward application;
- `transpose_mv` without coefficient conjugation;
- `adjoint_mv` with coefficient conjugation;
- explicit input/output shapes and flattened sizes;
- explicit `as_dense()` and `to_scipy()` interoperability paths.

Normal execution never densifies. Dense and SciPy materialization are named boundary operations and algebraically coalesce duplicate routes. The `LinearAction` protocol records the minimal structured action contract for matrix-free consumers without introducing a broader linear-algebra hierarchy.

## Integration changes

### Interpolation

`GatherStencil` now owns a `RowRelation` while retaining its interpolation-specific weights and support mask. Existing `indices`, `valid`, `source_size`, and query-shape access remain available through compatibility properties.

`gather_patches` and `apply_gather_stencil` use the shared gather and target-reduction kernels. Strict and renormalizing source-mask policies remain interpolation concerns above the sparse substrate. Inverse-distance stencil construction now accepts an explicit `case_shape`, enabling batched case-local reconstruction without global offset construction.

### Neighborhoods and neural operators

`QueryNeighborhood` now owns a `RowRelation` and exposes direct case-local `gather`. Its geometric payloads—relative vectors, distances, squared distances, and counts—remain on the neighborhood object.

Local integral/differential operators, geometry-aware inverse-distance reconstruction, and graph-transfer moment embeddings now gather source values, coordinates, and measures directly through the neighborhood relation. This removes repeated broadcasted `B × Q × S` source expansions and manual per-case index offsets.

### Graph execution

`GraphIR.edge_relation()` provides the canonical adapter from graph storage to the sparse substrate, including edge validity and explicit flow direction.

Shared routing now drives:

- weighted adjacency and normalized graph Laplacians;
- graph kernel-integral aggregation;
- graph diffusion incoming/outgoing reductions;
- graph neural-operator message aggregation;
- finite-volume divergence reductions;
- cotangent mesh-Laplacian gathers and reductions.

`GraphIR` remains the graph carrier. Node, edge, and global PyTrees, graph partitions, masks, batching, and graph-domain semantics are unchanged. The sparse relation is an execution view rather than a replacement representation.

### Cochain calculus

`CochainIncidence` now exposes:

- `exterior_derivative_map()` for the lower-to-upper action `Bᵀ`;
- `boundary_map()` for the upper-to-lower action `B`.

Metric exterior derivatives and codifferentials use the shared sparse linear kernels while retaining degree filtering, orientation signs, Hodge-star weighting, absolute/relative boundary policies, and active-cell semantics in the cochain layer.

## Numerical and semantic invariants

- Topology and numerical coefficients remain separate.
- Validity is distinct from a numerically zero coefficient.
- Invalid routes are inert before reduction rather than multiplied by zero afterward.
- Duplicate routes are preserved by relations and only summed by linear materialization or target reduction.
- Case boundaries are explicit for row layouts; no route may cross cases accidentally.
- Source/target order is preserved.
- Complex coefficients use algebraic transpose and conjugate adjoint as distinct operations.
- Sparse execution does not infer whether coefficients represent interpolation weights, graph measures, quadrature, incidence signs, or learned kernels.
- Dense conversion is explicit and never an internal fallback.

## Public surface

The root package now exports `phydrax.sparse` with:

- `EdgeRelation`
- `RowRelation`
- `SparseRelation`
- `RouteReduction`
- `LinearAction`
- `SparseLinearMap`
- `gather_routes`
- `mask_routes`
- `route_reduce`
- `linear_apply`
- `linear_transpose_apply`
- `linear_adjoint_apply`

The root API documentation and architectural overview describe the new layer, its invariants, and its boundaries.

## Deliberate scope boundaries

This does **not** make every feature described as “sparse” part of `phydrax.sparse`. The following remain in their existing semantic subsystems:

- Smolyak sparse-grid approximation and quadrature;
- sparse Gaussian-process/FITC approximations;
- low-rank covariance and noise factors;
- stochastic probes and sampled-coordinate estimators;
- arbitrary matrix-free callables;
- Fourier and NUFFT reconstruction;
- sampling designs and sparse graph-domain datasets.

It also does not replace `GraphIR`, `GatherStencil`, `QueryNeighborhood`, `CochainComplexIR`, or `OperatorTopology`. These objects continue to carry the domain-specific information that a numerical relation intentionally does not know.

## Review guide

A useful review order is:

1. `phydrax/sparse/_relation.py` for layout and validity invariants;
2. `phydrax/sparse/_ops.py` for masking, gathering, reduction, and adjoint semantics;
3. `phydrax/sparse/_linear.py` for the structured linear-action boundary;
4. interpolation and neighborhood adapters;
5. graph and cochain migrations;
6. root exports and documentation.
