### PR TITLE
Add exact flow-assisted NUTS inference

### DIFF
--- a/docs/api/uq/inference.md
+++ b/docs/api/uq/inference.md
@@ -41,6 +41,26 @@
             - validate
 
 
+### Posterior inspection
+
+::: phydrax.uq.diagnose_posterior
+
+---
+
+::: phydrax.uq.PosteriorCapabilities
+    options:
+        members:
+            - as_dict
+
+---
+
+::: phydrax.uq.PosteriorDiagnostics
+    options:
+        members:
+            - passed
+            - as_dict
+
+
 ### Normalized posterior terms
 
 ::: phydrax.uq.FixedObservationLikelihood
@@ -124,6 +144,30 @@
 ---
 
 ::: phydrax.uq.sample_hmc
+
+---
+
+
+### Flow-assisted NUTS
+
+::: phydrax.uq.sample_flow_nuts
+
+---
+
+::: phydrax.uq.FlowNUTSConfig
+    options:
+        members:
+            - __init__
+            - as_dict
+
+---
+
+::: phydrax.uq.FlowNUTSResult
+    options:
+        members:
+            - predict
+            - predict_observations
+            - convergence_report
 
 ---
 

--- a/docs/cookbook/uncertainty_quantification.md
+++ b/docs/cookbook/uncertainty_quantification.md
@@ -2,8 +2,8 @@
 
 This recipe covers independently initialized ensembles, proper scoring, split
 conformal calibration, uncertain-input propagation, explicit Bayesian physical
-parameters, MAP/NUTS/Laplace/Pathfinder inference, and scalable
-Gaussian-process model discrepancy.
+parameters, MAP/NUTS/flow-assisted NUTS/Laplace/Pathfinder inference, and
+scalable Gaussian-process model discrepancy.
 
 For geometry-aware output functions, independent source/query discretizations, and
 whole-field calibration, use the dedicated
@@ -244,7 +244,7 @@ those modules and avoids accidentally selecting only the last coordinate factor.
 See the posterior-contract section of the UQ guide for the complete separable
 selection pattern and its nonlinear joint-posterior interpretation.
 
-## 8. Use Pathfinder locally and tempered SMC for demonstrated multimodality
+## 8. Choose local, represented-mode, or discovery inference
 
 Pathfinder is a fast local approximation selected along an L-BFGS path:
 
@@ -257,10 +257,56 @@ pathfinder = phx.uq.fit_pathfinder(
 pathfinder_prediction = pathfinder.predict(posterior_query)
 ```
 
-Compare its moments and held-out scores against NUTS and dense Laplace. For a
-demonstrably multimodal low-dimensional posterior, use `sample_tempered_smc`
-instead. Its declared priors provide initial particles; inspect the adaptive
-temperature schedule, ESS, divergences, and surviving initial-particle count.
+Compare its moments and held-out scores against NUTS and dense Laplace. If a
+multimodal posterior's important modes are already represented, use exact
+flow-assisted NUTS and initialize chains across those modes:
+
+```python
+multimodal_problem = phx.uq.PosteriorProblem(
+    phx.uq.ParameterSpace(
+        jnp.asarray(0.0),
+        priors=phx.uq.Normal(0.0, 4.0),
+    ),
+    lambda value: jnp.logaddexp(
+        jnp.log(0.3) - 0.5 * ((value + 2.0) / 0.35) ** 2,
+        jnp.log(0.7) - 0.5 * ((value - 2.0) / 0.35) ** 2,
+    ),
+)
+flow_config = phx.uq.FlowNUTSConfig(
+    num_adaptation_rounds=3,
+    num_local_adaptation_steps=80,
+    num_global_adaptation_steps=20,
+    num_local_steps=2,
+    num_global_steps=1,
+    history_capacity_per_chain=256,
+    max_epochs=60,
+)
+flow_nuts = phx.uq.sample_flow_nuts(
+    multimodal_problem,
+    key=jr.key(9),
+    num_chains=4,
+    num_warmup=500,
+    num_samples=1000,
+    initial_positions=jnp.asarray([-2.0, -1.8, 1.8, 2.0]),
+    target_acceptance_rate=0.9,
+    config=flow_config,
+    chain_method="vectorized",
+)
+assert flow_nuts.diagnostics.max_rhat < 1.05
+assert jnp.mean(flow_nuts.global_acceptance_rate) > 0.0
+```
+
+The flow is trained only during adaptation. Every global transition uses the exact
+asymmetric independence Metropolis--Hastings correction, and the frozen production
+kernel alternates configured local NUTS and global flow steps. Inspect global
+acceptance, proposal ESS, nonfinite counts, mode occupancy, and ordinary rank
+diagnostics. This transports between represented modes; it does not certify that no
+unrepresented mode exists.
+
+Use `sample_tempered_smc` instead when low-dimensional mode discovery or a
+log-evidence estimate is required. Its declared priors provide initial particles;
+inspect the adaptive temperature schedule, ESS, divergences, and surviving
+initial-particle count.
 
 ## 9. Represent omitted physics with a GP discrepancy
 

--- a/docs/guides_uncertainty.md
+++ b/docs/guides_uncertainty.md
@@ -878,6 +878,27 @@ Use `FixedObservationLikelihood`, `FixedResidualLikelihood`, and
 posterior terms. `PosteriorProblem.from_terms(...)` combines them without routing
 through `FunctionalSolver.loss()`.
 
+Inspect the posterior contract before starting an expensive inference run:
+
+```python
+inspection = phx.uq.diagnose_posterior(
+    posterior,
+    key=jr.key(9),
+    num_prior_samples=16,
+)
+if not inspection.passed:
+    raise ValueError(inspection.as_dict())
+```
+
+The report evaluates the initial target and gradient, reports exact nonfinite
+gradient locations, checks unconstrained-to-physical round trips, compares eager,
+repeated, JIT, and VMAP evaluation, and optionally probes declared-prior samples.
+`inspection.capabilities` records only static semantic capabilities: factorized
+prior sampling, latent prediction, observation variance/sampling, and a normalized
+Gauss--Newton residual. It does not probe prediction callbacks with invented,
+domain-specific query arguments.
+
+
 ## MAP estimation
 
 `find_map` compiles the complete JAX-native strong-Wolfe L-BFGS transition and
@@ -942,6 +963,11 @@ warmup parameters, final chain states, energies, integration depths, determinist
 keys, adaptation and sampling runtimes, throughput, and sample-memory size. A
 repeated root key reproduces samples and diagnostics.
 
+Pass `initial_positions` with one leading chain axis when chains must begin at
+different represented modes; `initial_position` retains the replicated-start
+convenience. The two arguments are mutually exclusive.
+
+
 Long MCMC runs can checkpoint after a fixed number of completed draws per chain:
 pass `checkpoint_path`, `checkpoint_every`, and a stable caller-owned
 `checkpoint_id`. Resume with `resume_from` and the same sampling configuration.
@@ -955,6 +981,67 @@ adaptive collocation, minibatch likelihoods, active dropout, or other random sam
 inside `log_density`. NUTS is the default for low-dimensional physical parameters,
 noise scales, and explicitly selected small subspaces. Sampling every neural-network
 weight is deliberately not the default.
+
+## Flow-assisted NUTS
+
+`sample_flow_nuts` combines independently adapted NUTS chains with a shared
+FlowJAX normalizing flow. It is intended for posteriors with nonlinear global
+geometry or multiple modes that are already represented by the initial chains.
+It is not a mode-discovery algorithm and does not estimate evidence.
+
+```python
+flow_config = phx.uq.FlowNUTSConfig(
+    num_adaptation_rounds=4,
+    num_local_adaptation_steps=100,
+    num_global_adaptation_steps=20,
+    num_local_steps=3,
+    num_global_steps=1,
+    history_capacity_per_chain=1000,
+    flow_layers=6,
+    max_epochs=100,
+)
+flow_draws = phx.uq.sample_flow_nuts(
+    posterior,
+    key=jr.key(11),
+    num_chains=4,
+    num_warmup=1000,
+    num_samples=1000,
+    initial_positions={
+        "source": jnp.asarray([-3.0, -1.0, 1.0, 3.0]),
+    },
+    target_acceptance_rate=0.9,
+    config=flow_config,
+    chain_method="vectorized",
+)
+```
+
+All kernels act in flattened unconstrained coordinates. During adaptation, local
+NUTS transitions populate a fixed-capacity, chain-stratified reservoir; the flow is
+refit from pooled reservoir samples and tested with exact independence
+Metropolis--Hastings proposals. For current state `x`, proposal `y`, target `π`, and
+normalized flow density `q`, acceptance is
+`min(1, π(y) q(x) / (π(x) q(y)))`. Both proposal-density terms are mandatory.
+Nonfinite states or densities are rejected and counted.
+
+After the last adaptation round, Phydrax freezes both the flow and tuned NUTS
+parameters, runs an optional local-only stabilization phase, then returns draws from
+one fixed composite kernel. No returned draw trains the flow. `FlowNUTSResult`
+preserves the ordinary MCMC prediction and convergence interfaces and adds
+training/validation losses, adaptation proposal ESS, local/global acceptance,
+nonfinite global proposal counts, phase timings, bounded-memory accounting, and the
+frozen flow.
+
+Automatic chain initialization requires declared factorized priors. A custom joint
+log prior requires explicit `initial_positions`. Checkpointing commits complete
+adaptation rounds, stabilization chunks, and production chunks; resume reconstructs
+the dynamic FlowJAX arrays against a locally rebuilt static template and rejects
+configuration, package-version, shape, dtype, or flow-fingerprint mismatches.
+
+This implementation is native Phydrax orchestration, not a wrapper around
+[`flowMC`](https://github.com/kazewong/flowMC). The flow-assisted sampling rationale
+follows that work, while Phydrax retains its own posterior, exact-kernel,
+checkpoint, diagnostics, and result contracts.
+
 
 ## Dense and structured Laplace approximation
 
@@ -1112,10 +1199,13 @@ portable = phx.uq.read_result_archive(result_path)
 Both are ZIP containers with JSON metadata, individual NumPy array members,
 SHA-256 checksums, atomic replacement, and no pickle or Python object
 arrays. Portable archives export representable result arrays and explicitly list
-excluded live callables. `phx.uq.to_arviz(posterior_draws)` converts MCMC chains to
-ArviZ `posterior` and `sample_stats` groups while retaining separate `chain` and
-`draw` dimensions. Generic observed-data and pointwise-log-likelihood groups are
-omitted because `PosteriorProblem` does not promise that metadata.
+excluded live callables. `FlowNUTSResult` archives include frozen flow parameters,
+loss histories, local and global sampler statistics, deterministic keys, and phase
+timings. `phx.uq.to_arviz(posterior_draws)` accepts ordinary or flow-assisted MCMC,
+retains separate `chain` and `draw` dimensions, and adds flow acceptance, accepted
+proposal counts, log acceptance ratios, and nonfinite counts when present. Generic
+observed-data and pointwise-log-likelihood groups are omitted because
+`PosteriorProblem` does not promise that metadata.
 
 ## Gaussian-process model discrepancy
 
@@ -1215,19 +1305,22 @@ correlation, returning every exact failure rather than a generic warning.
 Phydrax currently recommends:
 
 1. NUTS for low-dimensional, effectively unimodal physical inverse problems.
-2. Exact dense Laplace as the small-problem Gaussian reference.
-3. Whitened GGN, diagonal, or low-rank Laplax for selected larger subspaces.
-4. EKI for derivative-free physical or reduced-coordinate inverse problems,
+2. Flow-assisted NUTS for represented multimodality or nonlinear global geometry at
+   moderate dimension; initialize chains across known modes and inspect exact global
+   acceptance and ordinary rank diagnostics.
+3. Exact dense Laplace as the small-problem Gaussian reference.
+4. Whitened GGN, diagonal, or low-rank Laplax for selected larger subspaces.
+5. EKI for derivative-free physical or reduced-coordinate inverse problems,
    benchmarked against NUTS or Laplace where feasible.
-5. Pathfinder for rapid local diagnostics, always benchmarked against NUTS.
-6. Tempered SMC only for demonstrated low-dimensional multimodal posteriors.
-7. Deep ensembles for independently trained neural-model epistemic variation.
-8. Exact GP discrepancy for moderate scalar data, explicit coregionalization for
+6. Pathfinder for rapid local diagnostics, always benchmarked against NUTS.
+7. Tempered SMC for low-dimensional mode discovery and evidence estimation.
+8. Deep ensembles for independently trained neural-model epistemic variation.
+9. Exact GP discrepancy for moderate scalar data, explicit coregionalization for
    correlated outputs, and FITC only when dense scaling fails.
 
-Mean-field VI, SWAG, SGMCMC, normalizing-flow posteriors, non-Gaussian/sparse
-variational GPs, and full-network HMC remain unsupported. None is silently
-approximated by the methods above.
+Mean-field VI, standalone variational normalizing-flow posteriors, SWAG, SGMCMC,
+non-Gaussian/sparse variational GPs, and full-network HMC remain unsupported. None
+is silently approximated by the methods above.
 
 ## Conformal calibration
 

--- a/phydrax/uq/__init__.py
+++ b/phydrax/uq/__init__.py
@@ -90,6 +90,7 @@ from ._fixed_lag import (
     FixedLagKalmanSmootherResult,
     FixedLagParticleSmootherResult,
 )
+from ._flow_mcmc import FlowNUTSConfig, FlowNUTSResult, sample_flow_nuts
 from ._guided_particle import (
     AbstractParticleProposal,
     AuxiliaryResamplingPolicy,
@@ -221,6 +222,11 @@ from ._posterior import (
     ParameterSubspace,
     PosteriorProblem,
     SigmoidIntervalBijector,
+)
+from ._posterior_diagnostics import (
+    diagnose_posterior,
+    PosteriorCapabilities,
+    PosteriorDiagnostics,
 )
 from ._posterior_terms import (
     AbstractPosteriorTerm,
@@ -540,6 +546,9 @@ __all__ = [
     "ParameterSpace",
     "ParameterSubspace",
     "PosteriorProblem",
+    "diagnose_posterior",
+    "PosteriorCapabilities",
+    "PosteriorDiagnostics",
     "GaussianPriorWhitening",
     "AbstractPosteriorTerm",
     "CompositePosteriorLikelihood",
@@ -550,6 +559,8 @@ __all__ = [
     "find_map",
     "MAPConvergenceError",
     "MAPResult",
+    "FlowNUTSConfig",
+    "FlowNUTSResult",
     "MCMCChainWarmup",
     "MCMCConvergenceError",
     "MCMCConvergenceReport",
@@ -558,6 +569,7 @@ __all__ = [
     "MCMCResult",
     "sample_hmc",
     "sample_nuts",
+    "sample_flow_nuts",
     "PathfinderResult",
     "fit_pathfinder",
     "TemperedSMCResult",

--- a/phydrax/uq/_flow_mcmc.py
+++ b/phydrax/uq/_flow_mcmc.py
@@ -1,0 +1,1700 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import importlib.metadata
+import time
+from pathlib import Path
+from typing import Any
+
+import blackjax
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import numpy as np
+from blackjax.mcmc.hmc import HMCState
+from jax.flatten_util import ravel_pytree
+from jaxtyping import Array, PyTree
+
+from .._strict import StrictModule
+from ._checkpoint import (
+    array_tree_fingerprint,
+    checkpoint_compatibility,
+    CheckpointCompatibilityError,
+    CheckpointCorruptionError,
+    pack_array_tree,
+    read_checkpoint_archive,
+    unpack_array_tree,
+    write_checkpoint_archive,
+)
+from ._diagnostics import mcmc_diagnostics, MCMCConvergenceReport
+from ._flow_proposal import (
+    _build_default_flow,
+    _fit_flow,
+    _initialize_replay,
+    _proposal_effective_sample_size,
+    _replay_data,
+    _ReplayBuffer,
+    _run_flow_block,
+    _update_replay,
+    _validate_flow,
+)
+from ._mcmc import (
+    _adapt_mcmc,
+    _stack_trees,
+    _tree_nbytes,
+    _unstack_tree,
+    ChainMethod,
+    MCMCChainWarmup,
+    MCMCResult,
+)
+from ._posterior import PosteriorProblem
+
+
+_INITIALIZATION_TAG = 0
+_WARMUP_TAG = 1
+_ADAPTATION_LOCAL_TAG = 2
+_REPLAY_TAG = 3
+_FLOW_INITIALIZATION_TAG = 4
+_FLOW_TRAINING_TAG = 5
+_ADAPTATION_GLOBAL_TAG = 6
+_STABILIZATION_TAG = 7
+_PRODUCTION_TAG = 8
+
+
+class FlowNUTSConfig(StrictModule):
+    """Static adaptation, proposal, and production controls for flow-assisted NUTS."""
+
+    num_adaptation_rounds: int = eqx.field(static=True)
+    num_local_adaptation_steps: int = eqx.field(static=True)
+    num_global_adaptation_steps: int = eqx.field(static=True)
+    num_stabilization_steps: int = eqx.field(static=True)
+    num_local_steps: int = eqx.field(static=True)
+    num_global_steps: int = eqx.field(static=True)
+    history_capacity_per_chain: int = eqx.field(static=True)
+    history_thinning: int = eqx.field(static=True)
+    flow_layers: int = eqx.field(static=True)
+    num_knots: int = eqx.field(static=True)
+    nn_width: int = eqx.field(static=True)
+    nn_depth: int = eqx.field(static=True)
+    learning_rate: float = eqx.field(static=True)
+    max_epochs: int = eqx.field(static=True)
+    max_patience: int = eqx.field(static=True)
+    batch_size: int = eqx.field(static=True)
+    validation_fraction: float = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        num_adaptation_rounds: int = 4,
+        num_local_adaptation_steps: int = 100,
+        num_global_adaptation_steps: int = 20,
+        num_stabilization_steps: int = 100,
+        num_local_steps: int = 10,
+        num_global_steps: int = 1,
+        history_capacity_per_chain: int = 1000,
+        history_thinning: int = 1,
+        flow_layers: int = 6,
+        num_knots: int = 8,
+        nn_width: int = 64,
+        nn_depth: int = 2,
+        learning_rate: float = 5e-4,
+        max_epochs: int = 100,
+        max_patience: int = 10,
+        batch_size: int = 256,
+        validation_fraction: float = 0.1,
+    ):
+        positive = {
+            "num_adaptation_rounds": num_adaptation_rounds,
+            "num_local_adaptation_steps": num_local_adaptation_steps,
+            "num_global_adaptation_steps": num_global_adaptation_steps,
+            "num_local_steps": num_local_steps,
+            "num_global_steps": num_global_steps,
+            "history_capacity_per_chain": history_capacity_per_chain,
+            "history_thinning": history_thinning,
+            "flow_layers": flow_layers,
+            "num_knots": num_knots,
+            "nn_width": nn_width,
+            "nn_depth": nn_depth,
+            "max_epochs": max_epochs,
+            "max_patience": max_patience,
+            "batch_size": batch_size,
+        }
+        normalized: dict[str, int] = {}
+        for name, value in positive.items():
+            count = int(value)
+            if count <= 0:
+                raise ValueError(f"{name} must be positive.")
+            normalized[name] = count
+        if normalized["history_thinning"] > normalized["num_local_adaptation_steps"]:
+            raise ValueError("history_thinning cannot exceed num_local_adaptation_steps.")
+        stabilization = int(num_stabilization_steps)
+        if stabilization < 0:
+            raise ValueError("num_stabilization_steps cannot be negative.")
+        rate = float(learning_rate)
+        if not jnp.isfinite(rate) or rate <= 0.0:
+            raise ValueError("learning_rate must be positive and finite.")
+        validation = float(validation_fraction)
+        if not 0.0 < validation < 0.5:
+            raise ValueError(
+                "validation_fraction must lie strictly between zero and one half."
+            )
+
+        self.num_adaptation_rounds = normalized["num_adaptation_rounds"]
+        self.num_local_adaptation_steps = normalized["num_local_adaptation_steps"]
+        self.num_global_adaptation_steps = normalized["num_global_adaptation_steps"]
+        self.num_stabilization_steps = stabilization
+        self.num_local_steps = normalized["num_local_steps"]
+        self.num_global_steps = normalized["num_global_steps"]
+        self.history_capacity_per_chain = normalized["history_capacity_per_chain"]
+        self.history_thinning = normalized["history_thinning"]
+        self.flow_layers = normalized["flow_layers"]
+        self.num_knots = normalized["num_knots"]
+        self.nn_width = normalized["nn_width"]
+        self.nn_depth = normalized["nn_depth"]
+        self.learning_rate = rate
+        self.max_epochs = normalized["max_epochs"]
+        self.max_patience = normalized["max_patience"]
+        self.batch_size = normalized["batch_size"]
+        self.validation_fraction = validation
+
+    def as_dict(self) -> dict[str, int | float]:
+        """Return the canonical JSON-compatible configuration identity."""
+        return {
+            "num_adaptation_rounds": self.num_adaptation_rounds,
+            "num_local_adaptation_steps": self.num_local_adaptation_steps,
+            "num_global_adaptation_steps": self.num_global_adaptation_steps,
+            "num_stabilization_steps": self.num_stabilization_steps,
+            "num_local_steps": self.num_local_steps,
+            "num_global_steps": self.num_global_steps,
+            "history_capacity_per_chain": self.history_capacity_per_chain,
+            "history_thinning": self.history_thinning,
+            "flow_layers": self.flow_layers,
+            "num_knots": self.num_knots,
+            "nn_width": self.nn_width,
+            "nn_depth": self.nn_depth,
+            "learning_rate": self.learning_rate,
+            "max_epochs": self.max_epochs,
+            "max_patience": self.max_patience,
+            "batch_size": self.batch_size,
+            "validation_fraction": self.validation_fraction,
+        }
+
+
+class FlowNUTSResult(StrictModule):
+    """Exact flow-assisted NUTS draws and global-proposal diagnostics."""
+
+    mcmc: MCMCResult
+    flow: Any
+    config: FlowNUTSConfig
+    training_losses: tuple[Array, ...]
+    validation_losses: tuple[Array, ...]
+    flow_training_duration_seconds: tuple[float, ...] = eqx.field(static=True)
+    adaptation_global_acceptance_rate: Array
+    adaptation_proposal_ess: Array
+    adaptation_history_size: Array
+    global_acceptance_rate: Array
+    global_accepted_count: Array
+    global_mean_log_acceptance_ratio: Array
+    global_nonfinite_count: Array
+    num_unique_initial_positions: int = eqx.field(static=True)
+    nuts_adaptation_duration_seconds: float = eqx.field(static=True)
+    flow_adaptation_duration_seconds: float = eqx.field(static=True)
+    stabilization_duration_seconds: float = eqx.field(static=True)
+    sampling_duration_seconds: float = eqx.field(static=True)
+    duration_seconds: float = eqx.field(static=True)
+    flow_parameter_memory_bytes: int = eqx.field(static=True)
+    history_memory_bytes: int = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        mcmc: MCMCResult,
+        flow: Any,
+        config: FlowNUTSConfig,
+        training_losses: tuple[Array, ...],
+        validation_losses: tuple[Array, ...],
+        flow_training_duration_seconds: tuple[float, ...],
+        adaptation_global_acceptance_rate: Array,
+        adaptation_proposal_ess: Array,
+        adaptation_history_size: Array,
+        global_acceptance_rate: Array,
+        global_accepted_count: Array,
+        global_mean_log_acceptance_ratio: Array,
+        global_nonfinite_count: Array,
+        num_unique_initial_positions: int,
+        nuts_adaptation_duration_seconds: float,
+        flow_adaptation_duration_seconds: float,
+        stabilization_duration_seconds: float,
+        sampling_duration_seconds: float,
+        duration_seconds: float,
+        history_memory_bytes: int,
+    ):
+        if not isinstance(mcmc, MCMCResult):
+            raise TypeError("mcmc must be an MCMCResult.")
+        if not isinstance(config, FlowNUTSConfig):
+            raise TypeError("config must be a FlowNUTSConfig.")
+        rounds = config.num_adaptation_rounds
+        if (
+            len(training_losses) != rounds
+            or len(validation_losses) != rounds
+            or len(flow_training_duration_seconds) != rounds
+        ):
+            raise ValueError(
+                "Flow loss and training-duration histories must match adaptation rounds."
+            )
+        expected_adaptation_shape = (rounds,)
+        if jnp.asarray(adaptation_global_acceptance_rate).shape != (
+            rounds,
+            mcmc.num_chains,
+        ):
+            raise ValueError(
+                "adaptation_global_acceptance_rate has an incompatible shape."
+            )
+        if jnp.asarray(adaptation_proposal_ess).shape != expected_adaptation_shape:
+            raise ValueError("adaptation_proposal_ess has an incompatible shape.")
+        if jnp.asarray(adaptation_history_size).shape != expected_adaptation_shape:
+            raise ValueError("adaptation_history_size has an incompatible shape.")
+        expected_draw_shape = (mcmc.num_chains, mcmc.num_draws)
+        for name, value in (
+            ("global_acceptance_rate", global_acceptance_rate),
+            ("global_accepted_count", global_accepted_count),
+            (
+                "global_mean_log_acceptance_ratio",
+                global_mean_log_acceptance_ratio,
+            ),
+            ("global_nonfinite_count", global_nonfinite_count),
+        ):
+            if jnp.asarray(value).shape != expected_draw_shape:
+                raise ValueError(f"{name} has an incompatible shape.")
+        timings = (
+            *flow_training_duration_seconds,
+            nuts_adaptation_duration_seconds,
+            flow_adaptation_duration_seconds,
+            stabilization_duration_seconds,
+            sampling_duration_seconds,
+            duration_seconds,
+        )
+        if any(not np.isfinite(value) or value < 0.0 for value in timings):
+            raise ValueError("Flow-NUTS durations must be finite and nonnegative.")
+
+        flow_parameters, _ = eqx.partition(flow, eqx.is_array)
+        self.mcmc = mcmc
+        self.flow = flow
+        self.config = config
+        self.training_losses = tuple(jnp.asarray(value) for value in training_losses)
+        self.validation_losses = tuple(jnp.asarray(value) for value in validation_losses)
+        self.flow_training_duration_seconds = tuple(
+            float(value) for value in flow_training_duration_seconds
+        )
+        self.adaptation_global_acceptance_rate = jnp.asarray(
+            adaptation_global_acceptance_rate
+        )
+        self.adaptation_proposal_ess = jnp.asarray(adaptation_proposal_ess)
+        self.adaptation_history_size = jnp.asarray(adaptation_history_size)
+        self.global_acceptance_rate = jnp.asarray(global_acceptance_rate)
+        self.global_accepted_count = jnp.asarray(global_accepted_count)
+        self.global_mean_log_acceptance_ratio = jnp.asarray(
+            global_mean_log_acceptance_ratio
+        )
+        self.global_nonfinite_count = jnp.asarray(global_nonfinite_count)
+        self.num_unique_initial_positions = int(num_unique_initial_positions)
+        self.nuts_adaptation_duration_seconds = float(nuts_adaptation_duration_seconds)
+        self.flow_adaptation_duration_seconds = float(flow_adaptation_duration_seconds)
+        self.stabilization_duration_seconds = float(stabilization_duration_seconds)
+        self.sampling_duration_seconds = float(sampling_duration_seconds)
+        self.duration_seconds = float(duration_seconds)
+        self.flow_parameter_memory_bytes = _tree_nbytes(flow_parameters)
+        self.history_memory_bytes = int(history_memory_bytes)
+
+    @property
+    def problem(self) -> PosteriorProblem:
+        return self.mcmc.problem
+
+    @property
+    def samples(self) -> PyTree[Array]:
+        return self.mcmc.samples
+
+    @property
+    def unconstrained_samples(self) -> PyTree[Array]:
+        return self.mcmc.unconstrained_samples
+
+    @property
+    def log_density(self) -> Array:
+        return self.mcmc.log_density
+
+    @property
+    def acceptance_rate(self) -> Array:
+        return self.mcmc.acceptance_rate
+
+    @property
+    def divergent(self) -> Array:
+        return self.mcmc.divergent
+
+    @property
+    def energy(self) -> Array:
+        return self.mcmc.energy
+
+    @property
+    def num_integration_steps(self) -> Array:
+        return self.mcmc.num_integration_steps
+
+    @property
+    def num_trajectory_expansions(self) -> Array:
+        return self.mcmc.num_trajectory_expansions
+
+    @property
+    def final_states(self) -> tuple[Any, ...]:
+        return self.mcmc.final_states
+
+    @property
+    def warmup(self) -> tuple[MCMCChainWarmup, ...]:
+        return self.mcmc.warmup
+
+    @property
+    def diagnostics(self):
+        return self.mcmc.diagnostics
+
+    @property
+    def root_key(self) -> Array:
+        return self.mcmc.root_key
+
+    @property
+    def chain_keys(self) -> Array:
+        return self.mcmc.chain_keys
+
+    @property
+    def algorithm(self) -> str:
+        return self.mcmc.algorithm
+
+    @property
+    def chain_method(self) -> ChainMethod:
+        return self.mcmc.chain_method
+
+    @property
+    def num_chains(self) -> int:
+        return self.mcmc.num_chains
+
+    @property
+    def num_draws(self) -> int:
+        return self.mcmc.num_draws
+
+    @property
+    def sample_memory_bytes(self) -> int:
+        return self.mcmc.sample_memory_bytes
+
+    @property
+    def samples_per_second(self) -> float:
+        return self.mcmc.samples_per_second
+
+    @property
+    def adaptation_duration_seconds(self) -> float:
+        return self.mcmc.adaptation_duration_seconds
+
+    def predict(self, *args: Any, **kwargs: Any):
+        """Evaluate latent predictions while preserving chain and draw axes."""
+        return self.mcmc.predict(*args, **kwargs)
+
+    def predict_observations(self, key: Array, /, *args: Any, **kwargs: Any):
+        """Draw observation predictions while preserving chain and draw axes."""
+        return self.mcmc.predict_observations(key, *args, **kwargs)
+
+    def convergence_report(self, **kwargs: Any) -> MCMCConvergenceReport:
+        """Apply the ordinary MCMC convergence gates to retained composite draws."""
+        return self.mcmc.convergence_report(**kwargs)
+
+
+def sample_flow_nuts(
+    problem: PosteriorProblem,
+    /,
+    *,
+    key: Array,
+    num_chains: int = 8,
+    num_warmup: int = 1000,
+    num_samples: int = 1000,
+    initial_positions: PyTree[Any] | None = None,
+    target_acceptance_rate: float = 0.8,
+    initial_step_size: float = 1.0,
+    is_mass_matrix_diagonal: bool = True,
+    max_num_doublings: int = 10,
+    config: FlowNUTSConfig | None = None,
+    chain_method: ChainMethod = "sequential",
+    checkpoint_path: str | Path | None = None,
+    checkpoint_every: int | None = None,
+    checkpoint_id: str | None = None,
+    resume_from: str | Path | None = None,
+) -> FlowNUTSResult:
+    """Run frozen-production NUTS with an exact learned global flow proposal."""
+    if not isinstance(problem, PosteriorProblem):
+        raise TypeError("problem must be a PosteriorProblem.")
+    flow_config = FlowNUTSConfig() if config is None else config
+    if not isinstance(flow_config, FlowNUTSConfig):
+        raise TypeError("config must be a FlowNUTSConfig or None.")
+    chains = int(num_chains)
+    warmup_steps = int(num_warmup)
+    draws = int(num_samples)
+    if chains < 2:
+        raise ValueError("num_chains must be at least two for convergence diagnostics.")
+    if warmup_steps <= 0:
+        raise ValueError("num_warmup must be positive.")
+    if draws < 4:
+        raise ValueError("num_samples must be at least four.")
+    target = float(target_acceptance_rate)
+    if not 0.0 < target < 1.0:
+        raise ValueError("target_acceptance_rate must lie strictly between zero and one.")
+    initial_step = float(initial_step_size)
+    if not jnp.isfinite(initial_step) or initial_step <= 0.0:
+        raise ValueError("initial_step_size must be positive and finite.")
+    doublings = int(max_num_doublings)
+    if doublings <= 0:
+        raise ValueError("max_num_doublings must be positive.")
+    method: ChainMethod = chain_method
+    if method not in ("sequential", "vectorized"):
+        raise ValueError("chain_method must be 'sequential' or 'vectorized'.")
+    if resume_from is not None and initial_positions is not None:
+        raise ValueError("initial_positions cannot be supplied when resuming flow NUTS.")
+
+    destination = (
+        Path(checkpoint_path)
+        if checkpoint_path is not None
+        else (Path(resume_from) if resume_from is not None else None)
+    )
+    if checkpoint_every is not None and destination is None:
+        raise ValueError("checkpoint_every requires checkpoint_path or resume_from.")
+    interval = min(100, draws) if checkpoint_every is None else int(checkpoint_every)
+    if interval <= 0:
+        raise ValueError("checkpoint_every must be positive.")
+    if destination is not None and (checkpoint_id is None or not str(checkpoint_id)):
+        raise ValueError("checkpoint_id is required for flow-NUTS checkpointing.")
+
+    root_key = jnp.asarray(key)
+    chain_keys = jr.split(root_key, chains)
+    flat_reference, unravel = ravel_pytree(problem.initial_position)
+    if flat_reference.size == 0:
+        raise ValueError("Flow NUTS requires at least one scalar parameter.")
+    if not jnp.issubdtype(flat_reference.dtype, jnp.floating):
+        raise TypeError("Flow NUTS requires real floating unconstrained coordinates.")
+    dimension = int(flat_reference.size)
+    minimum_training_samples = (
+        min(
+            flow_config.history_capacity_per_chain,
+            (flow_config.num_local_adaptation_steps + flow_config.history_thinning - 1)
+            // flow_config.history_thinning,
+        )
+        * chains
+    )
+    validation_count = round(flow_config.validation_fraction * minimum_training_samples)
+    if validation_count <= 0 or validation_count >= minimum_training_samples:
+        raise ValueError(
+            "The first adaptation round must provide non-empty flow train and "
+            "validation splits; increase chains, local steps, or replay capacity."
+        )
+
+    settings = {
+        "algorithm": "flow_nuts",
+        "num_chains": chains,
+        "num_warmup": warmup_steps,
+        "target_acceptance_rate": target,
+        "initial_step_size": initial_step,
+        "is_mass_matrix_diagonal": bool(is_mass_matrix_diagonal),
+        "max_num_doublings": doublings,
+        "chain_method": method,
+        "dimension": dimension,
+        "dtype": flat_reference.dtype.str,
+        "config": flow_config.as_dict(),
+        "flowjax_version": importlib.metadata.version("flowjax"),
+        "optax_version": importlib.metadata.version("optax"),
+        "root_key": [int(value) for value in jr.key_data(root_key).reshape(-1)],
+    }
+    compatibility = (
+        checkpoint_compatibility(
+            problem,
+            checkpoint_id=str(checkpoint_id),
+            settings=settings,
+        )
+        if destination is not None
+        else None
+    )
+    flat_logdensity = lambda position: problem.log_density(unravel(position))
+    started = time.perf_counter()
+
+    if resume_from is None:
+        if initial_positions is None:
+            if problem.parameter_space.priors is None:
+                raise ValueError(
+                    "Automatic flow-NUTS initialization requires factorized priors; "
+                    "provide initial_positions for a custom joint prior."
+                )
+            initial_tree = problem.parameter_space.sample_prior(
+                _fold_path(root_key, _INITIALIZATION_TAG),
+                num_samples=chains,
+            )
+        else:
+            initial_tree = initial_positions
+        flat_positions = _flatten_chain_positions(
+            initial_tree,
+            problem.initial_position,
+            chains=chains,
+            dimension=dimension,
+        )
+        values, gradients = jax.vmap(jax.value_and_grad(flat_logdensity))(flat_positions)
+        jax.block_until_ready(values)
+        if not bool(jnp.all(jnp.isfinite(values))) or not bool(
+            jnp.all(jnp.isfinite(gradients))
+        ):
+            raise FloatingPointError(
+                "Every initial flow-NUTS position needs finite target density and gradient."
+            )
+        num_unique_initial_positions = int(
+            np.unique(np.asarray(flat_positions), axis=0).shape[0]
+        )
+        warmup_keys = jax.vmap(lambda chain_key: _fold_path(chain_key, _WARMUP_TAG))(
+            chain_keys
+        )
+        (
+            current_states,
+            warmup_states,
+            step_sizes,
+            inverse_mass_matrices,
+            warmup_durations,
+            nuts_adaptation_duration,
+        ) = _adapt_mcmc(
+            blackjax.nuts,
+            flat_logdensity,
+            flat_positions,
+            warmup_keys=warmup_keys,
+            warmup_steps=warmup_steps,
+            target_acceptance_rate=target,
+            initial_step_size=initial_step,
+            is_mass_matrix_diagonal=bool(is_mass_matrix_diagonal),
+            extra_parameters={"max_num_doublings": doublings},
+            chain_method=method,
+        )
+        replay = _initialize_replay(
+            num_chains=chains,
+            capacity_per_chain=flow_config.history_capacity_per_chain,
+            dimension=dimension,
+            dtype=flat_reference.dtype,
+        )
+        flow = None
+        training_losses: list[Array] = []
+        validation_losses: list[Array] = []
+        flow_training_durations: list[float] = []
+        adaptation_acceptance: list[Array] = []
+        adaptation_ess: list[Array] = []
+        adaptation_history_size: list[Array] = []
+        completed_rounds = 0
+        completed_stabilization = 0
+        completed_draws = 0
+        flat_samples = jnp.empty((chains, 0, dimension), dtype=flat_reference.dtype)
+        log_density = jnp.empty((chains, 0), dtype=flat_reference.dtype)
+        acceptance_rate = jnp.empty((chains, 0), dtype=flat_reference.dtype)
+        divergent = jnp.empty((chains, 0), dtype=bool)
+        energy = jnp.empty((chains, 0), dtype=flat_reference.dtype)
+        num_integration_steps_array = jnp.empty((chains, 0), dtype=jnp.int32)
+        num_trajectory_expansions_array = jnp.empty((chains, 0), dtype=jnp.int32)
+        global_acceptance_rate = jnp.empty((chains, 0), dtype=flat_reference.dtype)
+        global_accepted_count = jnp.empty((chains, 0), dtype=jnp.int32)
+        global_mean_log_acceptance_ratio = jnp.empty(
+            (chains, 0), dtype=flat_reference.dtype
+        )
+        global_nonfinite_count = jnp.empty((chains, 0), dtype=jnp.int32)
+        flow_adaptation_duration = 0.0
+        stabilization_duration = 0.0
+        sampling_duration = 0.0
+        previous_duration = 0.0
+        frozen_flow_fingerprint = None
+    else:
+        if compatibility is None:
+            raise RuntimeError("Flow-NUTS resume compatibility was not initialized.")
+        (
+            current_states,
+            warmup_states,
+            step_sizes,
+            inverse_mass_matrices,
+            warmup_durations,
+            replay,
+            flow,
+            training_losses,
+            validation_losses,
+            flow_training_durations,
+            adaptation_acceptance,
+            adaptation_ess,
+            adaptation_history_size,
+            completed_rounds,
+            completed_stabilization,
+            completed_draws,
+            flat_samples,
+            log_density,
+            acceptance_rate,
+            divergent,
+            energy,
+            num_integration_steps_array,
+            num_trajectory_expansions_array,
+            global_acceptance_rate,
+            global_accepted_count,
+            global_mean_log_acceptance_ratio,
+            global_nonfinite_count,
+            num_unique_initial_positions,
+            nuts_adaptation_duration,
+            flow_adaptation_duration,
+            stabilization_duration,
+            sampling_duration,
+            previous_duration,
+            frozen_flow_fingerprint,
+        ) = _read_flow_nuts_checkpoint(
+            Path(resume_from),
+            compatibility=compatibility,
+            problem=problem,
+            flat_reference=flat_reference,
+            flat_logdensity=flat_logdensity,
+            root_key=root_key,
+            chains=chains,
+            config=flow_config,
+        )
+        if completed_draws > draws:
+            raise ValueError(
+                "num_samples cannot be smaller than completed checkpoint draws."
+            )
+
+    while completed_rounds < flow_config.num_adaptation_rounds:
+        round_started = time.perf_counter()
+        local_keys = _indexed_chain_keys(
+            chain_keys,
+            phase=_ADAPTATION_LOCAL_TAG,
+            group=completed_rounds,
+            start=0,
+            count=flow_config.num_local_adaptation_steps,
+        )
+        current_states, local_positions, _ = _advance_nuts_collect(
+            current_states,
+            step_sizes,
+            inverse_mass_matrices,
+            local_keys,
+            flat_logdensity,
+            max_num_doublings=doublings,
+            chain_method=method,
+        )
+        replay_samples = local_positions[:, :: flow_config.history_thinning, :]
+        replay_keys = _indexed_chain_keys(
+            chain_keys,
+            phase=_REPLAY_TAG,
+            group=completed_rounds,
+            start=0,
+            count=int(replay_samples.shape[1]),
+        )
+        replay = jax.jit(_update_replay)(replay, replay_samples, replay_keys)
+        replay_data = _replay_data(replay)
+        if flow is None:
+            flow = _build_default_flow(
+                _fold_path(root_key, _FLOW_INITIALIZATION_TAG),
+                replay_data,
+                flow_layers=flow_config.flow_layers,
+                num_knots=flow_config.num_knots,
+                nn_width=flow_config.nn_width,
+                nn_depth=flow_config.nn_depth,
+            )
+        training_started = time.perf_counter()
+        flow, train_loss, validation_loss = _fit_flow(
+            _fold_path(root_key, _FLOW_TRAINING_TAG, completed_rounds),
+            flow,
+            replay_data,
+            learning_rate=flow_config.learning_rate,
+            max_epochs=flow_config.max_epochs,
+            max_patience=flow_config.max_patience,
+            batch_size=flow_config.batch_size,
+            validation_fraction=flow_config.validation_fraction,
+        )
+        flow_training_durations.append(time.perf_counter() - training_started)
+        _validate_flow(
+            flow,
+            replay_data,
+            _fold_path(root_key, _FLOW_TRAINING_TAG, completed_rounds, 1),
+        )
+        global_keys = _indexed_chain_keys(
+            chain_keys,
+            phase=_ADAPTATION_GLOBAL_TAG,
+            group=completed_rounds,
+            start=0,
+            count=1,
+        )[:, 0]
+        flow_states, flow_info = _advance_flow_chains(
+            flow,
+            current_states,
+            global_keys,
+            flat_logdensity,
+            num_steps=flow_config.num_global_adaptation_steps,
+            chain_method=method,
+        )
+        current_states = _initialize_nuts_states(
+            flow_states.position,
+            flat_logdensity,
+            chain_method=method,
+        )
+        training_losses.append(train_loss)
+        validation_losses.append(validation_loss)
+        adaptation_acceptance.append(jnp.mean(flow_info.accepted, axis=1))
+        adaptation_ess.append(
+            _proposal_effective_sample_size(
+                flow_info.proposed_log_target,
+                flow_info.proposed_log_density,
+            )
+        )
+        adaptation_history_size.append(jnp.sum(replay.size))
+        completed_rounds += 1
+        jax.block_until_ready(current_states.position)
+        flow_adaptation_duration += time.perf_counter() - round_started
+        if destination is not None and compatibility is not None:
+            _write_flow_nuts_checkpoint(
+                destination,
+                compatibility=compatibility,
+                phase="adaptation",
+                completed_rounds=completed_rounds,
+                completed_stabilization=completed_stabilization,
+                completed_draws=completed_draws,
+                current_states=current_states,
+                warmup_states=warmup_states,
+                step_sizes=step_sizes,
+                inverse_mass_matrices=inverse_mass_matrices,
+                warmup_durations=warmup_durations,
+                replay=replay,
+                flow=flow,
+                training_losses=tuple(training_losses),
+                validation_losses=tuple(validation_losses),
+                flow_training_durations=tuple(flow_training_durations),
+                adaptation_acceptance=_stack_rows(adaptation_acceptance, chains),
+                adaptation_ess=jnp.asarray(adaptation_ess),
+                adaptation_history_size=jnp.asarray(adaptation_history_size),
+                flat_samples=flat_samples,
+                log_density=log_density,
+                acceptance_rate=acceptance_rate,
+                divergent=divergent,
+                energy=energy,
+                num_integration_steps=num_integration_steps_array,
+                num_trajectory_expansions=num_trajectory_expansions_array,
+                global_acceptance_rate=global_acceptance_rate,
+                global_accepted_count=global_accepted_count,
+                global_mean_log_acceptance_ratio=(global_mean_log_acceptance_ratio),
+                global_nonfinite_count=global_nonfinite_count,
+                num_unique_initial_positions=num_unique_initial_positions,
+                nuts_adaptation_duration=nuts_adaptation_duration,
+                flow_adaptation_duration=flow_adaptation_duration,
+                stabilization_duration=stabilization_duration,
+                sampling_duration=sampling_duration,
+                duration_seconds=previous_duration + time.perf_counter() - started,
+                frozen_flow_fingerprint=None,
+            )
+
+    if flow is None:
+        raise RuntimeError("Flow adaptation completed without a proposal distribution.")
+    if frozen_flow_fingerprint is None:
+        frozen_flow_fingerprint = _flow_fingerprint(flow)
+
+    while completed_stabilization < flow_config.num_stabilization_steps:
+        chunk = min(
+            interval,
+            flow_config.num_stabilization_steps - completed_stabilization,
+        )
+        phase_started = time.perf_counter()
+        draw_keys = _indexed_chain_keys(
+            chain_keys,
+            phase=_STABILIZATION_TAG,
+            group=0,
+            start=completed_stabilization,
+            count=chunk,
+        )
+        current_states, _, _ = _advance_nuts_collect(
+            current_states,
+            step_sizes,
+            inverse_mass_matrices,
+            draw_keys,
+            flat_logdensity,
+            max_num_doublings=doublings,
+            chain_method=method,
+        )
+        jax.block_until_ready(current_states.position)
+        stabilization_duration += time.perf_counter() - phase_started
+        completed_stabilization += chunk
+        if destination is not None and compatibility is not None:
+            _write_flow_nuts_checkpoint(
+                destination,
+                compatibility=compatibility,
+                phase="stabilization",
+                completed_rounds=completed_rounds,
+                completed_stabilization=completed_stabilization,
+                completed_draws=completed_draws,
+                current_states=current_states,
+                warmup_states=warmup_states,
+                step_sizes=step_sizes,
+                inverse_mass_matrices=inverse_mass_matrices,
+                warmup_durations=warmup_durations,
+                replay=replay,
+                flow=flow,
+                training_losses=tuple(training_losses),
+                validation_losses=tuple(validation_losses),
+                flow_training_durations=tuple(flow_training_durations),
+                adaptation_acceptance=_stack_rows(adaptation_acceptance, chains),
+                adaptation_ess=jnp.asarray(adaptation_ess),
+                adaptation_history_size=jnp.asarray(adaptation_history_size),
+                flat_samples=flat_samples,
+                log_density=log_density,
+                acceptance_rate=acceptance_rate,
+                divergent=divergent,
+                energy=energy,
+                num_integration_steps=num_integration_steps_array,
+                num_trajectory_expansions=num_trajectory_expansions_array,
+                global_acceptance_rate=global_acceptance_rate,
+                global_accepted_count=global_accepted_count,
+                global_mean_log_acceptance_ratio=(global_mean_log_acceptance_ratio),
+                global_nonfinite_count=global_nonfinite_count,
+                num_unique_initial_positions=num_unique_initial_positions,
+                nuts_adaptation_duration=nuts_adaptation_duration,
+                flow_adaptation_duration=flow_adaptation_duration,
+                stabilization_duration=stabilization_duration,
+                sampling_duration=sampling_duration,
+                duration_seconds=previous_duration + time.perf_counter() - started,
+                frozen_flow_fingerprint=frozen_flow_fingerprint,
+            )
+
+    while completed_draws < draws:
+        chunk = min(interval, draws - completed_draws)
+        phase_started = time.perf_counter()
+        draw_keys = _indexed_chain_keys(
+            chain_keys,
+            phase=_PRODUCTION_TAG,
+            group=0,
+            start=completed_draws,
+            count=chunk,
+        )
+        current_states, chunk_positions, metrics = _advance_composite_chains(
+            flow,
+            current_states,
+            step_sizes,
+            inverse_mass_matrices,
+            draw_keys,
+            flat_logdensity,
+            num_global_steps=flow_config.num_global_steps,
+            num_local_steps=flow_config.num_local_steps,
+            max_num_doublings=doublings,
+            chain_method=method,
+        )
+        jax.block_until_ready(metrics["log_density"])
+        sampling_duration += time.perf_counter() - phase_started
+        flat_samples = jnp.concatenate((flat_samples, chunk_positions), axis=1)
+        log_density = jnp.concatenate((log_density, metrics["log_density"]), axis=1)
+        acceptance_rate = jnp.concatenate(
+            (acceptance_rate, metrics["acceptance_rate"]), axis=1
+        )
+        divergent = jnp.concatenate((divergent, metrics["divergent"]), axis=1)
+        energy = jnp.concatenate((energy, metrics["energy"]), axis=1)
+        num_integration_steps_array = jnp.concatenate(
+            (
+                num_integration_steps_array,
+                metrics["num_integration_steps"],
+            ),
+            axis=1,
+        )
+        num_trajectory_expansions_array = jnp.concatenate(
+            (
+                num_trajectory_expansions_array,
+                metrics["num_trajectory_expansions"],
+            ),
+            axis=1,
+        )
+        global_acceptance_rate = jnp.concatenate(
+            (global_acceptance_rate, metrics["global_acceptance_rate"]), axis=1
+        )
+        global_accepted_count = jnp.concatenate(
+            (global_accepted_count, metrics["global_accepted_count"]), axis=1
+        )
+        global_mean_log_acceptance_ratio = jnp.concatenate(
+            (
+                global_mean_log_acceptance_ratio,
+                metrics["global_mean_log_acceptance_ratio"],
+            ),
+            axis=1,
+        )
+        global_nonfinite_count = jnp.concatenate(
+            (global_nonfinite_count, metrics["global_nonfinite_count"]), axis=1
+        )
+        completed_draws += chunk
+        if destination is not None and compatibility is not None:
+            _write_flow_nuts_checkpoint(
+                destination,
+                compatibility=compatibility,
+                phase="production",
+                completed_rounds=completed_rounds,
+                completed_stabilization=completed_stabilization,
+                completed_draws=completed_draws,
+                current_states=current_states,
+                warmup_states=warmup_states,
+                step_sizes=step_sizes,
+                inverse_mass_matrices=inverse_mass_matrices,
+                warmup_durations=warmup_durations,
+                replay=replay,
+                flow=flow,
+                training_losses=tuple(training_losses),
+                validation_losses=tuple(validation_losses),
+                flow_training_durations=tuple(flow_training_durations),
+                adaptation_acceptance=_stack_rows(adaptation_acceptance, chains),
+                adaptation_ess=jnp.asarray(adaptation_ess),
+                adaptation_history_size=jnp.asarray(adaptation_history_size),
+                flat_samples=flat_samples,
+                log_density=log_density,
+                acceptance_rate=acceptance_rate,
+                divergent=divergent,
+                energy=energy,
+                num_integration_steps=num_integration_steps_array,
+                num_trajectory_expansions=num_trajectory_expansions_array,
+                global_acceptance_rate=global_acceptance_rate,
+                global_accepted_count=global_accepted_count,
+                global_mean_log_acceptance_ratio=(global_mean_log_acceptance_ratio),
+                global_nonfinite_count=global_nonfinite_count,
+                num_unique_initial_positions=num_unique_initial_positions,
+                nuts_adaptation_duration=nuts_adaptation_duration,
+                flow_adaptation_duration=flow_adaptation_duration,
+                stabilization_duration=stabilization_duration,
+                sampling_duration=sampling_duration,
+                duration_seconds=previous_duration + time.perf_counter() - started,
+                frozen_flow_fingerprint=frozen_flow_fingerprint,
+            )
+
+    if _flow_fingerprint(flow) != frozen_flow_fingerprint:
+        raise RuntimeError("Frozen flow parameters changed during retained sampling.")
+    unconstrained_samples = jax.vmap(jax.vmap(unravel))(flat_samples)
+    samples = problem.parameter_space.constrain(unconstrained_samples)
+    diagnostics = mcmc_diagnostics(
+        samples,
+        acceptance_rate=acceptance_rate,
+        divergent=divergent,
+    )
+    jax.block_until_ready(diagnostics.max_rhat)
+    final_state_tuple = tuple(
+        _unravel_hmc_state(state, unravel)
+        for state in _unstack_tree(current_states, chains)
+    )
+    warmup_state_tuple = tuple(
+        _unravel_hmc_state(state, unravel)
+        for state in _unstack_tree(warmup_states, chains)
+    )
+    warmups = tuple(
+        MCMCChainWarmup(
+            state=warmup_state_tuple[index],
+            step_size=step_sizes[index],
+            inverse_mass_matrix=inverse_mass_matrices[index],
+            num_integration_steps=None,
+            duration_seconds=float(warmup_durations[index]),
+        )
+        for index in range(chains)
+    )
+    total_duration = previous_duration + time.perf_counter() - started
+    mcmc = MCMCResult(
+        problem=problem,
+        samples=samples,
+        unconstrained_samples=unconstrained_samples,
+        log_density=log_density,
+        acceptance_rate=acceptance_rate,
+        divergent=divergent,
+        energy=energy,
+        num_integration_steps=num_integration_steps_array,
+        num_trajectory_expansions=num_trajectory_expansions_array,
+        final_states=final_state_tuple,
+        warmup=warmups,
+        diagnostics=diagnostics,
+        root_key=root_key,
+        chain_keys=chain_keys,
+        algorithm="flow_nuts",
+        duration_seconds=total_duration,
+        max_num_doublings=doublings,
+        chain_method=method,
+        adaptation_duration_seconds=(
+            nuts_adaptation_duration + flow_adaptation_duration + stabilization_duration
+        ),
+        sampling_duration_seconds=sampling_duration,
+    )
+    return FlowNUTSResult(
+        mcmc=mcmc,
+        flow=flow,
+        config=flow_config,
+        training_losses=tuple(training_losses),
+        validation_losses=tuple(validation_losses),
+        flow_training_duration_seconds=tuple(flow_training_durations),
+        adaptation_global_acceptance_rate=_stack_rows(adaptation_acceptance, chains),
+        adaptation_proposal_ess=jnp.asarray(adaptation_ess),
+        adaptation_history_size=jnp.asarray(adaptation_history_size),
+        global_acceptance_rate=global_acceptance_rate,
+        global_accepted_count=global_accepted_count,
+        global_mean_log_acceptance_ratio=global_mean_log_acceptance_ratio,
+        global_nonfinite_count=global_nonfinite_count,
+        num_unique_initial_positions=num_unique_initial_positions,
+        nuts_adaptation_duration_seconds=nuts_adaptation_duration,
+        flow_adaptation_duration_seconds=flow_adaptation_duration,
+        stabilization_duration_seconds=stabilization_duration,
+        sampling_duration_seconds=sampling_duration,
+        duration_seconds=total_duration,
+        history_memory_bytes=_tree_nbytes(replay),
+    )
+
+
+def _fold_path(key: Array, *indices: int) -> Array:
+    result = key
+    for index in indices:
+        result = jr.fold_in(result, int(index))
+    return result
+
+
+def _indexed_chain_keys(
+    chain_keys: Array,
+    /,
+    *,
+    phase: int,
+    group: int,
+    start: int,
+    count: int,
+) -> Array:
+    indices = jnp.arange(start, start + count, dtype=jnp.uint32)
+
+    def chain_schedule(chain_key):
+        base = jr.fold_in(jr.fold_in(chain_key, phase), group)
+        return jax.vmap(lambda index: jr.fold_in(base, index))(indices)
+
+    return jax.vmap(chain_schedule)(chain_keys)
+
+
+def _flatten_chain_positions(
+    positions: PyTree[Any],
+    reference: PyTree[Any],
+    /,
+    *,
+    chains: int,
+    dimension: int,
+) -> Array:
+    if jax.tree_util.tree_structure(positions) != jax.tree_util.tree_structure(reference):
+        raise ValueError("initial_positions has an incompatible PyTree structure.")
+    position_leaves = jax.tree_util.tree_leaves(positions)
+    reference_leaves = jax.tree_util.tree_leaves(reference)
+    for value, expected in zip(position_leaves, reference_leaves, strict=True):
+        array = jnp.asarray(value)
+        expected_shape = (chains, *jnp.asarray(expected).shape)
+        if array.shape != expected_shape:
+            raise ValueError(
+                "Every initial_positions leaf needs shape "
+                f"{expected_shape}; received {array.shape}."
+            )
+        if not jnp.issubdtype(array.dtype, jnp.floating):
+            raise TypeError("Every initial_positions leaf must be a real floating array.")
+        if not bool(jnp.all(jnp.isfinite(array))):
+            raise ValueError("Every initial_positions leaf must be finite.")
+    flattened = []
+    for index in range(chains):
+        chain_position = jax.tree_util.tree_map(lambda value: value[index], positions)
+        flat, _ = ravel_pytree(chain_position)
+        if flat.shape != (dimension,):
+            raise ValueError("An initial position has an incompatible flattened shape.")
+        flattened.append(flat)
+    return jnp.stack(flattened)
+
+
+def _advance_nuts_collect(
+    current_states,
+    step_sizes,
+    inverse_mass_matrices,
+    keys,
+    logdensity_fn,
+    *,
+    max_num_doublings: int,
+    chain_method: ChainMethod,
+):
+    kernel = blackjax.nuts.build_kernel()
+
+    def run_chain(state, chain_keys, step_size, inverse_mass_matrix):
+        def transition(current, transition_key):
+            next_state, info = kernel(
+                transition_key,
+                current,
+                logdensity_fn,
+                step_size,
+                inverse_mass_matrix,
+                max_num_doublings,
+            )
+            return next_state, (next_state.position, info)
+
+        return jax.lax.scan(transition, state, chain_keys)
+
+    if chain_method == "vectorized":
+        return_values = jax.jit(jax.vmap(run_chain))(
+            current_states,
+            keys,
+            step_sizes,
+            inverse_mass_matrices,
+        )
+        final_states, (positions, infos) = return_values
+        return final_states, positions, infos
+
+    states = _unstack_tree(current_states, int(keys.shape[0]))
+    final_values = []
+    position_values = []
+    info_values = []
+    compiled = jax.jit(run_chain)
+    for index, state in enumerate(states):
+        final_state, (positions, infos) = compiled(
+            state,
+            keys[index],
+            step_sizes[index],
+            inverse_mass_matrices[index],
+        )
+        final_values.append(final_state)
+        position_values.append(positions)
+        info_values.append(infos)
+    return (
+        _stack_trees(final_values),
+        jnp.stack(position_values),
+        _stack_trees(info_values),
+    )
+
+
+def _advance_flow_chains(
+    flow,
+    current_states,
+    keys,
+    logdensity_fn,
+    *,
+    num_steps: int,
+    chain_method: ChainMethod,
+):
+    def run_chain(flow_value, state, transition_key):
+        return _run_flow_block(
+            transition_key,
+            state.position,
+            state.logdensity,
+            flow_value,
+            logdensity_fn,
+            num_steps=num_steps,
+        )
+
+    if chain_method == "vectorized":
+
+        def run_vectorized(flow_value, states, transition_keys):
+            return jax.vmap(
+                lambda state, transition_key: run_chain(flow_value, state, transition_key)
+            )(states, transition_keys)
+
+        return eqx.filter_jit(run_vectorized)(flow, current_states, keys)
+
+    states = _unstack_tree(current_states, int(keys.shape[0]))
+    final_values = []
+    info_values = []
+    compiled = eqx.filter_jit(run_chain)
+    for index, state in enumerate(states):
+        final_state, info = compiled(flow, state, keys[index])
+        final_values.append(final_state)
+        info_values.append(info)
+    return _stack_trees(final_values), _stack_trees(info_values)
+
+
+def _initialize_nuts_states(
+    positions,
+    logdensity_fn,
+    *,
+    chain_method: ChainMethod,
+):
+    if chain_method == "vectorized":
+        return jax.jit(jax.vmap(lambda value: blackjax.nuts.init(value, logdensity_fn)))(
+            positions
+        )
+    compiled = jax.jit(lambda value: blackjax.nuts.init(value, logdensity_fn))
+    return _stack_trees([compiled(position) for position in positions])
+
+
+def _advance_composite_chains(
+    flow,
+    current_states,
+    step_sizes,
+    inverse_mass_matrices,
+    draw_keys,
+    logdensity_fn,
+    *,
+    num_global_steps: int,
+    num_local_steps: int,
+    max_num_doublings: int,
+    chain_method: ChainMethod,
+):
+    kernel = blackjax.nuts.build_kernel()
+
+    def run_chain(
+        flow_value,
+        state,
+        chain_draw_keys,
+        step_size,
+        inverse_mass_matrix,
+    ):
+        def composite(current_state, draw_key):
+            global_key = jr.fold_in(draw_key, 0)
+            local_base_key = jr.fold_in(draw_key, 1)
+            flow_state, flow_info = _run_flow_block(
+                global_key,
+                current_state.position,
+                current_state.logdensity,
+                flow_value,
+                logdensity_fn,
+                num_steps=num_global_steps,
+            )
+            local_state = blackjax.nuts.init(flow_state.position, logdensity_fn)
+            local_keys = jax.vmap(lambda index: jr.fold_in(local_base_key, index))(
+                jnp.arange(num_local_steps, dtype=jnp.uint32)
+            )
+
+            def local_transition(carry, transition_key):
+                next_state, info = kernel(
+                    transition_key,
+                    carry,
+                    logdensity_fn,
+                    step_size,
+                    inverse_mass_matrix,
+                    max_num_doublings,
+                )
+                return next_state, info
+
+            final_state, local_info = jax.lax.scan(
+                local_transition,
+                local_state,
+                local_keys,
+            )
+            finite_log_ratio = jnp.isfinite(flow_info.log_acceptance_ratio)
+            finite_count = jnp.sum(finite_log_ratio)
+            mean_log_ratio = jnp.where(
+                finite_count > 0,
+                jnp.sum(
+                    jnp.where(
+                        finite_log_ratio,
+                        flow_info.log_acceptance_ratio,
+                        jnp.zeros_like(flow_info.log_acceptance_ratio),
+                    )
+                )
+                / finite_count,
+                -jnp.inf,
+            )
+            metrics = {
+                "log_density": final_state.logdensity,
+                "acceptance_rate": jnp.mean(local_info.acceptance_rate),
+                "divergent": jnp.any(local_info.is_divergent),
+                "energy": local_info.energy[-1],
+                "num_integration_steps": jnp.sum(local_info.num_integration_steps),
+                "num_trajectory_expansions": jnp.max(
+                    local_info.num_trajectory_expansions
+                ),
+                "global_acceptance_rate": jnp.mean(
+                    flow_info.accepted.astype(final_state.position.dtype)
+                ),
+                "global_accepted_count": jnp.sum(flow_info.accepted, dtype=jnp.int32),
+                "global_mean_log_acceptance_ratio": mean_log_ratio,
+                "global_nonfinite_count": jnp.sum(flow_info.nonfinite, dtype=jnp.int32),
+            }
+            return final_state, (final_state.position, metrics)
+
+        return jax.lax.scan(composite, state, chain_draw_keys)
+
+    if chain_method == "vectorized":
+
+        def run_vectorized(
+            flow_value,
+            states,
+            keys,
+            chain_step_sizes,
+            chain_mass_matrices,
+        ):
+            return jax.vmap(
+                lambda state, chain_keys, step_size, mass_matrix: run_chain(
+                    flow_value,
+                    state,
+                    chain_keys,
+                    step_size,
+                    mass_matrix,
+                )
+            )(states, keys, chain_step_sizes, chain_mass_matrices)
+
+        final_states, (positions, metrics) = eqx.filter_jit(run_vectorized)(
+            flow,
+            current_states,
+            draw_keys,
+            step_sizes,
+            inverse_mass_matrices,
+        )
+        return final_states, positions, metrics
+
+    states = _unstack_tree(current_states, int(draw_keys.shape[0]))
+    final_values = []
+    position_values = []
+    metric_values = []
+    compiled = eqx.filter_jit(run_chain)
+    for index, state in enumerate(states):
+        final_state, (positions, metrics) = compiled(
+            flow,
+            state,
+            draw_keys[index],
+            step_sizes[index],
+            inverse_mass_matrices[index],
+        )
+        final_values.append(final_state)
+        position_values.append(positions)
+        metric_values.append(metrics)
+    return (
+        _stack_trees(final_values),
+        jnp.stack(position_values),
+        _stack_trees(metric_values),
+    )
+
+
+def _flow_fingerprint(flow) -> dict[str, Any]:
+    parameters, _ = eqx.partition(flow, eqx.is_array)
+    return array_tree_fingerprint(parameters)
+
+
+def _unravel_hmc_state(state, unravel) -> HMCState:
+    return HMCState(
+        position=unravel(state.position),
+        logdensity=state.logdensity,
+        logdensity_grad=unravel(state.logdensity_grad),
+    )
+
+
+def _stack_rows(values: list[Array], width: int) -> Array:
+    if not values:
+        return jnp.empty((0, width), dtype=float)
+    return jnp.stack(values)
+
+
+def _write_flow_nuts_checkpoint(
+    destination,
+    *,
+    compatibility,
+    phase,
+    completed_rounds,
+    completed_stabilization,
+    completed_draws,
+    current_states,
+    warmup_states,
+    step_sizes,
+    inverse_mass_matrices,
+    warmup_durations,
+    replay,
+    flow,
+    training_losses,
+    validation_losses,
+    flow_training_durations,
+    adaptation_acceptance,
+    adaptation_ess,
+    adaptation_history_size,
+    flat_samples,
+    log_density,
+    acceptance_rate,
+    divergent,
+    energy,
+    num_integration_steps,
+    num_trajectory_expansions,
+    global_acceptance_rate,
+    global_accepted_count,
+    global_mean_log_acceptance_ratio,
+    global_nonfinite_count,
+    num_unique_initial_positions,
+    nuts_adaptation_duration,
+    flow_adaptation_duration,
+    stabilization_duration,
+    sampling_duration,
+    duration_seconds,
+    frozen_flow_fingerprint,
+):
+    arrays = {
+        "step_sizes": step_sizes,
+        "inverse_mass_matrices": inverse_mass_matrices,
+        "warmup_durations": warmup_durations,
+        "replay_values": replay.values,
+        "replay_size": replay.size,
+        "replay_seen": replay.seen,
+        "adaptation_acceptance": adaptation_acceptance,
+        "adaptation_ess": adaptation_ess,
+        "adaptation_history_size": adaptation_history_size,
+        "flat_samples": flat_samples,
+        "log_density": log_density,
+        "acceptance_rate": acceptance_rate,
+        "divergent": divergent,
+        "energy": energy,
+        "num_integration_steps": num_integration_steps,
+        "num_trajectory_expansions": num_trajectory_expansions,
+        "global_acceptance_rate": global_acceptance_rate,
+        "global_accepted_count": global_accepted_count,
+        "global_mean_log_acceptance_ratio": global_mean_log_acceptance_ratio,
+        "global_nonfinite_count": global_nonfinite_count,
+    }
+    flow_parameters, _ = eqx.partition(flow, eqx.is_array)
+    training_names = []
+    validation_names = []
+    for index, loss in enumerate(training_losses):
+        name = f"training_loss/{index:06d}"
+        arrays[name] = loss
+        training_names.append(name)
+    for index, loss in enumerate(validation_losses):
+        name = f"validation_loss/{index:06d}"
+        arrays[name] = loss
+        validation_names.append(name)
+    state = {
+        "phase": str(phase),
+        "completed_rounds": int(completed_rounds),
+        "completed_stabilization": int(completed_stabilization),
+        "completed_draws": int(completed_draws),
+        "num_unique_initial_positions": int(num_unique_initial_positions),
+        "nuts_adaptation_duration_seconds": float(nuts_adaptation_duration),
+        "flow_adaptation_duration_seconds": float(flow_adaptation_duration),
+        "stabilization_duration_seconds": float(stabilization_duration),
+        "sampling_duration_seconds": float(sampling_duration),
+        "duration_seconds": float(duration_seconds),
+        "frozen_flow_fingerprint": frozen_flow_fingerprint,
+        "current_state_tree": pack_array_tree("current_state", current_states, arrays),
+        "warmup_state_tree": pack_array_tree("warmup_state", warmup_states, arrays),
+        "flow_parameter_tree": pack_array_tree(
+            "flow_parameters", flow_parameters, arrays
+        ),
+        "training_loss_arrays": training_names,
+        "validation_loss_arrays": validation_names,
+        "flow_training_duration_seconds": [
+            float(value) for value in flow_training_durations
+        ],
+    }
+    write_checkpoint_archive(
+        destination,
+        kind="flow_nuts",
+        compatibility=compatibility,
+        state=state,
+        arrays=arrays,
+    )
+
+
+def _read_flow_nuts_checkpoint(
+    source,
+    *,
+    compatibility,
+    problem,
+    flat_reference,
+    flat_logdensity,
+    root_key,
+    chains,
+    config,
+):
+    state, arrays = read_checkpoint_archive(
+        source,
+        kind="flow_nuts",
+        compatibility=compatibility,
+    )
+    phase = state.get("phase")
+    if phase not in ("adaptation", "stabilization", "production"):
+        raise CheckpointCorruptionError("Flow-NUTS checkpoint phase is invalid.")
+    completed_rounds = int(state.get("completed_rounds", -1))
+    completed_stabilization = int(state.get("completed_stabilization", -1))
+    completed_draws = int(state.get("completed_draws", -1))
+    if not 0 <= completed_rounds <= config.num_adaptation_rounds:
+        raise CheckpointCorruptionError(
+            "Flow-NUTS checkpoint adaptation-round count is invalid."
+        )
+    if not 0 <= completed_stabilization <= config.num_stabilization_steps:
+        raise CheckpointCorruptionError(
+            "Flow-NUTS checkpoint stabilization count is invalid."
+        )
+    if completed_draws < 0:
+        raise CheckpointCorruptionError(
+            "Flow-NUTS checkpoint production-draw count is invalid."
+        )
+    if phase != "adaptation" and completed_rounds != config.num_adaptation_rounds:
+        raise CheckpointCorruptionError(
+            "Flow-NUTS checkpoint entered a frozen phase before adaptation completed."
+        )
+
+    one_state = blackjax.nuts.init(flat_reference, flat_logdensity)
+    state_template = jax.tree_util.tree_map(
+        lambda value: jnp.broadcast_to(value, (chains, *value.shape)),
+        one_state,
+    )
+    current_states = unpack_array_tree(
+        state["current_state_tree"], arrays, state_template
+    )
+    warmup_states = unpack_array_tree(state["warmup_state_tree"], arrays, state_template)
+    dummy_data = jnp.stack(
+        (jnp.zeros_like(flat_reference), jnp.ones_like(flat_reference))
+    )
+    flow_template = _build_default_flow(
+        _fold_path(root_key, _FLOW_INITIALIZATION_TAG),
+        dummy_data,
+        flow_layers=config.flow_layers,
+        num_knots=config.num_knots,
+        nn_width=config.nn_width,
+        nn_depth=config.nn_depth,
+    )
+    parameter_template, static = eqx.partition(flow_template, eqx.is_array)
+    flow_parameters = unpack_array_tree(
+        state["flow_parameter_tree"], arrays, parameter_template
+    )
+    flow = eqx.combine(flow_parameters, static)
+
+    training_names = state.get("training_loss_arrays")
+    validation_names = state.get("validation_loss_arrays")
+    if not isinstance(training_names, list) or not isinstance(validation_names, list):
+        raise CheckpointCorruptionError("Flow loss-array specifications are invalid.")
+    if (
+        len(training_names) != completed_rounds
+        or len(validation_names) != completed_rounds
+    ):
+        raise CheckpointCorruptionError(
+            "Flow loss histories do not match completed adaptation rounds."
+        )
+    training_losses = [_loss_array(arrays, name) for name in training_names]
+    validation_losses = [_loss_array(arrays, name) for name in validation_names]
+    flow_training_durations = state.get("flow_training_duration_seconds")
+    if (
+        not isinstance(flow_training_durations, list)
+        or len(flow_training_durations) != completed_rounds
+        or any(
+            not isinstance(value, int | float) or not np.isfinite(value) or value < 0.0
+            for value in flow_training_durations
+        )
+    ):
+        raise CheckpointCorruptionError(
+            "Flow training durations do not match completed adaptation rounds."
+        )
+    flow_training_durations = [float(value) for value in flow_training_durations]
+
+    step_sizes = _required_array(arrays, "step_sizes", leading=chains)
+    inverse_mass_matrices = _required_array(
+        arrays, "inverse_mass_matrices", leading=chains
+    )
+    warmup_durations = _required_array(arrays, "warmup_durations", shape=(chains,))
+    replay = _ReplayBuffer(
+        values=_required_array(
+            arrays,
+            "replay_values",
+            shape=(chains, config.history_capacity_per_chain, flat_reference.size),
+        ),
+        size=_required_array(arrays, "replay_size", shape=(chains,)),
+        seen=_required_array(arrays, "replay_seen", shape=(chains,)),
+    )
+    adaptation_acceptance = _required_array(
+        arrays,
+        "adaptation_acceptance",
+        shape=(completed_rounds, chains),
+    )
+    adaptation_ess = _required_array(arrays, "adaptation_ess", shape=(completed_rounds,))
+    adaptation_history_size = _required_array(
+        arrays,
+        "adaptation_history_size",
+        shape=(completed_rounds,),
+    )
+    draw_shape = (chains, completed_draws)
+    flat_samples = _required_array(
+        arrays,
+        "flat_samples",
+        shape=(chains, completed_draws, flat_reference.size),
+    )
+    log_density = _required_array(arrays, "log_density", shape=draw_shape)
+    acceptance_rate = _required_array(arrays, "acceptance_rate", shape=draw_shape)
+    divergent = _required_array(arrays, "divergent", shape=draw_shape)
+    energy = _required_array(arrays, "energy", shape=draw_shape)
+    num_integration_steps = _required_array(
+        arrays, "num_integration_steps", shape=draw_shape
+    )
+    num_trajectory_expansions = _required_array(
+        arrays, "num_trajectory_expansions", shape=draw_shape
+    )
+    global_acceptance_rate = _required_array(
+        arrays, "global_acceptance_rate", shape=draw_shape
+    )
+    global_accepted_count = _required_array(
+        arrays, "global_accepted_count", shape=draw_shape
+    )
+    global_mean_log_acceptance_ratio = _required_array(
+        arrays,
+        "global_mean_log_acceptance_ratio",
+        shape=draw_shape,
+    )
+    global_nonfinite_count = _required_array(
+        arrays, "global_nonfinite_count", shape=draw_shape
+    )
+    frozen_flow_fingerprint = state.get("frozen_flow_fingerprint")
+    if phase != "adaptation" and not isinstance(frozen_flow_fingerprint, dict):
+        raise CheckpointCorruptionError(
+            "Frozen flow-NUTS checkpoint is missing its flow fingerprint."
+        )
+    if isinstance(frozen_flow_fingerprint, dict) and (
+        _flow_fingerprint(flow) != frozen_flow_fingerprint
+    ):
+        raise CheckpointCompatibilityError(
+            "Checkpoint flow parameters do not match the frozen fingerprint."
+        )
+    _validate_flow(
+        flow,
+        _replay_data(replay),
+        _fold_path(root_key, _FLOW_TRAINING_TAG, completed_rounds, 1),
+    )
+    return (
+        current_states,
+        warmup_states,
+        step_sizes,
+        inverse_mass_matrices,
+        warmup_durations,
+        replay,
+        flow,
+        training_losses,
+        validation_losses,
+        flow_training_durations,
+        [value for value in adaptation_acceptance],
+        [value for value in adaptation_ess],
+        [value for value in adaptation_history_size],
+        completed_rounds,
+        completed_stabilization,
+        completed_draws,
+        flat_samples,
+        log_density,
+        acceptance_rate,
+        divergent,
+        energy,
+        num_integration_steps,
+        num_trajectory_expansions,
+        global_acceptance_rate,
+        global_accepted_count,
+        global_mean_log_acceptance_ratio,
+        global_nonfinite_count,
+        int(state["num_unique_initial_positions"]),
+        float(state["nuts_adaptation_duration_seconds"]),
+        float(state["flow_adaptation_duration_seconds"]),
+        float(state["stabilization_duration_seconds"]),
+        float(state["sampling_duration_seconds"]),
+        float(state["duration_seconds"]),
+        frozen_flow_fingerprint,
+    )
+
+
+def _required_array(arrays, name, *, shape=None, leading=None):
+    if name not in arrays:
+        raise CheckpointCorruptionError(f"Checkpoint array {name!r} is missing.")
+    value = jnp.asarray(arrays[name])
+    if shape is not None and value.shape != shape:
+        raise CheckpointCompatibilityError(
+            f"Checkpoint array {name!r} has an incompatible shape."
+        )
+    if leading is not None and (value.ndim == 0 or value.shape[0] != leading):
+        raise CheckpointCompatibilityError(
+            f"Checkpoint array {name!r} has an incompatible leading axis."
+        )
+    return value
+
+
+def _loss_array(arrays, name) -> Array:
+    if not isinstance(name, str) or name not in arrays:
+        raise CheckpointCorruptionError("A checkpoint flow loss array is missing.")
+    value = jnp.asarray(arrays[name])
+    if value.ndim != 1 or not bool(jnp.all(jnp.isfinite(value))):
+        raise CheckpointCorruptionError("A checkpoint flow loss history is invalid.")
+    return value
+
+
+__all__ = ["FlowNUTSConfig", "FlowNUTSResult", "sample_flow_nuts"]

--- a/phydrax/uq/_flow_proposal.py
+++ b/phydrax/uq/_flow_proposal.py
@@ -1,0 +1,348 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from typing import Any, NamedTuple
+
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+from flowjax.bijections import RationalQuadraticSpline
+from flowjax.distributions import AbstractDistribution, Normal
+from flowjax.flows import coupling_flow, triangular_spline_flow
+from flowjax.train import fit_to_data
+from jaxtyping import Array
+
+
+class _ReplayBuffer(NamedTuple):
+    values: Array
+    size: Array
+    seen: Array
+
+
+class _FlowProposalState(NamedTuple):
+    position: Array
+    log_target: Array
+    log_proposal: Array
+
+
+class _FlowProposalBlockInfo(NamedTuple):
+    accepted: Array
+    log_acceptance_ratio: Array
+    nonfinite: Array
+    proposed_log_target: Array
+    proposed_log_density: Array
+
+
+def _initialize_replay(
+    *,
+    num_chains: int,
+    capacity_per_chain: int,
+    dimension: int,
+    dtype: Any,
+) -> _ReplayBuffer:
+    return _ReplayBuffer(
+        values=jnp.zeros(
+            (int(num_chains), int(capacity_per_chain), int(dimension)),
+            dtype=dtype,
+        ),
+        size=jnp.zeros((int(num_chains),), dtype=jnp.int32),
+        seen=jnp.zeros((int(num_chains),), dtype=jnp.int32),
+    )
+
+
+def _update_replay(
+    replay: _ReplayBuffer,
+    samples: Array,
+    keys: Array,
+) -> _ReplayBuffer:
+    """Apply independent, fixed-capacity reservoir updates for every chain."""
+    values = jnp.asarray(samples)
+    if values.ndim != 3:
+        raise ValueError("Replay samples must have shape (chain, sample, dimension).")
+    if values.shape[0] != replay.values.shape[0]:
+        raise ValueError("Replay samples have an incompatible chain count.")
+    if values.shape[2] != replay.values.shape[2]:
+        raise ValueError("Replay samples have an incompatible event dimension.")
+    if keys.shape[:2] != values.shape[:2]:
+        raise ValueError("Replay keys must match the chain and sample axes.")
+
+    capacity = int(replay.values.shape[1])
+
+    def update_chain(chain_values, chain_size, chain_seen, chain_samples, chain_keys):
+        def update_one(carry, item):
+            current_values, current_size, current_seen = carry
+            sample, key = item
+            next_seen = current_seen + jnp.asarray(1, dtype=jnp.int32)
+            candidate = jr.randint(
+                key,
+                (),
+                minval=0,
+                maxval=next_seen,
+                dtype=jnp.int32,
+            )
+            filling = current_size < capacity
+            replace = filling | (candidate < capacity)
+            index = jnp.where(
+                filling,
+                current_size,
+                jnp.minimum(candidate, capacity - 1),
+            )
+            updated_values = jax.lax.cond(
+                replace,
+                lambda data: data.at[index].set(sample),
+                lambda data: data,
+                current_values,
+            )
+            next_size = jnp.minimum(current_size + 1, capacity)
+            return (updated_values, next_size, next_seen), None
+
+        (final_values, final_size, final_seen), _ = jax.lax.scan(
+            update_one,
+            (chain_values, chain_size, chain_seen),
+            (chain_samples, chain_keys),
+        )
+        return final_values, final_size, final_seen
+
+    updated_values, updated_size, updated_seen = jax.vmap(update_chain)(
+        replay.values,
+        replay.size,
+        replay.seen,
+        values,
+        keys,
+    )
+    return _ReplayBuffer(updated_values, updated_size, updated_seen)
+
+
+def _replay_data(replay: _ReplayBuffer) -> Array:
+    if not bool(jnp.all(replay.size == replay.size[0])):
+        raise RuntimeError("Chain-stratified replay sizes must remain equal.")
+    size = int(replay.size[0])
+    if size <= 0:
+        raise ValueError("Flow training requires at least one replay sample per chain.")
+    return replay.values[:, :size, :].reshape((-1, replay.values.shape[-1]))
+
+
+def _build_default_flow(
+    key: Array,
+    data: Array,
+    /,
+    *,
+    flow_layers: int,
+    num_knots: int,
+    nn_width: int,
+    nn_depth: int,
+) -> AbstractDistribution:
+    samples = jnp.asarray(data)
+    if samples.ndim != 2 or samples.shape[0] < 2 or samples.shape[1] < 1:
+        raise ValueError("Flow initialization requires a non-empty matrix of samples.")
+    if not jnp.issubdtype(samples.dtype, jnp.floating):
+        raise TypeError("Flow samples must use a real floating dtype.")
+
+    location = jnp.mean(samples, axis=0)
+    scale = jnp.std(samples, axis=0)
+    tolerance = jnp.sqrt(jnp.finfo(samples.dtype).eps) * jnp.maximum(
+        jnp.ones_like(location), jnp.abs(location)
+    )
+    base = Normal(location, jnp.maximum(scale, tolerance))
+    dimension = int(samples.shape[1])
+    if dimension == 1:
+        return triangular_spline_flow(
+            key,
+            base_dist=base,
+            flow_layers=int(flow_layers),
+            knots=int(num_knots),
+            invert=True,
+        )
+
+    transformer = RationalQuadraticSpline(knots=int(num_knots), interval=3.0)
+    return coupling_flow(
+        key,
+        base_dist=base,
+        transformer=transformer,
+        flow_layers=int(flow_layers),
+        nn_width=int(nn_width),
+        nn_depth=int(nn_depth),
+        invert=True,
+    )
+
+
+def _fit_flow(
+    key: Array,
+    flow: AbstractDistribution,
+    data: Array,
+    /,
+    *,
+    learning_rate: float,
+    max_epochs: int,
+    max_patience: int,
+    batch_size: int,
+    validation_fraction: float,
+) -> tuple[AbstractDistribution, Array, Array]:
+    samples = jnp.asarray(data)
+    validation_count = round(float(validation_fraction) * int(samples.shape[0]))
+    training_count = int(samples.shape[0]) - validation_count
+    if validation_count <= 0 or validation_count >= int(samples.shape[0]):
+        raise ValueError(
+            "Flow training data must produce non-empty train and validation splits."
+        )
+    trained, losses = fit_to_data(
+        key,
+        flow,
+        samples,
+        learning_rate=float(learning_rate),
+        max_epochs=int(max_epochs),
+        max_patience=int(max_patience),
+        batch_size=min(int(batch_size), training_count),
+        val_prop=float(validation_fraction),
+        return_best=True,
+        show_progress=False,
+    )
+    training_loss = jnp.asarray(losses["train"])
+    validation_loss = jnp.asarray(losses["val"])
+    if not bool(jnp.all(jnp.isfinite(training_loss))) or not bool(
+        jnp.all(jnp.isfinite(validation_loss))
+    ):
+        raise FloatingPointError("Flow training produced a nonfinite loss.")
+    return trained, training_loss, validation_loss
+
+
+def _validate_flow(
+    flow: AbstractDistribution,
+    data: Array,
+    key: Array,
+    /,
+) -> None:
+    samples = jnp.asarray(data)
+    expected_shape = (int(samples.shape[-1]),)
+    if flow.shape != expected_shape:
+        raise ValueError(
+            f"Flow event shape {flow.shape} does not match {expected_shape}."
+        )
+    if flow.cond_shape is not None:
+        raise ValueError("Flow proposal must be unconditional.")
+    data_log_density = flow.log_prob(samples)
+    proposed, proposed_log_density = flow.sample_and_log_prob(
+        key,
+        sample_shape=(min(8, int(samples.shape[0])),),
+    )
+    if proposed.shape[1:] != expected_shape:
+        raise ValueError("Flow proposal samples have an incompatible event shape.")
+    if not bool(jnp.all(jnp.isfinite(data_log_density))):
+        raise FloatingPointError("Flow density is nonfinite on its training data.")
+    if not bool(jnp.all(jnp.isfinite(proposed))) or not bool(
+        jnp.all(jnp.isfinite(proposed_log_density))
+    ):
+        raise FloatingPointError("Flow proposal produced a nonfinite sample or density.")
+
+
+def _independence_mh_scan(
+    initial_state: _FlowProposalState,
+    proposed_positions: Array,
+    proposed_log_targets: Array,
+    proposed_log_densities: Array,
+    log_uniforms: Array,
+) -> tuple[_FlowProposalState, _FlowProposalBlockInfo]:
+    """Apply exact sequential independence-MH decisions to prepared proposals."""
+
+    def transition(state, proposal):
+        position, log_target, log_proposal, log_uniform = proposal
+        finite = (
+            jnp.all(jnp.isfinite(position))
+            & jnp.isfinite(log_target)
+            & jnp.isfinite(log_proposal)
+            & jnp.isfinite(state.log_target)
+            & jnp.isfinite(state.log_proposal)
+        )
+        raw_ratio = log_target - state.log_target + state.log_proposal - log_proposal
+        log_acceptance_ratio = jnp.where(
+            finite,
+            jnp.minimum(jnp.zeros((), dtype=raw_ratio.dtype), raw_ratio),
+            -jnp.inf,
+        )
+        accepted = finite & (log_uniform < log_acceptance_ratio)
+        next_state = _FlowProposalState(
+            position=jnp.where(accepted, position, state.position),
+            log_target=jnp.where(accepted, log_target, state.log_target),
+            log_proposal=jnp.where(accepted, log_proposal, state.log_proposal),
+        )
+        return next_state, (accepted, log_acceptance_ratio, ~finite)
+
+    final_state, (accepted, log_acceptance_ratio, nonfinite) = jax.lax.scan(
+        transition,
+        initial_state,
+        (
+            proposed_positions,
+            proposed_log_targets,
+            proposed_log_densities,
+            log_uniforms,
+        ),
+    )
+    return final_state, _FlowProposalBlockInfo(
+        accepted=accepted,
+        log_acceptance_ratio=log_acceptance_ratio,
+        nonfinite=nonfinite,
+        proposed_log_target=proposed_log_targets,
+        proposed_log_density=proposed_log_densities,
+    )
+
+
+def _run_flow_block(
+    key: Array,
+    position: Array,
+    log_target: Array,
+    flow: AbstractDistribution,
+    logdensity_fn: Any,
+    /,
+    *,
+    num_steps: int,
+) -> tuple[_FlowProposalState, _FlowProposalBlockInfo]:
+    proposal_key, acceptance_key = jr.split(key)
+    proposed_positions, proposed_log_densities = flow.sample_and_log_prob(
+        proposal_key,
+        sample_shape=(int(num_steps),),
+    )
+    proposed_log_targets = jax.vmap(logdensity_fn)(proposed_positions)
+    current_log_proposal = flow.log_prob(position)
+    tiny = jnp.finfo(proposed_positions.dtype).tiny
+    log_uniforms = jnp.log(
+        jr.uniform(
+            acceptance_key,
+            (int(num_steps),),
+            minval=tiny,
+            maxval=1.0,
+            dtype=proposed_positions.dtype,
+        )
+    )
+    return _independence_mh_scan(
+        _FlowProposalState(position, log_target, current_log_proposal),
+        proposed_positions,
+        proposed_log_targets,
+        proposed_log_densities,
+        log_uniforms,
+    )
+
+
+def _proposal_effective_sample_size(
+    proposed_log_target: Array,
+    proposed_log_density: Array,
+) -> Array:
+    log_weights = jnp.ravel(proposed_log_target - proposed_log_density)
+    finite = jnp.isfinite(log_weights)
+
+    def finite_ess(values):
+        masked = jnp.where(finite, values, -jnp.inf)
+        weights = jax.nn.softmax(masked)
+        return jnp.reciprocal(jnp.sum(weights**2))
+
+    return jax.lax.cond(
+        jnp.any(finite),
+        finite_ess,
+        lambda values: jnp.zeros((), dtype=values.dtype),
+        log_weights,
+    )
+
+
+__all__: list[str] = []

--- a/phydrax/uq/_mcmc.py
+++ b/phydrax/uq/_mcmc.py
@@ -244,6 +244,7 @@ def sample_nuts(
     num_warmup: int = 1000,
     num_samples: int = 1000,
     initial_position: PyTree[Any] | None = None,
+    initial_positions: PyTree[Any] | None = None,
     target_acceptance_rate: float = 0.8,
     initial_step_size: float = 1.0,
     is_mass_matrix_diagonal: bool = True,
@@ -265,6 +266,7 @@ def sample_nuts(
         num_warmup=num_warmup,
         num_samples=num_samples,
         initial_position=initial_position,
+        initial_positions=initial_positions,
         target_acceptance_rate=target_acceptance_rate,
         initial_step_size=initial_step_size,
         is_mass_matrix_diagonal=is_mass_matrix_diagonal,
@@ -287,6 +289,7 @@ def sample_hmc(
     num_warmup: int = 1000,
     num_samples: int = 1000,
     initial_position: PyTree[Any] | None = None,
+    initial_positions: PyTree[Any] | None = None,
     target_acceptance_rate: float = 0.8,
     initial_step_size: float = 1.0,
     is_mass_matrix_diagonal: bool = True,
@@ -307,6 +310,7 @@ def sample_hmc(
         num_warmup=num_warmup,
         num_samples=num_samples,
         initial_position=initial_position,
+        initial_positions=initial_positions,
         target_acceptance_rate=target_acceptance_rate,
         initial_step_size=initial_step_size,
         is_mass_matrix_diagonal=is_mass_matrix_diagonal,
@@ -329,6 +333,7 @@ def _sample_mcmc(
     num_warmup: int,
     num_samples: int,
     initial_position: PyTree[Any] | None,
+    initial_positions: PyTree[Any] | None,
     target_acceptance_rate: float,
     initial_step_size: float,
     is_mass_matrix_diagonal: bool,
@@ -359,8 +364,17 @@ def _sample_mcmc(
     method: ChainMethod = chain_method
     if method not in ("sequential", "vectorized"):
         raise ValueError("chain_method must be 'sequential' or 'vectorized'.")
-    if resume_from is not None and initial_position is not None:
-        raise ValueError("initial_position cannot be supplied when resuming MCMC.")
+    if initial_position is not None and initial_positions is not None:
+        raise ValueError(
+            "initial_position and initial_positions cannot both be supplied."
+        )
+    if resume_from is not None and (
+        initial_position is not None or initial_positions is not None
+    ):
+        raise ValueError(
+            "initial_position and initial_positions cannot be supplied when "
+            "resuming MCMC."
+        )
 
     destination = (
         Path(checkpoint_path)
@@ -375,10 +389,45 @@ def _sample_mcmc(
     if destination is not None and (checkpoint_id is None or not str(checkpoint_id)):
         raise ValueError("checkpoint_id is required for MCMC checkpointing.")
 
-    position = problem.initial_position if initial_position is None else initial_position
-    problem.parameter_space.constrain(position)
-    value, gradient = jax.value_and_grad(problem.log_density)(position)
-    if not bool(jnp.isfinite(value)) or any(
+    if initial_positions is None:
+        position = (
+            problem.initial_position if initial_position is None else initial_position
+        )
+        problem.parameter_space.constrain(position)
+        value, gradient = jax.value_and_grad(problem.log_density)(position)
+        chain_positions = jax.tree_util.tree_map(
+            lambda leaf: jnp.broadcast_to(leaf, (chains, *leaf.shape)),
+            position,
+        )
+        values = value
+    else:
+        position = problem.initial_position
+        if jax.tree_util.tree_structure(
+            initial_positions
+        ) != jax.tree_util.tree_structure(problem.initial_position):
+            raise ValueError(
+                "initial_positions must have the ParameterSpace initial PyTree structure."
+            )
+        reference_leaves = jax.tree_util.tree_leaves(problem.initial_position)
+        position_leaves = jax.tree_util.tree_leaves(initial_positions)
+        for position_leaf, reference_leaf in zip(
+            position_leaves,
+            reference_leaves,
+            strict=True,
+        ):
+            if not eqx.is_inexact_array(position_leaf):
+                raise TypeError("Every initial_positions leaf must be an inexact array.")
+            expected_shape = (chains, *reference_leaf.shape)
+            if position_leaf.shape != expected_shape:
+                raise ValueError(
+                    "Every initial_positions leaf must have shape "
+                    f"{expected_shape}; received {position_leaf.shape}."
+                )
+        chain_positions = jax.tree_util.tree_map(jnp.asarray, initial_positions)
+        values, gradient = jax.vmap(jax.value_and_grad(problem.log_density))(
+            chain_positions
+        )
+    if not bool(jnp.all(jnp.isfinite(values))) or any(
         bool(jnp.any(~jnp.isfinite(jnp.asarray(leaf))))
         for leaf in jax.tree_util.tree_leaves(gradient)
     ):
@@ -424,7 +473,7 @@ def _sample_mcmc(
         ) = _adapt_mcmc(
             algorithm_factory,
             logdensity_fn,
-            position,
+            chain_positions,
             warmup_keys=warmup_keys,
             warmup_steps=warmup_steps,
             target_acceptance_rate=target,
@@ -616,7 +665,7 @@ def _sample_mcmc(
 def _adapt_mcmc(
     algorithm_factory,
     logdensity_fn,
-    position,
+    positions,
     *,
     warmup_keys,
     warmup_steps,
@@ -638,15 +687,15 @@ def _adapt_mcmc(
     if chain_method == "vectorized":
         started = time.perf_counter()
 
-        def adapt_chain(warmup_key):
+        def adapt_chain(warmup_key, chain_position):
             result, _ = adaptation_run(
                 warmup_key,
-                position,
+                chain_position,
                 num_steps=warmup_steps,
             )
             return result
 
-        results = jax.jit(jax.vmap(adapt_chain))(warmup_keys)
+        results = jax.jit(jax.vmap(adapt_chain))(warmup_keys, positions)
         jax.block_until_ready(results.state.position)
         duration = time.perf_counter() - started
         durations = jnp.full((warmup_keys.shape[0],), duration)
@@ -659,15 +708,16 @@ def _adapt_mcmc(
             duration,
         )
 
+    chain_positions = _unstack_tree(positions, int(warmup_keys.shape[0]))
     states = []
     step_sizes = []
     mass_matrices = []
     durations = []
-    for warmup_key in warmup_keys:
+    for warmup_key, chain_position in zip(warmup_keys, chain_positions, strict=True):
         started = time.perf_counter()
         result, _ = adaptation_run(
             warmup_key,
-            position,
+            chain_position,
             num_steps=warmup_steps,
         )
         jax.block_until_ready(result.state.position)

--- a/phydrax/uq/_posterior_diagnostics.py
+++ b/phydrax/uq/_posterior_diagnostics.py
@@ -1,0 +1,324 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from typing import Any
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jaxtyping import Array, PyTree
+
+from .._strict import StrictModule
+from ._posterior import PosteriorProblem
+
+
+class PosteriorCapabilities(StrictModule):
+    """Static posterior primitives available to inference methods."""
+
+    factorized_prior: bool = eqx.field(static=True)
+    automatic_prior_sampling: bool = eqx.field(static=True)
+    prediction: bool = eqx.field(static=True)
+    observation_variance: bool = eqx.field(static=True)
+    observation_sampling: bool = eqx.field(static=True)
+    gauss_newton_residual: bool = eqx.field(static=True)
+    automatic_flow_nuts_initialization: bool = eqx.field(static=True)
+    automatic_tempered_smc_initialization: bool = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        factorized_prior: bool,
+        prediction: bool,
+        observation_variance: bool,
+        observation_sampling: bool,
+        gauss_newton_residual: bool,
+    ):
+        has_factorized_prior = bool(factorized_prior)
+        self.factorized_prior = has_factorized_prior
+        self.automatic_prior_sampling = has_factorized_prior
+        self.prediction = bool(prediction)
+        self.observation_variance = bool(observation_variance)
+        self.observation_sampling = bool(observation_sampling)
+        self.gauss_newton_residual = bool(gauss_newton_residual)
+        self.automatic_flow_nuts_initialization = has_factorized_prior
+        self.automatic_tempered_smc_initialization = has_factorized_prior
+
+    def as_dict(self) -> dict[str, bool]:
+        """Return machine-readable capability flags."""
+        return {
+            "factorized_prior": self.factorized_prior,
+            "automatic_prior_sampling": self.automatic_prior_sampling,
+            "prediction": self.prediction,
+            "observation_variance": self.observation_variance,
+            "observation_sampling": self.observation_sampling,
+            "gauss_newton_residual": self.gauss_newton_residual,
+            "automatic_flow_nuts_initialization": (
+                self.automatic_flow_nuts_initialization
+            ),
+            "automatic_tempered_smc_initialization": (
+                self.automatic_tempered_smc_initialization
+            ),
+        }
+
+
+class PosteriorDiagnostics(StrictModule):
+    """Structured eager, compiled, vectorized, and coordinate checks."""
+
+    capabilities: PosteriorCapabilities
+    initial_log_density: Array
+    gradient_norm: Array
+    roundtrip_error: PyTree[Array]
+    max_roundtrip_error: Array
+    prior_sample_finite_fraction: Array | None
+    nonfinite_gradient_locations: tuple[str, ...] = eqx.field(static=True)
+    roundtrip_failure_locations: tuple[str, ...] = eqx.field(static=True)
+    repeated_evaluation_matches: bool = eqx.field(static=True)
+    jit_evaluation_matches: bool = eqx.field(static=True)
+    vmap_evaluation_matches: bool = eqx.field(static=True)
+    failures: tuple[str, ...] = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        capabilities: PosteriorCapabilities,
+        initial_log_density: Array,
+        gradient_norm: Array,
+        roundtrip_error: PyTree[Array],
+        max_roundtrip_error: Array,
+        prior_sample_finite_fraction: Array | None,
+        nonfinite_gradient_locations: tuple[str, ...],
+        roundtrip_failure_locations: tuple[str, ...],
+        repeated_evaluation_matches: bool,
+        jit_evaluation_matches: bool,
+        vmap_evaluation_matches: bool,
+        failures: tuple[str, ...],
+    ):
+        self.capabilities = capabilities
+        self.initial_log_density = jnp.asarray(initial_log_density)
+        self.gradient_norm = jnp.asarray(gradient_norm)
+        self.roundtrip_error = roundtrip_error
+        self.max_roundtrip_error = jnp.asarray(max_roundtrip_error)
+        self.prior_sample_finite_fraction = (
+            None
+            if prior_sample_finite_fraction is None
+            else jnp.asarray(prior_sample_finite_fraction)
+        )
+        self.nonfinite_gradient_locations = tuple(nonfinite_gradient_locations)
+        self.roundtrip_failure_locations = tuple(roundtrip_failure_locations)
+        self.repeated_evaluation_matches = bool(repeated_evaluation_matches)
+        self.jit_evaluation_matches = bool(jit_evaluation_matches)
+        self.vmap_evaluation_matches = bool(vmap_evaluation_matches)
+        self.failures = tuple(failures)
+
+    @property
+    def passed(self) -> bool:
+        return not self.failures
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return scalar evidence, exact locations, and capability flags."""
+        return {
+            "passed": self.passed,
+            "failures": self.failures,
+            "initial_log_density": float(self.initial_log_density),
+            "gradient_norm": float(self.gradient_norm),
+            "max_roundtrip_error": float(self.max_roundtrip_error),
+            "prior_sample_finite_fraction": (
+                None
+                if self.prior_sample_finite_fraction is None
+                else float(self.prior_sample_finite_fraction)
+            ),
+            "nonfinite_gradient_locations": self.nonfinite_gradient_locations,
+            "roundtrip_failure_locations": self.roundtrip_failure_locations,
+            "repeated_evaluation_matches": self.repeated_evaluation_matches,
+            "jit_evaluation_matches": self.jit_evaluation_matches,
+            "vmap_evaluation_matches": self.vmap_evaluation_matches,
+            "capabilities": self.capabilities.as_dict(),
+        }
+
+
+def diagnose_posterior(
+    problem: PosteriorProblem,
+    /,
+    *,
+    key: Array | None = None,
+    num_prior_samples: int = 8,
+    rtol: float = 1e-6,
+    atol: float = 1e-7,
+) -> PosteriorDiagnostics:
+    """Evaluate numerical posterior contracts without selecting an inference backend."""
+    if not isinstance(problem, PosteriorProblem):
+        raise TypeError("problem must be a PosteriorProblem.")
+    count = int(num_prior_samples)
+    if count <= 0:
+        raise ValueError("num_prior_samples must be positive.")
+    relative_tolerance = float(rtol)
+    absolute_tolerance = float(atol)
+    if relative_tolerance < 0.0 or absolute_tolerance < 0.0:
+        raise ValueError("rtol and atol cannot be negative.")
+
+    capabilities = PosteriorCapabilities(
+        factorized_prior=problem.parameter_space.priors is not None,
+        prediction=problem.predict_fn is not None,
+        observation_variance=problem.observation_variance_fn is not None,
+        observation_sampling=problem.sample_observation_fn is not None,
+        gauss_newton_residual=problem.gauss_newton_residual_fn is not None,
+    )
+    position = problem.initial_position
+    value_and_grad = jax.value_and_grad(problem.log_density)
+    initial_log_density, gradient = value_and_grad(position)
+    repeated_log_density, repeated_gradient = value_and_grad(position)
+    compiled_log_density, compiled_gradient = jax.jit(value_and_grad)(position)
+    batched_position = jax.tree_util.tree_map(
+        lambda value: jnp.broadcast_to(value, (2, *value.shape)),
+        position,
+    )
+    vectorized_log_density = jax.vmap(problem.log_density)(batched_position)
+    physical = problem.parameter_space.constrain(position)
+    restored = problem.parameter_space.unconstrain(physical)
+    roundtrip_error = jax.tree_util.tree_map(
+        lambda left, right: jnp.max(jnp.abs(jnp.asarray(left) - jnp.asarray(right))),
+        position,
+        restored,
+    )
+    max_roundtrip_error = _tree_max(roundtrip_error)
+    nonfinite_gradient_locations = _nonfinite_locations(gradient)
+    roundtrip_failure_locations = _roundtrip_failures(
+        position,
+        restored,
+        rtol=relative_tolerance,
+        atol=absolute_tolerance,
+    )
+    repeated_matches = bool(jnp.array_equal(initial_log_density, repeated_log_density))
+    repeated_matches = repeated_matches and _tree_allclose(
+        gradient,
+        repeated_gradient,
+        rtol=0.0,
+        atol=0.0,
+    )
+    jit_matches = bool(
+        jnp.allclose(
+            initial_log_density,
+            compiled_log_density,
+            rtol=relative_tolerance,
+            atol=absolute_tolerance,
+        )
+    ) and _tree_allclose(
+        gradient,
+        compiled_gradient,
+        rtol=relative_tolerance,
+        atol=absolute_tolerance,
+    )
+    vmap_matches = bool(
+        jnp.allclose(
+            vectorized_log_density,
+            jnp.broadcast_to(initial_log_density, (2,)),
+            rtol=relative_tolerance,
+            atol=absolute_tolerance,
+        )
+    )
+
+    prior_sample_finite_fraction = None
+    if key is not None and capabilities.automatic_prior_sampling:
+        prior_positions = problem.parameter_space.sample_prior(
+            key,
+            num_samples=count,
+        )
+        prior_log_density = jax.vmap(problem.log_density)(prior_positions)
+        prior_sample_finite_fraction = jnp.mean(jnp.isfinite(prior_log_density))
+
+    gradient_norm = jnp.sqrt(
+        sum(
+            (
+                jnp.sum(jnp.asarray(leaf, dtype=float) ** 2)
+                for leaf in jax.tree_util.tree_leaves(gradient)
+            ),
+            jnp.zeros((), dtype=float),
+        )
+    )
+    failures: list[str] = []
+    if not bool(jnp.isfinite(initial_log_density)):
+        failures.append("initial_log_density_nonfinite")
+    if nonfinite_gradient_locations:
+        failures.append("initial_gradient_nonfinite")
+    if roundtrip_failure_locations:
+        failures.append("coordinate_roundtrip_failed")
+    if not repeated_matches:
+        failures.append("repeated_evaluation_mismatch")
+    if not jit_matches:
+        failures.append("jit_evaluation_mismatch")
+    if not vmap_matches:
+        failures.append("vmap_evaluation_mismatch")
+    if prior_sample_finite_fraction is not None and not bool(
+        prior_sample_finite_fraction == 1.0
+    ):
+        failures.append("prior_sample_log_density_nonfinite")
+
+    return PosteriorDiagnostics(
+        capabilities=capabilities,
+        initial_log_density=initial_log_density,
+        gradient_norm=gradient_norm,
+        roundtrip_error=roundtrip_error,
+        max_roundtrip_error=max_roundtrip_error,
+        prior_sample_finite_fraction=prior_sample_finite_fraction,
+        nonfinite_gradient_locations=nonfinite_gradient_locations,
+        roundtrip_failure_locations=roundtrip_failure_locations,
+        repeated_evaluation_matches=repeated_matches,
+        jit_evaluation_matches=jit_matches,
+        vmap_evaluation_matches=vmap_matches,
+        failures=tuple(failures),
+    )
+
+
+def _nonfinite_locations(tree: PyTree[Any]) -> tuple[str, ...]:
+    locations: list[str] = []
+    for path, leaf in jax.tree_util.tree_flatten_with_path(tree)[0]:
+        value = np.asarray(leaf)
+        base = jax.tree_util.keystr(path) or "<root>"
+        for index in np.argwhere(~np.isfinite(value)):
+            suffix = ""
+            if value.ndim:
+                suffix = "[" + ",".join(str(int(item)) for item in index) + "]"
+            locations.append(base + suffix)
+    return tuple(locations)
+
+
+def _roundtrip_failures(
+    original: PyTree[Any],
+    restored: PyTree[Any],
+    *,
+    rtol: float,
+    atol: float,
+) -> tuple[str, ...]:
+    locations = []
+    original_leaves = jax.tree_util.tree_flatten_with_path(original)[0]
+    restored_leaves = jax.tree_util.tree_leaves(restored)
+    for (path, left), right in zip(original_leaves, restored_leaves, strict=True):
+        if not bool(jnp.allclose(left, right, rtol=rtol, atol=atol)):
+            locations.append(jax.tree_util.keystr(path) or "<root>")
+    return tuple(locations)
+
+
+def _tree_allclose(left, right, *, rtol: float, atol: float) -> bool:
+    comparisons = jax.tree_util.tree_map(
+        lambda first, second: jnp.allclose(
+            first,
+            second,
+            rtol=rtol,
+            atol=atol,
+        ),
+        left,
+        right,
+    )
+    return all(bool(value) for value in jax.tree_util.tree_leaves(comparisons))
+
+
+def _tree_max(tree: PyTree[Any]) -> Array:
+    leaves = [jnp.asarray(value) for value in jax.tree_util.tree_leaves(tree)]
+    return jnp.max(jnp.stack(leaves))
+
+
+__all__ = ["PosteriorCapabilities", "PosteriorDiagnostics", "diagnose_posterior"]

--- a/phydrax/uq/_result_export.py
+++ b/phydrax/uq/_result_export.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import base64
+import json
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -29,6 +30,7 @@ from ._diagnostics import MCMCConvergenceReport
 from ._discrepancy_diagnostics import DiscrepancyIdentifiabilityReport
 from ._eki import EnsembleKalmanResult
 from ._ensemble_filter import EnsembleFilterResult, EnsembleSmootherResult
+from ._flow_mcmc import FlowNUTSResult
 from ._kalman import KalmanFilterResult, KalmanSmootherResult
 from ._laplace import LaplaceResult
 from ._laplax_backend import StructuredLaplaceResult
@@ -150,10 +152,14 @@ def read_result_archive(path: str | Path, /) -> UQResultArchive:
     )
 
 
-def to_arviz(result: MCMCResult, /):
+def to_arviz(result: MCMCResult | FlowNUTSResult, /):
     """Convert chain-preserving MCMC draws and sampler statistics to ArviZ."""
-    if not isinstance(result, MCMCResult):
-        raise TypeError("to_arviz currently supports MCMCResult only.")
+    if isinstance(result, FlowNUTSResult):
+        mcmc_result = result.mcmc
+    elif isinstance(result, MCMCResult):
+        mcmc_result = result
+    else:
+        raise TypeError("to_arviz supports MCMCResult and FlowNUTSResult only.")
     try:
         import arviz as az
     except ImportError as error:  # pragma: no cover - dependency is declared
@@ -162,7 +168,7 @@ def to_arviz(result: MCMCResult, /):
     posterior: dict[str, np.ndarray] = {}
     dimensions: dict[str, list[str]] = {}
     coordinates: dict[str, np.ndarray] = {}
-    for path, leaf in jax.tree_util.tree_flatten_with_path(result.samples)[0]:
+    for path, leaf in jax.tree_util.tree_flatten_with_path(mcmc_result.samples)[0]:
         path_string = jax.tree_util.keystr(path) or "<root>"
         name = encode_parameter_name(path_string)
         value = np.asarray(leaf)
@@ -175,14 +181,34 @@ def to_arviz(result: MCMCResult, /):
         dimensions[name] = parameter_dims
 
     sample_stats = {
-        "lp": np.asarray(result.log_density),
-        "acceptance_rate": np.asarray(result.acceptance_rate),
-        "diverging": np.asarray(result.divergent),
-        "energy": np.asarray(result.energy),
-        "n_steps": np.asarray(result.num_integration_steps),
-        "tree_depth": np.asarray(result.num_trajectory_expansions),
+        "lp": np.asarray(mcmc_result.log_density),
+        "acceptance_rate": np.asarray(mcmc_result.acceptance_rate),
+        "diverging": np.asarray(mcmc_result.divergent),
+        "energy": np.asarray(mcmc_result.energy),
+        "n_steps": np.asarray(mcmc_result.num_integration_steps),
+        "tree_depth": np.asarray(mcmc_result.num_trajectory_expansions),
     }
-    inference_data = az.from_dict(
+    posterior_attributes = {
+        "phydrax_algorithm": mcmc_result.algorithm,
+        "phydrax_chain_method": mcmc_result.chain_method,
+    }
+    if isinstance(result, FlowNUTSResult):
+        sample_stats.update(
+            {
+                "flow_acceptance_rate": np.asarray(result.global_acceptance_rate),
+                "flow_accepted_count": np.asarray(result.global_accepted_count),
+                "flow_mean_log_acceptance_ratio": np.asarray(
+                    result.global_mean_log_acceptance_ratio
+                ),
+                "flow_nonfinite_count": np.asarray(result.global_nonfinite_count),
+            }
+        )
+        posterior_attributes["phydrax_flow_nuts_config"] = json.dumps(
+            result.config.as_dict(),
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    return az.from_dict(
         {
             "posterior": posterior,
             "sample_stats": sample_stats,
@@ -190,14 +216,8 @@ def to_arviz(result: MCMCResult, /):
         sample_dims=("chain", "draw"),
         dims=dimensions,
         coords=coordinates,
-        attrs={
-            "posterior": {
-                "phydrax_algorithm": result.algorithm,
-                "phydrax_chain_method": result.chain_method,
-            }
-        },
+        attrs={"posterior": posterior_attributes},
     )
-    return inference_data
 
 
 def encode_parameter_name(path: str, /) -> str:
@@ -315,6 +335,78 @@ def _adapt_result(result, arrays, fields, trees):
             "collapse_step": result.diagnostics.collapse_step,
         }
         return "ensemble_kalman_inversion", metadata, ("problem",)
+
+    if isinstance(result, FlowNUTSResult):
+        mcmc = result.mcmc
+        _put_tree(trees, arrays, "samples", result.samples)
+        _put_tree(trees, arrays, "unconstrained_samples", result.unconstrained_samples)
+        _put_tree(trees, arrays, "final_states", result.final_states)
+        _put_tree(
+            trees, arrays, "warmup_states", tuple(item.state for item in result.warmup)
+        )
+        _put_tree(trees, arrays, "diagnostics.rhat", result.diagnostics.rhat)
+        _put_tree(trees, arrays, "diagnostics.bulk_ess", result.diagnostics.bulk_ess)
+        _put_tree(trees, arrays, "diagnostics.tail_ess", result.diagnostics.tail_ess)
+        _put_tree(trees, arrays, "training_losses", result.training_losses)
+        _put_tree(trees, arrays, "validation_losses", result.validation_losses)
+        _put_array_leaves(trees, arrays, "flow_parameters", result.flow)
+        for name, value in (
+            ("log_density", result.log_density),
+            ("acceptance_rate", result.acceptance_rate),
+            ("divergent", result.divergent),
+            ("energy", result.energy),
+            ("num_integration_steps", result.num_integration_steps),
+            ("num_trajectory_expansions", result.num_trajectory_expansions),
+            ("chain_keys", result.chain_keys),
+            (
+                "adaptation_global_acceptance_rate",
+                result.adaptation_global_acceptance_rate,
+            ),
+            ("adaptation_proposal_ess", result.adaptation_proposal_ess),
+            ("adaptation_history_size", result.adaptation_history_size),
+            ("global_acceptance_rate", result.global_acceptance_rate),
+            ("global_accepted_count", result.global_accepted_count),
+            (
+                "global_mean_log_acceptance_ratio",
+                result.global_mean_log_acceptance_ratio,
+            ),
+            ("global_nonfinite_count", result.global_nonfinite_count),
+        ):
+            _put_field(fields, arrays, name, value)
+        _put_field(fields, arrays, "root_key", jr.key_data(result.root_key))
+        _put_field(
+            fields,
+            arrays,
+            "warmup.step_size",
+            jnp.stack([item.step_size for item in result.warmup]),
+        )
+        _put_field(
+            fields,
+            arrays,
+            "warmup.inverse_mass_matrix",
+            jnp.stack([item.inverse_mass_matrix for item in result.warmup]),
+        )
+        metadata = {
+            "algorithm": result.algorithm,
+            "chain_method": result.chain_method,
+            "num_chains": result.num_chains,
+            "num_draws": result.num_draws,
+            "num_unique_initial_positions": result.num_unique_initial_positions,
+            "duration_seconds": result.duration_seconds,
+            "nuts_adaptation_duration_seconds": (result.nuts_adaptation_duration_seconds),
+            "flow_adaptation_duration_seconds": (result.flow_adaptation_duration_seconds),
+            "flow_training_duration_seconds": list(result.flow_training_duration_seconds),
+            "stabilization_duration_seconds": (result.stabilization_duration_seconds),
+            "sampling_duration_seconds": result.sampling_duration_seconds,
+            "samples_per_second": result.samples_per_second,
+            "sample_memory_bytes": result.sample_memory_bytes,
+            "flow_parameter_memory_bytes": result.flow_parameter_memory_bytes,
+            "history_memory_bytes": result.history_memory_bytes,
+            "max_num_doublings": mcmc.max_num_doublings,
+            "config": result.config.as_dict(),
+            "warmup_duration_seconds": [item.duration_seconds for item in result.warmup],
+        }
+        return "flow_nuts", metadata, ("mcmc.problem", "flow.static")
 
     if isinstance(result, MCMCResult):
         _put_tree(trees, arrays, "samples", result.samples)

--- a/tests/integration/test_uq_benchmark_matrix.py
+++ b/tests/integration/test_uq_benchmark_matrix.py
@@ -24,7 +24,7 @@ def test_complete_uq_benchmark_matrix_passes_and_writes_machine_report(tmp_path)
     assert report.passed
     assert tuple(scenario.name for scenario in report.scenarios) == tuple(SCENARIOS)
     assert "schema_version" not in payload
-    assert payload["summary"]["scenario_count"] == 6
+    assert payload["summary"]["scenario_count"] == 7
     assert payload["summary"]["scenarios_failed"] == 0
     assert all(
         category["failed"] == 0

--- a/tests/integration/test_uq_flow_mcmc.py
+++ b/tests/integration/test_uq_flow_mcmc.py
@@ -1,0 +1,82 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import coordax as cx
+import jax.numpy as jnp
+import jax.random as jr
+
+import phydrax as phx
+
+
+def test_flow_nuts_recovers_conjugate_posterior_and_predictive_axes():
+    sensor_x = jnp.linspace(0.05, 0.95, 16)
+    basis = 0.5 * sensor_x * (1.0 - sensor_x)
+    observation_scale = 0.05
+    observations = 2.5 * basis
+    prior_scale = 2.0
+    exact_variance = 1.0 / (
+        1.0 / prior_scale**2 + jnp.vdot(basis, basis) / observation_scale**2
+    )
+    exact_mean = exact_variance * (jnp.vdot(basis, observations) / observation_scale**2)
+    problem = phx.uq.PosteriorProblem(
+        phx.uq.ParameterSpace(
+            {"source": jnp.asarray(2.0)},
+            priors={"source": phx.uq.Normal(0.0, prior_scale)},
+        ),
+        lambda parameters: (
+            -0.5
+            * jnp.sum(
+                ((observations - parameters["source"] * basis) / observation_scale) ** 2
+            )
+        ),
+        predict=lambda parameters, query: cx.Field(
+            parameters["source"] * 0.5 * query * (1.0 - query),
+            dims=("x",),
+        ),
+    )
+    config = phx.uq.FlowNUTSConfig(
+        num_adaptation_rounds=2,
+        num_local_adaptation_steps=16,
+        num_global_adaptation_steps=4,
+        num_stabilization_steps=8,
+        num_local_steps=2,
+        num_global_steps=1,
+        history_capacity_per_chain=32,
+        flow_layers=2,
+        num_knots=6,
+        nn_width=16,
+        nn_depth=1,
+        max_epochs=8,
+        max_patience=8,
+        batch_size=16,
+        validation_fraction=0.2,
+    )
+
+    result = phx.uq.sample_flow_nuts(
+        problem,
+        key=jr.key(40),
+        num_chains=4,
+        num_warmup=80,
+        num_samples=120,
+        target_acceptance_rate=0.9,
+        max_num_doublings=7,
+        config=config,
+        chain_method="vectorized",
+    )
+    prediction = result.predict(jnp.linspace(0.0, 1.0, 9), batch_size=64)
+    estimated_mean = jnp.mean(result.samples["source"])
+    estimated_variance = jnp.var(result.samples["source"])
+
+    assert result.samples["source"].shape == (4, 120)
+    assert jnp.abs(estimated_mean - exact_mean) < 0.025
+    assert jnp.abs(estimated_variance - exact_variance) < 0.003
+    assert result.diagnostics.max_rhat < 1.1
+    assert result.diagnostics.divergence_count == 0
+    assert jnp.sum(result.global_accepted_count) > 0
+    assert prediction.samples.dims == (
+        "__phydra_uq_chain",
+        "__phydra_uq_draw",
+        "x",
+    )
+    assert prediction.samples.shape == (4, 120, 9)

--- a/tests/integration/test_uq_flow_mcmc_multimodal.py
+++ b/tests/integration/test_uq_flow_mcmc_multimodal.py
@@ -1,0 +1,83 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax.numpy as jnp
+import jax.random as jr
+import jax.scipy as jsp
+
+import phydrax as phx
+
+
+def test_flow_nuts_recovers_represented_asymmetric_modes():
+    prior_scale = 4.0
+    likelihood_scale = 0.35
+    mode_location = 2.2
+    positive_weight = 0.7
+    component_variance = 1.0 / (1.0 / likelihood_scale**2 + 1.0 / prior_scale**2)
+    component_mean = component_variance * mode_location / likelihood_scale**2
+    expected_mean = (2.0 * positive_weight - 1.0) * component_mean
+    expected_variance = component_variance + 4.0 * (
+        positive_weight * (1.0 - positive_weight) * component_mean**2
+    )
+
+    def log_likelihood(value):
+        return jsp.special.logsumexp(
+            jnp.stack(
+                (
+                    jnp.log(1.0 - positive_weight)
+                    - 0.5 * ((value + mode_location) / likelihood_scale) ** 2,
+                    jnp.log(positive_weight)
+                    - 0.5 * ((value - mode_location) / likelihood_scale) ** 2,
+                )
+            )
+        )
+
+    problem = phx.uq.PosteriorProblem(
+        phx.uq.ParameterSpace(
+            jnp.asarray(0.0),
+            priors=phx.uq.Normal(0.0, prior_scale),
+        ),
+        log_likelihood,
+    )
+    config = phx.uq.FlowNUTSConfig(
+        num_adaptation_rounds=2,
+        num_local_adaptation_steps=30,
+        num_global_adaptation_steps=8,
+        num_stabilization_steps=20,
+        num_local_steps=2,
+        num_global_steps=1,
+        history_capacity_per_chain=60,
+        flow_layers=3,
+        num_knots=8,
+        nn_width=24,
+        nn_depth=1,
+        learning_rate=1e-3,
+        max_epochs=20,
+        max_patience=20,
+        batch_size=32,
+        validation_fraction=0.2,
+    )
+    result = phx.uq.sample_flow_nuts(
+        problem,
+        key=jr.key(41),
+        num_chains=4,
+        num_warmup=100,
+        num_samples=250,
+        initial_positions=jnp.asarray([-2.2, -2.0, 2.0, 2.2]),
+        target_acceptance_rate=0.9,
+        max_num_doublings=7,
+        config=config,
+        chain_method="vectorized",
+    )
+    samples = result.samples
+    positive_mass = jnp.mean(samples > 0.0)
+    transitions = jnp.sum((samples[:, 1:] > 0.0) != (samples[:, :-1] > 0.0))
+
+    assert jnp.abs(positive_mass - positive_weight) < 0.1
+    assert jnp.abs(jnp.mean(samples) - expected_mean) < 0.25
+    assert jnp.abs(jnp.var(samples) - expected_variance) / expected_variance < 0.2
+    assert transitions >= 4
+    assert result.diagnostics.max_rhat < 1.15
+    assert result.diagnostics.divergence_count == 0
+    assert jnp.sum(result.global_accepted_count) > 0

--- a/tests/unit/uq/test_flow_mcmc.py
+++ b/tests/unit/uq/test_flow_mcmc.py
@@ -1,0 +1,233 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import coordax as cx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+import phydrax as phx
+
+
+def _small_config(**overrides):
+    settings = {
+        "num_adaptation_rounds": 1,
+        "num_local_adaptation_steps": 4,
+        "num_global_adaptation_steps": 2,
+        "num_stabilization_steps": 1,
+        "num_local_steps": 1,
+        "num_global_steps": 1,
+        "history_capacity_per_chain": 4,
+        "history_thinning": 1,
+        "flow_layers": 1,
+        "num_knots": 4,
+        "nn_width": 8,
+        "nn_depth": 1,
+        "learning_rate": 1e-3,
+        "max_epochs": 2,
+        "max_patience": 2,
+        "batch_size": 2,
+        "validation_fraction": 0.25,
+    }
+    settings.update(overrides)
+    return phx.uq.FlowNUTSConfig(**settings)
+
+
+def _positive_problem():
+    return phx.uq.PosteriorProblem(
+        phx.uq.ParameterSpace(
+            {"rate": jnp.asarray(0.0)},
+            priors={"rate": phx.uq.LogNormal(0.0, 0.8)},
+            bijectors={"rate": phx.uq.ExpBijector()},
+        ),
+        lambda parameters: -0.5 * ((parameters["rate"] - 1.5) / 0.25) ** 2,
+        predict=lambda parameters, query: cx.Field(
+            parameters["rate"] * query,
+            dims=("query",),
+        ),
+    )
+
+
+def _nested_constrained_problem():
+    return phx.uq.PosteriorProblem(
+        phx.uq.ParameterSpace(
+            {
+                "positive": jnp.asarray(0.0),
+                "nested": {"bounded": jnp.asarray(0.0)},
+            },
+            priors={
+                "positive": phx.uq.LogNormal(0.0, 0.8),
+                "nested": {"bounded": phx.uq.Uniform(-1.0, 2.0)},
+            },
+            bijectors={
+                "positive": phx.uq.ExpBijector(),
+                "nested": {"bounded": phx.uq.SigmoidIntervalBijector(-1.0, 2.0)},
+            },
+        ),
+        lambda parameters: (
+            -0.5
+            * ((parameters["positive"] - 1.2) ** 2 + parameters["nested"]["bounded"] ** 2)
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    ("name", "value"),
+    [
+        ("num_adaptation_rounds", 0),
+        ("num_stabilization_steps", -1),
+        ("num_local_steps", 0),
+        ("history_capacity_per_chain", 0),
+        ("history_thinning", 5),
+        ("learning_rate", 0.0),
+        ("validation_fraction", 0.5),
+    ],
+)
+def test_flow_nuts_config_rejects_invalid_controls(name, value):
+    with pytest.raises(ValueError):
+        _small_config(**{name: value})
+
+
+def test_flow_nuts_preserves_transformed_parameters_and_result_contract():
+    result = phx.uq.sample_flow_nuts(
+        _positive_problem(),
+        key=jr.key(10),
+        num_chains=2,
+        num_warmup=20,
+        num_samples=8,
+        target_acceptance_rate=0.9,
+        max_num_doublings=5,
+        config=_small_config(),
+        chain_method="vectorized",
+    )
+    prediction = result.predict(jnp.asarray([1.0, 2.0]))
+
+    assert result.algorithm == "flow_nuts"
+    assert result.samples["rate"].shape == (2, 8)
+    assert result.unconstrained_samples["rate"].shape == (2, 8)
+    assert jnp.all(result.samples["rate"] > 0.0)
+    assert result.log_density.shape == (2, 8)
+    assert result.global_acceptance_rate.shape == (2, 8)
+    assert result.global_accepted_count.shape == (2, 8)
+    assert result.global_nonfinite_count.shape == (2, 8)
+    assert result.adaptation_global_acceptance_rate.shape == (1, 2)
+    assert result.adaptation_proposal_ess.shape == (1,)
+    assert result.adaptation_history_size.shape == (1,)
+    assert len(result.training_losses) == 1
+    assert len(result.validation_losses) == 1
+    assert len(result.flow_training_duration_seconds) == 1
+    assert result.flow_parameter_memory_bytes > 0
+    assert result.history_memory_bytes > 0
+    assert prediction.samples.shape == (2, 8, 2)
+
+
+def test_flow_nuts_roundtrips_nested_positive_and_bounded_parameters():
+    result = phx.uq.sample_flow_nuts(
+        _nested_constrained_problem(),
+        key=jr.key(14),
+        num_chains=2,
+        num_warmup=12,
+        num_samples=4,
+        max_num_doublings=4,
+        config=_small_config(max_epochs=1, max_patience=1),
+        chain_method="vectorized",
+    )
+
+    assert result.samples["positive"].shape == (2, 4)
+    assert result.samples["nested"]["bounded"].shape == (2, 4)
+    assert jnp.all(result.samples["positive"] > 0.0)
+    assert jnp.all(result.samples["nested"]["bounded"] > -1.0)
+    assert jnp.all(result.samples["nested"]["bounded"] < 2.0)
+    assert result.unconstrained_samples["nested"]["bounded"].shape == (2, 4)
+
+
+def test_flow_nuts_requires_explicit_starts_for_custom_joint_prior():
+    problem = phx.uq.PosteriorProblem(
+        phx.uq.ParameterSpace(
+            jnp.asarray(0.0),
+            log_prior=lambda value: -0.5 * value**2,
+        ),
+        lambda value: -0.5 * (value - 0.3) ** 2,
+    )
+
+    with pytest.raises(ValueError, match="initial_positions"):
+        phx.uq.sample_flow_nuts(
+            problem,
+            key=jr.key(11),
+            num_chains=2,
+            num_warmup=10,
+            num_samples=4,
+            config=_small_config(),
+        )
+
+
+def test_flow_nuts_validates_leading_chain_axes_before_warmup():
+    problem = _positive_problem()
+
+    with pytest.raises(ValueError, match="shape"):
+        phx.uq.sample_flow_nuts(
+            problem,
+            key=jr.key(12),
+            num_chains=2,
+            num_warmup=10,
+            num_samples=4,
+            initial_positions={"rate": jnp.zeros((3,))},
+            config=_small_config(),
+        )
+
+
+def test_flow_nuts_sequential_and_vectorized_methods_share_semantic_keys():
+    common = {
+        "key": jr.key(13),
+        "num_chains": 2,
+        "num_warmup": 12,
+        "num_samples": 4,
+        "target_acceptance_rate": 0.9,
+        "max_num_doublings": 4,
+        "config": _small_config(max_epochs=1, max_patience=1),
+    }
+
+    sequential = phx.uq.sample_flow_nuts(
+        _positive_problem(),
+        chain_method="sequential",
+        **common,
+    )
+    vectorized = phx.uq.sample_flow_nuts(
+        _positive_problem(),
+        chain_method="vectorized",
+        **common,
+    )
+    sample_comparisons = jax.tree_util.tree_map(
+        lambda left, right: jnp.allclose(left, right, rtol=1e-13, atol=1e-13),
+        sequential.samples,
+        vectorized.samples,
+    )
+
+    assert jnp.array_equal(sequential.chain_keys, vectorized.chain_keys)
+    assert all(jax.tree_util.tree_leaves(sample_comparisons))
+    assert jnp.allclose(
+        sequential.log_density,
+        vectorized.log_density,
+        rtol=1e-13,
+        atol=1e-13,
+    )
+    assert jnp.allclose(
+        sequential.acceptance_rate,
+        vectorized.acceptance_rate,
+        rtol=1e-13,
+        atol=1e-13,
+    )
+    assert jnp.array_equal(
+        sequential.global_acceptance_rate,
+        vectorized.global_acceptance_rate,
+    )
+    assert jnp.array_equal(
+        sequential.global_accepted_count,
+        vectorized.global_accepted_count,
+    )
+    assert jnp.array_equal(
+        sequential.global_nonfinite_count,
+        vectorized.global_nonfinite_count,
+    )

--- a/tests/unit/uq/test_flow_mcmc_checkpoint.py
+++ b/tests/unit/uq/test_flow_mcmc_checkpoint.py
@@ -1,0 +1,355 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import hashlib
+import io
+import json
+import zipfile
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import numpy as np
+import pytest
+
+import phydrax as phx
+import phydrax.uq._flow_mcmc as flow_module
+
+
+def _problem():
+    return phx.uq.PosteriorProblem(
+        phx.uq.ParameterSpace(jnp.asarray(0.0), priors=phx.uq.Normal(0.0, 2.0)),
+        lambda value: -0.5 * ((value - 0.4) / 0.6) ** 2,
+    )
+
+
+def _config(**overrides):
+    settings = {
+        "num_adaptation_rounds": 1,
+        "num_local_adaptation_steps": 4,
+        "num_global_adaptation_steps": 2,
+        "num_stabilization_steps": 1,
+        "num_local_steps": 1,
+        "num_global_steps": 1,
+        "history_capacity_per_chain": 4,
+        "flow_layers": 1,
+        "num_knots": 4,
+        "nn_width": 8,
+        "nn_depth": 1,
+        "max_epochs": 1,
+        "max_patience": 1,
+        "batch_size": 2,
+        "validation_fraction": 0.25,
+    }
+    settings.update(overrides)
+    return phx.uq.FlowNUTSConfig(**settings)
+
+
+def _assert_tree_equal(left, right):
+    comparisons = jax.tree_util.tree_map(jnp.array_equal, left, right)
+    assert all(jax.tree_util.tree_leaves(comparisons))
+
+
+def _assert_flow_arrays_equal(left, right):
+    left_arrays, _ = eqx.partition(left, eqx.is_array)
+    right_arrays, _ = eqx.partition(right, eqx.is_array)
+    _assert_tree_equal(left_arrays, right_arrays)
+
+
+def _rewrite_checkpoint(path, mutate):
+    with zipfile.ZipFile(path, mode="r") as archive:
+        members = {name: archive.read(name) for name in archive.namelist()}
+    manifest = json.loads(members["manifest.json"])
+    mutate(manifest, members)
+    members["manifest.json"] = json.dumps(
+        manifest,
+        allow_nan=False,
+        indent=2,
+        sort_keys=True,
+    ).encode("utf-8")
+    with zipfile.ZipFile(
+        path,
+        mode="w",
+        compression=zipfile.ZIP_STORED,
+        strict_timestamps=False,
+    ) as archive:
+        archive.writestr("manifest.json", members.pop("manifest.json"))
+        for name in sorted(members):
+            archive.writestr(name, members[name])
+
+
+def _replace_checkpoint_array(manifest, members, name, value):
+    record = manifest["arrays"][name]
+    buffer = io.BytesIO()
+    np.save(buffer, value, allow_pickle=False)
+    payload = buffer.getvalue()
+    members[record["member"]] = payload
+    record["shape"] = list(value.shape)
+    record["dtype"] = value.dtype.str
+    record["sha256"] = hashlib.sha256(payload).hexdigest()
+
+
+@pytest.mark.parametrize(
+    ("phase", "progress_field", "progress"),
+    [
+        ("adaptation", "completed_rounds", 1),
+        ("stabilization", "completed_stabilization", 1),
+        ("production", "completed_draws", 3),
+    ],
+)
+def test_interrupted_flow_nuts_resume_is_exact_at_every_phase_boundary(
+    tmp_path,
+    monkeypatch,
+    phase,
+    progress_field,
+    progress,
+):
+    problem = _problem()
+    common = {
+        "key": jr.key(20),
+        "num_chains": 2,
+        "num_warmup": 16,
+        "num_samples": 6,
+        "max_num_doublings": 4,
+        "config": _config(),
+        "chain_method": "vectorized",
+    }
+    direct = phx.uq.sample_flow_nuts(problem, **common)
+    checkpoint = tmp_path / f"flow-nuts-{phase}.phxckpt"
+    original_write = flow_module._write_flow_nuts_checkpoint
+
+    def interrupting_write(destination, **kwargs):
+        original_write(destination, **kwargs)
+        if kwargs["phase"] == phase and kwargs[progress_field] == progress:
+            raise RuntimeError("simulated flow interruption")
+
+    monkeypatch.setattr(
+        flow_module,
+        "_write_flow_nuts_checkpoint",
+        interrupting_write,
+    )
+    with pytest.raises(RuntimeError, match="simulated flow interruption"):
+        phx.uq.sample_flow_nuts(
+            problem,
+            checkpoint_path=checkpoint,
+            checkpoint_every=3,
+            checkpoint_id=f"flow-resume-{phase}",
+            **common,
+        )
+    monkeypatch.setattr(
+        flow_module,
+        "_write_flow_nuts_checkpoint",
+        original_write,
+    )
+
+    def adaptation_must_not_run(*args, **kwargs):
+        raise AssertionError("completed flow adaptation repeated during resume")
+
+    monkeypatch.setattr(flow_module, "_adapt_mcmc", adaptation_must_not_run)
+    monkeypatch.setattr(flow_module, "_fit_flow", adaptation_must_not_run)
+    resumed = phx.uq.sample_flow_nuts(
+        problem,
+        checkpoint_every=3,
+        checkpoint_id=f"flow-resume-{phase}",
+        resume_from=checkpoint,
+        **common,
+    )
+
+    _assert_tree_equal(resumed.samples, direct.samples)
+    _assert_tree_equal(resumed.unconstrained_samples, direct.unconstrained_samples)
+    _assert_flow_arrays_equal(resumed.flow, direct.flow)
+    assert jnp.array_equal(resumed.log_density, direct.log_density)
+    assert jnp.array_equal(resumed.acceptance_rate, direct.acceptance_rate)
+    assert jnp.array_equal(resumed.divergent, direct.divergent)
+    assert jnp.array_equal(
+        resumed.global_acceptance_rate,
+        direct.global_acceptance_rate,
+    )
+    assert jnp.array_equal(
+        resumed.global_accepted_count,
+        direct.global_accepted_count,
+    )
+    assert all(
+        jnp.array_equal(left, right)
+        for left, right in zip(
+            resumed.training_losses,
+            direct.training_losses,
+            strict=True,
+        )
+    )
+
+
+def test_flow_nuts_checkpoint_rejects_changed_configuration(tmp_path):
+    problem = _problem()
+    checkpoint = tmp_path / "flow-config.phxckpt"
+    common = {
+        "key": jr.key(21),
+        "num_chains": 2,
+        "num_warmup": 12,
+        "num_samples": 4,
+        "max_num_doublings": 4,
+        "chain_method": "vectorized",
+        "checkpoint_id": "flow-config",
+    }
+    phx.uq.sample_flow_nuts(
+        problem,
+        config=_config(),
+        checkpoint_path=checkpoint,
+        checkpoint_every=2,
+        **common,
+    )
+
+    with pytest.raises(phx.uq.CheckpointCompatibilityError):
+        phx.uq.sample_flow_nuts(
+            problem,
+            config=_config(num_local_steps=2),
+            resume_from=checkpoint,
+            checkpoint_every=2,
+            **common,
+        )
+    extended_settings = common | {"num_samples": 6}
+    resumed = phx.uq.sample_flow_nuts(
+        problem,
+        config=_config(),
+        resume_from=checkpoint,
+        checkpoint_every=2,
+        **extended_settings,
+    )
+    direct = phx.uq.sample_flow_nuts(
+        problem,
+        config=_config(),
+        **extended_settings,
+    )
+
+    _assert_tree_equal(resumed.samples, direct.samples)
+    assert jnp.array_equal(
+        resumed.global_acceptance_rate,
+        direct.global_acceptance_rate,
+    )
+
+
+def test_flow_checkpoint_rejects_package_array_and_dtype_tampering(tmp_path):
+    problem = _problem()
+    checkpoint = tmp_path / "flow-tampering.phxckpt"
+    common = {
+        "key": jr.key(23),
+        "num_chains": 2,
+        "num_warmup": 12,
+        "num_samples": 4,
+        "max_num_doublings": 4,
+        "chain_method": "vectorized",
+        "checkpoint_id": "flow-tampering",
+        "config": _config(),
+    }
+    phx.uq.sample_flow_nuts(
+        problem,
+        checkpoint_path=checkpoint,
+        checkpoint_every=2,
+        **common,
+    )
+    original = checkpoint.read_bytes()
+
+    def resume():
+        return phx.uq.sample_flow_nuts(
+            problem,
+            resume_from=checkpoint,
+            checkpoint_every=2,
+            **common,
+        )
+
+    def change_flowjax_version(manifest, members):
+        manifest["compatibility"]["settings"]["flowjax_version"] = "0.0.invalid"
+
+    _rewrite_checkpoint(checkpoint, change_flowjax_version)
+    with pytest.raises(phx.uq.CheckpointCompatibilityError):
+        resume()
+    checkpoint.write_bytes(original)
+
+    def remove_flow_array(manifest, members):
+        name = next(
+            name for name in manifest["arrays"] if name.startswith("flow_parameters/")
+        )
+        members.pop(manifest["arrays"][name]["member"])
+
+    _rewrite_checkpoint(checkpoint, remove_flow_array)
+    with pytest.raises(phx.uq.CheckpointCorruptionError):
+        resume()
+    checkpoint.write_bytes(original)
+
+    def change_global_shape(manifest, members):
+        record = manifest["arrays"]["global_acceptance_rate"]
+        value = np.load(io.BytesIO(members[record["member"]]), allow_pickle=False)
+        _replace_checkpoint_array(
+            manifest,
+            members,
+            "global_acceptance_rate",
+            np.zeros((2, 3), dtype=value.dtype),
+        )
+
+    _rewrite_checkpoint(checkpoint, change_global_shape)
+    with pytest.raises(phx.uq.CheckpointCompatibilityError):
+        resume()
+    checkpoint.write_bytes(original)
+
+    def change_flow_dtype(manifest, members):
+        candidates = []
+        for name, record in manifest["arrays"].items():
+            if not name.startswith("flow_parameters/"):
+                continue
+            value = np.load(
+                io.BytesIO(members[record["member"]]),
+                allow_pickle=False,
+            )
+            if value.dtype.kind == "f":
+                candidates.append((name, value))
+        name, value = candidates[0]
+        dtype = np.float32 if value.dtype != np.dtype(np.float32) else np.float64
+        _replace_checkpoint_array(
+            manifest,
+            members,
+            name,
+            value.astype(dtype),
+        )
+
+    _rewrite_checkpoint(checkpoint, change_flow_dtype)
+    with pytest.raises(phx.uq.CheckpointCompatibilityError):
+        resume()
+
+
+@pytest.fixture(scope="module")
+def portable_flow_result():
+    return phx.uq.sample_flow_nuts(
+        _problem(),
+        key=jr.key(22),
+        num_chains=2,
+        num_warmup=12,
+        num_samples=4,
+        max_num_doublings=4,
+        config=_config(),
+        chain_method="vectorized",
+    )
+
+
+def test_flow_nuts_portable_export_and_arviz_include_global_statistics(
+    tmp_path,
+    portable_flow_result,
+):
+    destination = tmp_path / "flow-result.phxuq"
+    phx.uq.export_result(portable_flow_result, destination)
+    archive = phx.uq.read_result_archive(destination)
+    inference_data = phx.uq.to_arviz(portable_flow_result)
+
+    assert archive.kind == "flow_nuts"
+    assert archive.metadata["algorithm"] == "flow_nuts"
+    assert len(archive.metadata["flow_training_duration_seconds"]) == 1
+    assert "global_acceptance_rate" in archive.fields
+    assert "flow_parameters" in archive.trees
+    assert archive.tree("samples")["<root>"].shape == (2, 4)
+    assert np.array_equal(
+        inference_data.sample_stats["flow_acceptance_rate"],
+        np.asarray(portable_flow_result.global_acceptance_rate),
+    )
+    assert inference_data.posterior.sizes["chain"] == 2
+    assert inference_data.posterior.sizes["draw"] == 4

--- a/tests/unit/uq/test_flow_proposal.py
+++ b/tests/unit/uq/test_flow_proposal.py
@@ -1,0 +1,174 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+
+from phydrax.uq._flow_proposal import (
+    _build_default_flow,
+    _fit_flow,
+    _FlowProposalState,
+    _independence_mh_scan,
+    _initialize_replay,
+    _replay_data,
+    _update_replay,
+)
+
+
+def _normal_log_density(value, *, location=0.0):
+    return -0.5 * (value - location) ** 2 - 0.5 * jnp.log(2.0 * jnp.pi)
+
+
+def test_independence_mh_uses_both_proposal_density_terms_and_rejects_nonfinite():
+    current = jnp.asarray([0.25])
+    proposal = jnp.asarray([[1.5], [jnp.nan]])
+    current_target = _normal_log_density(current[0])
+    current_proposal = _normal_log_density(current[0], location=1.0)
+    proposed_target = jnp.asarray([_normal_log_density(1.5), -1.0])
+    proposed_density = jnp.asarray([_normal_log_density(1.5, location=1.0), -1.0])
+    expected = jnp.minimum(
+        0.0,
+        proposed_target[0] - current_target + current_proposal - proposed_density[0],
+    )
+
+    final, info = _independence_mh_scan(
+        _FlowProposalState(current, current_target, current_proposal),
+        proposal,
+        proposed_target,
+        proposed_density,
+        jnp.asarray([-100.0, -100.0]),
+    )
+
+    assert jnp.allclose(info.log_acceptance_ratio[0], expected)
+    assert info.accepted[0]
+    assert not info.accepted[1]
+    assert info.nonfinite[1]
+    assert jnp.array_equal(final.position, proposal[0])
+
+
+def test_asymmetric_independence_mh_recovers_the_target_not_the_proposal():
+    count = 50_000
+    proposal_key, acceptance_key = jr.split(jr.key(4))
+    proposed_positions = 1.0 + jr.normal(proposal_key, (count, 1))
+    proposed_log_targets = jax.vmap(lambda value: _normal_log_density(value[0]))(
+        proposed_positions
+    )
+    proposed_log_densities = jax.vmap(
+        lambda value: _normal_log_density(value[0], location=1.0)
+    )(proposed_positions)
+    log_uniforms = jnp.log(jr.uniform(acceptance_key, (count,)))
+    initial = _FlowProposalState(
+        jnp.zeros((1,)),
+        _normal_log_density(0.0),
+        _normal_log_density(0.0, location=1.0),
+    )
+
+    def transition(state, item):
+        proposed, log_target, log_proposal, log_uniform = item
+        next_state, _ = _independence_mh_scan(
+            state,
+            proposed[None, :],
+            log_target[None],
+            log_proposal[None],
+            log_uniform[None],
+        )
+        return next_state, next_state.position[0]
+
+    _, samples = jax.jit(
+        lambda: jax.lax.scan(
+            transition,
+            initial,
+            (
+                proposed_positions,
+                proposed_log_targets,
+                proposed_log_densities,
+                log_uniforms,
+            ),
+        )
+    )()
+    retained = samples[5_000:]
+
+    assert jnp.abs(jnp.mean(retained)) < 0.05
+    assert jnp.abs(jnp.var(retained) - 1.0) < 0.08
+    assert jnp.abs(jnp.mean(retained) - 1.0) > 0.8
+
+
+def test_chain_stratified_reservoir_is_bounded_and_reproducible():
+    replay = _initialize_replay(
+        num_chains=2,
+        capacity_per_chain=3,
+        dimension=1,
+        dtype=jnp.float32,
+    )
+    samples = jnp.arange(10, dtype=jnp.float32).reshape((2, 5, 1))
+    keys = jax.vmap(lambda key: jr.split(key, 5))(jr.split(jr.key(5), 2))
+
+    first = jax.jit(_update_replay)(replay, samples, keys)
+    second = jax.jit(_update_replay)(replay, samples, keys)
+
+    assert jnp.array_equal(first.values, second.values)
+    assert jnp.array_equal(first.size, jnp.asarray([3, 3]))
+    assert jnp.array_equal(first.seen, jnp.asarray([5, 5]))
+    assert _replay_data(first).shape == (6, 1)
+
+
+def test_default_flow_supports_scalar_and_vector_events():
+    scalar_data = jnp.linspace(-2.0, 2.0, 16)[:, None]
+    vector_data = jnp.stack((scalar_data[:, 0], scalar_data[:, 0] ** 2), axis=1)
+    scalar = _build_default_flow(
+        jr.key(6),
+        scalar_data,
+        flow_layers=1,
+        num_knots=4,
+        nn_width=8,
+        nn_depth=1,
+    )
+    vector = _build_default_flow(
+        jr.key(7),
+        vector_data,
+        flow_layers=1,
+        num_knots=4,
+        nn_width=8,
+        nn_depth=1,
+    )
+
+    scalar_sample, scalar_log_density = scalar.sample_and_log_prob(jr.key(8))
+    vector_sample, vector_log_density = vector.sample_and_log_prob(jr.key(9))
+
+    assert scalar.shape == (1,)
+    assert vector.shape == (2,)
+    assert scalar_sample.shape == (1,)
+    assert vector_sample.shape == (2,)
+    assert jnp.isfinite(scalar_log_density)
+    assert jnp.isfinite(vector_log_density)
+
+
+def test_flow_training_caps_oversized_batches_to_the_training_split():
+    data = jnp.linspace(-2.0, 2.0, 10)[:, None]
+    flow = _build_default_flow(
+        jr.key(10),
+        data,
+        flow_layers=1,
+        num_knots=4,
+        nn_width=8,
+        nn_depth=1,
+    )
+
+    trained, training_loss, validation_loss = _fit_flow(
+        jr.key(11),
+        flow,
+        data,
+        learning_rate=1e-3,
+        max_epochs=1,
+        max_patience=1,
+        batch_size=64,
+        validation_fraction=0.2,
+    )
+
+    assert trained.shape == (1,)
+    assert training_loss.shape == (1,)
+    assert validation_loss.shape == (1,)
+    assert jnp.all(jnp.isfinite(training_loss))
+    assert jnp.all(jnp.isfinite(validation_loss))

--- a/tests/unit/uq/test_mcmc_checkpoint.py
+++ b/tests/unit/uq/test_mcmc_checkpoint.py
@@ -140,3 +140,46 @@ def test_mcmc_checkpoint_rejects_incompatible_identity_and_corruption(tmp_path):
             checkpoint_path=None,
             resume_from=checkpoint,
         )
+
+
+def test_mcmc_accepts_distinct_initial_positions_for_each_chain():
+    problem = _problem()
+    initial_positions = jnp.asarray([[-1.5, -1.0], [1.5, 1.0]])
+
+    result = phx.uq.sample_nuts(
+        problem,
+        key=jr.key(921),
+        num_chains=2,
+        num_warmup=12,
+        num_samples=4,
+        initial_positions=initial_positions,
+        initial_step_size=0.2,
+        max_num_doublings=4,
+        chain_method="vectorized",
+    )
+
+    assert result.samples.shape == (2, 4, 2)
+
+
+def test_mcmc_rejects_ambiguous_or_misshaped_initial_positions():
+    problem = _problem()
+
+    with pytest.raises(ValueError, match="cannot both"):
+        phx.uq.sample_nuts(
+            problem,
+            key=jr.key(922),
+            num_chains=2,
+            num_warmup=8,
+            num_samples=4,
+            initial_position=jnp.zeros((2,)),
+            initial_positions=jnp.zeros((2, 2)),
+        )
+    with pytest.raises(ValueError, match="shape"):
+        phx.uq.sample_nuts(
+            problem,
+            key=jr.key(923),
+            num_chains=2,
+            num_warmup=8,
+            num_samples=4,
+            initial_positions=jnp.zeros((3, 2)),
+        )

--- a/tests/unit/uq/test_posterior_diagnostics.py
+++ b/tests/unit/uq/test_posterior_diagnostics.py
@@ -1,0 +1,86 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax.numpy as jnp
+import jax.random as jr
+
+import phydrax as phx
+
+
+def test_posterior_diagnostics_cover_compilation_vectorization_and_capabilities():
+    problem = phx.uq.PosteriorProblem(
+        phx.uq.ParameterSpace(
+            {
+                "positive": jnp.asarray(0.2),
+                "bounded": jnp.asarray(-0.4),
+            },
+            priors={
+                "positive": phx.uq.LogNormal(0.0, 1.0),
+                "bounded": phx.uq.Uniform(-2.0, 3.0),
+            },
+            bijectors={
+                "positive": phx.uq.ExpBijector(),
+                "bounded": phx.uq.SigmoidIntervalBijector(-2.0, 3.0),
+            },
+        ),
+        lambda values: -0.5 * ((values["positive"] - 1.0) ** 2 + values["bounded"] ** 2),
+        predict=lambda values, query: values["positive"] * query,
+        observation_variance=lambda values, query: jnp.ones_like(query),
+        sample_observation=lambda key, values, query: values["positive"] * query,
+        gauss_newton_residual=lambda values: jnp.asarray(
+            [values["positive"] - 1.0, values["bounded"]]
+        ),
+    )
+
+    diagnostics = phx.uq.diagnose_posterior(
+        problem,
+        key=jr.key(1),
+        num_prior_samples=16,
+    )
+
+    assert diagnostics.passed
+    assert diagnostics.max_roundtrip_error < 1e-6
+    assert diagnostics.prior_sample_finite_fraction == 1.0
+    assert diagnostics.capabilities.factorized_prior
+    assert diagnostics.capabilities.prediction
+    assert diagnostics.capabilities.observation_variance
+    assert diagnostics.capabilities.observation_sampling
+    assert diagnostics.capabilities.gauss_newton_residual
+    assert diagnostics.capabilities.automatic_flow_nuts_initialization
+    assert diagnostics.as_dict()["failures"] == ()
+
+
+def test_posterior_diagnostics_report_nonfinite_density_and_gradient_locations():
+    problem = phx.uq.PosteriorProblem(
+        phx.uq.ParameterSpace(
+            {"x": jnp.asarray(-1.0)},
+            priors={"x": phx.uq.Normal(0.0, 1.0)},
+        ),
+        lambda values: jnp.sqrt(values["x"]),
+    )
+
+    diagnostics = phx.uq.diagnose_posterior(problem)
+
+    assert not diagnostics.passed
+    assert "initial_log_density_nonfinite" in diagnostics.failures
+    assert "initial_gradient_nonfinite" in diagnostics.failures
+    assert diagnostics.nonfinite_gradient_locations == ("['x']",)
+
+
+def test_custom_prior_capabilities_do_not_claim_automatic_initialization():
+    problem = phx.uq.PosteriorProblem(
+        phx.uq.ParameterSpace(
+            jnp.asarray(0.0),
+            log_prior=lambda value: -0.5 * value**2,
+        ),
+        lambda value: -0.5 * value**2,
+    )
+
+    diagnostics = phx.uq.diagnose_posterior(problem, key=jr.key(2))
+
+    assert diagnostics.passed
+    assert not diagnostics.capabilities.factorized_prior
+    assert not diagnostics.capabilities.automatic_prior_sampling
+    assert not diagnostics.capabilities.automatic_flow_nuts_initialization
+    assert diagnostics.prior_sample_finite_fraction is None

--- a/tools/uq_benchmarks/configuration.py
+++ b/tools/uq_benchmarks/configuration.py
@@ -25,6 +25,13 @@ class BenchmarkConfiguration:
     calibration_cases: int
     gp_repeats: int
     jit_warm_repetitions: int
+    flow_adaptation_rounds: int
+    flow_local_adaptation_steps: int
+    flow_global_adaptation_steps: int
+    flow_epochs: int
+    flow_history_capacity: int
+    flow_local_steps: int
+    flow_global_steps: int
 
     def as_dict(self) -> dict[str, int | str]:
         return asdict(self)
@@ -42,6 +49,13 @@ PROFILES: dict[ProfileName, BenchmarkConfiguration] = {
         calibration_cases=256,
         gp_repeats=5,
         jit_warm_repetitions=3,
+        flow_adaptation_rounds=2,
+        flow_local_adaptation_steps=40,
+        flow_global_adaptation_steps=12,
+        flow_epochs=40,
+        flow_history_capacity=80,
+        flow_local_steps=2,
+        flow_global_steps=3,
     ),
     "standard": BenchmarkConfiguration(
         profile="standard",
@@ -54,6 +68,13 @@ PROFILES: dict[ProfileName, BenchmarkConfiguration] = {
         calibration_cases=2_048,
         gp_repeats=12,
         jit_warm_repetitions=10,
+        flow_adaptation_rounds=4,
+        flow_local_adaptation_steps=80,
+        flow_global_adaptation_steps=20,
+        flow_epochs=80,
+        flow_history_capacity=256,
+        flow_local_steps=3,
+        flow_global_steps=2,
     ),
 }
 

--- a/tools/uq_benchmarks/report.py
+++ b/tools/uq_benchmarks/report.py
@@ -284,7 +284,15 @@ def collect_environment() -> dict[str, Any]:
         "devices": devices,
         "package_versions": {
             name: package_version(name)
-            for name in ("phydrax", "jax", "equinox", "blackjax", "laplax")
+            for name in (
+                "phydrax",
+                "jax",
+                "equinox",
+                "blackjax",
+                "flowjax",
+                "optax",
+                "laplax",
+            )
         },
     }
 

--- a/tools/uq_benchmarks/scenarios.py
+++ b/tools/uq_benchmarks/scenarios.py
@@ -812,6 +812,278 @@ def multimodal_tempered_inference(
     )
 
 
+def flow_assisted_multimodal(
+    configuration: BenchmarkConfiguration,
+    seed: int,
+) -> ScenarioResult:
+    """Measure exact flow-assisted transport across represented posterior modes."""
+    started = time.perf_counter()
+    root_key = jr.key(seed)
+    dimension = 4
+    prior_scale = 4.0
+    positive_weight = 0.7
+    component_location = jnp.asarray([2.2, -1.8, 1.5, 2.0])
+    likelihood_covariance = jnp.asarray(
+        [
+            [0.20, 0.04, 0.00, 0.02],
+            [0.04, 0.16, 0.03, 0.00],
+            [0.00, 0.03, 0.18, -0.02],
+            [0.02, 0.00, -0.02, 0.22],
+        ]
+    )
+    likelihood_precision = jnp.linalg.inv(likelihood_covariance)
+    component_covariance = jnp.linalg.inv(
+        likelihood_precision + jnp.eye(dimension) / prior_scale**2
+    )
+    component_mean = component_covariance @ likelihood_precision @ component_location
+    exact_mean = (2.0 * positive_weight - 1.0) * component_mean
+    exact_covariance = component_covariance + 4.0 * positive_weight * (
+        1.0 - positive_weight
+    ) * jnp.outer(component_mean, component_mean)
+
+    def component_log_density(value, location):
+        difference = value - location
+        return -0.5 * difference @ likelihood_precision @ difference
+
+    def log_likelihood(value):
+        return jsp.special.logsumexp(
+            jnp.stack(
+                (
+                    jnp.log(1.0 - positive_weight)
+                    + component_log_density(value, -component_location),
+                    jnp.log(positive_weight)
+                    + component_log_density(value, component_location),
+                )
+            )
+        )
+
+    problem = phx.uq.PosteriorProblem(
+        phx.uq.ParameterSpace(
+            jnp.zeros((dimension,)),
+            priors=phx.uq.Normal(0.0, prior_scale),
+        ),
+        log_likelihood,
+    )
+    initial_signs = jnp.where(
+        jnp.arange(configuration.num_chains) % 2 == 0,
+        -1.0,
+        1.0,
+    )
+    initial_positions = initial_signs[:, None] * component_mean[None, :]
+    cold, compile_seconds, execute = _jit_timings(
+        log_likelihood,
+        component_mean,
+        repetitions=configuration.jit_warm_repetitions,
+    )
+    nuts, nuts_seconds = _timed_call(
+        lambda: phx.uq.sample_nuts(
+            problem,
+            key=jr.fold_in(root_key, 1),
+            num_chains=configuration.num_chains,
+            num_warmup=configuration.num_warmup,
+            num_samples=configuration.num_draws,
+            initial_positions=initial_positions,
+            initial_step_size=0.12,
+            target_acceptance_rate=0.9,
+            max_num_doublings=8,
+            chain_method="vectorized",
+        )
+    )
+    flow_config = phx.uq.FlowNUTSConfig(
+        num_adaptation_rounds=configuration.flow_adaptation_rounds,
+        num_local_adaptation_steps=configuration.flow_local_adaptation_steps,
+        num_global_adaptation_steps=configuration.flow_global_adaptation_steps,
+        num_stabilization_steps=20,
+        num_local_steps=configuration.flow_local_steps,
+        num_global_steps=configuration.flow_global_steps,
+        history_capacity_per_chain=configuration.flow_history_capacity,
+        history_thinning=1,
+        flow_layers=3,
+        num_knots=8,
+        nn_width=32,
+        nn_depth=2,
+        learning_rate=1e-3,
+        max_epochs=configuration.flow_epochs,
+        max_patience=configuration.flow_epochs,
+        batch_size=64,
+        validation_fraction=0.2,
+    )
+    flow, flow_seconds = _timed_call(
+        lambda: phx.uq.sample_flow_nuts(
+            problem,
+            key=jr.fold_in(root_key, 2),
+            num_chains=configuration.num_chains,
+            num_warmup=configuration.num_warmup,
+            num_samples=configuration.num_draws,
+            initial_positions=initial_positions,
+            initial_step_size=0.12,
+            target_acceptance_rate=0.9,
+            max_num_doublings=8,
+            config=flow_config,
+            chain_method="vectorized",
+        )
+    )
+    flat_flow = flow.samples.reshape((-1, dimension))
+    flat_nuts = nuts.samples.reshape((-1, dimension))
+    flow_positive = flat_flow @ component_mean > 0.0
+    nuts_positive = flat_nuts @ component_mean > 0.0
+    chain_modes = flow.samples @ component_mean > 0.0
+    nuts_chain_modes = nuts.samples @ component_mean > 0.0
+    flow_transitions = jnp.sum(
+        chain_modes[:, 1:] != chain_modes[:, :-1],
+        axis=1,
+    )
+    nuts_transitions = jnp.sum(
+        nuts_chain_modes[:, 1:] != nuts_chain_modes[:, :-1],
+        axis=1,
+    )
+    estimated_covariance = jnp.cov(flat_flow, rowvar=False)
+    proposal_ess_fraction = flow.adaptation_proposal_ess[-1] / (
+        configuration.num_chains * configuration.flow_global_adaptation_steps
+    )
+    max_rhat = 1.15 if configuration.profile == "smoke" else 1.05
+    min_ess = 20.0 if configuration.profile == "smoke" else 200.0
+    mode_mass_error = 0.15 if configuration.profile == "smoke" else 0.06
+    mean_rmse = 0.30 if configuration.profile == "smoke" else 0.12
+    covariance_error = 0.30 if configuration.profile == "smoke" else 0.15
+    minimum_global_acceptance = 0.03 if configuration.profile == "smoke" else 0.05
+    minimum_proposal_ess_fraction = 0.05 if configuration.profile == "smoke" else 0.10
+    sample_count = configuration.num_chains * configuration.num_draws
+    metrics = {
+        "flow_mode_mass_error": metric(
+            jnp.abs(jnp.mean(flow_positive) - positive_weight),
+            "accuracy",
+            maximum=mode_mass_error,
+        ),
+        "flow_posterior_mean_rmse": metric(
+            jnp.sqrt(jnp.mean((jnp.mean(flat_flow, axis=0) - exact_mean) ** 2)),
+            "accuracy",
+            maximum=mean_rmse,
+        ),
+        "flow_covariance_relative_frobenius_error": metric(
+            jnp.linalg.norm(estimated_covariance - exact_covariance)
+            / jnp.linalg.norm(exact_covariance),
+            "accuracy",
+            maximum=covariance_error,
+        ),
+        "ordinary_nuts_mode_mass_error": metric(
+            jnp.abs(jnp.mean(nuts_positive) - positive_weight),
+            "diagnostic",
+        ),
+        "minimum_flow_mode_transitions_per_chain": metric(
+            jnp.min(flow_transitions),
+            "convergence",
+            minimum=1.0,
+        ),
+        "minimum_nuts_mode_transitions_per_chain": metric(
+            jnp.min(nuts_transitions),
+            "diagnostic",
+        ),
+        "max_rhat": metric(
+            flow.diagnostics.max_rhat,
+            "convergence",
+            maximum=max_rhat,
+        ),
+        "min_bulk_ess": metric(
+            flow.diagnostics.min_bulk_ess,
+            "convergence",
+            minimum=min_ess,
+        ),
+        "divergence_count": metric(
+            flow.diagnostics.divergence_count,
+            "convergence",
+            maximum=0.0,
+        ),
+        "global_acceptance_rate": metric(
+            jnp.mean(flow.global_acceptance_rate),
+            "convergence",
+            minimum=minimum_global_acceptance,
+        ),
+        "proposal_ess_fraction": metric(
+            proposal_ess_fraction,
+            "diagnostic",
+            minimum=minimum_proposal_ess_fraction,
+        ),
+        "nuts_seconds": metric(nuts_seconds, "performance", unit="s"),
+        "flow_seconds": metric(flow_seconds, "performance", unit="s"),
+        "flow_adaptation_seconds": metric(
+            flow.adaptation_duration_seconds,
+            "performance",
+            unit="s",
+        ),
+        "flow_training_seconds": metric(
+            sum(flow.flow_training_duration_seconds),
+            "performance",
+            unit="s",
+        ),
+        "flow_production_seconds": metric(
+            flow.sampling_duration_seconds,
+            "performance",
+            unit="s",
+        ),
+        "flow_samples_per_second": metric(
+            sample_count / flow.sampling_duration_seconds,
+            "performance",
+            unit="sample/s",
+        ),
+        "flow_min_bulk_ess_per_second": metric(
+            flow.diagnostics.min_bulk_ess / flow_seconds,
+            "performance",
+            unit="1/s",
+        ),
+        "flow_parameter_memory_bytes": metric(
+            flow.flow_parameter_memory_bytes,
+            "performance",
+            unit="byte",
+        ),
+        "flow_history_memory_bytes": metric(
+            flow.history_memory_bytes,
+            "performance",
+            unit="byte",
+        ),
+        "production_global_target_evaluations": metric(
+            sample_count * configuration.flow_global_steps,
+            "performance",
+        ),
+        "production_local_integration_steps": metric(
+            jnp.sum(flow.num_integration_steps),
+            "performance",
+        ),
+        **_performance_metrics(
+            wall_seconds=time.perf_counter() - started,
+            cold_seconds=cold,
+            compile_seconds=compile_seconds,
+            execution_seconds=execute,
+            sample_memory_bytes=(
+                nuts.sample_memory_bytes
+                + flow.sample_memory_bytes
+                + flow.flow_parameter_memory_bytes
+                + flow.history_memory_bytes
+            ),
+        ),
+    }
+    return ScenarioResult(
+        name="flow_assisted_multimodal",
+        description=flow_assisted_multimodal.__doc__ or "",
+        seed=seed,
+        metrics=metrics,
+        metadata={
+            "profile": configuration.profile,
+            "dimension": dimension,
+            "positive_mode_weight": positive_weight,
+            "component_means": [
+                (-component_mean).tolist(),
+                component_mean.tolist(),
+            ],
+            "component_covariance": component_covariance.tolist(),
+            "exact_mean": exact_mean.tolist(),
+            "exact_covariance": exact_covariance.tolist(),
+            "initial_positions": initial_positions.tolist(),
+            "flow_config": flow_config.as_dict(),
+        },
+    )
+
+
 def _poisson_basis(x):
     return 0.5 * x * (1.0 - x)
 
@@ -1377,6 +1649,7 @@ SCENARIOS: dict[str, Scenario] = {
     "multimodal_tempered_inference": multimodal_tempered_inference,
     "misspecified_pde_discrepancy": misspecified_pde_discrepancy,
     "correlated_vector_discrepancy": correlated_vector_discrepancy,
+    "flow_assisted_multimodal": flow_assisted_multimodal,
 }
 
 


### PR DESCRIPTION
## Summary

Adds a native, exact flow-assisted NUTS sampler for multimodal posteriors and nonlinear global geometry. The implementation combines independently adapted BlackJAX NUTS transitions with FlowJAX independence proposals while preserving `PosteriorProblem.log_density` as the sole target-density authority.

This absorbs the useful local/global transport pattern from flowMC and the model-inspection ergonomics associated with Bayeux without adding a backend registry, generic sampler framework, or second posterior abstraction.

## Why

Ordinary NUTS is effective for connected local geometry, but it can remain trapped when important posterior regions are separated by low-density barriers. A learned proposal can connect represented regions, provided that:

- every global transition includes the full asymmetric independence-MH correction;
- training is isolated from retained production draws;
- the flow and local NUTS parameters are frozen before production;
- chain identity and chain/draw axes remain explicit;
- replay memory, key scheduling, checkpointing, and diagnostics are bounded and reproducible.

The new sampler implements those constraints directly rather than treating the learned flow as an approximate posterior replacement.

## Public API

Adds the following exports under `phydrax.uq`:

- `FlowNUTSConfig`: immutable controls for adaptation rounds, local/global step counts, stabilization, bounded history, flow architecture, and fitting.
- `sample_flow_nuts(...)`: exact flow-assisted posterior sampling with explicit chain initialization, sequential or vectorized chain execution, checkpointing, and resume.
- `FlowNUTSResult`: an MCMC-compatible result that delegates ordinary posterior draws, prediction, observation prediction, convergence reporting, chain keys, warmup state, and local diagnostics while exposing flow-specific evidence.
- `diagnose_posterior(...)`, `PosteriorCapabilities`, and `PosteriorDiagnostics`: backend-independent posterior inspection and capability reporting.

`sample_nuts(...)` and `sample_hmc(...)` also accept `initial_positions`, a model-shaped PyTree with one leading chain axis. The existing single-position `initial_position` path remains unchanged and mutually exclusive with the new argument.

## Exact flow proposal kernel

`phydrax/uq/_flow_proposal.py` provides the internal proposal machinery:

- unconditional FlowJAX coupling flows with rational-quadratic-spline transformers;
- scalar and vector event support;
- proposal sampling together with normalized `log q` evaluation;
- exact sequential independence-MH transitions using `log target + log proposal` ratios;
- unconditional rejection of nonfinite positions, target values, or proposal densities;
- batch/scan-equivalent transition semantics;
- proposal effective sample size computed from normalized importance weights.

No external sampler state machine or flowMC serialization layer is imported.

## Adaptation and production lifecycle

The sampler uses a deterministic tagged key hierarchy for initialization, ordinary warmup, each adaptation round, flow fitting, stabilization, and each retained draw.

1. Resolve independently dispersed starts from declared factorized priors or caller-provided chain-batched positions.
2. Flatten every chain through one canonical `ravel_pytree` contract and validate finite target values and gradients.
3. Adapt one BlackJAX NUTS kernel per chain.
4. Alternate bounded local-history collection, per-chain reservoir updates, flow fitting, and exact global proposal blocks.
5. Reinitialize BlackJAX state at the accepted final adaptation positions.
6. Freeze the flow and tuned NUTS parameters.
7. Run an optional local-only stabilization phase.
8. Produce each retained draw through one fixed composite local/global kernel.

The replay buffer is fixed-capacity and chain-stratified. Only thinned local NUTS states enter the buffer, preventing rejected global proposals from duplicating mode mass and preventing newest-only FIFO behavior. Every flow fit starts from a deterministic initialization and optimizer state, so completed adaptation rounds are independently replayable.

Returned draws never update the flow or replay history.

## Results and diagnostics

`FlowNUTSResult` preserves separate chain and draw dimensions and adds:

- train and validation loss histories for each completed flow fit;
- adaptation-time global acceptance, proposal ESS, and replay occupancy;
- per-draw global acceptance rate, accepted count, mean log acceptance ratio, and nonfinite count;
- ordinary local NUTS acceptance, divergence, energy, integration-step, and tree-expansion diagnostics;
- initial-position diversity;
- NUTS adaptation, flow adaptation, flow fitting, stabilization, and production timings;
- posterior sample, replay-history, and flow-parameter memory accounting.

`diagnose_posterior(...)` evaluates the existing posterior contract before selecting an inference method. It reports initial density, gradient norm, exact nonfinite gradient locations, constrain/unconstrain roundtrip errors by PyTree leaf, repeated-call agreement, JIT agreement, VMAP agreement, optional prior-draw finite fraction, and static capability flags. Model callback failures retain their original exceptions and tracebacks.

## Checkpoint and resume contract

Flow-assisted runs reuse the existing atomic ZIP/JSON/NumPy checkpoint infrastructure. Checkpoints persist completed phase progress, current flat BlackJAX states, per-chain warmup records, tuned step sizes and mass matrices, the bounded reservoir, fitted flow parameters, loss histories, adaptation statistics, retained draws, deterministic keys, and accumulated phase durations.

Compatibility checks cover the problem fingerprint, parameter structure, dimensions and dtypes, chain count and execution method, NUTS settings, full flow configuration, supported flow family, JAX/BlackJAX/Equinox/FlowJAX versions, and the frozen flow fingerprint.

Requested draw count, checkpoint cadence, and wall-clock values are intentionally excluded from compatibility identity. A completed checkpoint can therefore be resumed for additional draws without repeating warmup or completed flow adaptation. Shape, dtype, archive member, package-version, flow-fingerprint, and configuration mismatches fail explicitly.

## Portable interchange

Portable `.phxuq` export now supports `FlowNUTSResult`, including physical and unconstrained samples, local diagnostics, flow parameters, fit histories, flow-specific statistics, keys, configuration, memory accounting, and phase metadata.

`to_arviz(...)` accepts ordinary and flow-assisted MCMC results. Flow results add acceptance, accepted-proposal count, mean log acceptance ratio, and nonfinite-proposal count to `sample_stats` while retaining separate chain and draw dimensions.

## Scientific benchmark and documentation

Adds a deterministic asymmetric four-dimensional Gaussian-mixture scenario with analytic posterior component means, covariance, total mean, total covariance, and mode weights. It compares ordinary NUTS and flow-assisted NUTS from equivalent mode-stratified starts and records moment error, mode-mass error, rank diagnostics, proposal ESS, cross-mode transitions, divergences, global acceptance, local integration work, global target evaluations, phase timings, throughput, and memory.

The UQ guide, cookbook, and API reference document posterior inspection, initialization requirements, adaptation versus production boundaries, checkpoint semantics, result interchange, and method selection relative to ordinary NUTS, Pathfinder, and tempered SMC.

## Scope boundaries

This change intentionally does not add:

- a generic inference-backend registry;
- standalone normalizing-flow variational inference;
- automatic mode discovery;
- evidence estimation from flow-assisted NUTS;
- full-network neural posterior sampling;
- compatibility shims for flowMC state or serialization formats.

Tempered SMC remains the discovery/evidence method for low-dimensional multimodal problems. Flow-assisted NUTS is the repeated exact-sampling method once important posterior regions are represented.