### PR TITLE
Stabilize boundary factors and hard-constraint gates

### DIFF
--- a/docs/api/constraints/enforced.md
+++ b/docs/api/constraints/enforced.md
@@ -25,6 +25,17 @@ see [Enforced constraint pipelines](../solver/enforced_constraints.md).
     unfiltered `Boundary()` component, then associate those ansätze with the
     filtered components passed to `enforce_blend`.
 
+!!! info
+    Geometry value and derivative ansätze intentionally use different units.
+    `enforce_dirichlet` uses a dimensionless enforcement gate that is zero on the
+    boundary and order one in the interior. Neumann, Robin, traction, and Sommerfeld
+    use the dimensional `boundary_ansatz_factor`, whose outward boundary derivative
+    is one, and its gradient as a smooth off-boundary normal extension. This gradient
+    agrees with the outward unit normal on regular boundary points but need not remain
+    unit length in the interior. Public normal calculations continue to use the
+    geometry ADF and normal provider. The compact gate remains an explicit option for
+    Dirichlet and preservation overlays.
+
 ::: phydrax.constraints.enforce_dirichlet
 
 ---

--- a/docs/api/domain/components.md
+++ b/docs/api/domain/components.md
@@ -65,6 +65,7 @@ overlap.
             - normals
             - normal
             - sdf
+            - enforcement_gate
 
 ---
 

--- a/docs/api/domain/geometry1d.md
+++ b/docs/api/domain/geometry1d.md
@@ -4,6 +4,7 @@
     options:
         members:
             - __init__
+            - make_enforcement_gate
             - sample_interior
             - sample_boundary
             - length

--- a/docs/api/domain/geometry2d.md
+++ b/docs/api/domain/geometry2d.md
@@ -2,6 +2,15 @@
 
 ## Mesh-based geometries
 
+CAD geometry exposes four distinct scalar fields. `predicate_sdf` is used for
+inside/outside classification. `boundary_factor` (also available as `adf`) is the
+scale-covariant, compactly saturated field used by geometry operations and normal
+construction; it equals signed distance in a boundary collar but does not claim
+metric distance in the interior. `boundary_ansatz_factor` is a dimensional,
+unit-boundary-jet rescaling of the global R-equivalence profile used by derivative
+hard constraints. `make_enforcement_gate(...)` supplies the corresponding
+dimensionless gate for Dirichlet ansätze and preservation overlays.
+
 ### Boolean / CSG operations
 
 `Geometry2DFromCAD` supports boolean operations via operator overloading:
@@ -28,6 +37,8 @@
     options:
         members:
             - __init__
+            - boundary_ansatz_factor
+            - make_enforcement_gate
             - __add__
             - __sub__
             - __and__

--- a/docs/api/domain/geometry3d.md
+++ b/docs/api/domain/geometry3d.md
@@ -7,6 +7,15 @@ finite, nondegenerate, consistently oriented, and watertight after
 sanitization; open or zero-volume surfaces are rejected before distance fields,
 sampling, or boundary normals are constructed.
 
+CAD geometry exposes four distinct scalar fields. `predicate_sdf` is used for
+inside/outside classification. `boundary_factor` (also available as `adf`) is the
+scale-covariant, compactly saturated field used by geometry operations and normal
+construction; it equals signed distance in a boundary collar but does not claim
+metric distance in the interior. `boundary_ansatz_factor` is a dimensional,
+unit-boundary-jet rescaling of the global R-equivalence profile used by derivative
+hard constraints. `make_enforcement_gate(...)` supplies the corresponding
+dimensionless gate for Dirichlet ansätze and preservation overlays.
+
 ### Boolean / CSG operations
 
 `Geometry3DFromCAD` supports boolean operations via operator overloading:
@@ -33,6 +42,8 @@ sampling, or boundary normals are constructed.
     options:
         members:
             - __init__
+            - boundary_ansatz_factor
+            - make_enforcement_gate
             - __add__
             - __sub__
             - __and__

--- a/docs/api/domain/hyperrectangle.md
+++ b/docs/api/domain/hyperrectangle.md
@@ -45,6 +45,7 @@ vector.
     options:
         members:
             - __init__
+            - make_enforcement_gate
             - label
             - spatial_dim
             - bounds

--- a/docs/api/solver/enforced_constraints.md
+++ b/docs/api/solver/enforced_constraints.md
@@ -12,6 +12,14 @@ For the underlying ansatz constructors (`enforce_dirichlet`, `enforce_neumann`, 
     - `EnforcedConstraintPipelines` topologically orders multi-field dependencies (`co_vars`).
     - Graph value overlays built with `enforce_graph_values` are generic overlays and can be passed through `constraint_terms`.
     - For a detailed mathematical treatment of the PCI pipeline (including BVH-weighted boundary blending, boundary–initial gating, and the interior anchor/data stage), see [Appendix → Physics-Constrained Interpolation](../../appendix/physics_constrained_interpolation.md).
+    - Geometry factors used in boundary/initial and interior-data preservation
+      gates are dimensionless. `gate_method="auto"` selects the global CAD
+      R-equivalence gate. Select `"compact"` on `EnforcedConstraintPipeline`,
+      `EnforcedConstraintPipelines.build`, or `FunctionalSolver` to use the compact
+      fallback; `gate_saturation_fraction` and `gate_linear_fraction` then configure
+      its extent. Configure each Dirichlet boundary term on `enforce_dirichlet`.
+      None of these settings alter the boundary-defining field used by derivative
+      constraints.
 
 ::: phydrax.solver.SingleFieldEnforcedConstraint
     options:

--- a/docs/api/solver/functional_solver.md
+++ b/docs/api/solver/functional_solver.md
@@ -22,6 +22,11 @@ For a conceptual overview (loss evaluation, enforced pipelines, training loop be
     - `solve(..., tensorboard_log_dir=...)` writes TensorBoard scalar logs.
     - `save_onnx("u", ...)` exports one named ansatz function for deployment.
     - Discrete data constraints report data-fit diagnostics alongside their loss.
+    - `gate_method="auto"` selects the global, dimensionless CAD R-equivalence
+      preservation gate. Select `"compact"` to use the compact fallback;
+      `gate_saturation_fraction` and `gate_linear_fraction` then configure its
+      transition. Configure a boundary term's gate on `enforce_dirichlet` itself.
+      None of these settings changes derivative constraints.
 
 ## Typical usage
 

--- a/docs/appendix/physics_constrained_interpolation.md
+++ b/docs/appendix/physics_constrained_interpolation.md
@@ -72,131 +72,275 @@ The remaining sections specify concrete constructions and the invariance proofs.
 
 ## A.2. Boundary enforced ansätze
 
-Let $\Omega\subset\mathbb R^d$ be a geometry factor with boundary $\partial\Omega$.
-Assume a signed distance–like function $\phi:\Omega\to\mathbb R$ satisfying $\phi=0$ on $\partial\Omega$,
-and an outward unit normal $n$ on $\partial\Omega$.
+Let $\Omega\subset\mathbb R^d$ be a geometry factor with boundary
+$\partial\Omega$. Phydrax keeps three zero-set-preserving fields distinct:
 
-The statements below are written in an ideal smooth setting; in practice Phydrax uses an
-approximate distance function and numerically defined boundary normals. Exactness claims
-should be interpreted as exact for the idealized $\phi,n$, and “up to numerical tolerance”
-in typical discretized settings.
+- a signed distance-like geometry field $\phi$, used by geometry operations and
+  public normal construction;
+- a dimensionless enforcement gate $\beta$, with $\beta=0$ on
+  $\partial\Omega$ and $\beta=\mathcal O(1)$ in the interior, for value ansätze
+  and constraint-preserving overlays; and
+- a dimensional boundary ansatz factor $\psi$, with $\psi=0$ and
+  $\partial_n\psi=1$ on $\partial\Omega$, for derivative hard constraints.
+
+The outward unit normal is denoted by $n$. Derivative ansätze use the canonical
+off-boundary extension $\nu=\nabla\psi$. At every regular boundary point,
+$\nu=n$; in the interior, $\nu$ is not normalized and may vanish smoothly at a
+medial set. For CAD geometries, all three fields share the same boundary zero set
+up to floating-point tolerance; mesh edges and vertices use the established
+outward pseudonormal because a unique classical normal does not exist.
 
 ### A.2.1. Dirichlet (value) constraints
 
 Given a target $g:\partial\Omega\to\mathbb R^C$, define:
 
 $$
-u^\star(x)\;=\; g(x) + \phi(x)\,\bigl(u(x)-g(x)\bigr).
+u^\star(x)\;=\; g(x) + \beta(x)\,\bigl(u(x)-g(x)\bigr).
 $$
 
-**Proposition A.1 (Dirichlet exactness).** If $\phi=0$ on $\partial\Omega$, then $u^\star=g$ on $\partial\Omega$.
+**Proposition A.1 (Dirichlet exactness).** If $\beta=0$ on
+$\partial\Omega$, then $u^\star=g$ on $\partial\Omega$.
 
-*Proof.* For $x\in\partial\Omega$, $\phi(x)=0$ implies $u^\star(x)=g(x)$. $\square$
+*Proof.* For $x\in\partial\Omega$, $\beta(x)=0$ implies
+$u^\star(x)=g(x)$. $\square$
 
 ### A.2.2. Neumann (normal derivative) constraints
 
-Given a target $g:\partial\Omega\to\mathbb R^C$ for $\partial_n u=g$, define:
+Given a target $g:\partial\Omega\to\mathbb R^C$ for $\partial_n u=g$, define
+$\nu=\nabla\psi$ and:
 
 $$
-u^\star \;=\; u + \frac{\phi}{\partial_n\phi}\,\bigl(g-\partial_n u\bigr).
+u^\star \;=\; u + \psi\,\bigl(g-D_\nu u\bigr).
 $$
 
-**Proposition A.2 (Neumann exactness).** Assume $u,\phi$ are differentiable and $\partial_n\phi\neq 0$ on $\partial\Omega$.
-Then $\partial_n u^\star=g$ on $\partial\Omega$.
+**Proposition A.2 (Neumann exactness).** Assume $u,\psi$ are differentiable,
+$\psi=0$, and $\partial_n\psi=1$ on $\partial\Omega$. Then
+$\partial_n u^\star=g$ on every regular boundary point.
 
-*Proof.* Differentiate along $n$:
+*Proof.* Because $\psi$ is constant on the boundary, its tangential derivatives
+vanish there. Hence $\nu=\nabla\psi=n$ and $D_\nu u=\partial_nu$ on the boundary.
+Differentiating the ansatz along $n$ gives:
 
 $$
 \partial_n u^\star
-=\partial_n u + \partial_n\left(\frac{\phi}{\partial_n\phi}\right)\bigl(g-\partial_n u\bigr)
-+ \frac{\phi}{\partial_n\phi}\bigl(\partial_n g - \partial_n\partial_n u\bigr).
+=\partial_n u + \partial_n\psi\bigl(g-D_\nu u\bigr)
++ \psi\,\partial_n\bigl(g-D_\nu u\bigr).
 $$
 
-On $\partial\Omega$, $\phi=0$ annihilates the last term. Moreover,
+On $\partial\Omega$, $\psi=0$ annihilates the last term and
+$\partial_n\psi=1$, hence
+$\partial_n u^\star=\partial_n u+(g-\partial_nu)=g$. $\square$
 
-$$
-\partial_n\left(\frac{\phi}{\partial_n\phi}\right)
-=\frac{\partial_n\phi}{\partial_n\phi}+\phi\cdot(\cdots)=1
-\quad\text{on }\partial\Omega.
-$$
-
-Hence $\partial_n u^\star=\partial_n u + (g-\partial_n u)=g$ on $\partial\Omega$. $\square$
+Using $\nu$ rather than normalizing a nearest-boundary field changes no boundary
+operator. It only chooses a differentiable interior extension for the residual,
+avoiding artificial normal jumps where nearest boundary points are nonunique.
 
 ### A.2.3. Robin (mixed) constraints
 
-For $a\,u + b\,\partial_n u = g$ on $\partial\Omega$, one may use the analogous correction:
+For $a\,u + b\,\partial_n u = g$ on $\partial\Omega$, use
 
 $$
-u^\star \;=\; u + \frac{\phi}{b\,\partial_n\phi}\,\bigl(g-a\,u-b\,\partial_n u\bigr),
+u^\star \;=\; u + \frac{\psi}{b}\,
+\bigl(g-a\,u-b\,D_\nu u\bigr),
 $$
 
-under the nondegeneracy assumption $b\,\partial_n\phi\neq 0$ on $\partial\Omega$.
-The proof is the same as Proposition A.2: the correction term vanishes on the boundary but has
-the correct first normal derivative to cancel the residual of the Robin operator.
+under the nondegeneracy assumption $b\neq0$ on $\partial\Omega$. The proof is
+the same as Proposition A.2 because $D_\nu u=\partial_nu$ on the boundary.
 
-### A.2.4. Approximate distance field (ADF) and blur
+### A.2.4. Scale-normalized boundary fields
 
-PCI relies on a signed distance–like function $\phi$ to build boundary factors and normals.
-Phydrax constructs a smooth **approximate distance field (ADF)** from a mesh and, by default,
-applies a local Gaussian blur to improve stability of downstream derivatives.
+Hard constraints need a reliable zero set, while PDE optimization also needs
+well-conditioned derivatives. Phydrax therefore keeps five mesh-geometry roles
+distinct:
 
-#### A.2.4.1. Base smooth distance (mesh ADF)
+- `predicate_sdf`: a signed distance-like field used for inside/outside classification;
+- `boundary_factor` (also exposed as `adf`): the compact dimensional geometry
+  field $\phi$ used by geometry operations and public normal construction;
+- `make_enforcement_gate(...)`: the dimensionless field $\beta$ used by
+  Dirichlet ansätze and preservation overlays;
+- `boundary_ansatz_factor`: the dimensional unit-jet field $\psi$ used by
+  derivative hard constraints, with $\nu=\nabla\psi$ as their canonical
+  off-boundary normal extension; and
+- the boundary-normal provider: the outward analytic or mesh pseudonormal field.
 
-Let $\mathcal M$ be a triangulated surface defining $\partial\Omega$. For each query point $x$,
-Phydrax computes a smooth proxy distance by combining candidate triangle distances with a soft-min:
-
-$$
-d(x)\;\approx\;\operatorname{softmin}_\beta\{\,d_T(x)\,\}_{T\in\mathcal C(x)},
-$$
-
-where $d_T(x)$ is the point-to-triangle distance and $\mathcal C(x)$ is a BVH-selected candidate
-set (beam traversal of a packed AABB tree). The softness parameter $\beta>0$ controls the
-sharpness of the soft-min; smaller $\beta$ yields a smoother blend of nearby triangle distances.
-
-For 2D geometries built from CAD, Phydrax extrudes the mesh to 3D and evaluates the 3D ADF away
-from end caps so that the resulting distance coincides with the 2D boundary distance on the
-side walls.
-
-An optional **squash** transform can be applied:
+Let $D>0$ be the geometry diameter and $c$ the center of its axis-aligned bounds.
+All mesh-distance calculations use normalized coordinates
 
 $$
-\rho(s)=\delta\,\operatorname{tanh}\!\left(\frac{s}{\delta}\right),
+y=\frac{x-c}{D}.
 $$
 
-which is linear near $s=0$ but saturates in the interior to limit curvature. The *unsquashed*
-field (pre-$\operatorname{tanh}$) is exposed as `adf_orig`.
-
-#### A.2.4.2. Local ADF blur
-
-Given a base field $\phi_{\text{orig}}$ (typically `adf_orig`), the blurred ADF is defined by
-sampling in a local neighborhood:
+This makes BVH geometry, regularizers, soft-min sharpness, collar widths, and
+saturation thresholds independent of the physical coordinate scale. Returned values
+are multiplied by $D$, so uniform scaling by $s>0$ satisfies
 
 $$
-\phi_{\text{blur}}(x)
+\phi_{s\Omega}(s x)=s\,\phi_\Omega(x).
+$$
+
+#### A.2.4.1. Boundary-preserving smooth extension
+
+The mesh construction computes a closest-point signed distance $d_{\mathrm{exact}}$
+and a soft candidate-triangle extension $d_{\mathrm{soft}}$. It does not blend them at
+the boundary. For a normalized collar radius $r_0$, the blend is
+
+$$
+q
 =
-\frac{\phi_{\text{orig}}(x)+\sum_{i=1}^m w_i(x)\,\phi_{\text{orig}}(x+r(x)u_i)}
-{1+\sum_{i=1}^m w_i(x)}.
+d_{\mathrm{exact}}
++B\!\left(\lvert d_{\mathrm{exact}}\rvert\right)
+\left(d_{\mathrm{soft}}-d_{\mathrm{exact}}\right),
 $$
 
-Here $(u_i)$ are deterministic offsets on the unit disk (2D Fibonacci disk) or unit ball
-(3D Fibonacci sphere with radial stratification). The radius is adaptive:
+where $B=0$ on $[0,r_0/2]$, $B=1$ on $[r_0,\infty)$, and the transition is the
+order-five generalized smoothstep
 
 $$
-r(x)=\max\!\bigl(\sqrt{\phi_{\text{orig}}(x)^2+\varepsilon^2}-\varepsilon,\ r_{\min}\bigr),
+B(u)=462u^6-1980u^7+3465u^8-3080u^9+1386u^{10}-252u^{11},
+\qquad
+u=\frac{2\lvert d_{\mathrm{exact}}\rvert-r_0}{r_0}
 $$
 
-and the Gaussian weights are
+clipped to $[0,1]$. Thus $q=d_{\mathrm{exact}}$ throughout an open boundary collar,
+rather than merely agreeing at one point. In the closest-point custom derivative,
+queries within a scale-normalized numerical collar use the mesh pseudonormal directly.
+This removes the machine-epsilon transition that would otherwise create unbounded
+higher derivatives at the zero set.
+
+For planar CAD geometry, the triangulation is extruded only to reuse the 3D mesh
+kernel; queries are evaluated on the sidewall away from the end caps. The final
+boundary-factor scale is the planar diameter, not the artificial extrusion height.
+
+#### A.2.4.2. Compact smooth saturation
+
+The closest-point map is nonsmooth at medial sets. The dimensional
+boundary-defining factor does not need to carry that nonsmoothness into a PDE
+residual. Let
 
 $$
-w_i(x)=\exp\!\left(-\frac{\|r(x)\,u_i\|^2}{2(\sigma\,r(x))^2+\varepsilon}\right),
+\delta=0.05D,\qquad r=\frac{|q|}{\delta},
 $$
 
-with $\sigma=\texttt{sigma_scale}$. The parameters $(\varepsilon,r_{\min})$ prevent numerical
-instabilities and collapse of the kernel near the boundary.
+and define
 
-**Implementation note.** By default, `geom.adf` is set to the blurred field
-$\phi_{\text{blur}}=\texttt{adf_blur}(\texttt{adf_orig})$, while `adf_orig` provides the
-unsquashed base field. Thus enforced boundary ansätze use the blurred ADF by default.
+$$
+G(u)
+=u-66u^7+\frac{495}{2}u^8-385u^9+308u^{10}-126u^{11}+21u^{12}.
+$$
+
+The final factor is
+
+$$
+\phi(q)=
+\begin{cases}
+q, & r\le \tfrac12,\\[2mm]
+\operatorname{sign}(q)\,\delta
+\left[\tfrac12+\tfrac12G(2r-1)\right],
+& \tfrac12<r<1,\\[2mm]
+\operatorname{sign}(q)\,\tfrac34\delta, & r\ge 1.
+\end{cases}
+$$
+
+The polynomial agrees with the identity through sixth order at the inner join and is
+flat through sixth order at the outer join. Consequently:
+
+$$
+\phi=0,\qquad \nabla\phi=n,\qquad \|\nabla\phi\|=1
+\quad\text{on a regular boundary face},
+$$
+
+the whole inner collar is exactly linear, and all derivatives vanish once the plateau
+is reached. Medial-axis candidate changes beyond the saturation threshold therefore
+cannot enter any derivative of the enforced ansatz. The sign remains negative inside
+and positive outside.
+
+`adf_orig` exposes the unsquashed smooth distance-like source for diagnostics and
+classification. `adf_blur(...)` remains an explicit utility, but a blur is not applied
+to the final boundary factor: averaging across the zero set would move the boundary
+and destroy the hard-constraint guarantee.
+
+#### A.2.4.3. Dimensionless optimization gate
+
+The compact saturation used by the geometry ADF is not a good universal
+multiplier for a PINN ansatz: it can attenuate the network over most of the
+domain while concentrating large second and higher derivatives in a thin
+transition. Dirichlet ansätze and pipeline preservation overlays therefore use
+the global gate $\beta$, while derivative hard constraints use its dimensional
+unit-jet counterpart $\psi$.
+
+Let $L$ be the shortest positive span of the geometry's axis-aligned bounds.
+For the CAD default, let $d_i(x)$ be distances to the triangles in the
+BVH-selected candidate beam. Away from the boundary collar, Phydrax uses the
+order-12 negative-power R-equivalence field
+
+$$
+r(x)=\left(\sum_i d_i(x)^{-12}\right)^{-1/12}.
+$$
+
+This field is bounded by the nearest candidate distance but combines competing
+patches smoothly instead of selecting one. In the collar
+$\operatorname{dist}(x,\partial\Omega)\le L/8$, the source is the exact mesh
+distance; a $C^6$ transition couples it to $r$ by distance $L/4$. Thus the gate
+has the exact mesh zero set and local boundary behavior without extending a
+nearest-facet field to the medial axis.
+
+For an interior signed source $q\le0$, define
+
+$$
+z=1.15\frac{-q}{L/2},
+\qquad
+\beta=z(2-z).
+$$
+
+The dimensionless calibration compensates for the amplitude reduction inherent
+in a negative-power aggregate. The resulting gate is zero on the boundary,
+order one across the interior, scale invariant
+$\beta_{r\Omega}(rx)=\beta_\Omega(x)$, and has no manufactured compact-to-flat
+transition. `method="auto"` and `method="global_r_equivalence"` select this CAD
+gate. `method="compact"` retains the $C^6$ compact transform from A.2.4.2;
+`saturation_fraction` and `linear_fraction` configure only that fallback.
+
+For the signed source convention $q<0$ inside and $\partial_n q=1$ at a regular
+boundary point,
+
+$$
+\partial_n\beta=-\frac{4.6}{L}.
+$$
+
+Derivative hard constraints therefore use
+
+$$
+\psi=-\frac{L}{4.6}\,\beta,
+\qquad
+\psi|_{\partial\Omega}=0,
+\qquad
+\partial_n\psi|_{\partial\Omega}=1,
+\qquad
+\nu=\nabla\psi.
+$$
+
+This constant boundary-jet normalization stays finite throughout the interior.
+The unnormalized extension $\nu$ may vanish at an interior maximum, which is
+smooth and harmless because $\nu=n$ on the boundary. This intentionally avoids
+both a discontinuous everywhere-unit normal extension and the pointwise quotient
+$\beta/\partial_n\beta$, which is singular where the broad gate reaches an
+interior maximum.
+
+For an interval $[a,b]$, Phydrax uses the analytic gate
+$4(x-a)(b-x)/(b-a)^2$. For an axis-aligned hyperrectangle it uses the product
+of these per-axis gates. These exact analytic profiles are dimensionless, smooth,
+equal to one at the box center, and unaffected by mesh-specific `method`,
+`saturation_fraction`, or `linear_fraction` controls. At a genuine sharp CAD edge
+or corner, no globally smooth defining function can also retain a unique nonzero
+normal; those features keep the documented finite pseudoderivative convention.
+
+For mesh-only input, the R-equivalence aggregate is evaluated over a finite
+BVH candidate beam. It is therefore not invariant under retessellation: changing
+facet density can shift interior amplitudes even when the represented surface
+is nearly unchanged. Boundary zeros, sign, and uniform-scale covariance remain
+the enforced contracts. Candidate routing is discrete as well; the negative
+power suppresses omitted distant facets, but Phydrax does not claim a global
+smoothness guarantee across every possible beam-selection change.
 
 ## A.3. Piecewise boundary constraints and blending
 
@@ -372,6 +516,16 @@ In the gated branch, boundary constraints remain satisfied by construction becau
 boundary. The gate is chosen to vanish to sufficiently high order to preserve boundary constraints involving spatial
 derivatives up to a prescribed order.
 
+For boundary labels $\ell$ with constrained derivative order $K_\ell$, the
+implementation uses
+
+$$
+\gamma(x)=\prod_\ell |\beta_\ell(x_\ell)|^{K_\ell+1}.
+$$
+
+The dimensionless base gate $\beta_\ell$ controls conditioning; the exponent
+controls vanishing order and therefore which boundary derivatives are preserved.
+
 **Remark (initial exactness tradeoff).** If the initial-enforcement map produces a candidate with
 $u_{\text{init}}(\cdot,t_0)=g_0(\cdot)$, then on the initial slice:
 
@@ -388,7 +542,9 @@ satisfied approximately away from the boundary (subject to compatibility at $\pa
 
 ### A.6.1. Vanishing-order lemma (derivative preservation)
 
-Let $s$ be a local normal coordinate to $\partial\Omega$ (e.g. $s=\phi(x)$). Consider an update:
+Let $s$ be a local normal coordinate to $\partial\Omega$ (for example,
+$s=\phi(x)$). The base enforcement gate satisfies
+$\beta(x)=\mathcal O(|s|)$ near a regular boundary point. Consider an update:
 
 $$
 u_{\text{new}} = u + \gamma(s)\,(v-u),
@@ -436,30 +592,36 @@ where $y_m$ is represented by an interpolant (e.g. a cubic Hermite spline in tim
 
 ### A.7.2. The protecting gate M(z)
 
-Let boundary constraints for a geometry label $\ell=x$ involve derivatives up to order $K_x$ (e.g. Dirichlet: $K_x=0$,
-Neumann/Robin: $K_x=1$). Let initial constraints fix time derivatives up to order $K_t$.
+Let boundary constraints for a geometry label $\ell=x$ involve derivatives up
+to order $K_x$ (e.g. Dirichlet: $K_x=0$, Neumann/Robin: $K_x=1$). Let initial
+constraints fix time derivatives up to order $K_t$.
 
 Define a gate:
 
 $$
 M(z)
 =
-\Bigl(\prod_{\ell\in\mathcal B} |\phi_\ell(z_\ell)|^{K_\ell+1}\Bigr)
+\Bigl(\prod_{\ell\in\mathcal B}
+|\beta_\ell(z_\ell)|^{K_\ell+1}\Bigr)
 \cdot (\mathop{\text{max}}(t-t_0,0))^{K_t+1},
 $$
 
-with $\mathcal B\subseteq \mathcal L$ the set of geometry labels with boundary constraints and $\phi_\ell$ a signed
-distance–like function for that geometry factor.
+with $\mathcal B\subseteq\mathcal L$ the set of geometry labels with boundary
+constraints and $\beta_\ell$ the dimensionless enforcement gate for that
+geometry factor.
 
-On domains where $t\ge t_0$ identically, $\mathop{\text{max}}(t-t_0,0)=t-t_0$, so this reduces to $(t-t_0)^{K_t+1}$. The $\text{max}$ form
-is convenient to keep $M$ nonnegative and real-valued.
+On domains where $t\ge t_0$ identically,
+$\mathop{\text{max}}(t-t_0,0)=t-t_0$, so this reduces to
+$(t-t_0)^{K_t+1}$. The $\text{max}$ form is convenient to keep $M$
+nonnegative and real-valued.
 
 Key properties:
 
-- $M(z)=0$ on constrained boundary sets (where $\phi_\ell=0$),
+- $M(z)=0$ on constrained boundary sets (where $\beta_\ell=0$),
 - $M(z)=0$ on the initial slice $t=t_0$,
-- $M$ vanishes to high enough order so that derivatives of $M(\cdot)h(\cdot)$ up to the constrained orders also vanish
-  on those sets (formalized below).
+- $M$ vanishes to high enough order so that derivatives of
+  $M(\cdot)h(\cdot)$ up to the constrained orders also vanish on those sets
+  (formalized below).
 
 Anchors/tracks are required to satisfy $M(z_i)>0$; placing an interior anchor on a constrained set is incompatible with
 the goal of preserving those enforced constraints.

--- a/docs/guides_solver.md
+++ b/docs/guides_solver.md
@@ -168,6 +168,24 @@ exactly by construction (rather than penalizing violations).
 Pipelines are applied before any soft constraints are evaluated, so all residuals see the
 post-processed (enforced) fields.
 
+Geometry Dirichlet ansätze and pipeline preservation overlays use a dimensionless
+gate that is broad by default. CAD Neumann, Robin, Sommerfeld, and traction ansätze
+use a dimensional rescaling of the same global R-equivalence profile whose outward
+normal derivative is one. Their interior residuals use the factor gradient as a
+smooth normal extension; it equals the outward unit normal at regular boundary
+points but can vanish at medial sets. Public normal calculations continue to use the
+geometry ADF and normal provider. Select `gate_method="compact"` to use the compact
+Dirichlet and overlay fallback; only then do `gate_saturation_fraction` and
+`gate_linear_fraction` tune its transition. Exact analytic geometry gates ignore
+these mesh-specific controls.
+
+Boundary constraints whose operators contain spatial derivatives must declare
+that order on `SingleFieldEnforcedConstraint` or
+`MultiFieldEnforcedConstraint`. Set `max_derivative_order=0` for Dirichlet
+values and `max_derivative_order=1` for Neumann, Robin, Sommerfeld, or traction
+conditions. Later initial/data overlays are then multiplied by
+$\beta^{K+1}$, preserving boundary derivatives through order $K$.
+
 See [API → Solver → Enforced constraint pipelines](api/solver/enforced_constraints.md) for the pipeline
 types and constructors.
 

--- a/phydrax/constraints/_enforced.py
+++ b/phydrax/constraints/_enforced.py
@@ -18,7 +18,7 @@ from .._bvh import beam_select_leaf_items, build_point_bvh
 from .._callable import _ensure_special_kwonly_args
 from .._doc import DOC_KEY0
 from .._strict import StrictModule
-from ..domain._base import _AbstractGeometry
+from ..domain._base import _AbstractGeometry, EnforcementGateMethod
 from ..domain._components import (
     Boundary,
     DomainComponent,
@@ -35,6 +35,7 @@ from ..operators.differential._domain_ops import (
     cauchy_stress,
     directional_derivative,
     dt,
+    grad,
     partial_n,
 )
 from ..operators.differential._hooks import (
@@ -336,6 +337,35 @@ def _enforced_constraint_weight_fn(
     return _weight_point
 
 
+def _boundary_ansatz_factor(
+    component: DomainComponent,
+    factor: _AbstractGeometry,
+    *,
+    var: str,
+) -> DomainFunction:
+    return DomainFunction(
+        domain=component.domain,
+        deps=(var,),
+        func=factor.boundary_ansatz_factor,
+        metadata={},
+    )
+
+
+def _boundary_ansatz_normal_extension(
+    psi: DomainFunction,
+    *,
+    var: str,
+    mode: Literal["reverse", "forward"],
+) -> DomainFunction:
+    r"""Return the canonical smooth normal extension $\nu=\nabla\psi$.
+
+    The unit-jet contract for ``psi`` gives $\nu=n$ on every regular boundary
+    point. Unlike an everywhere-normalized nearest-boundary field, ``nu`` may
+    vanish in the interior and therefore need not jump across a medial set.
+    """
+    return grad(psi, var=var, mode=mode)
+
+
 def _reject_filtered_boundary(
     component: DomainComponent,
     /,
@@ -346,7 +376,7 @@ def _reject_filtered_boundary(
     if component.where or component.where_all is not None:
         raise ValueError(
             f"{op_name} cannot directly enforce a filtered Boundary() component "
-            f"for {var!r}: its signed-distance gate vanishes on the full boundary. "
+            f"for {var!r}: its geometry gate vanishes on the full boundary. "
             "Build one ansatz per boundary piece and combine them with enforce_blend."
         )
 
@@ -358,21 +388,28 @@ def enforce_dirichlet(
     *,
     var: str = "x",
     target: DomainFunction | ArrayLike | None = None,
+    gate_method: EnforcementGateMethod = "auto",
+    gate_saturation_fraction: float = 0.5,
+    gate_linear_fraction: float = 0.5,
 ) -> DomainFunction:
     r"""Enforced Dirichlet ansatz enforcing $u=g$ on a component.
 
-    Constructs an ansatz $u^*$ that satisfies the Dirichlet condition exactly on the
-    selected component (boundary or fixed slice). For a geometry boundary with signed
-    distance field $\phi$ (so $\phi=0$ on $\partial\Omega$), this uses
+    For a geometry boundary, this uses a dimensionless enforcement gate $b$ that is
+    zero on $\partial\Omega$ and order one in the interior:
 
     $$
-    u^*(x) = g(x) + \phi(x)\,(u(x) - g(x)),
+    u^*(x) = g(x) + b(x)\,(u(x) - g(x)).
     $$
 
-    which guarantees $u^*(x)=g(x)$ on $\partial\Omega$.
+    The gate is intentionally distinct from the geometry's signed boundary-defining
+    field. Boundary-normal APIs continue to use that geometry field. Derivative hard
+    constraints instead use a dimensional unit-jet factor $\psi$ and its canonical
+    smooth extension $\nu=\nabla\psi$. ``gate_method="auto"`` uses the global
+    R-equivalence gate for CAD geometry; the saturation and linear fractions configure
+    the explicit ``"compact"`` fallback. Exact analytic gates ignore these mesh controls.
 
-    For scalar domains (e.g. time), an appropriate vanishing factor $\phi(t)$ is
-    constructed from $(t-t_0)$, $(t-t_1)$, etc.
+    For scalar domains (e.g. time), an appropriate vanishing factor is constructed
+    directly from $(t-t_0)$, $(t-t_1)$, etc.
     """
     if isinstance(component, DomainComponentUnion):
         raise TypeError(
@@ -406,8 +443,13 @@ def enforce_dirichlet(
             var=var,
             op_name="enforce_dirichlet",
         )
-        phi = component.sdf(var=var)
-        return blend_with_gate(value_fn, u, phi)
+        gate = component.enforcement_gate(
+            method=gate_method,
+            var=var,
+            saturation_fraction=gate_saturation_fraction,
+            linear_fraction=gate_linear_fraction,
+        )
+        return blend_with_gate(value_fn, u, gate)
 
     if isinstance(factor, _AbstractScalarDomain):
         t = DomainFunction(domain=component.domain, deps=(var,), func=_IdentityCallable())
@@ -438,15 +480,19 @@ def enforce_neumann(
 ) -> DomainFunction:
     r"""Enforced Neumann ansatz enforcing $\partial u/\partial n = g$ on a boundary.
 
-    For a geometry boundary with signed distance field $\phi$ and outward normal $n$,
+    For a geometry boundary, let $\psi$ be a dimensional ansatz factor satisfying
+    $\psi=0$ and $\partial_n\psi=1$, and define its canonical interior normal
+    extension $\nu=\nabla\psi$. Because $\nu=n$ on every regular boundary point,
     this constructs
 
     $$
-    u^* = u + \frac{\phi}{\partial\phi/\partial n}\,\bigl(g - \partial u/\partial n\bigr),
+    u^* = u + \psi\,\bigl(g - D_\nu u\bigr),
     $$
 
-    which yields $\partial u^*/\partial n = g$ on $\partial\Omega$ under mild regularity
-    assumptions.
+    which yields $\partial u^*/\partial n = g$ on $\partial\Omega$ under mild
+    regularity assumptions. Unlike an everywhere-normalized nearest-boundary field,
+    $\nu$ can vanish smoothly at medial sets. CAD geometries use the globally
+    conditioned R-equivalence profile for $\psi$ rather than the compact geometry ADF.
     """
     if isinstance(component, DomainComponentUnion):
         raise TypeError(
@@ -467,14 +513,13 @@ def enforce_neumann(
         raise ValueError("enforce_neumann requires component Boundary() for var.")
     _reject_filtered_boundary(component, var=var, op_name="enforce_neumann")
 
-    phi = component.sdf(var=var)
-    n = component.normal(var=var)
+    psi = _boundary_ansatz_factor(component, factor, var=var)
+    normal_extension = _boundary_ansatz_normal_extension(psi, var=var, mode=mode)
 
-    du_dn = directional_derivative(u, n, var=var, mode=mode)
-    dphi_dn = directional_derivative(phi, n, var=var, mode=mode)
+    du_dnu = directional_derivative(u, normal_extension, var=var, mode=mode)
 
     value = 0.0 if target is None else _coerce_value(target, u)
-    out = u + (phi / dphi_dn) * (value - du_dn)
+    out = u + psi * (value - du_dnu)
     return _guard_no_coord_separable(out, var=var, op_name="enforce_neumann")
 
 
@@ -498,8 +543,13 @@ def enforce_traction(
     \sigma(u^*)\,n = t_{\text{target}}
     $$
 
-    on the boundary by adding a displacement correction proportional to the signed
-    distance $\phi$.
+    on the boundary by adding a displacement correction proportional to the
+    dimensional unit-jet ansatz factor $\psi$.
+
+    Interior residuals and decompositions use $\nu=\nabla\psi$ in place of an
+    everywhere-normalized pseudonormal. Since $\nu=n$ on every regular boundary point,
+    this leaves the stated boundary traction unchanged while avoiding artificial
+    medial-set jumps.
 
     Let
 
@@ -522,15 +572,14 @@ def enforce_traction(
     and return the hard-constraint ansatz
 
     $$
-    u^*(x) \;=\; u(x) + \phi(x)\,v(x).
+    u^*(x) \;=\; u(x) + \psi(x)\,v(x).
     $$
 
-    In the idealized setting where $\phi$ is a signed distance field near the boundary
-    (so $\partial\phi/\partial n \approx 1$) and $v$ varies slowly in the normal
-    direction, the induced traction correction is approximately
-    $\sigma(\phi v)\,n \approx \mu\,v_t + (\lambda+2\mu)\,v_n$ (with
-    $v_n=(v\cdot n)\,n$ and $v_t=v-v_n$), making $u^*$ enforce the target traction to
-    first order.
+    Since $\partial\psi/\partial n=1$ on the boundary, when $v$ varies slowly in
+    the normal direction the induced traction correction is approximately
+    $\sigma(\psi v)\,n \approx \mu\,v_t + (\lambda+2\mu)\,v_n$ (with
+    $v_n=(v\cdot n)\,n$ and $v_t=v-v_n$), making $u^*$ enforce the target traction
+    to first order.
     """
     if isinstance(component, DomainComponentUnion):
         raise TypeError(
@@ -551,8 +600,8 @@ def enforce_traction(
         raise ValueError("enforce_traction requires component Boundary() for var.")
     _reject_filtered_boundary(component, var=var, op_name="enforce_traction")
 
-    phi = component.sdf(var=var)
-    n = component.normal(var=var)
+    psi = _boundary_ansatz_factor(component, factor, var=var)
+    normal_extension = _boundary_ansatz_normal_extension(psi, var=var, mode=mode)
 
     if target is None:
         target_val: DomainFunction | ArrayLike = 0.0
@@ -579,17 +628,17 @@ def enforce_traction(
     )
 
     sigma = cauchy_stress(u, lambda_=lambda_fn, mu=mu_fn, var=var, mode=mode)
-    traction = einsum("...ij,...j->...i", sigma, n)
+    traction = einsum("...ij,...j->...i", sigma, normal_extension)
 
     r = target_fn - traction
-    r_dot_n = einsum("...i,...i->...", r, n)
-    r_n = einsum("...,...i->...i", r_dot_n, n)
+    r_dot_n = einsum("...i,...i->...", r, normal_extension)
+    r_n = einsum("...,...i->...i", r_dot_n, normal_extension)
     r_t = r - r_n
 
     denom_n = lambda_fn + 2.0 * mu_fn
     v = (r_t / mu_fn) + (r_n / denom_n)
 
-    out = u + phi * v
+    out = u + psi * v
     return _guard_no_coord_separable(out, var=var, op_name="enforce_traction")
 
 
@@ -606,20 +655,18 @@ def enforce_robin(
 ) -> DomainFunction:
     r"""Enforced Robin ansatz enforcing $a\,u + b\,\partial u/\partial n = g$.
 
-    On a geometry boundary, this constructs a corrected field that satisfies the Robin
-    condition exactly by using a signed distance factor $\phi$ and normal derivative
-    of $\phi$.
-
-    Let $r = g - a\,u - b\,\partial u/\partial n$ be the residual. With signed distance
-    field $\phi$ and outward normal $n$, define $d\phi/dn = \partial\phi/\partial n$.
-    The returned ansatz is
+    On a geometry boundary, let $\psi$ be a dimensional ansatz factor satisfying
+    $\psi=0$ and $\partial_n\psi=1$, and let $\nu=\nabla\psi$. Define the
+    extended residual $r=g-a\,u-b\,D_\nu u$. Since $\nu=n$ on the boundary, the
+    returned ansatz
 
     $$
-    u^* \;=\; u + \frac{\phi}{b\,(\partial\phi/\partial n)}\,r,
+    u^* \;=\; u + \frac{\psi}{b}\,r
     $$
 
-    which yields $a\,u^* + b\,\partial u^*/\partial n = g$ on $\partial\Omega$ under
-    mild regularity assumptions.
+    yields $a\,u^* + b\,\partial u^*/\partial n = g$ on $\partial\Omega$ under
+    mild regularity assumptions, without requiring a discontinuous unit-normal
+    extension in the interior.
     """
     if isinstance(component, DomainComponentUnion):
         raise TypeError(
@@ -650,10 +697,9 @@ def enforce_robin(
         if b_val.shape == () and float(b_val) == 0.0:
             return enforce_dirichlet(u, component, var=var, target=g / a)
 
-    phi = component.sdf(var=var)
-    n = component.normal(var=var)
-    du_dn = directional_derivative(u, n, var=var, mode=mode)
-    dphi_dn = directional_derivative(phi, n, var=var, mode=mode)
+    psi = _boundary_ansatz_factor(component, factor, var=var)
+    normal_extension = _boundary_ansatz_normal_extension(psi, var=var, mode=mode)
+    du_dnu = directional_derivative(u, normal_extension, var=var, mode=mode)
 
     if isinstance(a, DomainFunction):
         a_fn = a
@@ -669,8 +715,8 @@ def enforce_robin(
     else:
         g_fn = DomainFunction(domain=u.domain, deps=(), func=g, metadata={})
 
-    r = g_fn - a_fn * u - b_fn * du_dn
-    out = u + (phi / (b_fn * dphi_dn)) * r
+    r = g_fn - a_fn * u - b_fn * du_dnu
+    out = u + (psi / b_fn) * r
     return _guard_no_coord_separable(out, var=var, op_name="enforce_robin")
 
 
@@ -693,22 +739,22 @@ def enforce_sommerfeld(
     \frac{\partial u}{\partial n} + \frac{1}{c}\frac{\partial u}{\partial t} = g
     $$
 
-    on the selected boundary component by correcting $u$ using a signed-distance factor.
-
-    With signed distance field $\phi$ and $d\phi/dn = \partial\phi/\partial n$, let
+    on the selected boundary component using a dimensional ansatz factor $\psi$
+    satisfying $\psi=0$ and $\partial_n\psi=1$. With the smooth interior extension
+    $\nu=\nabla\psi$, let
 
     $$
-    r = g - \frac{\partial u}{\partial n} - \frac{1}{c}\frac{\partial u}{\partial t}.
+    r = g - D_\nu u - \frac{1}{c}\frac{\partial u}{\partial t}.
     $$
 
     The returned ansatz is
 
     $$
-    u^* \;=\; u + \frac{\phi}{\partial\phi/\partial n}\,r,
+    u^* \;=\; u + \psi\,r,
     $$
 
-    which yields the Sommerfeld condition on $\partial\Omega$ under the same
-    assumptions as `enforce_neumann`.
+    which yields the Sommerfeld condition on $\partial\Omega$ because $\nu=n$
+    there, under the same assumptions as `enforce_neumann`.
     """
     if isinstance(component, DomainComponentUnion):
         raise TypeError(
@@ -731,11 +777,10 @@ def enforce_sommerfeld(
         raise ValueError("enforce_sommerfeld requires component Boundary() for var.")
     _reject_filtered_boundary(component, var=var, op_name="enforce_sommerfeld")
 
-    phi = component.sdf(var=var)
-    n = component.normal(var=var)
-    du_dn = directional_derivative(u, n, var=var, mode=mode)
+    psi = _boundary_ansatz_factor(component, factor, var=var)
+    normal_extension = _boundary_ansatz_normal_extension(psi, var=var, mode=mode)
+    du_dnu = directional_derivative(u, normal_extension, var=var, mode=mode)
     du_dt = dt(u, var=time_var, mode=mode)
-    dphi_dn = directional_derivative(phi, n, var=var, mode=mode)
 
     c = 1.0 if wavespeed is None else _coerce_value(wavespeed, u)
     g = 0.0 if target is None else _coerce_value(target, u)
@@ -749,8 +794,8 @@ def enforce_sommerfeld(
     else:
         g_fn = DomainFunction(domain=u.domain, deps=(), func=g, metadata={})
 
-    r = g_fn - du_dn - (1.0 / c_fn) * du_dt
-    out = u + (phi / dphi_dn) * r
+    r = g_fn - du_dnu - (1.0 / c_fn) * du_dt
+    out = u + psi * r
     return _guard_no_coord_separable(out, var=var, op_name="enforce_sommerfeld")
 
 

--- a/phydrax/domain/__init__.py
+++ b/phydrax/domain/__init__.py
@@ -43,7 +43,7 @@ from . import (
     geometry3d,
     graph,
 )
-from ._base import GeometryTransitionKind, GeometryTransitionResult
+from ._base import EnforcementGateMethod, GeometryTransitionKind, GeometryTransitionResult
 from ._chart import CADChartAtlas
 from ._components import (
     Boundary,
@@ -151,6 +151,7 @@ __all__ = [
     "geometry3d",
     # time domain
     "ScalarInterval",
+    "EnforcementGateMethod",
     "GeometryTransitionKind",
     "GeometryTransitionResult",
     "TimeInterval",

--- a/phydrax/domain/_base.py
+++ b/phydrax/domain/_base.py
@@ -3,6 +3,7 @@
 #
 
 import functools as ft
+import math
 from abc import abstractmethod
 from collections.abc import Callable, Sequence
 from typing import Literal, TypeAlias
@@ -17,6 +18,16 @@ from .._strict import AbstractAttribute, StrictModule
 from ._domain import _AbstractUnaryDomain
 
 
+EnforcementGateMethod: TypeAlias = Literal[
+    "auto",
+    "global_r_equivalence",
+    "compact",
+]
+
+_GLOBAL_GATE_CALIBRATION = 1.15
+_GLOBAL_GATE_BOUNDARY_SLOPE = 4.0 * _GLOBAL_GATE_CALIBRATION
+
+
 GeometryTransitionKind: TypeAlias = Literal[
     "unsupported",
     "interval_reflection",
@@ -25,6 +36,83 @@ GeometryTransitionKind: TypeAlias = Literal[
     "mesh_walk",
     "chart_retraction",
 ]
+
+
+def _validate_enforcement_gate_fractions(
+    saturation_fraction: float,
+    linear_fraction: float,
+) -> tuple[float, float]:
+    saturation = float(saturation_fraction)
+    linear = float(linear_fraction)
+    if not math.isfinite(saturation) or not 0.0 < saturation <= 0.5:
+        raise ValueError(
+            "saturation_fraction must be finite and in the interval (0, 0.5]."
+        )
+    if not math.isfinite(linear) or not 0.0 < linear < 1.0:
+        raise ValueError(
+            "linear_fraction must be finite and strictly between zero and one."
+        )
+    return saturation, linear
+
+
+def _make_compact_enforcement_gate(
+    distance: Callable[[Array], Array],
+    *,
+    scale: float,
+    saturation_fraction: float,
+    linear_fraction: float,
+) -> Callable[[Array], Array]:
+    from .geometry3d._sdf import make_compact_boundary_factor
+
+    compact = make_compact_boundary_factor(
+        distance,
+        scale=scale,
+        saturation_fraction=saturation_fraction,
+        linear_fraction=linear_fraction,
+    )
+    plateau = (
+        saturation_fraction * scale * (linear_fraction + 0.5 * (1.0 - linear_fraction))
+    )
+
+    def gate(points: Array) -> Array:
+        return -compact(points) / plateau
+
+    return jax.jit(gate)
+
+
+def _make_global_enforcement_gate(
+    distance: Callable[[Array], Array],
+    *,
+    scale: float,
+) -> Callable[[Array], Array]:
+    """Map a smooth signed distance source to a broad dimensionless gate."""
+    half_span = jnp.asarray(0.5 * scale, dtype=float)
+
+    def gate(points: Array) -> Array:
+        coordinate = -_GLOBAL_GATE_CALIBRATION * distance(points) / half_span
+        interior = coordinate * (2.0 - coordinate)
+        exterior = 2.0 * coordinate / (1.0 + jnp.abs(coordinate))
+        return jnp.where(coordinate >= 0.0, interior, exterior)
+
+    return jax.jit(gate)
+
+
+def _make_global_boundary_ansatz_factor(
+    distance: Callable[[Array], Array],
+    *,
+    scale: float,
+) -> Callable[[Array], Array]:
+    r"""Build a dimensional global gate with outward unit boundary derivative."""
+    gate = _make_global_enforcement_gate(distance, scale=scale)
+    coefficient = jnp.asarray(
+        -float(scale) / _GLOBAL_GATE_BOUNDARY_SLOPE,
+        dtype=float,
+    )
+
+    def factor(points: Array) -> Array:
+        return coefficient * gate(points)
+
+    return jax.jit(factor)
 
 
 class GeometryTransitionResult(StrictModule):
@@ -63,7 +151,13 @@ class GeometryTransitionResult(StrictModule):
 
 
 class _AbstractGeometry(_AbstractUnaryDomain):
-    """Abstract (spatial) geometry."""
+    """Abstract spatial geometry.
+
+    ``adf`` is the signed boundary-defining factor used by differentiable geometry
+    consumers and normal construction. ``boundary_ansatz_factor`` is the dimensional
+    unit-boundary-jet field used by derivative hard constraints; CAD implementations
+    may give it a smoother global interior profile than ``adf``.
+    """
 
     adf: AbstractAttribute[Callable[[Array], Array]]
 
@@ -88,6 +182,78 @@ class _AbstractGeometry(_AbstractUnaryDomain):
     @property
     def var_dim(self) -> int:
         return int(self.spatial_dim)
+
+    @property
+    def enforcement_characteristic_length(self) -> float:
+        """Shortest bounding-box span used to scale a dimensionless solver gate."""
+        bounds = jnp.asarray(self.bounds, dtype=float)
+        widths = bounds[1] - bounds[0]
+        length = float(jnp.min(widths))
+        if not math.isfinite(length) or length <= 0.0:
+            raise ValueError(
+                f"{type(self).__name__} must have a finite positive bounding-box span."
+            )
+        return length
+
+    @property
+    def boundary_ansatz_factor(self) -> Callable[[Array], Array]:
+        r"""Dimensional vanishing factor with outward unit boundary derivative.
+
+        The default is ``adf``. CAD geometries override it with a globally smooth
+        R-equivalence profile while retaining the same boundary zero and first jet.
+        """
+        return self.adf
+
+    def make_enforcement_gate(
+        self,
+        *,
+        method: EnforcementGateMethod = "auto",
+        saturation_fraction: float = 0.5,
+        linear_fraction: float = 0.5,
+    ) -> Callable[[Array], Array]:
+        r"""Build a dimensionless, optimization-conditioned Dirichlet gate.
+
+        The gate is zero on the boundary, positive inside, and order one away from
+        it. It is deliberately separate from ``adf`` and
+        ``boundary_ansatz_factor``: boundary-normal APIs use ``adf``, while derivative
+        hard constraints use the dimensional unit-jet ansatz factor and its gradient.
+        ``method="auto"`` selects an exact analytic gate when available and the global
+        R-equivalence gate for CAD meshes. Analytic builders retain their fixed exact
+        profiles; ``method`` and the profile fractions control CAD or generic fallbacks.
+        """
+        saturation, linear = _validate_enforcement_gate_fractions(
+            saturation_fraction, linear_fraction
+        )
+        if method not in ("auto", "global_r_equivalence", "compact"):
+            raise ValueError(
+                "method must be 'auto', 'global_r_equivalence', or 'compact', "
+                f"got {method!r}."
+            )
+        builder = self._enforcement_gate_builder
+        if builder is not None:
+            return builder(
+                method=method,
+                saturation_fraction=saturation,
+                linear_fraction=linear,
+            )
+        if method == "global_r_equivalence":
+            return _make_global_enforcement_gate(
+                self.adf,
+                scale=self.enforcement_characteristic_length,
+            )
+        return _make_compact_enforcement_gate(
+            self.adf,
+            scale=self.enforcement_characteristic_length,
+            saturation_fraction=saturation,
+            linear_fraction=linear,
+        )
+
+    @property
+    def _enforcement_gate_builder(
+        self,
+    ) -> Callable[..., Callable[[Array], Array]] | None:
+        """Return an optional geometry-specific gate builder."""
+        return None
 
     @property
     @abstractmethod
@@ -215,9 +381,9 @@ class _AbstractGeometry(_AbstractUnaryDomain):
             crossing = current + lower[:, None] * remaining
             normal = normal_batch(crossing)
             tail = (1.0 - lower)[:, None] * remaining
-            reflected_tail = tail - 2.0 * jnp.sum(
-                tail * normal, axis=1, keepdims=True
-            ) * normal
+            reflected_tail = (
+                tail - 2.0 * jnp.sum(tail * normal, axis=1, keepdims=True) * normal
+            )
             inside_crossing = crossing - inset * normal
             current = jnp.where(outside[:, None], inside_crossing, proposed)
             remaining = jnp.where(outside[:, None], reflected_tail, 0.0)
@@ -267,10 +433,14 @@ class _AbstractGeometry(_AbstractUnaryDomain):
 
         gradient = gradients(pts)
         norm_sq = jnp.sum(gradient * gradient, axis=1, keepdims=True)
-        tangent = delta - (
-            jnp.sum(delta * gradient, axis=1, keepdims=True)
-            / jnp.maximum(norm_sq, jnp.finfo(pts.dtype).eps)
-        ) * gradient
+        tangent = (
+            delta
+            - (
+                jnp.sum(delta * gradient, axis=1, keepdims=True)
+                / jnp.maximum(norm_sq, jnp.finfo(pts.dtype).eps)
+            )
+            * gradient
+        )
         retracted = pts + tangent
         proposed = retracted
         for _ in range(6):

--- a/phydrax/domain/_components.py
+++ b/phydrax/domain/_components.py
@@ -25,7 +25,7 @@ from .._sampling import (
     SampleAddress,
 )
 from .._strict import StrictModule
-from ._base import _AbstractGeometry
+from ._base import _AbstractGeometry, EnforcementGateMethod
 from ._dataset import DatasetDomain
 from ._domain import _AbstractDomain, RelabeledDomain
 from ._function import DomainFunction
@@ -205,6 +205,53 @@ class _SdfCallable(StrictModule):
         pts = pts_in.reshape((-1, d))
         sdf = self.geom.adf(pts)
         return jnp.asarray(sdf, dtype=float).reshape(pts_in.shape[:-1])
+
+
+class _EnforcementGateCallable(StrictModule):
+    gate: Callable[[Array], Array]
+    dim: int
+
+    def __init__(
+        self,
+        geom: _AbstractGeometry,
+        *,
+        method: EnforcementGateMethod,
+        saturation_fraction: float,
+        linear_fraction: float,
+    ):
+        self.gate = geom.make_enforcement_gate(
+            method=method,
+            saturation_fraction=saturation_fraction,
+            linear_fraction=linear_fraction,
+        )
+        self.dim = int(geom.var_dim)
+
+    def __call__(self, x: Any, /, *, key=None, **kwargs: Any) -> Array:
+        del key, kwargs
+        if isinstance(x, tuple):
+            coords = tuple(jnp.asarray(c, dtype=float).reshape((-1,)) for c in x)
+            if len(coords) != self.dim:
+                raise ValueError(
+                    "coord-separable enforcement gate expects "
+                    f"{self.dim} coordinate arrays, got {len(coords)}."
+                )
+            grid = broadcasted_grid(coords)
+            points = grid.reshape((-1, self.dim))
+            values = self.gate(points)
+            return jnp.asarray(values, dtype=float).reshape(grid.shape[:-1])
+
+        points_in = jnp.asarray(x, dtype=float)
+        if points_in.ndim == 0:
+            if self.dim != 1:
+                raise ValueError("Expected a geometry point with shape (..., dim).")
+            return jnp.asarray(self.gate(points_in.reshape(())), dtype=float).reshape(())
+        if points_in.ndim == 1:
+            return jnp.asarray(self.gate(points_in), dtype=float)
+        if points_in.shape[-1] != self.dim:
+            raise ValueError("Expected a geometry point with shape (..., dim).")
+        points = points_in.reshape((-1, self.dim))
+        values = self.gate(points)
+        return jnp.asarray(values, dtype=float).reshape(points_in.shape[:-1])
 
 
 def _sample_geometry(
@@ -1281,13 +1328,17 @@ class DomainComponent(StrictModule):
         )
 
     def sdf(self, /, *, var: str) -> DomainFunction:
-        r"""Return a `DomainFunction` for the signed distance field $\phi(x)$.
+        r"""Return the geometry's signed boundary-defining field $\phi(x)$.
 
-        The sign convention is geometry-dependent but typically:
+        The field preserves the geometry zero set and uses the convention
 
         - $\phi(x) < 0$ inside $\Omega$,
         - $\phi(x) = 0$ on $\partial\Omega$,
         - $\phi(x) > 0$ outside $\Omega$.
+
+        Its magnitude is not guaranteed to equal metric distance away from the
+        boundary. CAD geometries compactly saturate this geometry field; derivative
+        hard constraints use their separately conditioned unit-jet ansatz factor.
         """
         if var not in self.domain.labels:
             raise KeyError(f"Label {var!r} not in domain {self.domain.labels}.")
@@ -1301,6 +1352,51 @@ class DomainComponent(StrictModule):
             )
 
         return DomainFunction(domain=self.domain, deps=(var,), func=_SdfCallable(factor))
+
+    def enforcement_gate(
+        self,
+        /,
+        *,
+        method: EnforcementGateMethod = "auto",
+        var: str,
+        saturation_fraction: float = 0.5,
+        linear_fraction: float = 0.5,
+    ) -> DomainFunction:
+        r"""Return a dimensionless gate for optimization-conditioned hard constraints.
+
+        The gate is zero on the selected geometry boundary and positive, typically
+        order one, in the interior. Unlike :meth:`sdf`, it is not used to define
+        normals or derivative boundary conditions.
+        """
+        if var not in self.domain.labels:
+            raise KeyError(f"Label {var!r} not in domain {self.domain.labels}.")
+
+        component = self.spec.component_for(var)
+        if not isinstance(component, Boundary):
+            raise ValueError(
+                "DomainComponent.enforcement_gate is only defined for Boundary() "
+                "components."
+            )
+
+        factor = self.domain.factor(var)
+        if isinstance(factor, RelabeledDomain):
+            factor = factor.base
+        if not isinstance(factor, _AbstractGeometry):
+            raise TypeError(
+                "enforcement_gate(var=...) requires a geometry label, "
+                f"got {type(factor).__name__}."
+            )
+
+        return DomainFunction(
+            domain=self.domain,
+            deps=(var,),
+            func=_EnforcementGateCallable(
+                factor,
+                method=method,
+                saturation_fraction=saturation_fraction,
+                linear_fraction=linear_fraction,
+            ),
+        )
 
 
 class DomainComponentUnion(StrictModule):

--- a/phydrax/domain/_hyperrectangle.py
+++ b/phydrax/domain/_hyperrectangle.py
@@ -12,7 +12,7 @@ from jaxtyping import Array, ArrayLike, Bool, Float, Key
 
 from .._doc import DOC_KEY0
 from .._sampling import get_sampler_host, seed_from_key
-from ._base import _AbstractGeometry, GeometryTransitionKind
+from ._base import _AbstractGeometry, EnforcementGateMethod, GeometryTransitionKind
 from ._grid import broadcasted_grid
 from ._structure import _validate_label
 
@@ -69,6 +69,30 @@ class HyperRectangle(_AbstractGeometry):
     @property
     def adf(self) -> Callable[[Array], Array]:
         return self._adf
+
+    @property
+    def _enforcement_gate_builder(
+        self,
+    ) -> Callable[..., Callable[[Array], Array]]:
+        return self._make_enforcement_gate
+
+    def _make_enforcement_gate(
+        self,
+        *,
+        method: EnforcementGateMethod = "auto",
+        saturation_fraction: float = 0.5,
+        linear_fraction: float = 0.5,
+    ) -> Callable[[Array], Array]:
+        """Build the analytic dimensionless product gate for a box."""
+        widths = self.upper - self.lower
+
+        def gate(points: Array) -> Array:
+            pts, single = self._points_2d(points)
+            axis_gates = 4.0 * (pts - self.lower) * (self.upper - pts) / (widths * widths)
+            values = jnp.prod(axis_gates, axis=-1)
+            return values[0] if single else values
+
+        return jax.jit(gate)
 
     @property
     def spatial_dim(self) -> int:

--- a/phydrax/domain/geometry1d/_primitives.py
+++ b/phydrax/domain/geometry1d/_primitives.py
@@ -12,6 +12,7 @@ from jaxtyping import Array, ArrayLike, Bool, Float, Key
 
 from ..._doc import DOC_KEY0
 from ..._sampling import get_sampler_host, seed_from_key
+from .._base import EnforcementGateMethod
 from ._base import _AbstractGeometry1D
 
 
@@ -47,6 +48,31 @@ class Interval1d(_AbstractGeometry1D):
     @property
     def adf(self) -> Callable[[Array], Array]:
         return self._adf
+
+    @property
+    def _enforcement_gate_builder(
+        self,
+    ) -> Callable[..., Callable[[Array], Array]]:
+        return self._make_enforcement_gate
+
+    def _make_enforcement_gate(
+        self,
+        *,
+        method: EnforcementGateMethod = "auto",
+        saturation_fraction: float = 0.5,
+        linear_fraction: float = 0.5,
+    ) -> Callable[[Array], Array]:
+        """Build the interval's fixed analytic dimensionless gate.
+
+        The interval has an exact smooth gate, so mesh-specific method and profile
+        controls do not alter it.
+        """
+        del method, saturation_fraction, linear_fraction
+
+        def gate(points: Array) -> Array:
+            return -4.0 * self.adf(points) / self.length
+
+        return jax.jit(gate)
 
     @property
     def length(self) -> Array:
@@ -219,11 +245,11 @@ class Interval1d(_AbstractGeometry1D):
         return jnp.where(pts < midpoint, -jnp.ones_like(pts), jnp.ones_like(pts))
 
     def _adf(self, points: Array) -> Array:
-        """Signed distance to the interval [start, end].
+        """Smooth signed boundary-defining field for ``[start, end]``.
 
-        Negative inside the interval, 0 on the boundary, positive outside.
-        Uses a parabolic surrogate with unit slope at the
-        endpoints.
+        The field is negative inside, zero at both endpoints, and positive outside,
+        with outward unit derivative at the endpoints. It is not the exact distance:
+        its parabolic interior deliberately remains differentiable at the midpoint.
         """
         x = jnp.asarray(points, dtype=float)
         a = self.start

--- a/phydrax/domain/geometry2d/_from_cad.py
+++ b/phydrax/domain/geometry2d/_from_cad.py
@@ -21,10 +21,17 @@ import trimesh
 from jaxtyping import Array, ArrayLike, Bool, Float, Key
 
 from ..._doc import DOC_KEY0
+from ..._sampling import get_sampler_host, seed_from_key
+from .._base import (
+    _make_compact_enforcement_gate,
+    _make_global_boundary_ansatz_factor,
+    _make_global_enforcement_gate,
+    EnforcementGateMethod,
+)
 from .._chart import CADChartAtlas
 from .._measure_partition import GeometryMeasurePartition
-from ..._sampling import get_sampler_host, seed_from_key
 from ..geometry3d._mesh import Geometry3DFromCAD
+from ..geometry3d._sdf import make_compact_boundary_factor
 from ..geometry3d._utils import (
     _boolean_mesh,
     _canonicalize_mesh_arrays,
@@ -44,8 +51,11 @@ class Geometry2DFromCAD(_AbstractGeometry2D):
     - interior points $x\in\Omega$ by sampling triangles proportional to their area;
     - boundary points $x\in\partial\Omega$ by sampling edges proportional to length.
 
-    The geometry also provides a smooth signed distance-like function $\phi(x)$ (via
-    `adf`) that is used for containment tests and for estimating normals when needed.
+    `predicate_sdf` supplies signed classification values. `boundary_factor` (also
+    exposed as `adf`) supplies the compact dimensional field used by geometry
+    operations. `boundary_ansatz_factor` supplies the globally conditioned,
+    dimensional unit-jet field for derivative hard constraints, and
+    `make_enforcement_gate` supplies the dimensionless Dirichlet and overlay gate.
     """
 
     mesh: meshio.Mesh
@@ -65,6 +75,8 @@ class Geometry2DFromCAD(_AbstractGeometry2D):
     interior_measure_partition: GeometryMeasurePartition
     boundary_measure_partition: GeometryMeasurePartition
     boundary_chart_atlas: CADChartAtlas
+    predicate_sdf: Callable[[Array], Array]
+    boundary_factor: Callable[[Array], Array]
     adf: Callable[[Array], Array]
 
     def __init__(
@@ -128,7 +140,55 @@ class Geometry2DFromCAD(_AbstractGeometry2D):
         )
         self.boundary_chart_atlas = CADChartAtlas(self.boundary_measure_partition)
 
-        self.adf = self.adf_blur(self.adf_orig, radius_fn=self.adf_orig)
+        self.predicate_sdf = self.adf_orig
+        self.boundary_factor = make_compact_boundary_factor(
+            self.predicate_sdf,
+            scale=self.diameter,
+        )
+        self.adf = self.boundary_factor
+
+    @cached_property
+    def _enforcement_distance(self) -> Callable[[Array], Array]:
+        """R-equivalent distance source with an exact local boundary collar."""
+        length = self.enforcement_characteristic_length
+        return self._make_smooth_mesh_sdf(
+            squash=False,
+            r0=0.25 * length,
+            equivalence_power=12.0,
+        )
+
+    @cached_property
+    def boundary_ansatz_factor(self) -> Callable[[Array], Array]:
+        """Globally conditioned CAD factor with an outward unit boundary jet."""
+        return _make_global_boundary_ansatz_factor(
+            self._enforcement_distance,
+            scale=self.enforcement_characteristic_length,
+        )
+
+    @property
+    def _enforcement_gate_builder(
+        self,
+    ) -> Callable[..., Callable[[Array], Array]]:
+        return self._make_enforcement_gate
+
+    def _make_enforcement_gate(
+        self,
+        *,
+        method: EnforcementGateMethod,
+        saturation_fraction: float,
+        linear_fraction: float,
+    ) -> Callable[[Array], Array]:
+        if method == "compact":
+            return _make_compact_enforcement_gate(
+                self._enforcement_distance,
+                scale=self.enforcement_characteristic_length,
+                saturation_fraction=saturation_fraction,
+                linear_fraction=linear_fraction,
+            )
+        return _make_global_enforcement_gate(
+            self._enforcement_distance,
+            scale=self.enforcement_characteristic_length,
+        )
 
     @cached_property
     def _mesh_signature(self) -> tuple[np.ndarray, np.ndarray]:
@@ -168,6 +228,7 @@ class Geometry2DFromCAD(_AbstractGeometry2D):
         beam_steps: int | None = None,
         r0: float | None = None,
         rho_delta: float | None = None,
+        equivalence_power: float | None = None,
         squash: bool = True,
     ) -> Callable[[Array], Array]:
         sdf_3d = self.geom_3d_extruded._make_smooth_mesh_sdf(
@@ -177,6 +238,7 @@ class Geometry2DFromCAD(_AbstractGeometry2D):
             beam_steps=beam_steps,
             r0=r0,
             rho_delta=rho_delta,
+            equivalence_power=equivalence_power,
             squash=squash,
         )
         z0 = jnp.asarray(self.diameter * 2.0, dtype=float)
@@ -218,7 +280,7 @@ class Geometry2DFromCAD(_AbstractGeometry2D):
 
     @cached_property
     def adf_orig(self) -> Callable[[Array], Array]:
-        """Unsquashed smooth distance (returns `d` before tanh saturation)."""
+        """Unsquashed smooth distance-like source used by geometric predicates."""
         return self._make_smooth_mesh_sdf(squash=False)
 
     def adf_blur(
@@ -447,8 +509,7 @@ class Geometry2DFromCAD(_AbstractGeometry2D):
         squared_distances = x_diff**2 + y_diff**2
 
         max_squared_distance = np.max(squared_distances)
-        max_distance = np.sqrt(max_squared_distance + np.finfo(float).eps)
-        return max_distance
+        return float(np.sqrt(max_squared_distance))
 
     @cached_property
     def _geom_3d_extruded(self):

--- a/phydrax/domain/geometry3d/_mesh.py
+++ b/phydrax/domain/geometry3d/_mesh.py
@@ -17,6 +17,12 @@ import trimesh
 from jaxtyping import Array, ArrayLike, Bool, Float, Key
 
 from ..._doc import DOC_KEY0
+from .._base import (
+    _make_compact_enforcement_gate,
+    _make_global_boundary_ansatz_factor,
+    _make_global_enforcement_gate,
+    EnforcementGateMethod,
+)
 from .._chart import CADChartAtlas
 from .._measure_partition import GeometryMeasurePartition
 from ._base import _AbstractGeometry3D
@@ -37,8 +43,11 @@ class Geometry3DFromCAD(_AbstractGeometry3D):
     - boundary points $x\in\partial\Omega$ by sampling triangles proportional to their area;
     - interior points $x\in\Omega$ via mesh-based strategies (see `sample_interior`).
 
-    A smooth signed distance-like function $\phi(x)$ is provided via `adf`, and is
-    used for containment tests and for estimating boundary normals.
+    `predicate_sdf` supplies signed classification values. `boundary_factor` (also
+    exposed as `adf`) supplies the compact dimensional field used by geometry
+    operations. `boundary_ansatz_factor` supplies the globally conditioned,
+    dimensional unit-jet field for derivative hard constraints, and
+    `make_enforcement_gate` supplies the dimensionless Dirichlet and overlay gate.
     """
 
     mesh: trimesh.Trimesh
@@ -51,6 +60,8 @@ class Geometry3DFromCAD(_AbstractGeometry3D):
     volume_proportion: Array
     boundary_measure_partition: GeometryMeasurePartition
     boundary_chart_atlas: CADChartAtlas
+    predicate_sdf: Callable[[Array], Array]
+    boundary_factor: Callable[[Array], Array]
     adf: Callable[[Array], Array]
     _boundary_normals_field: Callable[[Array], Array]
 
@@ -93,10 +104,60 @@ class Geometry3DFromCAD(_AbstractGeometry3D):
             self.mesh.volume / np.prod(bounds), dtype=float
         )
 
-        self.adf = self.adf_blur(self.adf_orig, radius_fn=self.adf_orig)
+        from ._sdf import make_compact_boundary_factor
+
+        self.predicate_sdf = self.adf_orig
+        self.boundary_factor = make_compact_boundary_factor(
+            self.predicate_sdf,
+            scale=self.diameter,
+        )
+        self.adf = self.boundary_factor
         from ._normals import make_smooth_mesh_normal_field
 
         self._boundary_normals_field = make_smooth_mesh_normal_field(self)
+
+    @ft.cached_property
+    def _enforcement_distance(self) -> Callable[[Array], Array]:
+        """R-equivalent distance source with an exact local boundary collar."""
+        length = self.enforcement_characteristic_length
+        return self._make_smooth_mesh_sdf(
+            squash=False,
+            r0=0.25 * length,
+            equivalence_power=12.0,
+        )
+
+    @ft.cached_property
+    def boundary_ansatz_factor(self) -> Callable[[Array], Array]:
+        """Globally conditioned CAD factor with an outward unit boundary jet."""
+        return _make_global_boundary_ansatz_factor(
+            self._enforcement_distance,
+            scale=self.enforcement_characteristic_length,
+        )
+
+    @property
+    def _enforcement_gate_builder(
+        self,
+    ) -> Callable[..., Callable[[Array], Array]]:
+        return self._make_enforcement_gate
+
+    def _make_enforcement_gate(
+        self,
+        *,
+        method: EnforcementGateMethod,
+        saturation_fraction: float,
+        linear_fraction: float,
+    ) -> Callable[[Array], Array]:
+        if method == "compact":
+            return _make_compact_enforcement_gate(
+                self._enforcement_distance,
+                scale=self.enforcement_characteristic_length,
+                saturation_fraction=saturation_fraction,
+                linear_fraction=linear_fraction,
+            )
+        return _make_global_enforcement_gate(
+            self._enforcement_distance,
+            scale=self.enforcement_characteristic_length,
+        )
 
     @ft.cached_property
     def _mesh_signature(self) -> tuple[np.ndarray, np.ndarray]:
@@ -119,14 +180,14 @@ class Geometry3DFromCAD(_AbstractGeometry3D):
 
     @ft.cached_property
     def adf_alt(self) -> Callable[[Array], Array]:
-        """Alternative ADF using an exact BVH traversal for the `d_exact` term."""
+        """Legacy original-coordinate ADF retained for diagnostics."""
         from ._sdf import make_smooth_mesh_sdf_alt
 
         return make_smooth_mesh_sdf_alt(self)
 
     @ft.cached_property
     def adf_orig(self) -> Callable[[Array], Array]:
-        """Unsquashed smooth distance (returns `d` before tanh saturation)."""
+        """Unsquashed smooth distance-like source used by geometric predicates."""
         from ._sdf import make_smooth_mesh_sdf
 
         return make_smooth_mesh_sdf(self, squash=False)
@@ -298,6 +359,7 @@ class Geometry3DFromCAD(_AbstractGeometry3D):
         beam_steps: int | None = None,
         r0: float | None = None,
         rho_delta: float | None = None,
+        equivalence_power: float | None = None,
         squash: bool = True,
     ) -> Callable[[jnp.ndarray], jnp.ndarray]:
         from ._sdf import make_smooth_mesh_sdf
@@ -310,6 +372,7 @@ class Geometry3DFromCAD(_AbstractGeometry3D):
             beam_steps=beam_steps,
             r0=r0,
             rho_delta=rho_delta,
+            equivalence_power=equivalence_power,
             squash=squash,
         )
 
@@ -348,7 +411,7 @@ class Geometry3DFromCAD(_AbstractGeometry3D):
         z_diff = verts[:, None, 2] - verts[None, :, 2]
         squared_distances = x_diff**2 + y_diff**2 + z_diff**2
         max_squared_distance = jnp.max(squared_distances)
-        return jnp.sqrt(max_squared_distance + jnp.finfo(float).eps).item()
+        return jnp.sqrt(max_squared_distance).item()
 
     def _boundary_normals_orig_nograd(
         self, points: Array

--- a/phydrax/domain/geometry3d/_sdf.py
+++ b/phydrax/domain/geometry3d/_sdf.py
@@ -55,7 +55,20 @@ class _MeshSDFImpl:
         V_in = jnp.asarray(self.mesh_vertices)
         if dtype is None:
             dtype = V_in.dtype
-        V = jnp.asarray(V_in, dtype=dtype)
+        if bvh is None:
+            bounds_min = np.min(np.asarray(self.mesh_vertices, dtype=float), axis=0)
+            bounds_max = np.max(np.asarray(self.mesh_vertices, dtype=float), axis=0)
+            origin_value = 0.5 * (bounds_min + bounds_max)
+            distance_scale_value = float(np.linalg.norm(bounds_max - bounds_min))
+            if not np.isfinite(distance_scale_value) or distance_scale_value <= 0.0:
+                raise ValueError("Mesh diameter must be finite and positive.")
+        else:
+            # A caller-supplied BVH uses the caller's coordinate system.
+            origin_value = np.zeros((3,), dtype=float)
+            distance_scale_value = 1.0
+        world_origin = jnp.asarray(origin_value, dtype=dtype)
+        distance_scale = jnp.asarray(distance_scale_value, dtype=dtype)
+        V = (jnp.asarray(V_in, dtype=dtype) - world_origin) / distance_scale
         F = jnp.asarray(self.mesh_faces)
 
         if V.ndim != 2 or V.shape[-1] != 3:
@@ -72,7 +85,7 @@ class _MeshSDFImpl:
             elif dtype == jnp.float32:
                 eps = 1e-9
             else:
-                eps = 1e-12
+                eps = 1e-15
 
         eps = jnp.array(eps, dtype=dtype)
         zero = jnp.array(0.0, dtype=dtype)
@@ -90,8 +103,8 @@ class _MeshSDFImpl:
         # ---------------------------------------------------------------------
         # Pseudonormal sign precomputation (host-side, static)
         # ---------------------------------------------------------------------
-        V_np = np.asarray(self.mesh.vertices, dtype=float)
-        F_np = np.asarray(self.mesh.faces, dtype=np.int64)
+        V_np = np.asarray(V, dtype=float)
+        F_np = np.asarray(self.mesh_faces, dtype=np.int64)
         a_np = V_np[F_np[:, 0]]
         b_np = V_np[F_np[:, 1]]
         c_np = V_np[F_np[:, 2]]
@@ -220,25 +233,25 @@ class _MeshSDFImpl:
 
             vc = d1 * d4 - d3 * d2
             cond_ab = (vc <= zero) & (d1 >= zero) & (d3 <= zero)
-            t_ab = d1 / (d1 - d3 + eps)
+            t_ab = d1 / jnp.maximum(d1 - d3, eps)
             diff_ab = u + t_ab[..., None] * ab_t
             dist2_ab = _dot(diff_ab, diff_ab)
 
             vb = d5 * d2 - d1 * d6
             cond_ac = (vb <= zero) & (d2 >= zero) & (d6 <= zero)
-            t_ac = d2 / (d2 - d6 + eps)
+            t_ac = d2 / jnp.maximum(d2 - d6, eps)
             diff_ac = u + t_ac[..., None] * ac_t
             dist2_ac = _dot(diff_ac, diff_ac)
 
             va = d3 * d6 - d5 * d4
             cond_bc = (va <= zero) & ((d4 - d3) >= zero) & ((d5 - d6) >= zero)
-            t_bc = (d4 - d3) / ((d4 - d3) + (d5 - d6) + eps)
+            t_bc = (d4 - d3) / jnp.maximum((d4 - d3) + (d5 - d6), eps)
             diff_bc = v + t_bc[..., None] * bc_t
             dist2_bc = _dot(diff_bc, diff_bc)
 
             denom = va + vb + vc
-            v_face = vb / (denom + eps)
-            w_face = vc / (denom + eps)
+            v_face = vb / jnp.maximum(denom, eps)
+            w_face = vc / jnp.maximum(denom, eps)
             diff_face = u + v_face[..., None] * ab_t + w_face[..., None] * ac_t
             dist2_face = _dot(diff_face, diff_face)
 
@@ -282,22 +295,22 @@ class _MeshSDFImpl:
 
             vc = d1 * d4 - d3 * d2
             cond_ab = (vc <= zero) & (d1 >= zero) & (d3 <= zero)
-            t_ab = d1 / (d1 - d3 + eps)
+            t_ab = d1 / jnp.maximum(d1 - d3, eps)
             diff_ab = u + t_ab[..., None] * ab_t
 
             vb = d5 * d2 - d1 * d6
             cond_ac = (vb <= zero) & (d2 >= zero) & (d6 <= zero)
-            t_ac = d2 / (d2 - d6 + eps)
+            t_ac = d2 / jnp.maximum(d2 - d6, eps)
             diff_ac = u + t_ac[..., None] * ac_t
 
             va = d3 * d6 - d5 * d4
             cond_bc = (va <= zero) & ((d4 - d3) >= zero) & ((d5 - d6) >= zero)
-            t_bc = (d4 - d3) / ((d4 - d3) + (d5 - d6) + eps)
+            t_bc = (d4 - d3) / jnp.maximum((d4 - d3) + (d5 - d6), eps)
             diff_bc = v + t_bc[..., None] * bc_t
 
             denom = va + vb + vc
-            v_face = vb / (denom + eps)
-            w_face = vc / (denom + eps)
+            v_face = vb / jnp.maximum(denom, eps)
+            w_face = vc / jnp.maximum(denom, eps)
             diff_face = u + v_face[..., None] * ab_t + w_face[..., None] * ac_t
 
             diff = diff_face
@@ -338,8 +351,8 @@ class _MeshSDFImpl:
             points: jnp.ndarray,
         ) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray]:
             """Return (signed, diff, side, unsigned, n_pseudo) for points."""
-            pts, out_shape, is_single = _coerce_points3(points)
-
+            pts_world, out_shape, is_single = _coerce_points3(points)
+            pts = (pts_world - world_origin) / distance_scale
             tri, valid = beam_select_leaf_items(
                 pts, bvh=bvh, beam_width=beam_width, steps=beam_steps
             )
@@ -376,7 +389,7 @@ class _MeshSDFImpl:
 
             unsigned = jnp.sqrt(jnp.maximum(dist2_min, zero))
             sgn = jnp.where(side < zero, -one, one)
-            signed = sgn * unsigned
+            signed = sgn * unsigned * distance_scale
 
             if is_single:
                 return (
@@ -404,18 +417,34 @@ class _MeshSDFImpl:
             (points,) = primals
             (t_points,) = tangents
 
-            val, diff, side, unsigned, n_pseudo = _sdf_primal_and_geom(points)
-            if t_points is None:
-                return val, jnp.zeros_like(val)
-
+            # Nearest-feature routing is discrete, and a polyhedral distance has no
+            # classical higher derivative at edge/vertex seams. Freeze that geometry
+            # under nested AD; the smooth envelope supplies derivatives away from
+            # the exact collar, while this exact field retains its unit first jet.
+            points_stopped = jax.lax.stop_gradient(points)
+            val, diff, side, unsigned, n_pseudo = _sdf_primal_and_geom(points_stopped)
+            boundary_collar = jnp.sqrt(eps)
+            safe_unsigned = jnp.maximum(unsigned, boundary_collar)
             sgn = jnp.where(side < zero, -one, one)
-            raw = sgn[..., None] * (-diff) / (unsigned[..., None] + eps)
-            raw_norm = jnp.sqrt(_dot(raw, raw))
-            use_cp = raw_norm > jnp.asarray(0.5, dtype=dtype)
-            grad_cp = raw / raw_norm[..., None]
+            raw = sgn[..., None] * (-diff) / safe_unsigned[..., None]
+            raw_norm_sq = _dot(raw, raw)
+            safe_raw_norm = jnp.sqrt(
+                jnp.maximum(raw_norm_sq, jnp.asarray(0.25, dtype=dtype))
+            )
+            grad_cp = raw / safe_raw_norm[..., None]
+            use_cp = unsigned > boundary_collar
             grad = jnp.where(use_cp[..., None], grad_cp, n_pseudo)
-            t_val = _dot(grad, t_points)
-            return val, t_val
+
+            points_array = jnp.asarray(points, dtype=dtype)
+            linear_primal = _dot(points_array, grad)
+            primal_val = (
+                jax.lax.stop_gradient(val)
+                + linear_primal
+                - jax.lax.stop_gradient(linear_primal)
+            )
+            if t_points is None:
+                return primal_val, jnp.zeros_like(val)
+            return primal_val, _dot(grad, t_points)
 
         return jax.jit(sdf)
 
@@ -430,10 +459,10 @@ class _MeshSDFImpl:
     ) -> Callable[[jnp.ndarray], jnp.ndarray]:
         """Build an exact (global-nearest) mesh SDF via BVH stack traversal.
 
-        This is an alternative to the default beam-selected implementation used by
-        `_make_mesh_sdf`. It is primarily intended as a reference/diagnostic
-        implementation when candidate-routing seams from the beam selection are
-        undesirable.
+        The smooth boundary factor uses this traversal for its exact boundary collar,
+        avoiding candidate-routing seams on dense or highly nonuniform meshes. The
+        beam-selected implementation remains available for sampling and containment
+        paths that prioritize throughput.
         """
         if leaf_size <= 0:
             raise ValueError(f"leaf_size must be positive, got {leaf_size}.")
@@ -441,7 +470,20 @@ class _MeshSDFImpl:
         V_in = jnp.asarray(self.mesh_vertices)
         if dtype is None:
             dtype = V_in.dtype
-        V = jnp.asarray(V_in, dtype=dtype)
+        if bvh is None:
+            bounds_min = np.min(np.asarray(self.mesh_vertices, dtype=float), axis=0)
+            bounds_max = np.max(np.asarray(self.mesh_vertices, dtype=float), axis=0)
+            origin_value = 0.5 * (bounds_min + bounds_max)
+            distance_scale_value = float(np.linalg.norm(bounds_max - bounds_min))
+            if not np.isfinite(distance_scale_value) or distance_scale_value <= 0.0:
+                raise ValueError("Mesh diameter must be finite and positive.")
+        else:
+            # A caller-supplied BVH uses the caller's coordinate system.
+            origin_value = np.zeros((3,), dtype=float)
+            distance_scale_value = 1.0
+        world_origin = jnp.asarray(origin_value, dtype=dtype)
+        distance_scale = jnp.asarray(distance_scale_value, dtype=dtype)
+        V = (jnp.asarray(V_in, dtype=dtype) - world_origin) / distance_scale
         F = jnp.asarray(self.mesh_faces)
 
         if V.ndim != 2 or V.shape[-1] != 3:
@@ -457,7 +499,7 @@ class _MeshSDFImpl:
             elif dtype == jnp.float32:
                 eps = 1e-9
             else:
-                eps = 1e-12
+                eps = 1e-15
 
         eps = jnp.asarray(eps, dtype=dtype)
         zero = jnp.asarray(0.0, dtype=dtype)
@@ -474,8 +516,8 @@ class _MeshSDFImpl:
         # ---------------------------------------------------------------------
         # Pseudonormal sign precomputation (host-side, static)
         # ---------------------------------------------------------------------
-        V_np = np.asarray(self.mesh.vertices, dtype=float)
-        F_np = np.asarray(self.mesh.faces, dtype=np.int64)
+        V_np = np.asarray(V, dtype=float)
+        F_np = np.asarray(self.mesh_faces, dtype=np.int64)
         a_np = V_np[F_np[:, 0]]
         b_np = V_np[F_np[:, 1]]
         c_np = V_np[F_np[:, 2]]
@@ -615,25 +657,25 @@ class _MeshSDFImpl:
 
             vc = d1 * d4 - d3 * d2
             cond_ab = (vc <= zero) & (d1 >= zero) & (d3 <= zero)
-            t_ab = d1 / (d1 - d3 + eps)
+            t_ab = d1 / jnp.maximum(d1 - d3, eps)
             diff_ab = u + t_ab[..., None] * ab_t
             dist2_ab = _dot(diff_ab, diff_ab)
 
             vb = d5 * d2 - d1 * d6
             cond_ac = (vb <= zero) & (d2 >= zero) & (d6 <= zero)
-            t_ac = d2 / (d2 - d6 + eps)
+            t_ac = d2 / jnp.maximum(d2 - d6, eps)
             diff_ac = u + t_ac[..., None] * ac_t
             dist2_ac = _dot(diff_ac, diff_ac)
 
             va = d3 * d6 - d5 * d4
             cond_bc = (va <= zero) & ((d4 - d3) >= zero) & ((d5 - d6) >= zero)
-            t_bc = (d4 - d3) / ((d4 - d3) + (d5 - d6) + eps)
+            t_bc = (d4 - d3) / jnp.maximum((d4 - d3) + (d5 - d6), eps)
             diff_bc = v + t_bc[..., None] * bc_t
             dist2_bc = _dot(diff_bc, diff_bc)
 
             denom = va + vb + vc
-            v_face = vb / (denom + eps)
-            w_face = vc / (denom + eps)
+            v_face = vb / jnp.maximum(denom, eps)
+            w_face = vc / jnp.maximum(denom, eps)
             diff_face = u + v_face[..., None] * ab_t + w_face[..., None] * ac_t
             dist2_face = _dot(diff_face, diff_face)
 
@@ -677,22 +719,22 @@ class _MeshSDFImpl:
 
             vc = d1 * d4 - d3 * d2
             cond_ab = (vc <= zero) & (d1 >= zero) & (d3 <= zero)
-            t_ab = d1 / (d1 - d3 + eps)
+            t_ab = d1 / jnp.maximum(d1 - d3, eps)
             diff_ab = u + t_ab * ab_t
 
             vb = d5 * d2 - d1 * d6
             cond_ac = (vb <= zero) & (d2 >= zero) & (d6 <= zero)
-            t_ac = d2 / (d2 - d6 + eps)
+            t_ac = d2 / jnp.maximum(d2 - d6, eps)
             diff_ac = u + t_ac * ac_t
 
             va = d3 * d6 - d5 * d4
             cond_bc = (va <= zero) & ((d4 - d3) >= zero) & ((d5 - d6) >= zero)
-            t_bc = (d4 - d3) / ((d4 - d3) + (d5 - d6) + eps)
+            t_bc = (d4 - d3) / jnp.maximum((d4 - d3) + (d5 - d6), eps)
             diff_bc = v + t_bc * bc_t
 
             denom = va + vb + vc
-            v_face = vb / (denom + eps)
-            w_face = vc / (denom + eps)
+            v_face = vb / jnp.maximum(denom, eps)
+            w_face = vc / jnp.maximum(denom, eps)
             diff_face = u + v_face * ab_t + w_face * ac_t
 
             diff = diff_face
@@ -738,18 +780,15 @@ class _MeshSDFImpl:
             best_d20 = inf
             best_tri0 = jnp.int32(0)
 
-            def _cond(state):
-                _, sp, _, _ = state
-                return sp > 0
-
             def _push(stack, sp, node):
                 stack = stack.at[sp].set(node)
                 return stack, sp + jnp.int32(1)
 
-            def _body(state):
+            def _body(_, state):
                 stack, sp, best_d2, best_tri = state
-                sp = sp - jnp.int32(1)
-                node = stack[sp]
+                active = sp > 0
+                sp = jnp.maximum(sp - jnp.int32(1), jnp.int32(0))
+                node = jnp.where(active, stack[sp], jnp.int32(-1))
                 state = (stack, sp, best_d2, best_tri)
 
                 def _process_node(state):
@@ -838,16 +877,19 @@ class _MeshSDFImpl:
 
                 return jax.lax.cond(node >= 0, _process_node, lambda s: s, state)
 
-            stack, sp, best_d2, best_tri = jax.lax.while_loop(
-                _cond, _body, (stack, sp0, best_d20, best_tri0)
+            stack, sp, best_d2, best_tri = jax.lax.fori_loop(
+                0,
+                int(bbox_min.shape[0]),
+                _body,
+                (stack, sp0, best_d20, best_tri0),
             )
             return best_d2, best_tri
 
         def _sdf_primal_and_geom(
             points: jnp.ndarray,
         ) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray]:
-            pts, out_shape, is_single = _coerce_points3(points)
-
+            pts_world, out_shape, is_single = _coerce_points3(points)
+            pts = (pts_world - world_origin) / distance_scale
             dist2_min, best_tri = jax.vmap(_traverse_best_triangle)(pts)
             unsigned = jnp.sqrt(jnp.maximum(dist2_min, zero))
 
@@ -870,7 +912,7 @@ class _MeshSDFImpl:
 
             diff, side, n_pseudo = jax.vmap(_geom_for_best)(pts, best_tri)
             sgn = jnp.where(side < zero, -one, one)
-            signed = sgn * unsigned
+            signed = sgn * unsigned * distance_scale
 
             if is_single:
                 return (
@@ -898,18 +940,32 @@ class _MeshSDFImpl:
             (points,) = primals
             (t_points,) = tangents
 
-            val, diff, side, unsigned, n_pseudo = _sdf_primal_and_geom(points)
-            if t_points is None:
-                return val, jnp.zeros_like(val)
-
+            # See the beam-search implementation above: freeze the selected mesh
+            # feature under higher AD and expose its stable unit first derivative.
+            points_stopped = jax.lax.stop_gradient(points)
+            val, diff, side, unsigned, n_pseudo = _sdf_primal_and_geom(points_stopped)
+            boundary_collar = jnp.sqrt(eps)
+            safe_unsigned = jnp.maximum(unsigned, boundary_collar)
             sgn = jnp.where(side < zero, -one, one)
-            raw = sgn[..., None] * (-diff) / (unsigned[..., None] + eps)
-            raw_norm = jnp.sqrt(_dot(raw, raw))
-            use_cp = raw_norm > jnp.asarray(0.5, dtype=dtype)
-            grad_cp = raw / raw_norm[..., None]
+            raw = sgn[..., None] * (-diff) / safe_unsigned[..., None]
+            raw_norm_sq = _dot(raw, raw)
+            safe_raw_norm = jnp.sqrt(
+                jnp.maximum(raw_norm_sq, jnp.asarray(0.25, dtype=dtype))
+            )
+            grad_cp = raw / safe_raw_norm[..., None]
+            use_cp = unsigned > boundary_collar
             grad = jnp.where(use_cp[..., None], grad_cp, n_pseudo)
-            t_val = _dot(grad, t_points)
-            return val, t_val
+
+            points_array = jnp.asarray(points, dtype=dtype)
+            linear_primal = _dot(points_array, grad)
+            primal_val = (
+                jax.lax.stop_gradient(val)
+                + linear_primal
+                - jax.lax.stop_gradient(linear_primal)
+            )
+            if t_points is None:
+                return primal_val, jnp.zeros_like(val)
+            return primal_val, _dot(grad, t_points)
 
         return jax.jit(sdf)
 
@@ -923,25 +979,46 @@ class _MeshSDFImpl:
         beam_steps: int | None = None,
         r0: float | None = None,
         rho_delta: float | None = None,
+        equivalence_power: float | None = None,
         squash: bool = True,
     ) -> Callable[[jnp.ndarray], jnp.ndarray]:
         """Build a pointwise smoothed mesh SDF with exact boundary behaviour.
 
         This returns a signed distance-like function `phi(p)` that:
-        - Matches the exact mesh SDF to first order at the boundary (phi=0 and dphi/dn=1).
-        - Replaces the non-smooth min over triangles by a soft-min over a BVH-selected leaf beam,
-          yielding meaningful higher derivatives away from the boundary layer.
+        - Equals the exact mesh SDF throughout an open boundary collar, with a stable
+          pseudonormal custom derivative at the zero set.
+        - Replaces the non-smooth min over triangles by a smooth aggregate over a
+          BVH-selected leaf beam away from that collar.
 
         Notes
         -----
         - Candidate triangle selection is treated as non-differentiable routing via
-          `stop_gradient`, so JAX higher derivatives reflect the soft-min distance
-          within the selected candidate set.
+          `stop_gradient`, so JAX higher derivatives reflect the smooth distance
+          aggregate within the selected candidate set.
+        - ``equivalence_power`` selects an inverse-power R-equivalence aggregate;
+          ``None`` retains the Gibbs-weighted RMS aggregate.
         """
         if beam_width <= 0:
             raise ValueError(f"beam_width must be positive, got {beam_width}.")
+        if equivalence_power is not None:
+            equivalence_power = float(equivalence_power)
+            if not np.isfinite(equivalence_power) or equivalence_power <= 0.0:
+                raise ValueError(
+                    "equivalence_power must be finite and positive, "
+                    f"got {equivalence_power}."
+                )
 
-        V = jnp.asarray(self.mesh_vertices)
+        V_world = jnp.asarray(self.mesh_vertices)
+        dtype = V_world.dtype
+        bounds_min = np.min(np.asarray(self.mesh_vertices, dtype=float), axis=0)
+        bounds_max = np.max(np.asarray(self.mesh_vertices, dtype=float), axis=0)
+        origin_value = 0.5 * (bounds_min + bounds_max)
+        distance_scale_value = float(np.linalg.norm(bounds_max - bounds_min))
+        if not np.isfinite(distance_scale_value) or distance_scale_value <= 0.0:
+            raise ValueError("Mesh diameter must be finite and positive.")
+        world_origin = jnp.asarray(origin_value, dtype=dtype)
+        distance_scale = jnp.asarray(distance_scale_value, dtype=dtype)
+        V = (V_world - world_origin) / distance_scale
         F = jnp.asarray(self.mesh_faces)
 
         if V.ndim != 2 or V.shape[-1] != 3:
@@ -951,29 +1028,30 @@ class _MeshSDFImpl:
         if int(F.shape[0]) == 0:
             raise ValueError("Mesh has no faces; cannot build an SDF.")
 
-        dtype = V.dtype
-
         if eps is None:
             if dtype == jnp.float16:
                 eps = 1e-4
             elif dtype == jnp.float32:
                 eps = 1e-9
             else:
-                eps = 1e-12
+                eps = 1e-15
         eps = jnp.asarray(eps, dtype=dtype)
         zero = jnp.asarray(0.0, dtype=dtype)
         one = jnp.asarray(1.0, dtype=dtype)
         inf = jnp.asarray(jnp.inf, dtype=dtype)
 
-        # Default smooth-min sharpness based on a fraction of the diameter.
+        # Work in normalized coordinates so all regularization is scale-covariant.
         if beta is None:
-            smooth_radius = float(0.075 * (self.diameter or 1.0))
-            beta = 1.0 / (smooth_radius * smooth_radius + 1e-30)
+            beta = 1.0 / (0.075**2 + 1e-30)
+        else:
+            beta = float(beta) * distance_scale_value**2
         beta = jnp.asarray(beta, dtype=dtype)
         if float(beta) <= 0.0:
             raise ValueError(f"beta must be positive, got {beta}.")
         if r0 is None:
-            r0 = float(0.05 * (self.diameter or 1.0))
+            r0 = 0.05
+        else:
+            r0 = float(r0) / distance_scale_value
         r0 = jnp.asarray(r0, dtype=dtype)
 
         # Boundary-linear, interior-saturating transform:
@@ -983,7 +1061,9 @@ class _MeshSDFImpl:
         squash_flag = bool(squash)
         if squash_flag:
             if rho_delta is None:
-                rho_delta = float(0.0111 * (self.diameter or 1.0))
+                rho_delta = 0.0111
+            else:
+                rho_delta = float(rho_delta) / distance_scale_value
             rho_delta = jnp.asarray(rho_delta, dtype=dtype)
             rho_delta = jnp.maximum(rho_delta, jnp.asarray(1e-12, dtype=dtype))
 
@@ -998,7 +1078,7 @@ class _MeshSDFImpl:
         # ---------------------------------------------------------------------
         # Static BVH (AABB tree) build (host-side)
         # ---------------------------------------------------------------------
-        V_np = np.asarray(self.mesh.vertices, dtype=float)
+        V_np = np.asarray(V, dtype=float)
         F_np = np.asarray(self.mesh.faces, dtype=np.int64)
         a_np = V_np[F_np[:, 0]]
         b_np = V_np[F_np[:, 1]]
@@ -1021,7 +1101,7 @@ class _MeshSDFImpl:
         if beam_steps <= 0:
             raise ValueError(f"beam_steps must be positive, got {beam_steps}.")
 
-        sdf_exact = _MeshSDFImpl._make_mesh_sdf(self, eps=eps, bvh=bvh)
+        sdf_exact = _MeshSDFImpl._make_mesh_sdf_traversal(self, eps=eps)
 
         def _point_triangle_dist2_a_ab_ac(
             p: jnp.ndarray,
@@ -1051,25 +1131,25 @@ class _MeshSDFImpl:
 
             vc = d1 * d4 - d3 * d2
             cond_ab = (vc <= zero) & (d1 >= zero) & (d3 <= zero)
-            t_ab = d1 / (d1 - d3 + eps)
+            t_ab = d1 / jnp.maximum(d1 - d3, eps)
             diff_ab = u + t_ab[..., None] * ab_t
             dist2_ab = _dot(diff_ab, diff_ab)
 
             vb = d5 * d2 - d1 * d6
             cond_ac = (vb <= zero) & (d2 >= zero) & (d6 <= zero)
-            t_ac = d2 / (d2 - d6 + eps)
+            t_ac = d2 / jnp.maximum(d2 - d6, eps)
             diff_ac = u + t_ac[..., None] * ac_t
             dist2_ac = _dot(diff_ac, diff_ac)
 
             va = d3 * d6 - d5 * d4
             cond_bc = (va <= zero) & ((d4 - d3) >= zero) & ((d5 - d6) >= zero)
-            t_bc = (d4 - d3) / ((d4 - d3) + (d5 - d6) + eps)
+            t_bc = (d4 - d3) / jnp.maximum((d4 - d3) + (d5 - d6), eps)
             diff_bc = v + t_bc[..., None] * bc_t
             dist2_bc = _dot(diff_bc, diff_bc)
 
             denom = va + vb + vc
-            v_face = vb / (denom + eps)
-            w_face = vc / (denom + eps)
+            v_face = vb / jnp.maximum(denom, eps)
+            w_face = vc / jnp.maximum(denom, eps)
             diff_face = u + v_face[..., None] * ab_t + w_face[..., None] * ac_t
             dist2_face = _dot(diff_face, diff_face)
 
@@ -1107,9 +1187,10 @@ class _MeshSDFImpl:
             return pts.reshape((-1, 3)), out_shape, False
 
         def sdf_smooth(points: jnp.ndarray) -> jnp.ndarray:
-            pts, out_shape, is_single = _coerce_points3(points)
+            pts_world, out_shape, is_single = _coerce_points3(points)
+            pts = (pts_world - world_origin) / distance_scale
 
-            d_exact = sdf_exact(pts)
+            d_exact = sdf_exact(pts_world) / distance_scale
             d_for_blend = jax.lax.stop_gradient(d_exact)
 
             pts_select = jax.lax.stop_gradient(pts)
@@ -1127,28 +1208,55 @@ class _MeshSDFImpl:
             dist2_use = jnp.where(valid, dist2, zero)
             has_valid = jnp.any(valid, axis=1)
 
-            scaled = jnp.where(valid, -beta * dist2, -inf)
-            logZ = jax.scipy.special.logsumexp(scaled, axis=1, keepdims=True)
-            weights = jnp.exp(scaled - logZ)
-            weights = jnp.where(valid, weights, zero)
-            m = jnp.sum(weights * dist2_use, axis=1)
-            unsigned_smooth = jnp.sqrt(jnp.maximum(m, zero))
+            if equivalence_power is None:
+                scaled = jnp.where(valid, -beta * dist2, -inf)
+                logZ = jax.scipy.special.logsumexp(scaled, axis=1, keepdims=True)
+                weights = jnp.exp(scaled - logZ)
+                weights = jnp.where(valid, weights, zero)
+                m = jnp.sum(weights * dist2_use, axis=1)
+                unsigned_smooth = jnp.sqrt(jnp.maximum(m, eps))
+            else:
+                power = jnp.asarray(equivalence_power, dtype=dtype)
+                log_inverse_distance = jnp.where(
+                    valid,
+                    -0.5 * power * jnp.log(jnp.maximum(dist2, eps)),
+                    -inf,
+                )
+                log_inverse_sum = jax.scipy.special.logsumexp(
+                    log_inverse_distance, axis=1
+                )
+                unsigned_smooth = jnp.exp(-log_inverse_sum / power)
             unsigned = jnp.where(has_valid, unsigned_smooth, jnp.abs(d_exact))
 
             sgn = jnp.where(d_exact < zero, -one, one)
             sgn = jax.lax.stop_gradient(sgn)
             d_smooth = sgn * unsigned
 
-            inv_r0 = one / (r0 + eps)
-            t = (d_for_blend * inv_r0) ** 2
-            t = jnp.minimum(t, one)
-            S = t * t * (3.0 - 2.0 * t)
+            blend_start = 0.5 * r0
+            blend_width = r0 - blend_start
+            blend_coordinate_raw = jnp.clip(
+                (jnp.abs(d_for_blend) - blend_start) / (blend_width + eps),
+                zero,
+                one,
+            )
+            blend_active = jnp.abs(d_for_blend) > blend_start
+            blend_coordinate = jnp.where(blend_active, blend_coordinate_raw, one)
+            S = (
+                462.0 * blend_coordinate**6
+                - 1980.0 * blend_coordinate**7
+                + 3465.0 * blend_coordinate**8
+                - 3080.0 * blend_coordinate**9
+                + 1386.0 * blend_coordinate**10
+                - 252.0 * blend_coordinate**11
+            )
+            S = jnp.where(blend_active, S, zero)
 
             d = d_exact + S * (d_smooth - d_exact)
             if squash_flag:
                 out = rho_delta * jnp.tanh(d / rho_delta)
             else:
                 out = d
+            out = out * distance_scale
             if is_single:
                 return out.reshape(())
             return out.reshape(out_shape)
@@ -1166,7 +1274,7 @@ class _MeshSDFImpl:
         r0: float | None = None,
         rho_delta: float | None = None,
     ) -> Callable[[jnp.ndarray], jnp.ndarray]:
-        """Like `_make_smooth_mesh_sdf`, but uses the exact BVH traversal for `d_exact`."""
+        """Build the legacy original-coordinate smooth SDF for diagnostics."""
         if beam_width <= 0:
             raise ValueError(f"beam_width must be positive, got {beam_width}.")
 
@@ -1188,7 +1296,7 @@ class _MeshSDFImpl:
             elif dtype == jnp.float32:
                 eps = 1e-9
             else:
-                eps = 1e-12
+                eps = 1e-15
         eps = jnp.asarray(eps, dtype=dtype)
         zero = jnp.asarray(0.0, dtype=dtype)
         one = jnp.asarray(1.0, dtype=dtype)
@@ -1269,25 +1377,25 @@ class _MeshSDFImpl:
 
             vc = d1 * d4 - d3 * d2
             cond_ab = (vc <= zero) & (d1 >= zero) & (d3 <= zero)
-            t_ab = d1 / (d1 - d3 + eps)
+            t_ab = d1 / jnp.maximum(d1 - d3, eps)
             diff_ab = u + t_ab[..., None] * ab_t
             dist2_ab = _dot(diff_ab, diff_ab)
 
             vb = d5 * d2 - d1 * d6
             cond_ac = (vb <= zero) & (d2 >= zero) & (d6 <= zero)
-            t_ac = d2 / (d2 - d6 + eps)
+            t_ac = d2 / jnp.maximum(d2 - d6, eps)
             diff_ac = u + t_ac[..., None] * ac_t
             dist2_ac = _dot(diff_ac, diff_ac)
 
             va = d3 * d6 - d5 * d4
             cond_bc = (va <= zero) & ((d4 - d3) >= zero) & ((d5 - d6) >= zero)
-            t_bc = (d4 - d3) / ((d4 - d3) + (d5 - d6) + eps)
+            t_bc = (d4 - d3) / jnp.maximum((d4 - d3) + (d5 - d6), eps)
             diff_bc = v + t_bc[..., None] * bc_t
             dist2_bc = _dot(diff_bc, diff_bc)
 
             denom = va + vb + vc
-            v_face = vb / (denom + eps)
-            w_face = vc / (denom + eps)
+            v_face = vb / jnp.maximum(denom, eps)
+            w_face = vc / jnp.maximum(denom, eps)
             diff_face = u + v_face[..., None] * ab_t + w_face[..., None] * ac_t
             dist2_face = _dot(diff_face, diff_face)
 
@@ -1436,6 +1544,7 @@ def make_smooth_mesh_sdf(
     beam_steps: int | None = None,
     r0: float | None = None,
     rho_delta: float | None = None,
+    equivalence_power: float | None = None,
     squash: bool = True,
 ) -> Callable[[jnp.ndarray], jnp.ndarray]:
     return _MeshSDFImpl._make_smooth_mesh_sdf(
@@ -1446,6 +1555,7 @@ def make_smooth_mesh_sdf(
         beam_steps=beam_steps,
         r0=r0,
         rho_delta=rho_delta,
+        equivalence_power=equivalence_power,
         squash=squash,
     )
 
@@ -1460,10 +1570,10 @@ def make_smooth_mesh_sdf_alt(
     r0: float | None = None,
     rho_delta: float | None = None,
 ) -> Callable[[jnp.ndarray], jnp.ndarray]:
-    """Smooth mesh SDF using exact BVH traversal for the `d_exact` term.
+    """Build the legacy original-coordinate smooth SDF for diagnostics.
 
-    This keeps the same soft-min smoothing as `make_smooth_mesh_sdf`, but replaces the
-    "exact" distance used in the boundary blending with a global-nearest BVH traversal.
+    Unlike the scale-normalized default, this variant shares one physical-coordinate
+    BVH between its global-nearest and soft-min terms.
     """
     return _MeshSDFImpl._make_smooth_mesh_sdf_alt(
         geom,
@@ -1476,8 +1586,87 @@ def make_smooth_mesh_sdf_alt(
     )
 
 
+def make_compact_boundary_factor(
+    distance: Callable[[jnp.ndarray], jnp.ndarray],
+    *,
+    scale: float,
+    saturation_fraction: float = 0.05,
+    linear_fraction: float = 0.5,
+) -> Callable[[jnp.ndarray], jnp.ndarray]:
+    r"""Compactly saturate a signed-distance-like field after an exact linear collar.
+
+    The scalar transform is odd and exactly the identity while
+    ``|distance| <= linear_fraction * saturation_fraction * scale``. A C6 transition
+    then reaches an exact plateau at ``saturation_fraction * scale``. Consequently,
+    the transform preserves every boundary derivative while preventing distant
+    medial-axis nonsmoothness from entering derivatives of the boundary factor.
+    """
+    scale_value = float(scale)
+    saturation_value = float(saturation_fraction)
+    linear_value = float(linear_fraction)
+    if not np.isfinite(scale_value) or scale_value <= 0.0:
+        raise ValueError(f"scale must be finite and positive, got {scale!r}.")
+    if not np.isfinite(saturation_value) or not 0.0 < saturation_value < 1.0:
+        raise ValueError(
+            "saturation_fraction must be finite and strictly between zero and one."
+        )
+    if not np.isfinite(linear_value) or not 0.0 < linear_value < 1.0:
+        raise ValueError(
+            "linear_fraction must be finite and strictly between zero and one."
+        )
+    delta_value = scale_value * saturation_value
+    transition_width = 1.0 - linear_value
+    plateau = linear_value + 0.5 * transition_width
+
+    def boundary_factor(points: jnp.ndarray) -> jnp.ndarray:
+        signed = jnp.asarray(distance(points))
+        delta = jnp.asarray(delta_value, dtype=signed.dtype)
+        z = jnp.abs(signed) / delta
+        u_raw = jnp.clip(
+            (z - linear_value) / transition_width,
+            jnp.asarray(0.0, dtype=signed.dtype),
+            jnp.asarray(1.0, dtype=signed.dtype),
+        )
+        # The transition polynomial is inactive in the linear collar. Evaluating
+        # its zero powers there can still produce 0*NaN tangents under nested AD
+        # when ``distance`` has a custom JVP, so keep the inactive input at one.
+        u = jnp.where(
+            z > linear_value,
+            u_raw,
+            jnp.asarray(1.0, dtype=signed.dtype),
+        )
+
+        # Integral of one minus the order-five generalized smoothstep. It agrees
+        # with ``u`` through sixth order at zero and is flat through sixth order at one.
+        transition = (
+            u
+            - 66.0 * u**7
+            + 247.5 * u**8
+            - 385.0 * u**9
+            + 308.0 * u**10
+            - 126.0 * u**11
+            + 21.0 * u**12
+        )
+        magnitude = linear_value + transition_width * transition
+        transition_denominator = jnp.where(
+            z > linear_value, z, jnp.asarray(1.0, dtype=signed.dtype)
+        )
+        plateau_denominator = jnp.where(z >= 1.0, z, jnp.asarray(1.0, dtype=signed.dtype))
+        ratio_transition = magnitude / transition_denominator
+        ratio_plateau = plateau / plateau_denominator
+        ratio = jnp.where(
+            z <= linear_value,
+            jnp.asarray(1.0, dtype=signed.dtype),
+            jnp.where(z < 1.0, ratio_transition, ratio_plateau),
+        )
+        return signed * ratio
+
+    return jax.jit(boundary_factor)
+
+
 __all__ = [
     "make_mesh_inside_predicate_fast",
+    "make_compact_boundary_factor",
     "make_mesh_sdf",
     "make_mesh_sdf_fast",
     "make_smooth_mesh_sdf",

--- a/phydrax/solver/_enforced_constraint_pipeline.py
+++ b/phydrax/solver/_enforced_constraint_pipeline.py
@@ -22,7 +22,7 @@ from .._interpolation import (
 )
 from .._strict import StrictModule
 from ..constraints._enforced import _enforced_constraint_weight_fn, enforce_initial
-from ..domain._base import _AbstractGeometry
+from ..domain._base import _AbstractGeometry, EnforcementGateMethod
 from ..domain._components import (
     Boundary,
     DomainComponent,
@@ -788,6 +788,11 @@ def _initial_overlay_boundary_compatible(
         for piece in overlay.pieces:
             if isinstance(piece, MultiFieldEnforcedConstraint):
                 return False
+            # A value-only probe cannot establish compatibility of derivative
+            # boundary conditions. Conservatively retain the powered boundary
+            # gate so later stages cannot alter the declared boundary jet.
+            if int(piece.max_derivative_order) > 0:
+                return False
 
     def _get_field_unavailable(name: str, /) -> DomainFunction:
         raise KeyError(
@@ -1161,7 +1166,7 @@ class _InteriorDataOverlay(StrictModule):
     evolution_var: str
     max_init_order: int
     t0: Array | None
-    geometry_factors: frozendict[str, _AbstractGeometry]
+    geometry_gates: frozendict[str, Callable[[Array], Array]]
     m_anchor: Array
     track_sources: tuple[_TrackOverlaySource, ...]
 
@@ -1174,6 +1179,9 @@ class _InteriorDataOverlay(StrictModule):
         gate_exponents: Mapping[str, int],
         evolution_var: str,
         max_init_order: int,
+        gate_method: EnforcementGateMethod,
+        gate_saturation_fraction: float,
+        gate_linear_fraction: float,
     ):
         self.anchor_set = anchor_set
         self.gate_exponents = frozendict(
@@ -1189,23 +1197,27 @@ class _InteriorDataOverlay(StrictModule):
                 t0 = jnp.asarray(factor.fixed("start"), dtype=float).reshape(())
         self.t0 = t0
 
-        geom: dict[str, _AbstractGeometry] = {}
-        for lbl in self.gate_exponents:
-            factor = _unwrap_factor(domain.factor(lbl))
+        gates: dict[str, Callable[[Array], Array]] = {}
+        for label in self.gate_exponents:
+            factor = _unwrap_factor(domain.factor(label))
             if not isinstance(factor, _AbstractGeometry):
                 raise TypeError(
                     "Boundary gating exponents must refer to geometry labels."
                 )
-            geom[lbl] = factor
-        self.geometry_factors = frozendict(geom)
+            gates[label] = factor.make_enforcement_gate(
+                method=gate_method,
+                saturation_fraction=gate_saturation_fraction,
+                linear_fraction=gate_linear_fraction,
+            )
+        self.geometry_gates = frozendict(gates)
 
         # Precompute M(anchor_i) to validate anchors and reuse inside the overlay.
         n = int(self.anchor_set.source_index.shape[0])
         m_anchor = jnp.ones((n,), dtype=float)
         for lbl, p in self.gate_exponents.items():
             x = jnp.asarray(self.anchor_set.anchors[lbl], dtype=float)
-            sdf = jax.vmap(self.geometry_factors[lbl].adf)(x)
-            m_anchor = m_anchor * (jnp.abs(sdf) ** int(p))
+            gate = self.geometry_gates[lbl](x)
+            m_anchor = m_anchor * (jnp.abs(gate) ** int(p))
 
         q = (self.max_init_order + 1) if self.max_init_order >= 0 else 0
         if q > 0:
@@ -1251,8 +1263,8 @@ class _InteriorDataOverlay(StrictModule):
                     raise ValueError(
                         "Hermite sensor tracks require boundary gating on the space label only."
                     )
-                sdf = jax.vmap(self.geometry_factors[lbl].adf)(sensors)
-                m_track = m_track * (jnp.abs(sdf) ** int(p))[:, None]
+                gate = self.geometry_gates[lbl](sensors)
+                m_track = m_track * (jnp.abs(gate) ** int(p))[:, None]
 
             if q > 0:
                 if self.t0 is None:
@@ -1302,7 +1314,7 @@ class _InteriorDataOverlay(StrictModule):
         track_sources = self.track_sources
 
         gate_exps = dict(self.gate_exponents)
-        geom_factors = dict(self.geometry_factors)
+        geom_gates = dict(self.geometry_gates)
         q = (self.max_init_order + 1) if self.max_init_order >= 0 else 0
         t0 = self.t0 if self.t0 is not None else jnp.asarray(0.0, dtype=float)
         evolution_var = self.evolution_var
@@ -1313,10 +1325,10 @@ class _InteriorDataOverlay(StrictModule):
         def _M_query(z_by_label: Mapping[str, Array], /) -> Array:
             m = jnp.asarray(1.0, dtype=float)
             for lbl, p in gate_exps.items():
-                sdf = jnp.asarray(
-                    geom_factors[lbl].adf(z_by_label[lbl]), dtype=float
-                ).reshape(())
-                m = m * (jnp.abs(sdf) ** int(p))
+                gate = jnp.asarray(geom_gates[lbl](z_by_label[lbl]), dtype=float).reshape(
+                    ()
+                )
+                m = m * (jnp.abs(gate) ** int(p))
             if q > 0:
                 t = jnp.asarray(z_by_label[evolution_var], dtype=float).reshape(())
                 m = m * (jnp.maximum(t - t0, 0.0) ** int(q))
@@ -1659,9 +1671,9 @@ class _InteriorDataOverlay(StrictModule):
                 corr = jnp.sum(wpsi[..., None] * r_b, axis=0)
 
             m_q = jnp.asarray(1.0, dtype=float)
-            for lbl, pwr in gate_exps.items():
-                sdf = jnp.asarray(geom_factors[lbl].adf(_geom_coords(lbl)), dtype=float)
-                m_q = m_q * (jnp.abs(sdf) ** int(pwr))
+            for lbl, power in gate_exps.items():
+                gate = jnp.asarray(geom_gates[lbl](_geom_coords(lbl)), dtype=float)
+                m_q = m_q * (jnp.abs(gate) ** int(power))
             if q > 0:
                 t = jnp.asarray(z[evolution_var], dtype=float).reshape(())
                 m_q = m_q * (jnp.maximum(t - t0, 0.0) ** int(q))
@@ -1757,6 +1769,9 @@ class EnforcedConstraintPipeline(StrictModule):
         interior_data: Sequence[EnforcedInteriorData] = (),
         evolution_var: str = "t",
         include_identity_remainder: bool = True,
+        gate_method: EnforcementGateMethod = "auto",
+        gate_saturation_fraction: float = 0.5,
+        gate_linear_fraction: float = 0.5,
         num_reference: int = 3_000_000,
         sampler: str = "latin_hypercube",
         key: Key[Array, ""] = DOC_KEY0,
@@ -1778,6 +1793,12 @@ class EnforcedConstraintPipeline(StrictModule):
         - `include_identity_remainder`: When blending multiple boundary pieces,
           include a remainder weight for the identity map (keeps $u$ unchanged
           away from all pieces).
+        - `gate_method`: CAD gate implementation. ``"auto"`` selects the global
+          R-equivalence gate; ``"compact"`` selects the compact fallback.
+        - `gate_saturation_fraction`: Relative extent of compact CAD preservation
+          gates. Used only when ``gate_method="compact"``.
+        - `gate_linear_fraction`: Fraction of the compact gate extent retaining a
+          linear boundary profile.
         - `num_reference`: Reference sample count used to normalize boundary blend weights.
         - `sampler`: Sampler used to draw reference points.
         - `key`: PRNG key used to draw reference points.
@@ -1933,58 +1954,33 @@ class EnforcedConstraintPipeline(StrictModule):
                 gate_factors_list.append(factor)
             gate_factors = tuple(gate_factors_list)
             gate_powers = tuple(int(boundary_exps[lbl]) for lbl in gate_labels)
-            gate_scales = tuple(
-                float(
-                    jnp.max(
-                        jnp.abs(
-                            jnp.asarray(
-                                f.adf(
-                                    f.sample_interior(
-                                        int(num_reference),
-                                        sampler=sampler,
-                                        key=jr.fold_in(key, i + 1),
-                                    )
-                                ),
-                                dtype=float,
-                            )
-                        )
-                    )
-                    + 1e-12
+            gate_functions = tuple(
+                factor.make_enforcement_gate(
+                    method=gate_method,
+                    saturation_fraction=gate_saturation_fraction,
+                    linear_fraction=gate_linear_fraction,
                 )
-                for i, f in enumerate(gate_factors)
-            )
-            gate_widths = tuple(
-                float(
-                    jnp.linalg.norm(
-                        jnp.asarray(f.mesh_bounds, dtype=float)[1]
-                        - jnp.asarray(f.mesh_bounds, dtype=float)[0]
-                    )
-                    + 1e-12
-                )
-                * 0.05
-                for f in gate_factors
+                for factor in gate_factors
             )
 
             def _gate(*args, key=None, **kwargs):
                 del key, kwargs
-                m = jnp.asarray(1.0, dtype=float)
-                for arg, factor, power, width, scale in zip(
+                value = jnp.asarray(1.0, dtype=float)
+                for arg, gate, power in zip(
                     args,
-                    gate_factors,
+                    gate_functions,
                     gate_powers,
-                    gate_widths,
-                    gate_scales,
                     strict=True,
                 ):
-                    sdf = jnp.asarray(factor.adf(arg), dtype=float)
-                    w = jnp.asarray(width, dtype=float)
-                    s = jnp.asarray(scale, dtype=float)
-                    x = jnp.abs(sdf) / (w * s + 1e-12)
+                    gate_value = jnp.clip(
+                        jnp.abs(jnp.asarray(gate(arg), dtype=float)),
+                        0.0,
+                        1.0,
+                    )
                     if int(power) != 1:
-                        x = x ** int(power)
-                    gamma = 1.0 - jnp.exp(-(x * x))
-                    m = m * gamma
-                return m
+                        gate_value = gate_value ** int(power)
+                    value = value * gate_value
+                return value
 
             self.boundary_gate = DomainFunction(
                 domain=u_base.domain,
@@ -2003,8 +1999,11 @@ class EnforcedConstraintPipeline(StrictModule):
                 u_base.domain,
                 anchor_set,
                 gate_exponents=boundary_exps,
+                gate_method=gate_method,
                 evolution_var=self.evolution_var,
                 max_init_order=max_init_order,
+                gate_saturation_fraction=gate_saturation_fraction,
+                gate_linear_fraction=gate_linear_fraction,
             )
         self.interior_data = interior_data_overlay
 
@@ -2091,6 +2090,9 @@ class EnforcedConstraintPipelines(StrictModule):
         interior_data: Sequence[EnforcedInteriorData] = (),
         evolution_var: str = "t",
         include_identity_remainder: bool = True,
+        gate_method: EnforcementGateMethod = "auto",
+        gate_saturation_fraction: float = 0.5,
+        gate_linear_fraction: float = 0.5,
         num_reference: int = 3_000_000,
         sampler: str = "latin_hypercube",
         key: Key[Array, ""] = DOC_KEY0,
@@ -2119,6 +2121,9 @@ class EnforcedConstraintPipelines(StrictModule):
                 constraints=cs,
                 interior_data=ds,
                 evolution_var=evolution_var,
+                gate_method=gate_method,
+                gate_saturation_fraction=gate_saturation_fraction,
+                gate_linear_fraction=gate_linear_fraction,
                 include_identity_remainder=include_identity_remainder,
                 num_reference=num_reference,
                 sampler=sampler,

--- a/phydrax/solver/_functional_solver.py
+++ b/phydrax/solver/_functional_solver.py
@@ -20,6 +20,7 @@ from .._strict import StrictModule
 from .._training import EvaluationParametersFn
 from ..constraints._base import AbstractConstraint
 from ..constraints._functional import FunctionalConstraint
+from ..domain._base import EnforcementGateMethod
 from ..domain._function import DomainFunction
 from ..operators.differential._runtime import derivative_runtime_context
 from ._enforced_constraint_pipeline import (
@@ -125,6 +126,9 @@ class FunctionalSolver(StrictModule):
         interior_data_terms: Sequence[EnforcedInteriorData] = (),
         evolution_var: str = "t",
         include_identity_remainder: bool = True,
+        gate_method: EnforcementGateMethod = "auto",
+        gate_saturation_fraction: float = 0.5,
+        gate_linear_fraction: float = 0.5,
         boundary_weight_num_reference: int = 500_000,
         boundary_weight_sampler: str = "latin_hypercube",
         boundary_weight_key: Key[Array, ""] = DOC_KEY0,
@@ -145,6 +149,11 @@ class FunctionalSolver(StrictModule):
         - `interior_data_terms`: Enforced interior data sources used to build `EnforcedConstraintPipelines`.
         - `evolution_var`: Name of the time-like label used for initial staging (default `"t"`).
         - `include_identity_remainder`: Boundary blending option for enforced pipelines.
+        - `gate_method`: CAD enforcement-gate implementation. ``"auto"`` selects the
+          global R-equivalence gate; ``"compact"`` selects the compact fallback.
+        - `gate_saturation_fraction`: Relative extent of compact CAD gates.
+        - `gate_linear_fraction`: Fraction of the compact gate extent retaining a
+          linear boundary profile.
         - `boundary_weight_num_reference`: Number of reference samples used for boundary blending weights.
         - `boundary_weight_sampler`: Sampler used to draw boundary blending references.
         - `boundary_weight_key`: PRNG key used to draw boundary blending references.
@@ -168,7 +177,10 @@ class FunctionalSolver(StrictModule):
                 constraints=constraint_terms,
                 interior_data=interior_data_terms,
                 evolution_var=str(evolution_var),
+                gate_method=gate_method,
                 include_identity_remainder=bool(include_identity_remainder),
+                gate_saturation_fraction=gate_saturation_fraction,
+                gate_linear_fraction=gate_linear_fraction,
                 num_reference=int(boundary_weight_num_reference),
                 sampler=str(boundary_weight_sampler),
                 key=boundary_weight_key,
@@ -277,9 +289,7 @@ class FunctionalSolver(StrictModule):
             for objective, objective_key in zip(
                 self.objectives, objective_keys, strict=True
             ):
-                total = total + objective.loss(
-                    functions, key=objective_key, **kwargs
-                )
+                total = total + objective.loss(functions, key=objective_key, **kwargs)
             iter_ = kwargs.get("iter_", None)
             for term in function_model_loss_values(
                 self.functions,

--- a/tests/integration/enforced_pipeline/test_pipeline_additional_edges.py
+++ b/tests/integration/enforced_pipeline/test_pipeline_additional_edges.py
@@ -25,8 +25,14 @@ from phydrax.domain import (
     TimeInterval,
 )
 from phydrax.integration import from_samples, mean_over
-from phydrax.operators.differential import directional_derivative, dt, partial_x
+from phydrax.operators.differential import (
+    cauchy_stress,
+    directional_derivative,
+    dt,
+    partial_x,
+)
 from phydrax.operators.integral import mean
+from phydrax.operators.linalg import einsum
 from phydrax.solver import (
     EnforcedConstraintPipelines,
     EnforcedInteriorData,
@@ -507,6 +513,42 @@ def test_pipeline_points_vs_coord_separable():
     assert jnp.allclose(out_sep, out_dense, atol=1e-6)
 
 
+def test_gated_pipeline_points_vs_coord_separable():
+    geom = Interval1d(0.0, 1.0)
+    boundary = geom.component({"x": Boundary()})
+
+    @geom.Function("x")
+    def u(x):
+        return x[0] ** 2
+
+    constraint = SingleFieldEnforcedConstraint(
+        "u",
+        boundary,
+        lambda f: enforce_dirichlet(f, boundary, var="x", target=0.0),
+    )
+    interior = EnforcedInteriorData(
+        "u",
+        points={"x": jnp.array([[0.25]], dtype=float)},
+        values=jnp.array([0.125], dtype=float),
+    )
+    pipes = EnforcedConstraintPipelines.build(
+        functions={"u": u},
+        constraints=[constraint],
+        interior_data=[interior],
+    )
+    u_enforced = pipes.apply({"u": u})["u"]
+    eval_jit = eqx.filter_jit(lambda f, b: f(b).data)
+
+    component = geom.component()
+    sep = component.sample_coord_separable({"x": 6}, num_points=())
+    x_axis = sep.points["x"][0].data
+    dense = _line_batch(geom, xs=x_axis)
+
+    out_sep = eval_jit(u_enforced, sep).reshape((-1,))
+    out_dense = eval_jit(u_enforced, dense).reshape((-1,))
+    assert jnp.allclose(out_sep, out_dense, atol=1e-6)
+
+
 def test_operator_stack_with_pipeline():
     geom = Interval1d(0.0, 1.0)
 
@@ -674,3 +716,106 @@ def test_where_all_weight_all_mean():
     eval_jit = eqx.filter_jit(lambda: mean(u, realization).data)
     out = eval_jit().reshape(())
     assert jnp.allclose(out, 0.75, atol=1e-6)
+
+
+def test_enforce_traction_cancels_nonzero_affine_boundary_traction():
+    geom = Square(center=(0.0, 0.0), side=2.0)
+    component = geom.component({"x": Boundary()})
+
+    @geom.Function("x")
+    def u(x):
+        return jnp.array([x[0], 0.0])
+
+    u_enforced = enforce_traction(
+        u,
+        component,
+        var="x",
+        lambda_=1.0,
+        mu=1.0,
+        target=jnp.array([0.0, 0.0]),
+    )
+    stress = cauchy_stress(
+        u_enforced,
+        lambda_=1.0,
+        mu=1.0,
+        var="x",
+    )
+    traction = einsum("...ij,...j->...i", stress, component.normal(var="x"))
+
+    structure = ProductStructure((("x",),)).canonicalize(geom.labels)
+    axis_names = structure.axis_names
+    assert axis_names is not None
+    axis = axis_names[0]
+    points = PointsBatch(
+        points=frozendict(
+            {
+                "x": cx.Field(
+                    jnp.array(
+                        [
+                            [-1.0, 0.2],
+                            [1.0, -0.3],
+                            [0.4, -1.0],
+                            [-0.2, 1.0],
+                        ],
+                        dtype=float,
+                    ),
+                    dims=(axis, None),
+                )
+            }
+        ),
+        structure=structure,
+    )
+
+    out = eqx.filter_jit(lambda f, b: f(b).data)(traction, points)
+    assert jnp.allclose(out, 0.0, atol=1e-5)
+
+
+def test_enforce_neumann_cad_ansatz_is_bounded_in_the_interior():
+    geom = Square(center=(0.0, 0.0), side=2.0)
+    component = geom.component({"x": Boundary()})
+
+    @geom.Function("x")
+    def u(x):
+        return x[0] * 0.0
+
+    u_enforced = enforce_neumann(
+        u,
+        component,
+        var="x",
+        target=1.0,
+        mode="forward",
+    )
+    coordinates = jnp.linspace(-0.95, 0.95, 101)
+    structure = ProductStructure((("x",),)).canonicalize(geom.labels)
+    axis_names = structure.axis_names
+    assert axis_names is not None
+    points = PointsBatch(
+        points=frozendict(
+            {
+                "x": cx.Field(
+                    jnp.stack((coordinates, jnp.zeros_like(coordinates)), axis=-1),
+                    dims=(axis_names[0], None),
+                )
+            }
+        ),
+        structure=structure,
+    )
+
+    values = jnp.asarray(u_enforced(points).data)
+    assert jnp.all(jnp.isfinite(values))
+    assert jnp.max(jnp.abs(values)) < 1.0
+
+    normal = component.normal(var="x")
+    du_dn = directional_derivative(u_enforced, normal, var="x", mode="forward")
+    boundary_points = PointsBatch(
+        points=frozendict(
+            {
+                "x": cx.Field(
+                    jnp.array([[-1.0, 0.0], [1.0, 0.0]]),
+                    dims=(axis_names[0], None),
+                )
+            }
+        ),
+        structure=structure,
+    )
+    assert jnp.allclose(du_dn(boundary_points).data, 1.0, atol=1e-3)

--- a/tests/integration/enforced_pipeline/test_pipeline_boundary_blend.py
+++ b/tests/integration/enforced_pipeline/test_pipeline_boundary_blend.py
@@ -3,12 +3,25 @@
 #
 
 import coordax as cx
+import jax
 import jax.numpy as jnp
 
 from phydrax._frozendict import frozendict
-from phydrax.constraints import enforce_dirichlet
-from phydrax.domain import Boundary, Interval1d, PointsBatch, ProductStructure
-from phydrax.solver import EnforcedConstraintPipelines, SingleFieldEnforcedConstraint
+from phydrax.constraints import enforce_dirichlet, enforce_neumann
+from phydrax.domain import (
+    Boundary,
+    FixedStart,
+    Interval1d,
+    PointsBatch,
+    ProductStructure,
+    Square,
+    TimeInterval,
+)
+from phydrax.solver import (
+    EnforcedConstraintPipelines,
+    FunctionalSolver,
+    SingleFieldEnforcedConstraint,
+)
 
 
 def _line_batch(domain, xs):
@@ -61,3 +74,154 @@ def test_boundary_subset_blend_matches_pieces():
     out = jnp.asarray(u_enforced(batch).data).reshape((-1,))
     assert jnp.allclose(out[0], 1.0, atol=1e-3)
     assert jnp.allclose(out[1], 2.0, atol=1e-3)
+
+
+def test_initial_overlay_boundary_gate_is_dimensionless_and_scale_invariant():
+    gate_values = []
+
+    for length in (1.0, 100.0):
+        domain = Interval1d(0.0, length) @ TimeInterval(0.0, 1.0)
+        boundary = domain.component({"x": Boundary()})
+        initial = domain.component({"t": FixedStart()})
+
+        @domain.Function("x", "t")
+        def u(x, t):
+            return x[0] * 0.0 + t * 0.0
+
+        @domain.Function("x")
+        def initial_target(x):
+            return jnp.sin(jnp.pi * x[0] / length)
+
+        terms = [
+            SingleFieldEnforcedConstraint(
+                "u",
+                boundary,
+                lambda f, boundary=boundary: enforce_dirichlet(
+                    f, boundary, var="x", target=0.0
+                ),
+            ),
+            SingleFieldEnforcedConstraint(
+                "u",
+                initial,
+                lambda f: f,
+                time_derivative_order=0,
+                initial_target=initial_target,
+            ),
+        ]
+        pipelines = EnforcedConstraintPipelines.build(
+            functions={"u": u},
+            constraints=terms,
+            num_reference=64,
+        )
+        gate = pipelines.pipelines["u"].boundary_gate
+        assert gate is not None
+        gate_values.append(
+            jnp.stack(
+                (
+                    gate.func(jnp.array([0.25 * length])),
+                    gate.func(jnp.array([0.5 * length])),
+                )
+            )
+        )
+
+    assert jnp.allclose(gate_values[0], jnp.array([0.75, 1.0]))
+    assert jnp.allclose(gate_values[0], gate_values[1])
+
+
+def test_initial_overlay_gate_preserves_declared_normal_derivative():
+    domain = Square(center=(0.0, 0.0), side=2.0) @ TimeInterval(0.0, 1.0)
+    boundary = domain.component({"x": Boundary()})
+    initial = domain.component({"t": FixedStart()})
+
+    @domain.Function("x", "t")
+    def u(x, t):
+        return x[0] * 0.0 + t * 0.0
+
+    @domain.Function("x")
+    def incompatible_initial_target(x):
+        return x[0]
+
+    terms = [
+        SingleFieldEnforcedConstraint(
+            "u",
+            boundary,
+            lambda f: enforce_neumann(
+                f,
+                boundary,
+                var="x",
+                target=0.0,
+                mode="forward",
+            ),
+            max_derivative_order=1,
+        ),
+        SingleFieldEnforcedConstraint(
+            "u",
+            initial,
+            lambda f: f,
+            time_derivative_order=0,
+            initial_target=incompatible_initial_target,
+        ),
+    ]
+    pipelines = EnforcedConstraintPipelines.build(
+        functions={"u": u},
+        constraints=terms,
+        num_reference=64,
+    )
+    pipeline = pipelines.pipelines["u"]
+    assert pipeline.initial_overlay_boundary_compatible is False
+
+    u_enforced = pipelines.apply({"u": u})["u"]
+    point = jnp.array([1.0, 0.0])
+    normal = boundary.normal(var="x").func(point)
+    derivative = jnp.dot(
+        jax.grad(lambda x: u_enforced.func(x, jnp.array(0.0)))(point),
+        normal,
+    )
+
+    assert jnp.allclose(derivative, 0.0, atol=1e-10)
+
+
+def test_functional_solver_configures_cad_preservation_gate_extent():
+    domain = Square(center=(0.0, 0.0), side=2.0) @ TimeInterval(0.0, 1.0)
+    boundary = domain.component({"x": Boundary()})
+    initial = domain.component({"t": FixedStart()})
+
+    @domain.Function("x", "t")
+    def u(x, t):
+        return x[0] * 0.0 + t * 0.0
+
+    @domain.Function("x")
+    def initial_target(x):
+        return (1.0 - x[0] ** 2) * (1.0 - x[1] ** 2)
+
+    terms = [
+        SingleFieldEnforcedConstraint(
+            "u",
+            boundary,
+            lambda f: enforce_dirichlet(f, boundary, var="x", target=0.0),
+        ),
+        SingleFieldEnforcedConstraint(
+            "u",
+            initial,
+            lambda f: f,
+            time_derivative_order=0,
+            initial_target=initial_target,
+        ),
+    ]
+    values = []
+    for saturation_fraction in (0.5, 0.2):
+        solver = FunctionalSolver(
+            functions={"u": u},
+            constraints=(),
+            constraint_terms=terms,
+            gate_method="compact",
+            gate_saturation_fraction=saturation_fraction,
+            boundary_weight_num_reference=64,
+        )
+        assert solver.constraint_pipelines is not None
+        gate = solver.constraint_pipelines.pipelines["u"].boundary_gate
+        assert gate is not None
+        values.append(gate.func(jnp.array([0.8, 0.0])))
+
+    assert 0.2 < float(values[0]) < 0.4
+    assert 0.6 < float(values[1]) < 0.8

--- a/tests/integration/test_solver_enforced_terms.py
+++ b/tests/integration/test_solver_enforced_terms.py
@@ -180,7 +180,7 @@ def test_enforced_constraints_respected_with_latent_contraction_model():
 
     @domain.Function("x")
     def u0_target(x):
-        return x[0]
+        return jnp.sin(jnp.pi * x[0])
 
     @domain.Function("x")
     def ut0_target(x):
@@ -226,7 +226,7 @@ def test_enforced_constraints_respected_with_latent_contraction_model():
     x_vals = jnp.linspace(0.0, 1.0, 17)
     x_interior = x_vals[1:-1]
     u_init = jax.vmap(lambda x: u.func(jnp.asarray([x]), 0.0))(x_interior).reshape((-1,))
-    assert jnp.max(jnp.abs(u_init - x_interior)) < 1e-6
+    assert jnp.max(jnp.abs(u_init - jnp.sin(jnp.pi * x_interior))) < 1e-6
 
     corner = u.func(jnp.asarray([1.0]), 0.0)
     assert jnp.abs(corner) < 1e-6

--- a/tests/test_sdf_smoothing_2d.py
+++ b/tests/test_sdf_smoothing_2d.py
@@ -6,7 +6,11 @@ import jax
 import jax.numpy as jnp
 import meshio
 import numpy as np
+import pytest
 
+from phydrax.constraints import enforce_dirichlet
+from phydrax.domain import Boundary
+from phydrax.domain.geometry2d import Ellipse
 from phydrax.domain.geometry2d._from_cad import Geometry2DFromCAD
 
 
@@ -42,3 +46,215 @@ def test_geometry2d_sdf_signs_and_boundary():
     assert float(sd_inside[0]) < 0.0
     assert float(sd_outside[0]) > 0.0
     assert np.isclose(float(sd_boundary[0]), 0.0, atol=1e-2)
+
+
+def test_dense_curved_mesh_adf_has_only_the_geometric_zero_set():
+    geometry = Ellipse(center=(0.0, 0.0), x_radius=1.25, y_radius=0.7)
+    theta = jnp.linspace(0.0, 2.0 * jnp.pi, 96, endpoint=False)
+    normalized_radii = jnp.asarray([0.75, 1.1, 1.3, 1.5])
+    points = jnp.stack(
+        [
+            1.25 * normalized_radii[:, None] * jnp.cos(theta),
+            0.7 * normalized_radii[:, None] * jnp.sin(theta),
+        ],
+        axis=-1,
+    ).reshape((-1, 2))
+
+    expected_inside = jnp.repeat(normalized_radii < 1.0, theta.size)
+    predicate_inside = geometry.predicate_sdf(points) < 0.0
+    factor_inside = geometry.boundary_factor(points) < 0.0
+
+    assert jnp.array_equal(predicate_inside, expected_inside)
+    assert jnp.array_equal(factor_inside, expected_inside)
+
+
+def _scaled_square(scale: float) -> Geometry2DFromCAD:
+    half = 0.5 * scale
+    points = np.array(
+        [
+            [-half, -half, 0.0],
+            [half, -half, 0.0],
+            [half, half, 0.0],
+            [-half, half, 0.0],
+        ],
+        dtype=float,
+    )
+    faces = np.array([[0, 1, 2], [0, 2, 3]], dtype=int)
+    return Geometry2DFromCAD(
+        meshio.Mesh(points=points, cells=[("triangle", faces)]),
+        recenter=False,
+    )
+
+
+def _derivative(function, order: int):
+    derivative = function
+    for _ in range(order):
+        derivative = jax.grad(derivative)
+    return derivative
+
+
+def test_boundary_factor_is_scale_covariant_with_exact_boundary_collar():
+    scales = (1e-7, 1.0)
+    geometries = tuple(_scaled_square(scale) for scale in scales)
+    normalized_points = jnp.array(
+        [[0.5, 0.0], [0.49, 0.1], [0.4, -0.15], [0.0, 0.0], [0.75, 0.1]]
+    )
+    normalized_values = []
+    normalized_ansatz_values = []
+
+    for scale, geometry in zip(scales, geometries, strict=True):
+        point = jnp.array([0.5 * scale, 0.0])
+        normal = jnp.array([1.0, 0.0])
+        assert abs(float(geometry.boundary_factor(point))) <= 1e-12 * scale
+        assert jnp.allclose(
+            jax.grad(geometry.boundary_factor)(point),
+            normal,
+            atol=1e-12,
+            rtol=0.0,
+        )
+        ansatz_factor = geometry.boundary_ansatz_factor
+        assert abs(float(ansatz_factor(point))) <= 1e-12 * scale
+        assert jnp.allclose(
+            jax.grad(ansatz_factor)(point),
+            normal,
+            atol=1e-10,
+            rtol=0.0,
+        )
+        normalized_ansatz_values.append(ansatz_factor(scale * normalized_points) / scale)
+
+        offsets = jnp.array([-0.02, -0.01, -0.002, 0.002, 0.01, 0.02]) * scale
+        profile = geometry.boundary_factor(point + offsets[:, None] * normal)
+        assert jnp.allclose(profile, offsets, atol=1e-12 * scale, rtol=1e-12)
+        normalized_values.append(
+            geometry.boundary_factor(scale * normalized_points) / scale
+        )
+
+    assert jnp.allclose(
+        normalized_values[0],
+        normalized_values[1],
+        atol=1e-10,
+        rtol=1e-10,
+    )
+    assert jnp.allclose(
+        normalized_ansatz_values[0],
+        normalized_ansatz_values[1],
+        atol=1e-10,
+        rtol=1e-10,
+    )
+
+
+def test_enforcement_gate_is_dimensionless_scale_invariant_and_broad():
+    scales = (1e-7, 1.0)
+    normalized_points = jnp.array([[0.5, 0.0], [0.4, 0.0], [0.25, 0.0], [0.0, 0.0]])
+    normalized_values = []
+    normalized_boundary_gradients = []
+
+    for scale in scales:
+        geometry = _scaled_square(scale)
+        gate = geometry.make_enforcement_gate()
+        normalized_values.append(gate(scale * normalized_points))
+        normalized_boundary_gradients.append(
+            scale * jax.grad(gate)(jnp.array([0.5 * scale, 0.0]))
+        )
+
+    assert jnp.allclose(
+        normalized_values[0],
+        normalized_values[1],
+        atol=1e-10,
+        rtol=1e-10,
+    )
+    assert jnp.allclose(
+        normalized_boundary_gradients[0],
+        normalized_boundary_gradients[1],
+        atol=1e-10,
+        rtol=1e-10,
+    )
+    values = normalized_values[0]
+    assert jnp.allclose(values[0], 0.0, atol=1e-10)
+    assert 0.35 < float(values[1]) < 0.5
+    assert float(values[2]) > 0.75
+    assert float(values[3]) > 0.9
+    assert jnp.all(jnp.diff(values) > 0.0)
+    assert jnp.linalg.norm(normalized_boundary_gradients[0]) < 5.0
+
+
+def test_compact_enforcement_gate_saturation_controls_transition_extent():
+    geometry = _scaled_square(1.0)
+    point = jnp.array([0.4, 0.0])
+
+    broad = geometry.make_enforcement_gate(method="compact", saturation_fraction=0.5)
+    compact = geometry.make_enforcement_gate(method="compact", saturation_fraction=0.2)
+
+    assert float(broad(point)) < 0.4
+    assert float(compact(point)) > 0.6
+
+
+def test_enforcement_gate_rejects_unknown_method():
+    geometry = _scaled_square(1.0)
+
+    with pytest.raises(ValueError, match="method must be"):
+        geometry.make_enforcement_gate(method="unknown")
+
+
+def test_boundary_factor_has_finite_flat_high_order_jets():
+    geometry = _scaled_square(1.0)
+    boundary_point = jnp.array([0.5, 0.0])
+    normal = jnp.array([1.0, 0.0])
+
+    def boundary_profile(offset):
+        return geometry.boundary_factor(boundary_point + offset * normal)
+
+    for order in (2, 3, 4):
+        value = _derivative(boundary_profile, order)(jnp.asarray(0.0))
+        assert jnp.isfinite(value)
+        assert jnp.allclose(value, 0.0, atol=1e-10)
+
+    def medial_profile(offset):
+        return geometry.boundary_factor(jnp.array([offset, 0.0]))
+
+    for order in (1, 2, 3, 4):
+        values = jnp.stack(
+            [
+                _derivative(medial_profile, order)(jnp.asarray(offset))
+                for offset in (-1e-4, 0.0, 1e-4)
+            ]
+        )
+        assert jnp.all(jnp.isfinite(values))
+        assert jnp.allclose(values, 0.0, atol=1e-10)
+
+
+def test_boundary_factor_transition_hessian_matches_finite_difference():
+    geometry = _scaled_square(1.0)
+    point = jnp.array([0.55, 0.125])
+    normal = jnp.array([1.0, 0.0])
+    step = jnp.asarray(1e-4)
+
+    hessian = jax.jacfwd(jax.jacfwd(geometry.boundary_factor))(point)
+    center = geometry.boundary_factor(point)
+    finite_difference = (
+        geometry.boundary_factor(point + step * normal)
+        - 2.0 * center
+        + geometry.boundary_factor(point - step * normal)
+    ) / step**2
+
+    assert jnp.abs(finite_difference) > 1.0
+    assert jnp.allclose(hessian[0, 0], finite_difference, atol=2e-3, rtol=2e-4)
+
+
+def test_cad_hard_ansatz_uses_boundary_factor_without_predicate_coupling():
+    geometry = _scaled_square(1.0)
+    assert geometry.predicate_sdf is not geometry.boundary_factor
+    assert abs(float(geometry.predicate_sdf(jnp.array([0.0, 0.0])))) > abs(
+        float(geometry.boundary_factor(jnp.array([0.0, 0.0])))
+    )
+
+    component = geometry.component({"x": Boundary()})
+
+    @geometry.Function("x")
+    def field(x):
+        del x
+        return jnp.asarray(1.0)
+
+    enforced = enforce_dirichlet(field, component, var="x", target=0.0)
+    boundary_value = enforced.func(jnp.array([0.5, 0.0]))
+    assert jnp.allclose(boundary_value, 0.0, atol=1e-12)

--- a/tests/unit/constraints/test_enforced_helpers.py
+++ b/tests/unit/constraints/test_enforced_helpers.py
@@ -3,6 +3,7 @@
 #
 
 import coordax as cx
+import jax
 import jax.numpy as jnp
 import pytest
 
@@ -368,3 +369,130 @@ def test_enforce_initial_supports_coord_separable_sampling():
     out = jnp.asarray(u_enforced(batch).data).reshape((-1,))
     assert jnp.allclose(out[0], 2.0, atol=1e-10)
     assert jnp.all(jnp.isfinite(out))
+
+
+def test_enforce_dirichlet_uses_dimensionless_geometry_gate():
+    geom = Interval1d(0.0, 100.0)
+    component = geom.component({"x": Boundary()})
+
+    @geom.Function("x")
+    def u(x):
+        del x
+        return jnp.asarray(1.0)
+
+    gate = component.enforcement_gate(var="x")
+    batch = _points_on_interval(geom, jnp.array([0.0, 50.0, 100.0]))
+    gate_values = jnp.asarray(gate(batch).data).reshape((-1,))
+    sdf_values = jnp.asarray(component.sdf(var="x")(batch).data).reshape((-1,))
+    enforced_values = jnp.asarray(
+        enforce_dirichlet(u, component, target=0.0)(batch).data
+    ).reshape((-1,))
+
+    assert jnp.allclose(gate_values, jnp.array([0.0, 1.0, 0.0]))
+    assert jnp.allclose(enforced_values, gate_values)
+    assert jnp.allclose(sdf_values[1], -25.0)
+
+
+@pytest.mark.parametrize(
+    ("saturation_fraction", "linear_fraction"),
+    ((0.0, 0.5), (0.6, 0.5), (0.5, 0.0), (0.5, 1.0)),
+)
+def test_enforcement_gate_rejects_invalid_profile_fractions(
+    saturation_fraction,
+    linear_fraction,
+):
+    geom = Interval1d(0.0, 1.0)
+    component = geom.component({"x": Boundary()})
+
+    with pytest.raises(ValueError):
+        component.enforcement_gate(
+            var="x",
+            saturation_fraction=saturation_fraction,
+            linear_fraction=linear_fraction,
+        )
+
+
+def test_interval_derivative_ansatze_are_continuous_at_midpoint():
+    geom = Interval1d(0.0, 1.0)
+    boundary = geom.component({"x": Boundary()})
+
+    @geom.Function("x")
+    def scalar(x):
+        return x[0]
+
+    @geom.Function("x")
+    def displacement(x):
+        return jnp.asarray([x[0]])
+
+    neumann = enforce_neumann(scalar, boundary, target=0.0)
+    robin = enforce_robin(
+        scalar,
+        boundary,
+        dirichlet_coeff=1.0,
+        neumann_coeff=1.0,
+        target=0.0,
+    )
+    traction = enforce_traction(
+        displacement,
+        boundary,
+        target=jnp.zeros((1,)),
+        lambda_=1.0,
+        mu=1.0,
+    )
+
+    time = TimeInterval(0.0, 1.0)
+    domain = geom @ time
+    spacetime_boundary = domain.component({"x": Boundary()})
+
+    @domain.Function("x", "t")
+    def wave(x, t):
+        return x[0] + t
+
+    sommerfeld = enforce_sommerfeld(
+        wave,
+        spacetime_boundary,
+        wavespeed=1.0,
+        target=0.0,
+    )
+
+    epsilon = 1e-6
+    points = jnp.asarray([[0.5 - epsilon], [0.5], [0.5 + epsilon]])
+    time_value = jnp.asarray(0.25)
+    profiles = (
+        jax.vmap(neumann.func)(points),
+        jax.vmap(robin.func)(points),
+        jax.vmap(lambda x: sommerfeld.func(x, time_value))(points),
+        jax.vmap(traction.func)(points)[:, 0],
+    )
+
+    for profile in profiles:
+        assert jnp.all(jnp.isfinite(profile))
+        assert jnp.max(jnp.abs(jnp.diff(profile))) < 1e-4
+        assert jnp.allclose(profile[1], 0.5 * (profile[0] + profile[2]), atol=1e-8)
+
+
+def test_interval_nonzero_neumann_and_robin_targets_are_exact():
+    geom = Interval1d(0.0, 1.0)
+    boundary = geom.component({"x": Boundary()})
+
+    @geom.Function("x")
+    def u(x):
+        return x[0] ** 2
+
+    normal = boundary.normal(var="x")
+    batch = _points_on_interval(geom, jnp.asarray([0.0, 1.0]))
+
+    neumann = enforce_neumann(u, boundary, target=1.25)
+    neumann_derivative = directional_derivative(neumann, normal, var="x")
+    assert jnp.allclose(neumann_derivative(batch).data, 1.25, atol=1e-8)
+
+    robin = enforce_robin(
+        u,
+        boundary,
+        dirichlet_coeff=2.0,
+        neumann_coeff=0.5,
+        target=3.0,
+    )
+    robin_derivative = directional_derivative(robin, normal, var="x")
+    residual = 2.0 * robin(batch).data + 0.5 * robin_derivative(batch).data
+    assert jnp.allclose(residual, 3.0, atol=1e-8)

--- a/tests/unit/domain/test_geometry_sdf_jvp_micro.py
+++ b/tests/unit/domain/test_geometry_sdf_jvp_micro.py
@@ -4,9 +4,12 @@
 
 import jax
 import jax.numpy as jnp
+import numpy as np
+import trimesh
 
 from phydrax.domain.geometry2d import Square
-from phydrax.domain.geometry3d import Cube
+from phydrax.domain.geometry3d import Cube, Geometry3DFromCAD
+from phydrax.domain.geometry3d._sdf import make_compact_boundary_factor
 
 
 def test_2d_sdf_jvp_vector_and_scalar_inputs():
@@ -44,3 +47,61 @@ def test_3d_sdf_jvp_vector_and_scalar_inputs():
     val_s, tval_s = jax.jvp(f, (jnp.array(0.1),), (jnp.array(0.0),))
     assert jnp.isfinite(val_s)
     assert jnp.isfinite(tval_s)
+
+
+def test_compact_boundary_factor_exact_zero_has_finite_identity_jet():
+    factor = make_compact_boundary_factor(
+        lambda point: point[0],
+        scale=1.0,
+    )
+
+    def profile(offset):
+        return factor(jnp.array([offset]))
+
+    derivatives = []
+    derivative = profile
+    for _ in range(4):
+        derivative = jax.grad(derivative)
+        derivatives.append(derivative(jnp.asarray(0.0)))
+
+    assert factor(jnp.array([0.0])) == 0.0
+    assert jnp.all(jnp.isfinite(jnp.stack(derivatives)))
+    assert jnp.allclose(jnp.stack(derivatives), jnp.array([1.0, 0.0, 0.0, 0.0]))
+
+
+def test_3d_enforcement_gate_corner_has_finite_pseudoderivatives():
+    geom = Cube(center=(0.0, 0.0, 0.0), side=1.0)
+    gate = geom.make_enforcement_gate()
+    corner = jnp.array([0.5, 0.5, 0.5])
+
+    gradient = jax.grad(gate)(corner)
+    hessian = jax.hessian(gate)(corner)
+
+    assert gate(corner) == 0.0
+    assert jnp.all(jnp.isfinite(gradient))
+    assert jnp.all(jnp.isfinite(hessian))
+
+
+def test_3d_enforcement_gate_vanishes_on_sliver_facet():
+    vertices = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [1e-3, 1e-2, 0.0],
+            [0.0, 0.0, 1.0],
+        ]
+    )
+    faces = np.array(
+        [
+            [0, 2, 1],
+            [0, 1, 3],
+            [1, 2, 3],
+            [2, 0, 3],
+        ]
+    )
+    mesh = trimesh.Trimesh(vertices=vertices, faces=faces, process=False)
+    geom = Geometry3DFromCAD(mesh)
+    gate = geom.make_enforcement_gate()
+    facet_point = jnp.asarray(np.array([0.026, 0.957, 0.017]) @ vertices[[0, 1, 2]])
+
+    assert jnp.abs(gate(facet_point)) < 1e-10

--- a/tests/unit/geometry/test_geometry_1d/test_primitives_1d.py
+++ b/tests/unit/geometry/test_geometry_1d/test_primitives_1d.py
@@ -2,6 +2,7 @@
 #  Copyright © 2026 PHYDRA, Inc. All rights reserved.
 #
 
+import jax
 import jax.numpy as jnp
 import jax.random as jr
 import numpy as np
@@ -63,3 +64,29 @@ def test_boundary_normals(simple_interval):
     expected_normals = np.array([[-1.0], [1.0]])
     computed_normals = simple_interval._boundary_normals(points)
     assert np.allclose(computed_normals, expected_normals, atol=1e-6)
+
+
+def test_boundary_fields_are_scale_covariant():
+    normalized_points = jnp.asarray([[0.0], [0.25], [0.5], [0.75], [1.0]])
+    normalized_factors = []
+    gate_values = []
+
+    for scale in (1e-7, 1.0):
+        interval = Interval1d(0.0, scale)
+        factor = interval.boundary_ansatz_factor
+        normalized_factors.append(factor(scale * normalized_points) / scale)
+        gate_values.append(interval.make_enforcement_gate()(scale * normalized_points))
+
+        assert jnp.allclose(
+            jax.grad(factor)(jnp.asarray([0.0])),
+            jnp.asarray([-1.0]),
+            atol=1e-10,
+        )
+        assert jnp.allclose(
+            jax.grad(factor)(jnp.asarray([scale])),
+            jnp.asarray([1.0]),
+            atol=1e-10,
+        )
+
+    assert jnp.allclose(normalized_factors[0], normalized_factors[1], atol=1e-10)
+    assert jnp.allclose(gate_values[0], gate_values[1], atol=1e-10)

--- a/tests/unit/geometry/test_geometry_3d/test_from_cad_3d.py
+++ b/tests/unit/geometry/test_geometry_3d/test_from_cad_3d.py
@@ -342,3 +342,85 @@ def test_sample_interior_separable(geometry_from_cube):
             )
             # The point should be in the positive octant
             assert np.all(point > 0)
+
+
+def test_boundary_factor_is_scale_covariant_with_unit_face_gradient():
+    scales = (1e-7, 1.0)
+    normalized_points = jnp.array(
+        [
+            [0.5, 0.0, 0.0],
+            [0.49, 0.1, -0.1],
+            [0.4, -0.15, 0.15],
+            [0.0, 0.0, 0.0],
+            [0.75, 0.1, -0.1],
+        ]
+    )
+    normalized_values = []
+    normalized_ansatz_values = []
+    normalized_gate_values = []
+    normalized_gate_gradients = []
+    normalized_gate_midpoints = []
+
+    for scale in scales:
+        geometry = Geometry3DFromCAD(
+            trimesh.creation.box(extents=(scale, scale, scale)),
+            recenter=False,
+        )
+        boundary_point = jnp.array([0.5 * scale, 0.0, 0.0])
+        assert abs(float(geometry.boundary_factor(boundary_point))) <= 1e-12 * scale
+        assert jnp.allclose(
+            jax.grad(geometry.boundary_factor)(boundary_point),
+            jnp.array([1.0, 0.0, 0.0]),
+            atol=1e-12,
+            rtol=0.0,
+        )
+        ansatz_factor = geometry.boundary_ansatz_factor
+        assert abs(float(ansatz_factor(boundary_point))) <= 1e-12 * scale
+        assert jnp.allclose(
+            jax.grad(ansatz_factor)(boundary_point),
+            jnp.array([1.0, 0.0, 0.0]),
+            atol=1e-10,
+            rtol=0.0,
+        )
+        normalized_ansatz_values.append(ansatz_factor(scale * normalized_points) / scale)
+        gate = geometry.make_enforcement_gate()
+        normalized_gate_values.append(gate(scale * normalized_points))
+        normalized_gate_gradients.append(scale * jax.grad(gate)(boundary_point))
+        normalized_gate_midpoints.append(gate(jnp.array([0.25 * scale, 0.0, 0.0])))
+        normalized_values.append(
+            geometry.boundary_factor(scale * normalized_points) / scale
+        )
+
+    assert jnp.allclose(
+        normalized_values[0],
+        normalized_values[1],
+        atol=1e-10,
+        rtol=1e-10,
+    )
+    assert jnp.allclose(
+        normalized_ansatz_values[0],
+        normalized_ansatz_values[1],
+        atol=1e-10,
+        rtol=1e-10,
+    )
+    assert jnp.allclose(
+        normalized_gate_values[0],
+        normalized_gate_values[1],
+        atol=1e-10,
+        rtol=1e-10,
+    )
+    assert jnp.allclose(
+        normalized_gate_gradients[0],
+        normalized_gate_gradients[1],
+        atol=1e-10,
+        rtol=1e-10,
+    )
+    assert jnp.allclose(
+        normalized_gate_midpoints[0],
+        normalized_gate_midpoints[1],
+        atol=1e-10,
+        rtol=1e-10,
+    )
+    assert float(normalized_gate_midpoints[0]) > 0.75
+    assert jnp.allclose(normalized_gate_values[0][0], 0.0, atol=1e-10)
+    assert float(normalized_gate_values[0][3]) > 0.9


### PR DESCRIPTION
## Summary

Separate the geometry fields used for classification, public normals, value enforcement, and derivative enforcement, then give each one an explicit mathematical and numerical contract.

This removes the overloaded use of a single mesh ADF as a predicate, a normal source, a PINN multiplier, and a derivative ansatz factor. CAD geometries now expose scale-covariant boundary fields, Dirichlet and preservation paths use a dimensionless broad gate, and derivative hard constraints use a dimensional unit-boundary-jet factor with a smooth canonical interior normal extension.

## Motivation

The previous implementation asked one signed distance-like field to satisfy several incompatible requirements:

- preserve the exact geometry zero set and inside/outside sign;
- supply stable boundary normals;
- remain broad and order one across the interior when multiplying a learned field;
- retain a dimensional unit normal derivative for Neumann-type corrections;
- avoid medial-axis and nearest-feature nonsmoothness in higher PDE derivatives;
- remain well conditioned under large or very small coordinate rescalings.

A compact, dimensional ADF is appropriate for local geometry operations but attenuates a network across most of a large domain. A broad dimensionless gate is appropriate for value ansätze but cannot directly supply the unit boundary jet required by derivative constraints. Normalizing nearest-boundary directions throughout the interior also creates discontinuities at medial sets. The previous pointwise division by the ADF normal derivative coupled all of these concerns and could become singular away from the boundary.

This change assigns each role its own field while keeping a shared boundary zero set.

## Boundary-field model

### Geometry classification and public normals

CAD geometry now keeps two explicit geometry-facing fields:

- `predicate_sdf` is the unsquashed signed distance-like source used for inside/outside classification.
- `boundary_factor`, also exposed through the existing `adf` interface, is a dimensional compact field used by differentiable geometry operations and public normal construction.

`boundary_factor` equals the exact mesh distance throughout an open boundary collar, then transitions through a C6 compact saturation before nearest-feature nonsmoothness can reach the interior plateau. It preserves the geometry zero set, sign, and complete boundary jet without claiming metric-distance magnitude in the interior.

Public `DomainComponent.normal(...)` behavior remains owned by the geometry normal provider. Analytic normals and mesh pseudonormals are not replaced by solver gates.

### Dimensionless enforcement gate

`make_enforcement_gate(...)` produces the field used by Dirichlet ansätze and constraint-preserving overlays:

- zero on the selected geometry boundary;
- positive and order one in the interior;
- invariant under uniform coordinate scaling;
- smooth across competing CAD patches away from the exact boundary collar.

For CAD geometry, `method="auto"` selects an order-12 negative-power R-equivalence aggregate with a scale-normalized boundary collar and C6 transition. `method="global_r_equivalence"` selects it explicitly. `method="compact"` retains the compact fallback, with `saturation_fraction` and `linear_fraction` controlling its transition.

Intervals and axis-aligned hyperrectangles retain their exact analytic parabolic/product gates. Mesh-specific method and profile controls are accepted consistently but intentionally do not alter those exact analytic profiles.

### Dimensional derivative ansatz factor

`boundary_ansatz_factor` is the dimensional field used by Neumann, Robin, Sommerfeld, and traction constructions. It satisfies:

- zero value on the boundary;
- outward unit normal derivative at every regular boundary point;
- uniform-scale covariance;
- finite interior values without a pointwise division by a vanishing derivative.

CAD implementations obtain this factor by a constant dimensional rescaling of the broad R-equivalence profile. Analytic geometries retain their exact unit-jet fields.

### Smooth interior normal extension

Derivative ansätze use the canonical extension `nu = grad(psi)`, where `psi` is the dimensional boundary ansatz factor. On every regular boundary point, `nu` equals the outward unit normal. In the interior it is deliberately not renormalized and may vanish smoothly at a medial set.

This preserves the stated boundary operators while avoiding discontinuous everywhere-unit nearest-boundary fields inside the residual correction.

## Mesh-distance machinery

The mesh SDF implementation now performs geometric calculations in diameter-normalized, centered coordinates and maps scalar distances back to physical units. This makes epsilon collars, smoothness radii, BVH geometry, and transition widths independent of the model's coordinate scale.

The exact boundary path uses global BVH traversal for its collar rather than beam-local nearest candidates. Nearest-feature routing is treated as discrete under nested autodiff, while the custom first derivative exposes the stable face/edge/vertex pseudonormal convention. This avoids machine-epsilon curvature spikes at exact boundary points without inventing classical higher derivatives at polyhedral seams.

The smooth interior path supports an inverse-power R-equivalence aggregate in addition to the retained Gibbs-weighted RMS form. A generalized order-five smoothstep gives the collar transition six vanishing derivatives at both joins. Compact saturation uses the integral of that profile so it agrees with the identity through sixth order at the inner join and reaches a sixth-order-flat plateau.

## Hard-constraint ansätze

### Dirichlet

`enforce_dirichlet` now multiplies the free field by the dimensionless enforcement gate instead of the dimensional geometry ADF. The boundary value remains exact, while the model retains useful amplitude through the interior.

The constructor accepts `gate_method`, `gate_saturation_fraction`, and `gate_linear_fraction` for explicit CAD gate selection.

### Neumann, Robin, and Sommerfeld

Derivative residuals now use `psi` and the smooth extension `nu = grad(psi)`:

- Neumann corrects with `psi * (g - D_nu u)`.
- Robin corrects with `(psi / b) * (g - a u - b D_nu u)`.
- Sommerfeld corrects with `psi * (g - D_nu u - c^-1 d_t u)`.

Because `psi` vanishes and has outward unit derivative on the boundary, and because `nu` equals the boundary normal there, the boundary relations remain exact under the documented regularity assumptions. The former pointwise `phi / d_n phi` normalization is removed.

### Traction

The traction residual and normal/tangential correction use the same smooth `nu` extension in the interior and the true outward normal on the regular boundary. The dimensional `psi` multiplier retains the documented first-order linear-elastic traction correction while eliminating artificial medial-set normal jumps.

## Enforced pipeline integration

The same gate policy now propagates through:

- `DomainComponent.enforcement_gate(...)`;
- `EnforcedConstraintPipeline`;
- `EnforcedConstraintPipelines.build(...)`;
- `FunctionalSolver`.

Boundary/initial preservation and exact interior-data overlays use powers of the dimensionless gate. For a boundary operator declaring derivative order `K`, the protecting multiplier uses gate order `K + 1`, so later overlays preserve the required boundary jet rather than only its value.

A value-only compatibility probe no longer bypasses protection for derivative boundary constraints. Such constraints conservatively retain the powered gate because equality of sampled values cannot establish equality of normal derivatives.

The prior sample-derived ADF normalization and exponential overlay profile are removed. Gate values now have a geometry-defined, scale-invariant meaning shared by boundary/initial staging and interior-data correction.

## Public API

The domain API now exports `EnforcementGateMethod` and exposes:

- `_AbstractGeometry.boundary_ansatz_factor`;
- `_AbstractGeometry.make_enforcement_gate(...)`;
- `DomainComponent.enforcement_gate(...)`;
- CAD `predicate_sdf` and `boundary_factor` roles;
- gate selection on Dirichlet enforcement, enforced pipelines, and `FunctionalSolver`.

Existing `adf`, `sdf`, and normal entry points remain available. Their documentation now states the boundary-defining rather than global metric-distance contract.

## Numerical and semantic invariants

- Classification, geometry differentiation, value enforcement, and derivative enforcement have distinct field ownership.
- All geometry-facing fields preserve the same boundary zero set.
- Dimensional boundary factors are covariant under uniform scaling.
- Solver gates are dimensionless and invariant under uniform scaling.
- Derivative ansatz factors have outward unit boundary derivative.
- Public normals retain analytic or mesh-pseudonormal semantics.
- Interior normal extensions may vanish smoothly and are never forced to jump across medial sets.
- Sharp CAD edges and vertices retain finite pseudonormal behavior; no unique classical normal is claimed there.
- Filtered `Boundary()` components remain rejected by direct geometry hard enforcers because their geometry gate vanishes on the full boundary.

## Documentation

The API pages, solver guide, and physics-constrained interpolation appendix now describe the separate field contracts, gate selection, scale covariance, C6 collar/saturation construction, derivative-ansatz proofs, and overlay vanishing-order guarantees.

## Deliberate scope boundaries

This change does not alter:

- the topological meaning or measure of `Boundary()`;
- endpoint normals for one-dimensional intervals;
- public surface-gradient, surface-divergence, surface-curl, or Laplace-Beltrami APIs;
- analytic geometry gates that already satisfy exact smooth contracts;
- the finite pseudonormal convention at genuine mesh edges and vertices.

It also does not claim that a compact boundary factor is metric distance throughout the domain. Only its zero set, sign, scale covariance, boundary collar, and boundary jet are part of the contract.

## Review guide

A useful review order is:

1. `phydrax/domain/_base.py` for the field contracts and generic gate builders;
2. `phydrax/domain/geometry3d/_sdf.py` for normalized mesh distance, collar blending, R-equivalence, and compact saturation;
3. `phydrax/domain/geometry2d/_from_cad.py` and `geometry3d/_mesh.py` for CAD field ownership;
4. `phydrax/domain/_components.py` for the component-level gate API;
5. `phydrax/constraints/_enforced.py` for value and derivative ansätze;
6. `phydrax/solver/_enforced_constraint_pipeline.py` for powered preservation and interior overlays;
7. `phydrax/solver/_functional_solver.py` for top-level option propagation;
8. the API pages and interpolation appendix for the formal contracts and derivations.