### PR TITLE
Add native stochastic-gradient MCMC inference

### DIFF
--- a/docs/api/uq/index.md
+++ b/docs/api/uq/index.md
@@ -1,11 +1,17 @@
 # Uncertainty quantification
 
-`phydrax.uq` provides explicit Bayesian posterior problems, MAP optimization,
-BlackJAX NUTS/HMC, Pathfinder, adaptive tempered SMC, dense and structured
-Laplace approximations, exact/sparse/correlated-output Gaussian-process model
-discrepancy, predictive fields, coherent stochastic models, likelihoods and
-proper scores, conformal calibration, uncertain-input propagation, and global
-sensitivity.
+`phydrax.uq` provides explicit exact and factorized posterior problems, MAP
+optimization, BlackJAX NUTS/HMC, fixed-step SGLD/SGNHT with control variates,
+flow-assisted NUTS, Pathfinder, adaptive tempered SMC, dense and structured Laplace
+approximations, exact/sparse/correlated-output Gaussian-process model discrepancy,
+predictive fields, coherent stochastic models, likelihoods and proper scores,
+conformal calibration, uncertain-input propagation, and global sensitivity.
+
+Stochastic-gradient samplers consume deterministic, content-addressed minibatch
+sources and preserve chain/draw structure, replay state, throughput, and mixing
+evidence. Their production draws are explicitly labeled unadjusted fixed-step
+approximations; they do not substitute for NUTS or Laplace reference checks when
+full-data inference is feasible.
 
 Neural-operator predictions use an operator-aware layer over the same protocol so
 source/query geometry, physical case axes, masks, quadrature, and channel metadata

--- a/docs/api/uq/inference.md
+++ b/docs/api/uq/inference.md
@@ -41,6 +41,78 @@
             - validate
 
 
+### Stochastic likelihood contracts
+
+`MinibatchPosteriorProblem` requires one normalized likelihood contribution per
+statistical factor. `MinibatchSource` epochs must cover every factor exactly once;
+padded entries are excluded by `LikelihoodBatch.factor_mask`. The stochastic
+estimate scales the active-factor mean by the declared population size and adds the
+prior and bijector Jacobian exactly once.
+
+For operator data, a factor is one complete physical case. Query points, channels,
+geometry, masks, and quadrature remain inside that factor and are never interpreted
+as independent observations.
+
+::: phydrax.uq.LikelihoodBatch
+    options:
+        members:
+            - __init__
+            - capacity
+            - factor_count
+
+---
+
+::: phydrax.uq.MinibatchSource
+
+---
+
+::: phydrax.uq.ArrayMinibatchSource
+    options:
+        members:
+            - __init__
+            - num_factors
+            - batch_capacity
+            - batches_per_epoch
+            - fingerprint
+            - configuration
+            - epoch
+
+---
+
+::: phydrax.uq.MinibatchPosteriorProblem
+    options:
+        members:
+            - __init__
+            - log_likelihood_factors
+            - log_likelihood_estimate
+            - log_density_estimate
+            - full_log_likelihood
+            - full_log_density
+            - predict
+            - conditional_observation_variance
+            - sample_observation
+            - validate
+
+---
+
+::: phydrax.uq.diagnose_minibatch_posterior
+
+---
+
+::: phydrax.uq.MinibatchPosteriorCapabilities
+    options:
+        members:
+            - as_dict
+
+---
+
+::: phydrax.uq.MinibatchPosteriorDiagnostics
+    options:
+        members:
+            - passed
+            - as_dict
+
+
 ### Posterior inspection
 
 ::: phydrax.uq.diagnose_posterior
@@ -146,6 +218,65 @@
 ::: phydrax.uq.sample_hmc
 
 ---
+
+### Fixed-step stochastic-gradient MCMC
+
+`sample_sgld` and `sample_sgnht` consume deterministic `MinibatchSource` epochs
+through a shared fixed-step runtime. They return approximate, unadjusted production
+draws: burn-in is discarded, but no Metropolis correction or automatic step-size
+adaptation is implied. Report step-size sensitivity and compare with NUTS or Laplace
+on a tractable reference before interpreting these draws quantitatively.
+
+::: phydrax.uq.sample_sgld
+
+---
+
+::: phydrax.uq.sample_sgnht
+
+---
+
+::: phydrax.uq.build_sgmcmc_control_variate
+
+---
+
+::: phydrax.uq.SGMCMCControlVariate
+
+---
+
+::: phydrax.uq.SGMCMCResult
+    options:
+        members:
+            - num_chains
+            - num_draws
+            - batch_fraction
+            - source_configuration
+            - predict
+            - predict_observations
+            - mixing_report
+
+---
+
+::: phydrax.uq.SGMCMCDiagnostics
+
+---
+
+::: phydrax.uq.SGMCMCMixingThresholds
+    options:
+        members:
+            - __init__
+
+---
+
+::: phydrax.uq.SGMCMCMixingReport
+    options:
+        members:
+            - raise_for_failure
+            - as_dict
+
+---
+
+::: phydrax.uq.SGMCMCMixingError
+
 
 
 ### Flow-assisted NUTS

--- a/docs/api/uq/operator.md
+++ b/docs/api/uq/operator.md
@@ -261,6 +261,42 @@ absent unless a user derives a different stochastic observation model explicitly
             - log_prob
             - standardized_residual
 
+## Operator minibatch likelihoods
+
+`OperatorBatchObservationLikelihood` evaluates a normalized observation model on a
+dynamically supplied `OperatorBatch`. It combines the batch query mask with the
+finite-observation mask, reduces all query and channel elements within each physical
+case, and returns exactly one factor per case.
+
+`OperatorMinibatchSource` adapts deterministic `OperatorBatchLoader` epochs to
+`LikelihoodBatch`. The loader must be shuffled, retain its final padded batch, and
+keep a fixed batch capacity. Case subsampling is supported; query-anchor subsampling,
+nonuniform factor weights, and stochastic geometry mutation within a case are not.
+
+::: phydrax.uq.OperatorLikelihoodData
+
+---
+
+::: phydrax.uq.OperatorBatchObservationLikelihood
+    options:
+        members:
+            - __init__
+            - per_case_log_prob
+            - __call__
+
+---
+
+::: phydrax.uq.OperatorMinibatchSource
+    options:
+        members:
+            - __init__
+            - num_factors
+            - batch_capacity
+            - batches_per_epoch
+            - fingerprint
+            - configuration
+            - epoch
+
 ## Whole-function conformal calibration
 
 `OperatorFunctionalConformal` treats one complete output field or trajectory as one

--- a/docs/cookbook/operator_uncertainty.md
+++ b/docs/cookbook/operator_uncertainty.md
@@ -321,6 +321,89 @@ The first operator-UQ implementation requires real physical outputs. Represent a
 complex field as named real/imaginary channels or as a real observable before
 constructing `OperatorPredictiveField`.
 
+## 5a. Scale selected-weight inference over physical cases
+
+When the number of physical cases makes full-data transitions prohibitive, adapt an
+`OperatorBatchLoader` rather than flattening query points. The source emits one
+likelihood factor per complete case:
+
+```python
+posterior_dataset = phx.nn.operator_dataset_from_arrays(
+    {"state": source_values[6:]},
+    {"output": posterior_target},
+    source_axes={"state": (axis,)},
+    query_axes=(axis,),
+)
+loader = phx.nn.OperatorBatchLoader(
+    posterior_dataset,
+    batch_size=2,
+    shuffle=True,
+    seed=41,
+    drop_last=False,
+    prefetch=1,
+)
+operator_source = phx.uq.OperatorMinibatchSource(
+    loader,
+    field_name="output",
+)
+
+
+def dynamic_scaled_prediction(parameters, batch):
+    base = members[0].predict(batch)
+    field = base.field("output")
+    return phx.nn.OperatorPrediction.from_field(
+        "output",
+        parameters["scale"] * field.values,
+        field.query_name,
+        base.query_geometry(field.query_name),
+        spec=field.spec,
+        case_axes=base.case_axes,
+        case_shape=base.case_shape,
+    )
+
+
+dynamic_likelihood = phx.uq.OperatorBatchObservationLikelihood(
+    dynamic_scaled_prediction,
+    phx.uq.GaussianLikelihood(0.05),
+)
+target_field = posterior_dataset.targets.field("output")
+full_data = phx.uq.OperatorLikelihoodData(
+    posterior_dataset.batch,
+    target_field.values,
+    output_spec=target_field.spec,
+    field_name="output",
+    query_name=target_field.query_name,
+)
+operator_problem = phx.uq.MinibatchPosteriorProblem(
+    parameter_space,
+    dynamic_likelihood,
+    num_factors=operator_source.num_factors,
+    full_log_likelihood=lambda parameters: jnp.sum(
+        dynamic_likelihood.per_case_log_prob(parameters, full_data)
+    ),
+)
+assert phx.uq.diagnose_minibatch_posterior(
+    operator_problem,
+    operator_source,
+).passed
+
+operator_sgld = phx.uq.sample_sgld(
+    operator_problem,
+    operator_source,
+    key=jr.key(42),
+    step_size=1e-5,
+    num_chains=4,
+    num_burnin=1000,
+    num_samples=2000,
+)
+```
+
+Use an explicit `ParameterSubspace` when sampling selected model weights; the
+reconstructed model remains frozen outside that subspace. Run a halved-step chain
+and compare it with the full-data Laplace or NUTS result above. SG-MCMC does not
+justify query-anchor subsampling: the query geometry, masks, channels, and all
+observed points stay coupled inside each physical-case factor.
+
 ## 6. Run the reproducible benchmark
 
 The UQ benchmark trains a four-member FNO ensemble on periodic Burgers and a

--- a/docs/cookbook/uncertainty_quantification.md
+++ b/docs/cookbook/uncertainty_quantification.md
@@ -2,8 +2,9 @@
 
 This recipe covers independently initialized ensembles, proper scoring, split
 conformal calibration, uncertain-input propagation, explicit Bayesian physical
-parameters, MAP/NUTS/flow-assisted NUTS/Laplace/Pathfinder inference, and
-scalable Gaussian-process model discrepancy.
+parameters, MAP/NUTS/flow-assisted NUTS/Laplace/Pathfinder inference,
+fixed-step SGLD/SGNHT for factorized data, and scalable Gaussian-process model
+discrepancy.
 
 For geometry-aware output functions, independent source/query discretizations, and
 whole-field calibration, use the dedicated
@@ -244,7 +245,122 @@ those modules and avoids accidentally selecting only the last coordinate factor.
 See the posterior-contract section of the UQ guide for the complete separable
 selection pattern and its nonlinear joint-posterior interpretation.
 
-## 8. Choose local, represented-mode, or discovery inference
+## 8. Scale a factorized likelihood with fixed-step SG-MCMC
+
+Keep the normalized per-observation likelihood from the exact reference problem,
+but expose each observation as one factor. The source owns deterministic epoch
+ordering and padded-tail masking:
+
+```python
+source = phx.uq.ArrayMinibatchSource(
+    {
+        "basis": sensor_basis,
+        "observation": observations,
+    },
+    batch_size=8,
+    seed=31,
+)
+
+
+def likelihood_factors(parameters, batch):
+    return observation_likelihood.log_prob(
+        parameters["source"] * batch.data["basis"],
+        batch.data["observation"],
+    )
+
+
+stochastic_problem = phx.uq.MinibatchPosteriorProblem(
+    parameter_space,
+    likelihood_factors,
+    num_factors=sensor_basis.size,
+    full_log_likelihood=posterior_problem.log_likelihood,
+    predict=lambda parameters, x: cx.Field(
+        parameters["source"] * 0.5 * x * (1.0 - x),
+        dims=("x",),
+    ),
+)
+inspection = phx.uq.diagnose_minibatch_posterior(
+    stochastic_problem,
+    source,
+)
+assert inspection.passed, inspection.as_dict()
+```
+
+Build a difference-estimator control variate at the exact MAP and run independent
+chains. `num_burnin` discards states; it does not tune the fixed step:
+
+```python
+control = phx.uq.build_sgmcmc_control_variate(
+    stochastic_problem,
+    source,
+    map_result.position,
+)
+sgld = phx.uq.sample_sgld(
+    stochastic_problem,
+    source,
+    key=jr.key(30),
+    step_size=1e-4,
+    num_chains=4,
+    num_burnin=1000,
+    num_samples=2000,
+    steps_per_sample=2,
+    control_variate=control,
+)
+sgld_refined = phx.uq.sample_sgld(
+    stochastic_problem,
+    source,
+    key=jr.key(31),
+    step_size=5e-5,
+    num_chains=4,
+    num_burnin=1000,
+    num_samples=2000,
+    steps_per_sample=2,
+    control_variate=control,
+)
+sgnht = phx.uq.sample_sgnht(
+    stochastic_problem,
+    source,
+    key=jr.key(32),
+    step_size=5e-4,
+    diffusion=0.01,
+    num_chains=4,
+    num_burnin=1000,
+    num_samples=2000,
+    steps_per_sample=2,
+    control_variate=control,
+)
+```
+
+Do not infer accuracy from rank diagnostics alone. Compare the base and halved-step
+posterior means and variances, then compare both with the NUTS and Laplace references
+already computed above:
+
+```python
+sgld_mean = jnp.mean(sgld.samples["source"])
+refined_mean = jnp.mean(sgld_refined.samples["source"])
+step_sensitivity = jnp.abs(sgld_mean - refined_mean)
+reference_error = jnp.abs(refined_mean - jnp.mean(nuts.samples["source"]))
+
+mixing = sgld_refined.mixing_report(
+    max_rhat=1.05,
+    min_bulk_ess=200,
+    min_tail_ess=200,
+)
+mixing.raise_for_failure()
+```
+
+Report `step_sensitivity`, reference moment/predictive discrepancies, stochastic
+gradient variance, throughput, memory, batch definition, and every fixed-step
+setting. SGLD and SGNHT are unadjusted approximations: there is no Metropolis
+correction or automatic step-size adaptation. Prefer exact NUTS or Laplace whenever
+full-data inference is feasible.
+
+For neural operators, use `OperatorBatchObservationLikelihood` with
+`OperatorMinibatchSource`; one complete physical case is one factor. Query points,
+channels, masks, geometry, and quadrature remain coupled within the case. The
+adapter intentionally does not subsample query anchors.
+
+## 9. Choose local, represented-mode, or discovery inference
 
 Pathfinder is a fast local approximation selected along an L-BFGS path:
 
@@ -308,7 +424,7 @@ log-evidence estimate is required. Its declared priors provide initial particles
 inspect the adaptive temperature schedule, ESS, divergences, and surviving
 initial-particle count.
 
-## 9. Represent omitted physics with a GP discrepancy
+## 10. Represent omitted physics with a GP discrepancy
 
 
 An ensemble cannot identify a physical mode that every member omits. Model that

--- a/docs/guides_uncertainty.md
+++ b/docs/guides_uncertainty.md
@@ -671,6 +671,7 @@ or quantiles are defined.
 | Cheap stochastic diagnostic | MC dropout with coherent full-function keys | Deep ensemble | Dropout spread is not calibrated automatically |
 | Random forcing, coefficients, geometry, or initial state | Preserve named input sample axes | Joint input/epistemic predictive design | Output query geometry must align across draws |
 | Small physical or calibration parameter posterior | NUTS/HMC or dense Laplace | Pathfinder or tempered SMC when justified | Likelihood must be normalized and deterministic |
+| Large factorized dataset or operator-case posterior | Fixed-step SGLD with a control variate | SGNHT after reference validation | Unadjusted draws require step-halving and exact-reference checks |
 | Selected neural-operator weights | Exact last-projection Laplace reference | Diagonal/Lanczos/LOBPCG Laplace | Full-weight inference is usually too large |
 | Distribution-free whole-field bands | `OperatorFunctionalConformal` | Score stratification or recalibration | Exchangeability does not survive arbitrary shifts |
 | Learned stochastic transition law | `GaussianFunctionOperator` with `uncertainty_source="process"` | Fixed-query `ConditionalFlowFunctionOperator` for demonstrated non-Gaussian residuals | A learned density is not a drift/diffusion identification |
@@ -982,6 +983,125 @@ inside `log_density`. NUTS is the default for low-dimensional physical parameter
 noise scales, and explicitly selected small subspaces. Sampling every neural-network
 weight is deliberately not the default.
 
+## Fixed-step stochastic-gradient MCMC
+
+Use stochastic-gradient MCMC only when the likelihood is a sum over many
+statistical factors and full-density transitions are the measured bottleneck.
+`MinibatchPosteriorProblem` makes that algebra explicit. A factor must be one
+independent likelihood contribution; it is not an arbitrary slice of a residual
+array. `ArrayMinibatchSource` emits deterministic shuffled epochs, retains the
+padded final batch, and excludes padding through `factor_mask`:
+
+```python
+minibatch_source = phx.uq.ArrayMinibatchSource(
+    {
+        "basis": sensor_basis,
+        "observation": observations,
+    },
+    batch_size=8,
+    seed=17,
+)
+
+
+def likelihood_factors(parameters, batch):
+    prediction = parameters["source"] * batch.data["basis"]
+    return observation_likelihood.log_prob(
+        prediction,
+        batch.data["observation"],
+    )
+
+
+minibatch_posterior = phx.uq.MinibatchPosteriorProblem(
+    parameter_space,
+    likelihood_factors,
+    num_factors=sensor_basis.size,
+    full_log_likelihood=posterior_problem.log_likelihood,
+    predict=lambda parameters, x: cx.Field(
+        parameters["source"] * 0.5 * x * (1.0 - x),
+        dims=("x",),
+    ),
+)
+minibatch_inspection = phx.uq.diagnose_minibatch_posterior(
+    minibatch_posterior,
+    minibatch_source,
+)
+if not minibatch_inspection.passed:
+    raise ValueError(minibatch_inspection.as_dict())
+```
+
+The inspection sums one complete epoch and compares both its value and gradient
+with `full_log_likelihood` when supplied. This catches incorrect population
+scaling, duplicated priors, missing factors, and source/problem mismatches before
+sampling.
+
+`sample_sgld` implements fixed-step overdamped Langevin updates.
+`sample_sgnht` adds momentum and a scalar thermostat to absorb stochastic-gradient
+noise:
+
+```python
+control = phx.uq.build_sgmcmc_control_variate(
+    minibatch_posterior,
+    minibatch_source,
+    map_result.position,
+)
+
+sgld = phx.uq.sample_sgld(
+    minibatch_posterior,
+    minibatch_source,
+    key=jr.key(20),
+    step_size=1e-4,
+    num_chains=4,
+    num_burnin=1000,
+    num_samples=2000,
+    steps_per_sample=2,
+    control_variate=control,
+    chain_method="vectorized",
+)
+sgnht = phx.uq.sample_sgnht(
+    minibatch_posterior,
+    minibatch_source,
+    key=jr.key(21),
+    step_size=5e-4,
+    diffusion=0.01,
+    num_chains=4,
+    num_burnin=1000,
+    num_samples=2000,
+    steps_per_sample=2,
+    control_variate=control,
+    chain_method="vectorized",
+)
+
+mixing = sgld.mixing_report(
+    max_rhat=1.05,
+    min_bulk_ess=200,
+    min_tail_ess=200,
+)
+mixing.raise_for_failure()
+```
+
+Both samplers preserve separate chain/draw axes, nested PyTrees, constrained
+physical samples, source configuration and fingerprint, deterministic keys,
+gradient/update throughput, memory, gradient-norm traces, and nonfinite-update
+locations. SGNHT additionally retains thermostat and momentum-norm traces.
+Checkpointing resumes the indexed source/transition schedule exactly and rejects
+changed problem, source, control-variate, PyTree, or sampler identities.
+
+These are unadjusted fixed-step approximations. Burn-in discards early states; it
+is not adaptation. Rank diagnostics measure between-chain mixing and do not detect
+stationary discretization bias. For every scientific use:
+
+1. rerun at half the step size and compare posterior and predictive moments;
+2. inspect stochastic-gradient variance, with and without a control variate;
+3. compare against NUTS or dense Laplace on a tractable reduced/reference problem;
+4. report the batch definition, population size, step size, burn-in, thinning,
+   update count, and approximation label.
+
+Prefer NUTS or Laplace when full-data inference is feasible. Current SG-MCMC
+sources support uniform factor subsampling only: no decreasing-step schedule,
+automatic step-size adaptation, query-anchor subsampling, likelihood-dependent
+sampling, multi-host source execution, SGHMC, pSGLD/RMSProp geometry, or online
+gradient-noise covariance estimation is implied.
+
 ## Flow-assisted NUTS
 
 `sample_flow_nuts` combines independently adapted NUTS chains with a shared
@@ -1201,11 +1321,14 @@ SHA-256 checksums, atomic replacement, and no pickle or Python object
 arrays. Portable archives export representable result arrays and explicitly list
 excluded live callables. `FlowNUTSResult` archives include frozen flow parameters,
 loss histories, local and global sampler statistics, deterministic keys, and phase
-timings. `phx.uq.to_arviz(posterior_draws)` accepts ordinary or flow-assisted MCMC,
-retains separate `chain` and `draw` dimensions, and adds flow acceptance, accepted
-proposal counts, log acceptance ratios, and nonfinite counts when present. Generic
-observed-data and pointwise-log-likelihood groups are omitted because
-`PosteriorProblem` does not promise that metadata.
+timings. `SGMCMCResult` archives include algorithm and approximation identities,
+source configuration and fingerprint, control-variate metadata, gradient/update
+accounting, thermostat or momentum traces when present, and deterministic replay
+keys. `phx.uq.to_arviz(posterior_draws)` accepts ordinary, flow-assisted, or
+stochastic-gradient MCMC and retains separate `chain` and `draw` dimensions.
+Method-specific sample statistics are added when present. Generic observed-data and
+pointwise-log-likelihood groups are omitted because neither posterior contract
+promises that metadata.
 
 ## Gaussian-process model discrepancy
 
@@ -1314,11 +1437,15 @@ Phydrax currently recommends:
    benchmarked against NUTS or Laplace where feasible.
 6. Pathfinder for rapid local diagnostics, always benchmarked against NUTS.
 7. Tempered SMC for low-dimensional mode discovery and evidence estimation.
-8. Deep ensembles for independently trained neural-model epistemic variation.
-9. Exact GP discrepancy for moderate scalar data, explicit coregionalization for
-   correlated outputs, and FITC only when dense scaling fails.
+8. Fixed-step SGLD, optionally with an exact-center control variate, for large
+   uniformly factorized likelihoods after step-halving and exact-reference checks.
+   Use SGNHT only when its momentum/thermostat dynamics improve measured mixing.
+9. Deep ensembles for independently trained neural-model epistemic variation.
+10. Exact GP discrepancy for moderate scalar data, explicit coregionalization for
+    correlated outputs, and FITC only when dense scaling fails.
 
-Mean-field VI, standalone variational normalizing-flow posteriors, SWAG, SGMCMC,
+Mean-field VI, standalone variational normalizing-flow posteriors, SWAG, SGHMC,
+pSGLD/RMSProp geometry, decreasing-step stochastic approximation,
 non-Gaussian/sparse variational GPs, and full-network HMC remain unsupported. None
 is silently approximated by the methods above.
 

--- a/phydrax/nn/operator_training/_fit.py
+++ b/phydrax/nn/operator_training/_fit.py
@@ -205,20 +205,6 @@ def _canonical_hash(value: Any, /) -> str:
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
-def _source_provenance_fingerprint(source: OperatorCaseSource, /) -> str:
-    records = []
-    for index in range(source.size):
-        provenance = source.case_metadata(index).provenance
-        records.append(
-            {"case_id": f"case:{index}"}
-            if provenance is None
-            else {
-                "case_id": provenance.case_id,
-                "identities": dict(provenance.identities),
-                "order": dict(provenance.order),
-            }
-        )
-    return _canonical_hash(records)
 
 
 def _raw_loader(
@@ -804,9 +790,8 @@ def fit_operator(
         )
         return eqx.apply_updates(current_parameters, updates), next_state
 
-    if jit:
-        gradient_fn = eqx.filter_jit(gradient_fn)
-        update_fn = eqx.filter_jit(update_fn)
+    run_gradient_fn = eqx.filter_jit(gradient_fn) if jit else gradient_fn
+    run_update_fn = eqx.filter_jit(update_fn) if jit else update_fn
 
     def prepared_epoch(loader: OperatorBatchLoader, epoch: int):
         for raw in loader.epoch(epoch):
@@ -907,11 +892,11 @@ def fit_operator(
             if raw_validation_loader is None
             else raw_validation_loader.configuration()
         ),
-        "train_provenance": _source_provenance_fingerprint(raw_train_loader.source),
-        "validation_provenance": (
+        "train_source_fingerprint": raw_train_loader.source_fingerprint(),
+        "validation_source_fingerprint": (
             None
             if raw_validation_loader is None
-            else _source_provenance_fingerprint(raw_validation_loader.source)
+            else raw_validation_loader.source_fingerprint()
         ),
         "sharding": (
             None
@@ -1136,7 +1121,7 @@ def fit_operator(
                     if control.stop_requested or signal_guard.stop_requested:
                         break
                     key = control.key_for(control.progress.microstep, site=0)
-                    total, components, gradient = gradient_fn(
+                    total, components, gradient = run_gradient_fn(
                         parameters,
                         training_batch.batch,
                         training_batch.targets,
@@ -1200,7 +1185,7 @@ def fit_operator(
                         gradient_accumulator,
                         1.0 / accumulated_cases,
                     )
-                    parameters, optimizer_state = update_fn(
+                    parameters, optimizer_state = run_update_fn(
                         parameters,
                         optimizer_state,
                         averaged_gradient,

--- a/phydrax/nn/operator_training/_loader.py
+++ b/phydrax/nn/operator_training/_loader.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 from collections import deque
 from dataclasses import dataclass
 from math import ceil
@@ -121,7 +123,86 @@ class OperatorBatchLoader:
             "drop_last": self.drop_last,
             "split": self.split,
             "sampling": sampling_contract,
+            "normalization": (
+                None if self.normalization is None else self.normalization.to_dict()
+            ),
+            "dtype_policy": (
+                None if self.dtype_policy is None else self.dtype_policy.to_dict()
+            ),
+            "sharding": (
+                None
+                if self.sharding_policy is None
+                else {
+                    "mesh_axis": self.sharding_policy.mesh_axis,
+                    "case_axis": self.sharding_policy.case_axis,
+                    "mesh_shape": list(self.sharding_policy.mesh.devices.shape),
+                    "device_count": int(self.sharding_policy.mesh.devices.size),
+                }
+            ),
         }
+    def source_fingerprint(self) -> str:
+        """Hash source identity, case provenance, geometry, inputs, and targets."""
+        digest = hashlib.sha256()
+        configuration = json.dumps(
+            self.configuration(),
+            allow_nan=False,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        digest.update(configuration.encode("utf-8"))
+        for index in range(self.source.size):
+            metadata = self.source.case_metadata(index)
+            provenance = metadata.provenance
+            provenance_record = (
+                {"case_id": f"case:{index}"}
+                if provenance is None
+                else {
+                    "case_id": provenance.case_id,
+                    "identities": dict(provenance.identities),
+                    "order": dict(provenance.order),
+                }
+            )
+            digest.update(
+                json.dumps(
+                    provenance_record,
+                    allow_nan=False,
+                    ensure_ascii=True,
+                    separators=(",", ":"),
+                    sort_keys=True,
+                ).encode("utf-8")
+            )
+            selected = read_operator_case_batch(
+                self.source,
+                (index,),
+                sampling=self.sampling,
+                split=self.split,
+                epoch=0,
+            )
+            _update_array_tree_digest(digest, "batch", selected.batch)
+            _update_array_tree_digest(digest, "targets", selected.targets)
+        return digest.hexdigest()
+
+    def indices_for_epoch(self, epoch: int, /) -> tuple[tuple[int, ...], ...]:
+        """Return deterministic case-index chunks without preparing device data."""
+        return self._indices(epoch)
+
+    def prepare_indices(
+        self,
+        indices: Sequence[int],
+        /,
+        *,
+        epoch: int,
+        batch_index: int,
+    ) -> OperatorTrainingBatch:
+        """Prepare explicit case indices through the configured loader pipeline."""
+        selected = tuple(int(index) for index in indices)
+        if not selected:
+            raise ValueError("indices must contain at least one case.")
+        if any(index < 0 or index >= self.source.size for index in selected):
+            raise ValueError("indices contain a case outside the source.")
+        return self._prepare(selected, int(epoch), int(batch_index))
+
 
     def fixed_query_fingerprints(
         self,
@@ -261,6 +342,24 @@ class OperatorBatchLoader:
                 batch_index, indices = item
                 queue.append(self._prepare(indices, epoch, batch_index))
             yield current
+
+
+def _update_array_tree_digest(
+    digest: Any,
+    prefix: str,
+    tree: Any,
+    /,
+) -> None:
+    for path, leaf in jax.tree_util.tree_flatten_with_path(tree)[0]:
+        value = np.asarray(leaf)
+        if value.dtype.hasobject:
+            continue
+        contiguous = np.ascontiguousarray(value)
+        digest.update(prefix.encode("utf-8"))
+        digest.update((jax.tree_util.keystr(path) or "<root>").encode("utf-8"))
+        digest.update(contiguous.dtype.str.encode("ascii"))
+        digest.update(json.dumps(contiguous.shape).encode("ascii"))
+        digest.update(contiguous.tobytes(order="C"))
 
 
 __all__ = ["OperatorBatchLoader", "OperatorTrainingBatch"]

--- a/phydrax/uq/__init__.py
+++ b/phydrax/uq/__init__.py
@@ -157,6 +157,17 @@ from ._metrics import (
     pinball_loss,
     student_t_crps,
 )
+from ._minibatch_diagnostics import (
+    diagnose_minibatch_posterior,
+    MinibatchPosteriorCapabilities,
+    MinibatchPosteriorDiagnostics,
+)
+from ._minibatch_posterior import (
+    ArrayMinibatchSource,
+    LikelihoodBatch,
+    MinibatchPosteriorProblem,
+    MinibatchSource,
+)
 from ._observation import LikelihoodObservationModel
 from ._operator import (
     operator_input_predictive,
@@ -167,7 +178,12 @@ from ._operator import (
     sample_operator_predictive,
 )
 from ._operator_conformal import OperatorFunctionalConformal
-from ._operator_likelihood import FixedOperatorObservationLikelihood
+from ._operator_likelihood import (
+    FixedOperatorObservationLikelihood,
+    OperatorBatchObservationLikelihood,
+    OperatorLikelihoodData,
+    OperatorMinibatchSource,
+)
 from ._operator_metrics import (
     operator_energy_score,
     operator_ensemble_crps,
@@ -302,6 +318,19 @@ from ._result_export import (
     UQResultArchive,
 )
 from ._sensitivity import sobol_indices, SobolResult
+from ._sgmcmc import (
+    build_sgmcmc_control_variate,
+    sample_sgld,
+    sample_sgnht,
+    SGMCMCControlVariate,
+    SGMCMCResult,
+)
+from ._sgmcmc_diagnostics import (
+    SGMCMCDiagnostics,
+    SGMCMCMixingError,
+    SGMCMCMixingReport,
+    SGMCMCMixingThresholds,
+)
 from ._smc import sample_tempered_smc, TemperedSMCResult
 from ._state_space_inference import (
     EXACT_STATE_SPACE_DEGENERATE_LIKELIHOOD,
@@ -533,6 +562,9 @@ __all__ = [
     "operator_interval_coverage",
     "operator_interval_width",
     "FixedOperatorObservationLikelihood",
+    "OperatorBatchObservationLikelihood",
+    "OperatorLikelihoodData",
+    "OperatorMinibatchSource",
     "operator_input_predictive",
     "operator_prediction_field",
     "OperatorPredictionInterval",
@@ -549,6 +581,13 @@ __all__ = [
     "diagnose_posterior",
     "PosteriorCapabilities",
     "PosteriorDiagnostics",
+    "ArrayMinibatchSource",
+    "LikelihoodBatch",
+    "MinibatchPosteriorProblem",
+    "MinibatchSource",
+    "diagnose_minibatch_posterior",
+    "MinibatchPosteriorCapabilities",
+    "MinibatchPosteriorDiagnostics",
     "GaussianPriorWhitening",
     "AbstractPosteriorTerm",
     "CompositePosteriorLikelihood",
@@ -570,6 +609,15 @@ __all__ = [
     "sample_hmc",
     "sample_nuts",
     "sample_flow_nuts",
+    "build_sgmcmc_control_variate",
+    "sample_sgld",
+    "sample_sgnht",
+    "SGMCMCControlVariate",
+    "SGMCMCDiagnostics",
+    "SGMCMCMixingError",
+    "SGMCMCMixingReport",
+    "SGMCMCMixingThresholds",
+    "SGMCMCResult",
     "PathfinderResult",
     "fit_pathfinder",
     "TemperedSMCResult",

--- a/phydrax/uq/_chain.py
+++ b/phydrax/uq/_chain.py
@@ -1,0 +1,110 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+from jaxtyping import Array, PyTree
+
+
+ChainMethod = Literal["sequential", "vectorized"]
+
+
+def _validate_chain_method(value: ChainMethod, /) -> ChainMethod:
+    if value not in ("sequential", "vectorized"):
+        raise ValueError("chain_method must be 'sequential' or 'vectorized'.")
+    return value
+
+
+def _prepare_chain_positions(
+    reference: PyTree[Any],
+    /,
+    *,
+    num_chains: int,
+    initial_position: PyTree[Any] | None = None,
+    initial_positions: PyTree[Any] | None = None,
+) -> tuple[PyTree[Any], PyTree[Array]]:
+    """Validate and construct one unbatched template plus chain-stacked positions."""
+    chains = int(num_chains)
+    if chains <= 0:
+        raise ValueError("num_chains must be positive.")
+    if initial_position is not None and initial_positions is not None:
+        raise ValueError(
+            "initial_position and initial_positions cannot both be supplied."
+        )
+    reference_structure = jax.tree_util.tree_structure(reference)
+    reference_leaves = jax.tree_util.tree_leaves(reference)
+    if not reference_leaves:
+        raise ValueError("Initial positions must contain at least one array leaf.")
+
+    if initial_positions is not None:
+        if jax.tree_util.tree_structure(initial_positions) != reference_structure:
+            raise ValueError(
+                "initial_positions must have the reference initial PyTree structure."
+            )
+        position_leaves = jax.tree_util.tree_leaves(initial_positions)
+        for position_leaf, reference_leaf in zip(
+            position_leaves,
+            reference_leaves,
+            strict=True,
+        ):
+            if not eqx.is_inexact_array(position_leaf):
+                raise TypeError("Every initial_positions leaf must be an inexact array.")
+            expected_shape = (chains, *reference_leaf.shape)
+            if position_leaf.shape != expected_shape:
+                raise ValueError(
+                    "Every initial_positions leaf must have shape "
+                    f"{expected_shape}; received {position_leaf.shape}."
+                )
+        return reference, jax.tree_util.tree_map(jnp.asarray, initial_positions)
+
+    position = reference if initial_position is None else initial_position
+    if jax.tree_util.tree_structure(position) != reference_structure:
+        raise ValueError("initial_position must have the reference initial PyTree structure.")
+    position_leaves = jax.tree_util.tree_leaves(position)
+    for position_leaf, reference_leaf in zip(
+        position_leaves,
+        reference_leaves,
+        strict=True,
+    ):
+        if not eqx.is_inexact_array(position_leaf):
+            raise TypeError("Every initial_position leaf must be an inexact array.")
+        if position_leaf.shape != reference_leaf.shape:
+            raise ValueError(
+                "Every initial_position leaf must have shape "
+                f"{reference_leaf.shape}; received {position_leaf.shape}."
+            )
+    arrays = jax.tree_util.tree_map(jnp.asarray, position)
+    return arrays, jax.tree_util.tree_map(
+        lambda leaf: jnp.broadcast_to(leaf, (chains, *leaf.shape)),
+        arrays,
+    )
+
+
+def _split_chain_keys(key: Array, num_chains: int, /) -> tuple[Array, Array]:
+    root_key = jnp.asarray(key)
+    return root_key, jr.split(root_key, int(num_chains))
+
+
+def _stack_trees(values):
+    return jax.tree_util.tree_map(lambda *leaves: jnp.stack(leaves), *values)
+
+
+def _unstack_tree(tree, count: int):
+    return tuple(
+        jax.tree_util.tree_map(lambda value: value[index], tree)
+        for index in range(int(count))
+    )
+
+
+def _tree_nbytes(tree: PyTree[Any], /) -> int:
+    return sum(int(jnp.asarray(leaf).nbytes) for leaf in jax.tree_util.tree_leaves(tree))
+
+
+__all__ = ["ChainMethod"]

--- a/phydrax/uq/_flow_mcmc.py
+++ b/phydrax/uq/_flow_mcmc.py
@@ -20,6 +20,14 @@ from jax.flatten_util import ravel_pytree
 from jaxtyping import Array, PyTree
 
 from .._strict import StrictModule
+from ._chain import (
+    _split_chain_keys,
+    _stack_trees,
+    _tree_nbytes,
+    _unstack_tree,
+    _validate_chain_method,
+    ChainMethod,
+)
 from ._checkpoint import (
     array_tree_fingerprint,
     checkpoint_compatibility,
@@ -42,15 +50,7 @@ from ._flow_proposal import (
     _update_replay,
     _validate_flow,
 )
-from ._mcmc import (
-    _adapt_mcmc,
-    _stack_trees,
-    _tree_nbytes,
-    _unstack_tree,
-    ChainMethod,
-    MCMCChainWarmup,
-    MCMCResult,
-)
+from ._mcmc import _adapt_mcmc, MCMCChainWarmup, MCMCResult
 from ._posterior import PosteriorProblem
 
 
@@ -451,9 +451,7 @@ def sample_flow_nuts(
     doublings = int(max_num_doublings)
     if doublings <= 0:
         raise ValueError("max_num_doublings must be positive.")
-    method: ChainMethod = chain_method
-    if method not in ("sequential", "vectorized"):
-        raise ValueError("chain_method must be 'sequential' or 'vectorized'.")
+    method = _validate_chain_method(chain_method)
     if resume_from is not None and initial_positions is not None:
         raise ValueError("initial_positions cannot be supplied when resuming flow NUTS.")
 
@@ -470,8 +468,7 @@ def sample_flow_nuts(
     if destination is not None and (checkpoint_id is None or not str(checkpoint_id)):
         raise ValueError("checkpoint_id is required for flow-NUTS checkpointing.")
 
-    root_key = jnp.asarray(key)
-    chain_keys = jr.split(root_key, chains)
+    root_key, chain_keys = _split_chain_keys(key, chains)
     flat_reference, unravel = ravel_pytree(problem.initial_position)
     if flat_reference.size == 0:
         raise ValueError("Flow NUTS requires at least one scalar parameter.")

--- a/phydrax/uq/_mcmc.py
+++ b/phydrax/uq/_mcmc.py
@@ -17,6 +17,15 @@ from jaxtyping import Array, PyTree
 
 from .._frozendict import frozendict
 from .._strict import StrictModule
+from ._chain import (
+    _prepare_chain_positions,
+    _split_chain_keys,
+    _stack_trees,
+    _tree_nbytes,
+    _unstack_tree,
+    _validate_chain_method,
+    ChainMethod,
+)
 from ._checkpoint import (
     checkpoint_compatibility,
     CheckpointCorruptionError,
@@ -37,9 +46,6 @@ from ._posterior_predictive import (
     sample_observations_from_position_samples,
 )
 from ._predictive import PredictiveField
-
-
-ChainMethod = Literal["sequential", "vectorized"]
 
 
 class MCMCChainWarmup(StrictModule):
@@ -361,13 +367,7 @@ def _sample_mcmc(
     initial_step = float(initial_step_size)
     if initial_step <= 0.0:
         raise ValueError("initial_step_size must be positive.")
-    method: ChainMethod = chain_method
-    if method not in ("sequential", "vectorized"):
-        raise ValueError("chain_method must be 'sequential' or 'vectorized'.")
-    if initial_position is not None and initial_positions is not None:
-        raise ValueError(
-            "initial_position and initial_positions cannot both be supplied."
-        )
+    method = _validate_chain_method(chain_method)
     if resume_from is not None and (
         initial_position is not None or initial_positions is not None
     ):
@@ -389,41 +389,17 @@ def _sample_mcmc(
     if destination is not None and (checkpoint_id is None or not str(checkpoint_id)):
         raise ValueError("checkpoint_id is required for MCMC checkpointing.")
 
+    position, chain_positions = _prepare_chain_positions(
+        problem.initial_position,
+        num_chains=chains,
+        initial_position=initial_position,
+        initial_positions=initial_positions,
+    )
     if initial_positions is None:
-        position = (
-            problem.initial_position if initial_position is None else initial_position
-        )
         problem.parameter_space.constrain(position)
         value, gradient = jax.value_and_grad(problem.log_density)(position)
-        chain_positions = jax.tree_util.tree_map(
-            lambda leaf: jnp.broadcast_to(leaf, (chains, *leaf.shape)),
-            position,
-        )
         values = value
     else:
-        position = problem.initial_position
-        if jax.tree_util.tree_structure(
-            initial_positions
-        ) != jax.tree_util.tree_structure(problem.initial_position):
-            raise ValueError(
-                "initial_positions must have the ParameterSpace initial PyTree structure."
-            )
-        reference_leaves = jax.tree_util.tree_leaves(problem.initial_position)
-        position_leaves = jax.tree_util.tree_leaves(initial_positions)
-        for position_leaf, reference_leaf in zip(
-            position_leaves,
-            reference_leaves,
-            strict=True,
-        ):
-            if not eqx.is_inexact_array(position_leaf):
-                raise TypeError("Every initial_positions leaf must be an inexact array.")
-            expected_shape = (chains, *reference_leaf.shape)
-            if position_leaf.shape != expected_shape:
-                raise ValueError(
-                    "Every initial_positions leaf must have shape "
-                    f"{expected_shape}; received {position_leaf.shape}."
-                )
-        chain_positions = jax.tree_util.tree_map(jnp.asarray, initial_positions)
         values, gradient = jax.vmap(jax.value_and_grad(problem.log_density))(
             chain_positions
         )
@@ -433,8 +409,7 @@ def _sample_mcmc(
     ):
         raise FloatingPointError("Initial MCMC log density and gradient must be finite.")
 
-    root_key = jnp.asarray(key)
-    chain_keys = jr.split(root_key, chains)
+    root_key, chain_keys = _split_chain_keys(key, chains)
     split_keys = jax.vmap(lambda chain_key: jr.split(chain_key, 2))(chain_keys)
     warmup_keys = split_keys[:, 0]
     sample_keys = split_keys[:, 1]
@@ -986,18 +961,6 @@ def _empty_sample_tree(position, chains):
     )
 
 
-def _stack_trees(values):
-    return jax.tree_util.tree_map(lambda *leaves: jnp.stack(leaves), *values)
-
-
-def _unstack_tree(tree, count):
-    return tuple(
-        jax.tree_util.tree_map(lambda value: value[index], tree) for index in range(count)
-    )
-
-
-def _tree_nbytes(tree: PyTree[Any], /) -> int:
-    return sum(int(jnp.asarray(leaf).nbytes) for leaf in jax.tree_util.tree_leaves(tree))
 
 
 __all__ = [

--- a/phydrax/uq/_minibatch_diagnostics.py
+++ b/phydrax/uq/_minibatch_diagnostics.py
@@ -1,0 +1,301 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array, PyTree
+
+from .._strict import StrictModule
+from ._minibatch_posterior import MinibatchPosteriorProblem, MinibatchSource
+from ._posterior_diagnostics import _nonfinite_locations, _tree_allclose
+
+
+class MinibatchPosteriorCapabilities(StrictModule):
+    """Static primitives available to stochastic-gradient inference."""
+
+    factorized_prior: bool = eqx.field(static=True)
+    automatic_prior_sampling: bool = eqx.field(static=True)
+    prediction: bool = eqx.field(static=True)
+    observation_variance: bool = eqx.field(static=True)
+    observation_sampling: bool = eqx.field(static=True)
+    full_log_density: bool = eqx.field(static=True)
+    control_variates: bool = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        factorized_prior: bool,
+        prediction: bool,
+        observation_variance: bool,
+        observation_sampling: bool,
+        full_log_density: bool,
+    ):
+        has_factorized_prior = bool(factorized_prior)
+        has_full_density = bool(full_log_density)
+        self.factorized_prior = has_factorized_prior
+        self.automatic_prior_sampling = has_factorized_prior
+        self.prediction = bool(prediction)
+        self.observation_variance = bool(observation_variance)
+        self.observation_sampling = bool(observation_sampling)
+        self.full_log_density = has_full_density
+        self.control_variates = True
+
+    def as_dict(self) -> dict[str, bool]:
+        return {
+            "factorized_prior": self.factorized_prior,
+            "automatic_prior_sampling": self.automatic_prior_sampling,
+            "prediction": self.prediction,
+            "observation_variance": self.observation_variance,
+            "observation_sampling": self.observation_sampling,
+            "full_log_density": self.full_log_density,
+            "control_variates": self.control_variates,
+        }
+
+
+class MinibatchPosteriorDiagnostics(StrictModule):
+    """Factor, source, stochastic-gradient, and optional full-density checks."""
+
+    capabilities: MinibatchPosteriorCapabilities
+    initial_log_density_estimate: Array
+    epoch_log_density: Array
+    stochastic_gradient_norm: Array
+    epoch_gradient_norm: Array
+    epoch_active_factor_count: int = eqx.field(static=True)
+    source_fingerprint: str = eqx.field(static=True)
+    nonfinite_gradient_locations: tuple[str, ...] = eqx.field(static=True)
+    repeated_evaluation_matches: bool = eqx.field(static=True)
+    jit_evaluation_matches: bool = eqx.field(static=True)
+    source_population_matches: bool = eqx.field(static=True)
+    epoch_factor_count_matches: bool = eqx.field(static=True)
+    full_log_density_matches: bool | None = eqx.field(static=True)
+    full_gradient_matches: bool | None = eqx.field(static=True)
+    failures: tuple[str, ...] = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        capabilities: MinibatchPosteriorCapabilities,
+        initial_log_density_estimate: Array,
+        epoch_log_density: Array,
+        stochastic_gradient_norm: Array,
+        epoch_gradient_norm: Array,
+        epoch_active_factor_count: int,
+        source_fingerprint: str,
+        nonfinite_gradient_locations: tuple[str, ...],
+        repeated_evaluation_matches: bool,
+        jit_evaluation_matches: bool,
+        source_population_matches: bool,
+        epoch_factor_count_matches: bool,
+        full_log_density_matches: bool | None,
+        full_gradient_matches: bool | None,
+        failures: tuple[str, ...],
+    ):
+        self.capabilities = capabilities
+        self.initial_log_density_estimate = jnp.asarray(initial_log_density_estimate)
+        self.epoch_log_density = jnp.asarray(epoch_log_density)
+        self.stochastic_gradient_norm = jnp.asarray(stochastic_gradient_norm)
+        self.epoch_gradient_norm = jnp.asarray(epoch_gradient_norm)
+        self.epoch_active_factor_count = int(epoch_active_factor_count)
+        self.source_fingerprint = str(source_fingerprint)
+        self.nonfinite_gradient_locations = tuple(nonfinite_gradient_locations)
+        self.repeated_evaluation_matches = bool(repeated_evaluation_matches)
+        self.jit_evaluation_matches = bool(jit_evaluation_matches)
+        self.source_population_matches = bool(source_population_matches)
+        self.epoch_factor_count_matches = bool(epoch_factor_count_matches)
+        self.full_log_density_matches = full_log_density_matches
+        self.full_gradient_matches = full_gradient_matches
+        self.failures = tuple(failures)
+
+    @property
+    def passed(self) -> bool:
+        return not self.failures
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "passed": self.passed,
+            "failures": self.failures,
+            "initial_log_density_estimate": float(self.initial_log_density_estimate),
+            "epoch_log_density": float(self.epoch_log_density),
+            "stochastic_gradient_norm": float(self.stochastic_gradient_norm),
+            "epoch_gradient_norm": float(self.epoch_gradient_norm),
+            "epoch_active_factor_count": self.epoch_active_factor_count,
+            "source_fingerprint": self.source_fingerprint,
+            "nonfinite_gradient_locations": self.nonfinite_gradient_locations,
+            "repeated_evaluation_matches": self.repeated_evaluation_matches,
+            "jit_evaluation_matches": self.jit_evaluation_matches,
+            "source_population_matches": self.source_population_matches,
+            "epoch_factor_count_matches": self.epoch_factor_count_matches,
+            "full_log_density_matches": self.full_log_density_matches,
+            "full_gradient_matches": self.full_gradient_matches,
+            "capabilities": self.capabilities.as_dict(),
+        }
+
+
+def diagnose_minibatch_posterior(
+    problem: MinibatchPosteriorProblem,
+    source: MinibatchSource,
+    /,
+    *,
+    rtol: float = 1e-6,
+    atol: float = 1e-7,
+) -> MinibatchPosteriorDiagnostics:
+    """Validate factor scaling and source identity before SG-MCMC compilation."""
+    if not isinstance(problem, MinibatchPosteriorProblem):
+        raise TypeError("problem must be a MinibatchPosteriorProblem.")
+    if not isinstance(source, MinibatchSource):
+        raise TypeError("source must implement MinibatchSource.")
+    relative_tolerance = float(rtol)
+    absolute_tolerance = float(atol)
+    if relative_tolerance < 0.0 or absolute_tolerance < 0.0:
+        raise ValueError("rtol and atol cannot be negative.")
+    if not source.fingerprint:
+        raise ValueError("source fingerprint must be non-empty.")
+    json.dumps(source.configuration(), allow_nan=False, sort_keys=True)
+
+    batches = tuple(source.epoch(0))
+    if len(batches) != int(source.batches_per_epoch):
+        raise ValueError("source epoch length does not match batches_per_epoch.")
+    if not batches:
+        raise ValueError("source epochs must contain at least one batch.")
+    if any(batch.capacity != int(source.batch_capacity) for batch in batches):
+        raise ValueError("source emitted a batch with incompatible capacity.")
+
+    position = problem.initial_position
+    first_batch = batches[0]
+    value_and_grad = jax.value_and_grad(problem.log_density_estimate)
+    initial_value, stochastic_gradient = value_and_grad(position, first_batch)
+    repeated_value, repeated_gradient = value_and_grad(position, first_batch)
+    compiled_value, compiled_gradient = eqx.filter_jit(
+        lambda current, current_batch: jax.value_and_grad(
+            problem.log_density_estimate
+        )(current, current_batch)
+    )(position, first_batch)
+
+    def epoch_log_density(current: PyTree[Any]) -> Array:
+        physical = problem.parameter_space.constrain(current)
+        likelihood = sum(
+            (
+                jnp.sum(problem.log_likelihood_factors(physical, batch))
+                for batch in batches
+            ),
+            jnp.zeros((), dtype=float),
+        )
+        return (
+            likelihood
+            + problem.parameter_space.log_prior(physical)
+            + problem.parameter_space.log_abs_det_jacobian(current)
+        )
+
+    epoch_value, epoch_gradient = jax.value_and_grad(epoch_log_density)(position)
+    active_count = sum(int(batch.factor_count) for batch in batches)
+    repeated_matches = bool(jnp.array_equal(initial_value, repeated_value)) and (
+        _tree_allclose(stochastic_gradient, repeated_gradient, rtol=0.0, atol=0.0)
+    )
+    jit_matches = bool(
+        jnp.allclose(
+            initial_value,
+            compiled_value,
+            rtol=relative_tolerance,
+            atol=absolute_tolerance,
+        )
+    ) and _tree_allclose(
+        stochastic_gradient,
+        compiled_gradient,
+        rtol=relative_tolerance,
+        atol=absolute_tolerance,
+    )
+    source_population_matches = int(source.num_factors) == problem.num_factors
+    epoch_factor_count_matches = active_count == problem.num_factors
+
+    full_value_matches = None
+    full_gradient_matches = None
+    if problem.full_log_likelihood_fn is not None:
+        full_value, full_gradient = jax.value_and_grad(problem.full_log_density)(position)
+        full_value_matches = bool(
+            jnp.allclose(
+                epoch_value,
+                full_value,
+                rtol=relative_tolerance,
+                atol=absolute_tolerance,
+            )
+        )
+        full_gradient_matches = _tree_allclose(
+            epoch_gradient,
+            full_gradient,
+            rtol=relative_tolerance,
+            atol=absolute_tolerance,
+        )
+
+    nonfinite_gradient_locations = _nonfinite_locations(stochastic_gradient)
+    stochastic_gradient_norm = _tree_l2_norm(stochastic_gradient)
+    epoch_gradient_norm = _tree_l2_norm(epoch_gradient)
+    capabilities = MinibatchPosteriorCapabilities(
+        factorized_prior=problem.parameter_space.priors is not None,
+        prediction=problem.predict_fn is not None,
+        observation_variance=problem.observation_variance_fn is not None,
+        observation_sampling=problem.sample_observation_fn is not None,
+        full_log_density=problem.full_log_likelihood_fn is not None,
+    )
+    failures: list[str] = []
+    if not bool(jnp.isfinite(initial_value)):
+        failures.append("initial_log_density_estimate_nonfinite")
+    if nonfinite_gradient_locations:
+        failures.append("initial_stochastic_gradient_nonfinite")
+    if not repeated_matches:
+        failures.append("repeated_evaluation_mismatch")
+    if not jit_matches:
+        failures.append("jit_evaluation_mismatch")
+    if not source_population_matches:
+        failures.append("source_population_mismatch")
+    if not epoch_factor_count_matches:
+        failures.append("epoch_factor_count_mismatch")
+    if not bool(jnp.isfinite(epoch_value)) or _nonfinite_locations(epoch_gradient):
+        failures.append("epoch_density_or_gradient_nonfinite")
+    if full_value_matches is False:
+        failures.append("full_log_density_mismatch")
+    if full_gradient_matches is False:
+        failures.append("full_gradient_mismatch")
+
+    return MinibatchPosteriorDiagnostics(
+        capabilities=capabilities,
+        initial_log_density_estimate=initial_value,
+        epoch_log_density=epoch_value,
+        stochastic_gradient_norm=stochastic_gradient_norm,
+        epoch_gradient_norm=epoch_gradient_norm,
+        epoch_active_factor_count=active_count,
+        source_fingerprint=source.fingerprint,
+        nonfinite_gradient_locations=nonfinite_gradient_locations,
+        repeated_evaluation_matches=repeated_matches,
+        jit_evaluation_matches=jit_matches,
+        source_population_matches=source_population_matches,
+        epoch_factor_count_matches=epoch_factor_count_matches,
+        full_log_density_matches=full_value_matches,
+        full_gradient_matches=full_gradient_matches,
+        failures=tuple(failures),
+    )
+
+
+def _tree_l2_norm(tree: PyTree[Any], /) -> Array:
+    return jnp.sqrt(
+        sum(
+            (
+                jnp.sum(jnp.asarray(leaf, dtype=float) ** 2)
+                for leaf in jax.tree_util.tree_leaves(tree)
+            ),
+            jnp.zeros((), dtype=float),
+        )
+    )
+
+
+__all__ = [
+    "diagnose_minibatch_posterior",
+    "MinibatchPosteriorCapabilities",
+    "MinibatchPosteriorDiagnostics",
+]

--- a/phydrax/uq/_minibatch_posterior.py
+++ b/phydrax/uq/_minibatch_posterior.py
@@ -1,0 +1,349 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Callable, Iterator, Mapping
+from math import ceil
+from typing import Any, Protocol, runtime_checkable
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jaxtyping import Array, ArrayLike, PyTree
+
+from .._strict import StrictModule
+from ._checkpoint import array_tree_fingerprint
+from ._posterior import ParameterSpace
+
+
+class LikelihoodBatch(StrictModule):
+    """Fixed-capacity likelihood data and its active-factor mask."""
+
+    data: PyTree[Any]
+    factor_mask: Array
+
+    def __init__(self, data: PyTree[Any], factor_mask: ArrayLike, /):
+        mask = jnp.asarray(factor_mask)
+        if mask.ndim != 1:
+            raise ValueError("factor_mask must be one-dimensional.")
+        if mask.dtype != jnp.bool_:
+            raise TypeError("factor_mask must have boolean dtype.")
+        if mask.shape[0] == 0:
+            raise ValueError("factor_mask must have positive capacity.")
+        if not bool(jnp.any(mask)):
+            raise ValueError("LikelihoodBatch must contain at least one active factor.")
+        self.data = data
+        self.factor_mask = mask
+
+    @property
+    def capacity(self) -> int:
+        return int(self.factor_mask.shape[0])
+
+    @property
+    def factor_count(self) -> Array:
+        return jnp.sum(self.factor_mask, dtype=jnp.int32)
+
+
+@runtime_checkable
+class MinibatchSource(Protocol):
+    """Deterministic, finite sequence of uniformly sampled likelihood batches."""
+
+    @property
+    def num_factors(self) -> int: ...
+
+    @property
+    def batch_capacity(self) -> int: ...
+
+    @property
+    def batches_per_epoch(self) -> int: ...
+
+    @property
+    def fingerprint(self) -> str: ...
+
+    def configuration(self) -> Mapping[str, Any]: ...
+
+    def epoch(self, epoch: int, /) -> Iterator[LikelihoodBatch]: ...
+
+
+class ArrayMinibatchSource(StrictModule):
+    """Deterministic shuffled epochs over array PyTrees with padded remainders."""
+
+    data: PyTree[Array]
+    _num_factors: int = eqx.field(static=True)
+    _batch_capacity: int = eqx.field(static=True)
+    _seed: int = eqx.field(static=True)
+    _batches_per_epoch: int = eqx.field(static=True)
+    _configuration_json: str = eqx.field(static=True)
+    _fingerprint: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        data: PyTree[ArrayLike],
+        /,
+        *,
+        batch_size: int,
+        seed: int = 0,
+    ):
+        leaves = jax.tree_util.tree_leaves(data)
+        if not leaves:
+            raise ValueError("ArrayMinibatchSource data must contain array leaves.")
+        arrays = jax.tree_util.tree_map(jnp.asarray, data)
+        array_leaves = jax.tree_util.tree_leaves(arrays)
+        population = int(array_leaves[0].shape[0]) if array_leaves[0].ndim else 0
+        if population <= 0:
+            raise ValueError("Every source data leaf needs a positive leading axis.")
+        for leaf in array_leaves:
+            if leaf.ndim == 0 or int(leaf.shape[0]) != population:
+                raise ValueError(
+                    "Every source data leaf must share the positive factor-leading axis."
+                )
+        capacity = int(batch_size)
+        if capacity <= 0:
+            raise ValueError("batch_size must be positive.")
+        source_seed = int(seed)
+        if source_seed < 0:
+            raise ValueError("seed must be nonnegative.")
+        batches = ceil(population / capacity)
+        configuration = {
+            "type": f"{type(self).__module__}.{type(self).__qualname__}",
+            "num_factors": population,
+            "batch_size": capacity,
+            "seed": source_seed,
+            "data": array_tree_fingerprint(arrays),
+        }
+        configuration_json = json.dumps(
+            configuration,
+            allow_nan=False,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        self.data = arrays
+        self._num_factors = population
+        self._batch_capacity = capacity
+        self._seed = source_seed
+        self._batches_per_epoch = batches
+        self._configuration_json = configuration_json
+        self._fingerprint = hashlib.sha256(configuration_json.encode("utf-8")).hexdigest()
+
+    @property
+    def num_factors(self) -> int:
+        return self._num_factors
+
+    @property
+    def batch_capacity(self) -> int:
+        return self._batch_capacity
+
+    @property
+    def batches_per_epoch(self) -> int:
+        return self._batches_per_epoch
+
+    @property
+    def fingerprint(self) -> str:
+        return self._fingerprint
+
+    def configuration(self) -> Mapping[str, Any]:
+        return json.loads(self._configuration_json)
+
+    def epoch(self, epoch: int, /) -> Iterator[LikelihoodBatch]:
+        epoch_index = int(epoch)
+        if epoch_index < 0:
+            raise ValueError("epoch must be nonnegative.")
+        generator = np.random.default_rng(
+            np.random.SeedSequence((self._seed, epoch_index))
+        )
+        permutation = generator.permutation(self._num_factors)
+        for start in range(0, self._num_factors, self._batch_capacity):
+            active_indices = permutation[start : start + self._batch_capacity]
+            active_count = int(active_indices.size)
+            if active_count < self._batch_capacity:
+                padded_indices = np.empty(self._batch_capacity, dtype=permutation.dtype)
+                padded_indices[:active_count] = active_indices
+                padded_indices[active_count:] = active_indices[-1]
+            else:
+                padded_indices = active_indices
+            batch_indices = jnp.asarray(padded_indices)
+            batch_data = jax.tree_util.tree_map(
+                lambda leaf: leaf[batch_indices],
+                self.data,
+            )
+            factor_mask = jnp.arange(self._batch_capacity) < active_count
+            yield LikelihoodBatch(batch_data, factor_mask)
+
+
+class MinibatchPosteriorProblem(StrictModule):
+    """Factorized posterior with unbiased minibatch likelihood estimators."""
+
+    parameter_space: ParameterSpace
+    log_likelihood_factors_fn: Callable[[PyTree[Any], LikelihoodBatch], ArrayLike]
+    num_factors: int = eqx.field(static=True)
+    full_log_likelihood_fn: Callable[[PyTree[Any]], ArrayLike] | None = eqx.field(
+        static=True
+    )
+    predict_fn: Callable[..., Any] | None = eqx.field(static=True)
+    observation_variance_fn: Callable[..., Any] | None = eqx.field(static=True)
+    sample_observation_fn: Callable[..., Any] | None = eqx.field(static=True)
+
+    def __init__(
+        self,
+        parameter_space: ParameterSpace,
+        log_likelihood_factors: Callable[
+            [PyTree[Any], LikelihoodBatch], ArrayLike
+        ],
+        /,
+        *,
+        num_factors: int,
+        full_log_likelihood: Callable[[PyTree[Any]], ArrayLike] | None = None,
+        predict: Callable[..., Any] | None = None,
+        observation_variance: Callable[..., Any] | None = None,
+        sample_observation: Callable[..., Any] | None = None,
+    ):
+        if not isinstance(parameter_space, ParameterSpace):
+            raise TypeError("parameter_space must be a ParameterSpace.")
+        if not callable(log_likelihood_factors):
+            raise TypeError("log_likelihood_factors must be callable.")
+        count = int(num_factors)
+        if count <= 0:
+            raise ValueError("num_factors must be positive.")
+        for name, function in (
+            ("full_log_likelihood", full_log_likelihood),
+            ("predict", predict),
+            ("observation_variance", observation_variance),
+            ("sample_observation", sample_observation),
+        ):
+            if function is not None and not callable(function):
+                raise TypeError(f"{name} must be callable or None.")
+        self.parameter_space = parameter_space
+        self.log_likelihood_factors_fn = log_likelihood_factors
+        self.num_factors = count
+        self.full_log_likelihood_fn = full_log_likelihood
+        self.predict_fn = predict
+        self.observation_variance_fn = observation_variance
+        self.sample_observation_fn = sample_observation
+
+    @property
+    def initial_position(self) -> PyTree[Any]:
+        return self.parameter_space.initial
+
+    def log_likelihood_factors(
+        self,
+        physical: PyTree[Any],
+        batch: LikelihoodBatch,
+        /,
+    ) -> Array:
+        if not isinstance(batch, LikelihoodBatch):
+            raise TypeError("batch must be a LikelihoodBatch.")
+        factors = jnp.asarray(
+            self.log_likelihood_factors_fn(physical, batch),
+            dtype=float,
+        )
+        if factors.ndim != 1 or factors.shape != batch.factor_mask.shape:
+            raise ValueError(
+                "log_likelihood_factors must return one scalar per batch capacity."
+            )
+        return jnp.where(batch.factor_mask, factors, jnp.zeros_like(factors))
+
+    def log_likelihood_estimate(
+        self,
+        physical: PyTree[Any],
+        batch: LikelihoodBatch,
+        /,
+    ) -> Array:
+        factors = self.log_likelihood_factors(physical, batch)
+        active_count = jnp.sum(batch.factor_mask, dtype=factors.dtype)
+        return jnp.asarray(self.num_factors, dtype=factors.dtype) * (
+            jnp.sum(factors) / active_count
+        )
+
+    def log_density_estimate(
+        self,
+        position: PyTree[Any],
+        batch: LikelihoodBatch,
+        /,
+    ) -> Array:
+        physical = self.parameter_space.constrain(position)
+        return (
+            self.log_likelihood_estimate(physical, batch)
+            + self.parameter_space.log_prior(physical)
+            + self.parameter_space.log_abs_det_jacobian(position)
+        )
+
+    def full_log_likelihood(self, physical: PyTree[Any], /) -> Array:
+        if self.full_log_likelihood_fn is None:
+            raise ValueError(
+                "MinibatchPosteriorProblem has no full log-likelihood function."
+            )
+        value = jnp.asarray(self.full_log_likelihood_fn(physical), dtype=float)
+        if value.ndim != 0:
+            raise ValueError("full_log_likelihood must return a scalar.")
+        return value
+
+    def full_log_density(self, position: PyTree[Any], /) -> Array:
+        physical = self.parameter_space.constrain(position)
+        return (
+            self.full_log_likelihood(physical)
+            + self.parameter_space.log_prior(physical)
+            + self.parameter_space.log_abs_det_jacobian(position)
+        )
+
+    def predict(self, position: PyTree[Any], /, *args: Any, **kwargs: Any) -> Any:
+        if self.predict_fn is None:
+            raise ValueError("MinibatchPosteriorProblem has no prediction function.")
+        physical = self.parameter_space.constrain(position)
+        return self.predict_fn(physical, *args, **kwargs)
+
+    def conditional_observation_variance(
+        self,
+        position: PyTree[Any],
+        /,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        if self.observation_variance_fn is None:
+            raise ValueError(
+                "MinibatchPosteriorProblem has no observation-variance function."
+            )
+        physical = self.parameter_space.constrain(position)
+        return self.observation_variance_fn(physical, *args, **kwargs)
+
+    def sample_observation(
+        self,
+        key: Any,
+        position: PyTree[Any],
+        /,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        if self.sample_observation_fn is None:
+            raise ValueError(
+                "MinibatchPosteriorProblem has no observation-sampling function."
+            )
+        physical = self.parameter_space.constrain(position)
+        return self.sample_observation_fn(key, physical, *args, **kwargs)
+
+    def validate(self, batch: LikelihoodBatch, /) -> tuple[Array, PyTree[Any]]:
+        value, gradient = jax.value_and_grad(self.log_density_estimate)(
+            self.initial_position,
+            batch,
+        )
+        if value.ndim != 0 or not bool(jnp.isfinite(value)):
+            raise FloatingPointError("Initial stochastic log density must be finite.")
+        if any(
+            bool(jnp.any(~jnp.isfinite(jnp.asarray(leaf))))
+            for leaf in jax.tree_util.tree_leaves(gradient)
+        ):
+            raise FloatingPointError("Initial stochastic gradient must be finite.")
+        return value, gradient
+
+
+__all__ = [
+    "ArrayMinibatchSource",
+    "LikelihoodBatch",
+    "MinibatchPosteriorProblem",
+    "MinibatchSource",
+]

--- a/phydrax/uq/_operator_likelihood.py
+++ b/phydrax/uq/_operator_likelihood.py
@@ -4,21 +4,28 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping
+import hashlib
+import json
+from collections.abc import Callable, Iterator, Mapping
 from typing import Any
 
 import coordax as cx
 import equinox as eqx
+import jax
 import jax.numpy as jnp
 from jaxtyping import Array, ArrayLike, PyTree
 
+from .._strict import StrictModule
 from ..nn.models.core._operator import (
     FunctionSamples,
     OperatorBatch,
     OperatorOutputSpec,
     OperatorPrediction,
 )
+from ..nn.operator_training._loader import OperatorBatchLoader
+from ._checkpoint import array_tree_fingerprint
 from ._likelihoods import AbstractLikelihood, GaussianLikelihood
+from ._minibatch_posterior import LikelihoodBatch
 from ._operator import (
     _broadcast_named,
     _output_mask,
@@ -27,6 +34,292 @@ from ._operator import (
     _select_prediction_field,
 )
 from ._posterior_terms import AbstractPosteriorTerm
+
+
+class OperatorLikelihoodData(StrictModule):
+    """One operator batch with aligned targets and finite-observation masks."""
+
+    batch: OperatorBatch
+    target: Array
+    output_spec: OperatorOutputSpec
+    observation_mask: Array
+    case_count: int = eqx.field(static=True)
+    field_name: str = eqx.field(static=True)
+    query_name: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        batch: OperatorBatch,
+        target: ArrayLike | cx.Field | OperatorPrediction,
+        /,
+        *,
+        output_spec: OperatorOutputSpec,
+        field_name: str,
+        query_name: str,
+        observation_mask: ArrayLike | cx.Field | None = None,
+    ):
+        if not isinstance(batch, OperatorBatch):
+            raise TypeError("batch must be an OperatorBatch.")
+        if not isinstance(output_spec, OperatorOutputSpec):
+            raise TypeError("output_spec must be an OperatorOutputSpec.")
+        selected_query_name = str(query_name)
+        selected_field_name = str(field_name)
+        if not selected_query_name or not selected_field_name:
+            raise ValueError("field_name and query_name must be non-empty.")
+        query = batch.query(selected_query_name)
+        expected_shape = (
+            batch.case_shape + query.sample_shape + output_spec.channel_shape
+        )
+        physical_dims = _physical_dims(query, output_spec, batch.case_axes)
+        target_array = _target_array(
+            target,
+            batch=batch,
+            query=query,
+            field_name=selected_field_name,
+            output_spec=output_spec,
+            expected_shape=expected_shape,
+            physical_dims=physical_dims,
+        )
+        combined_mask = _output_mask(
+            query, output_spec, batch.case_shape
+        ) & _observation_mask(
+            observation_mask,
+            expected_shape=expected_shape,
+            physical_dims=physical_dims,
+            has_channels=output_spec.channels != "scalar",
+        )
+        count = _case_count(batch.case_shape)
+        if bool(
+            jnp.any(~jnp.any(combined_mask.reshape((count, -1)), axis=-1))
+        ):
+            raise ValueError(
+                "Every physical operator case must contain at least one observation."
+            )
+        if bool(jnp.any(~jnp.isfinite(target_array) & combined_mask)):
+            raise ValueError("Observed operator targets must be finite.")
+        self.batch = batch
+        self.target = jnp.where(combined_mask, target_array, 0.0)
+        self.output_spec = output_spec
+        self.observation_mask = combined_mask
+        self.case_count = count
+        self.field_name = selected_field_name
+        self.query_name = selected_query_name
+
+
+class OperatorBatchObservationLikelihood(StrictModule):
+    """Per-case normalized likelihood for dynamically supplied operator batches."""
+
+    likelihood: AbstractLikelihood
+    predict_fn: Callable[
+        [PyTree[Any], OperatorBatch], OperatorPrediction
+    ] = eqx.field(static=True)
+    parameters_fn: Callable[
+        [PyTree[Any]], Mapping[str, ArrayLike | cx.Field]
+    ] | None = eqx.field(static=True)
+    label: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        predict: Callable[[PyTree[Any], OperatorBatch], OperatorPrediction],
+        likelihood: AbstractLikelihood,
+        /,
+        *,
+        parameters: Callable[
+            [PyTree[Any]], Mapping[str, ArrayLike | cx.Field]
+        ] | None = None,
+        label: str = "operator_observation",
+    ):
+        if not callable(predict):
+            raise TypeError("predict must be callable.")
+        if not isinstance(likelihood, AbstractLikelihood):
+            raise TypeError("likelihood must implement AbstractLikelihood.")
+        if parameters is not None and not callable(parameters):
+            raise TypeError("parameters must be callable or None.")
+        self.likelihood = likelihood
+        self.predict_fn = predict
+        self.parameters_fn = parameters
+        self.label = _label(label)
+
+    def _likelihood_parameters(
+        self, parameters: PyTree[Any], /
+    ) -> dict[str, Array]:
+        return _likelihood_parameter_values(self.parameters_fn, parameters)
+
+    def per_case_log_prob(
+        self,
+        parameters: PyTree[Any],
+        data: OperatorLikelihoodData,
+        /,
+    ) -> Array:
+        if not isinstance(data, OperatorLikelihoodData):
+            raise TypeError("data must be OperatorLikelihoodData.")
+        prediction = _validated_operator_prediction(
+            self.predict_fn(parameters, data.batch),
+            batch=data.batch,
+            target=data.target,
+            output_spec=data.output_spec,
+            field_name=data.field_name,
+            query_name=data.query_name,
+        )
+        return _operator_per_case_log_prob(
+            prediction,
+            target=data.target,
+            observation_mask=data.observation_mask,
+            likelihood=self.likelihood,
+            likelihood_parameters=self._likelihood_parameters(parameters),
+            case_count=data.case_count,
+        )
+
+    def __call__(
+        self,
+        parameters: PyTree[Any],
+        batch: LikelihoodBatch,
+        /,
+    ) -> Array:
+        if not isinstance(batch, LikelihoodBatch):
+            raise TypeError("batch must be a LikelihoodBatch.")
+        factors = self.per_case_log_prob(parameters, batch.data)
+        if factors.shape != batch.factor_mask.shape:
+            raise ValueError(
+                "Operator likelihood factors and batch factor_mask must align."
+            )
+        return jnp.where(batch.factor_mask, factors, jnp.zeros_like(factors))
+
+
+class OperatorMinibatchSource:
+    """Padded deterministic likelihood batches adapted from operator training data."""
+
+    def __init__(
+        self,
+        loader: OperatorBatchLoader,
+        /,
+        *,
+        field_name: str,
+        observation_mask: ArrayLike | None = None,
+    ):
+        if not isinstance(loader, OperatorBatchLoader):
+            raise TypeError("loader must be an OperatorBatchLoader.")
+        if loader.drop_last:
+            raise ValueError("Operator SG-MCMC does not permit drop_last=True.")
+        if not loader.shuffle:
+            raise ValueError("Operator SG-MCMC requires shuffle=True.")
+        if loader.sampling is not None:
+            raise ValueError(
+                "Operator SG-MCMC requires complete fixed anchor and query data."
+            )
+        if jax.process_count() != 1:
+            raise ValueError("Operator SG-MCMC currently requires one JAX process.")
+        selected_field_name = str(field_name)
+        if not selected_field_name:
+            raise ValueError("field_name must be non-empty.")
+        first = loader.prepare_indices((0,), epoch=0, batch_index=0)
+        field = first.targets.field(selected_field_name)
+        mask = None if observation_mask is None else jnp.asarray(
+            observation_mask, dtype=bool
+        )
+        if mask is not None and (
+            mask.ndim == 0 or int(mask.shape[0]) != loader.source.size
+        ):
+            raise ValueError(
+                "observation_mask must have the source case axis in front."
+            )
+        loader_fingerprint = loader.source_fingerprint()
+        configuration = {
+            "type": f"{type(self).__module__}.{type(self).__qualname__}",
+            "loader": loader.configuration(),
+            "loader_source_fingerprint": loader_fingerprint,
+            "field_name": selected_field_name,
+            "query_name": field.query_name,
+            "output_spec": {
+                "channels": field.spec.channels,
+                "component_names": list(field.spec.component_names),
+            },
+            "observation_mask": (
+                None if mask is None else array_tree_fingerprint(mask)
+            ),
+        }
+        configuration_json = json.dumps(
+            configuration,
+            allow_nan=False,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        self.loader = loader
+        self.field_name = selected_field_name
+        self.query_name = field.query_name
+        self.output_spec = field.spec
+        self.observation_mask = mask
+        self._configuration_json = configuration_json
+        self._fingerprint = hashlib.sha256(
+            configuration_json.encode("utf-8")
+        ).hexdigest()
+
+    @property
+    def num_factors(self) -> int:
+        return int(self.loader.source.size)
+
+    @property
+    def batch_capacity(self) -> int:
+        return self.loader.batch_size
+
+    @property
+    def batches_per_epoch(self) -> int:
+        return self.loader.batches_per_epoch
+
+    @property
+    def fingerprint(self) -> str:
+        return self._fingerprint
+
+    def configuration(self) -> Mapping[str, Any]:
+        return json.loads(self._configuration_json)
+
+    def epoch(self, epoch: int, /) -> Iterator[LikelihoodBatch]:
+        epoch_index = int(epoch)
+        if epoch_index < 0:
+            raise ValueError("epoch must be nonnegative.")
+        for batch_index, indices in enumerate(
+            self.loader.indices_for_epoch(epoch_index)
+        ):
+            active_count = len(indices)
+            padded_indices = indices + (indices[-1],) * (
+                self.batch_capacity - active_count
+            )
+            prepared = self.loader.prepare_indices(
+                indices,
+                epoch=epoch_index,
+                batch_index=batch_index,
+            )
+            operator_batch = prepared.batch
+            operator_targets = prepared.targets
+            if active_count < self.batch_capacity:
+                selection = jnp.concatenate(
+                    (
+                        jnp.arange(active_count),
+                        jnp.full(
+                            (self.batch_capacity - active_count,),
+                            active_count - 1,
+                        ),
+                    )
+                )
+                operator_batch = operator_batch.take(selection)
+                operator_targets = operator_targets.take(selection)
+            target_field = operator_targets.field(self.field_name)
+            selected_mask = (
+                None
+                if self.observation_mask is None
+                else self.observation_mask[jnp.asarray(padded_indices)]
+            )
+            data = OperatorLikelihoodData(
+                operator_batch,
+                target_field.values,
+                output_spec=self.output_spec,
+                field_name=self.field_name,
+                query_name=self.query_name,
+                observation_mask=selected_mask,
+            )
+            factor_mask = jnp.arange(self.batch_capacity) < active_count
+            yield LikelihoodBatch(data, factor_mask)
 
 
 class FixedOperatorObservationLikelihood(AbstractPosteriorTerm):
@@ -120,32 +413,14 @@ class FixedOperatorObservationLikelihood(AbstractPosteriorTerm):
         self.query_name = selected_query_name
 
     def _prediction(self, parameters: PyTree[Any], /) -> Array:
-        prediction = self.predict_fn(parameters)
-        if not isinstance(prediction, OperatorPrediction):
-            raise TypeError("Operator likelihood prediction must be OperatorPrediction.")
-        _, field, query = _select_prediction_field(
-            prediction,
-            self.field_name,
-        )
-        if (
-            prediction.case_axes != self.batch.case_axes
-            or prediction.case_shape != self.batch.case_shape
-            or field.spec.channels != self.output_spec.channels
-            or field.spec.component_names != self.output_spec.component_names
-        ):
-            raise ValueError(
-                "Operator likelihood prediction does not match the fixed batch contract."
-            )
-        values = jnp.asarray(field.values, dtype=float)
-        if values.shape != self.target.shape:
-            raise ValueError(
-                f"Operator likelihood prediction must have shape {self.target.shape}; "
-                f"got {values.shape}."
-            )
-        return _checked_query_values(
-            values,
-            query,
-            self.batch.query(self.query_name),
+        return _validated_operator_prediction(
+            self.predict_fn(parameters),
+            batch=self.batch,
+            target=self.target,
+            output_spec=self.output_spec,
+            field_name=self.field_name,
+            query_name=self.query_name,
+            contract="fixed batch",
         )
 
     def _likelihood_parameters(
@@ -153,39 +428,17 @@ class FixedOperatorObservationLikelihood(AbstractPosteriorTerm):
         parameters: PyTree[Any],
         /,
     ) -> dict[str, Array]:
-        if self.parameters_fn is None:
-            return {}
-        values = self.parameters_fn(parameters)
-        if not isinstance(values, Mapping):
-            raise TypeError("Likelihood parameters callback must return a mapping.")
-        return {
-            str(name): jnp.asarray(value.data if isinstance(value, cx.Field) else value)
-            for name, value in values.items()
-        }
+        return _likelihood_parameter_values(self.parameters_fn, parameters)
 
     def per_case_log_prob(self, parameters: PyTree[Any], /) -> Array:
-        prediction = self._prediction(parameters)
-        safe_prediction = jnp.where(self.observation_mask, prediction, 0.0)
-        values = jnp.asarray(
-            self.likelihood.log_prob(
-                safe_prediction,
-                self.target,
-                **self._likelihood_parameters(parameters),
-            ),
-            dtype=float,
+        return _operator_per_case_log_prob(
+            self._prediction(parameters),
+            target=self.target,
+            observation_mask=self.observation_mask,
+            likelihood=self.likelihood,
+            likelihood_parameters=self._likelihood_parameters(parameters),
+            case_count=self.case_count,
         )
-        values = jnp.broadcast_to(values, self.target.shape)
-        invalid_prediction = self.observation_mask & ~jnp.isfinite(prediction)
-        invalid_density = self.observation_mask & (
-            jnp.isnan(values) | jnp.isposinf(values)
-        )
-        elements = jnp.where(self.observation_mask, values, 0.0)
-        elements = jnp.where(
-            invalid_prediction | invalid_density,
-            -jnp.inf,
-            elements,
-        )
-        return jnp.sum(elements.reshape((self.case_count, -1)), axis=-1)
 
     def standardized_residual(self, parameters: PyTree[Any], /) -> Array:
         """Return fixed-Gaussian residuals with masked components set to zero."""
@@ -195,6 +448,93 @@ class FixedOperatorObservationLikelihood(AbstractPosteriorTerm):
         scale = jnp.broadcast_to(self.likelihood.scale, self.target.shape)
         residual = (self.target - prediction) / scale
         return jnp.where(self.observation_mask, residual, 0.0)
+
+
+def _validated_operator_prediction(
+    prediction: OperatorPrediction,
+    /,
+    *,
+    batch: OperatorBatch,
+    target: Array,
+    output_spec: OperatorOutputSpec,
+    field_name: str,
+    query_name: str,
+    contract: str = "batch",
+) -> Array:
+    if not isinstance(prediction, OperatorPrediction):
+        raise TypeError("Operator likelihood prediction must be OperatorPrediction.")
+    _, field, query = _select_prediction_field(prediction, field_name)
+    if (
+        prediction.case_axes != batch.case_axes
+        or prediction.case_shape != batch.case_shape
+        or field.spec.channels != output_spec.channels
+        or field.spec.component_names != output_spec.component_names
+    ):
+        raise ValueError(
+            f"Operator likelihood prediction does not match the {contract} contract."
+        )
+    values = jnp.asarray(field.values, dtype=float)
+    if values.shape != target.shape:
+        raise ValueError(
+            f"Operator likelihood prediction must have shape {target.shape}; "
+            f"got {values.shape}."
+        )
+    return _checked_query_values(
+        values,
+        query,
+        batch.query(query_name),
+    )
+
+
+def _likelihood_parameter_values(
+    callback: Callable[
+        [PyTree[Any]], Mapping[str, ArrayLike | cx.Field]
+    ] | None,
+    parameters: PyTree[Any],
+    /,
+) -> dict[str, Array]:
+    if callback is None:
+        return {}
+    values = callback(parameters)
+    if not isinstance(values, Mapping):
+        raise TypeError("Likelihood parameters callback must return a mapping.")
+    return {
+        str(name): jnp.asarray(value.data if isinstance(value, cx.Field) else value)
+        for name, value in values.items()
+    }
+
+
+def _operator_per_case_log_prob(
+    prediction: Array,
+    /,
+    *,
+    target: Array,
+    observation_mask: Array,
+    likelihood: AbstractLikelihood,
+    likelihood_parameters: Mapping[str, Array],
+    case_count: int,
+) -> Array:
+    safe_prediction = jnp.where(observation_mask, prediction, 0.0)
+    values = jnp.asarray(
+        likelihood.log_prob(
+            safe_prediction,
+            target,
+            **likelihood_parameters,
+        ),
+        dtype=float,
+    )
+    values = jnp.broadcast_to(values, target.shape)
+    invalid_prediction = observation_mask & ~jnp.isfinite(prediction)
+    invalid_density = observation_mask & (
+        jnp.isnan(values) | jnp.isposinf(values)
+    )
+    elements = jnp.where(observation_mask, values, 0.0)
+    elements = jnp.where(
+        invalid_prediction | invalid_density,
+        -jnp.inf,
+        elements,
+    )
+    return jnp.sum(elements.reshape((case_count, -1)), axis=-1)
 
 
 def _target_array(
@@ -322,4 +662,9 @@ def _label(value: str, /) -> str:
     return label
 
 
-__all__ = ["FixedOperatorObservationLikelihood"]
+__all__ = [
+    "FixedOperatorObservationLikelihood",
+    "OperatorBatchObservationLikelihood",
+    "OperatorLikelihoodData",
+    "OperatorMinibatchSource",
+]

--- a/phydrax/uq/_posterior_predictive.py
+++ b/phydrax/uq/_posterior_predictive.py
@@ -14,12 +14,13 @@ import jax.random as jr
 from jaxtyping import Array, PyTree
 
 from .._frozendict import frozendict
+from ._minibatch_posterior import MinibatchPosteriorProblem
 from ._posterior import PosteriorProblem
 from ._predictive import PredictiveField, SampleAxis, UncertaintySource
 
 
 def predict_from_position_samples(
-    problem: PosteriorProblem,
+    problem: PosteriorProblem | MinibatchPosteriorProblem,
     positions: PyTree[Array],
     /,
     *args: Any,
@@ -57,7 +58,7 @@ def predict_from_position_samples(
 
 
 def sample_observations_from_position_samples(
-    problem: PosteriorProblem,
+    problem: PosteriorProblem | MinibatchPosteriorProblem,
     key: Array,
     positions: PyTree[Array],
     /,
@@ -72,7 +73,7 @@ def sample_observations_from_position_samples(
 ) -> PredictiveField | frozendict[str, PredictiveField]:
     """Draw measurement noise while preserving posterior and observation axes."""
     if problem.sample_observation_fn is None:
-        raise ValueError("PosteriorProblem has no observation-sampling function.")
+        raise ValueError("Posterior problem has no observation-sampling function.")
     dimensions, sources = _sample_metadata(sample_dims, sample_sources)
     count = int(num_observation_samples)
     if count <= 0:

--- a/phydrax/uq/_result_export.py
+++ b/phydrax/uq/_result_export.py
@@ -38,6 +38,8 @@ from ._map import MAPResult
 from ._mcmc import MCMCResult
 from ._particle import ParticleFilterResult
 from ._pathfinder import PathfinderResult
+from ._sgmcmc import SGMCMCResult
+from ._sgmcmc_diagnostics import SGMCMCMixingReport
 from ._smc import TemperedSMCResult
 
 
@@ -152,14 +154,16 @@ def read_result_archive(path: str | Path, /) -> UQResultArchive:
     )
 
 
-def to_arviz(result: MCMCResult | FlowNUTSResult, /):
-    """Convert chain-preserving MCMC draws and sampler statistics to ArviZ."""
+def to_arviz(result: MCMCResult | FlowNUTSResult | SGMCMCResult, /):
+    """Convert chain-preserving posterior draws and honest sampler statistics."""
     if isinstance(result, FlowNUTSResult):
-        mcmc_result = result.mcmc
-    elif isinstance(result, MCMCResult):
-        mcmc_result = result
+        chain_result = result.mcmc
+    elif isinstance(result, (MCMCResult, SGMCMCResult)):
+        chain_result = result
     else:
-        raise TypeError("to_arviz supports MCMCResult and FlowNUTSResult only.")
+        raise TypeError(
+            "to_arviz supports MCMCResult, FlowNUTSResult, and SGMCMCResult only."
+        )
     try:
         import arviz as az
     except ImportError as error:  # pragma: no cover - dependency is declared
@@ -168,7 +172,7 @@ def to_arviz(result: MCMCResult | FlowNUTSResult, /):
     posterior: dict[str, np.ndarray] = {}
     dimensions: dict[str, list[str]] = {}
     coordinates: dict[str, np.ndarray] = {}
-    for path, leaf in jax.tree_util.tree_flatten_with_path(mcmc_result.samples)[0]:
+    for path, leaf in jax.tree_util.tree_flatten_with_path(chain_result.samples)[0]:
         path_string = jax.tree_util.keystr(path) or "<root>"
         name = encode_parameter_name(path_string)
         value = np.asarray(leaf)
@@ -180,34 +184,58 @@ def to_arviz(result: MCMCResult | FlowNUTSResult, /):
             coordinates[dimension] = np.arange(size)
         dimensions[name] = parameter_dims
 
-    sample_stats = {
-        "lp": np.asarray(mcmc_result.log_density),
-        "acceptance_rate": np.asarray(mcmc_result.acceptance_rate),
-        "diverging": np.asarray(mcmc_result.divergent),
-        "energy": np.asarray(mcmc_result.energy),
-        "n_steps": np.asarray(mcmc_result.num_integration_steps),
-        "tree_depth": np.asarray(mcmc_result.num_trajectory_expansions),
-    }
-    posterior_attributes = {
-        "phydrax_algorithm": mcmc_result.algorithm,
-        "phydrax_chain_method": mcmc_result.chain_method,
-    }
-    if isinstance(result, FlowNUTSResult):
-        sample_stats.update(
-            {
-                "flow_acceptance_rate": np.asarray(result.global_acceptance_rate),
-                "flow_accepted_count": np.asarray(result.global_accepted_count),
-                "flow_mean_log_acceptance_ratio": np.asarray(
-                    result.global_mean_log_acceptance_ratio
-                ),
-                "flow_nonfinite_count": np.asarray(result.global_nonfinite_count),
-            }
-        )
-        posterior_attributes["phydrax_flow_nuts_config"] = json.dumps(
-            result.config.as_dict(),
-            sort_keys=True,
-            separators=(",", ":"),
-        )
+    if isinstance(chain_result, SGMCMCResult):
+        sample_stats = {
+            "stochastic_gradient_norm": np.asarray(chain_result.gradient_norm),
+        }
+        if chain_result.log_density is not None:
+            sample_stats["lp"] = np.asarray(chain_result.log_density)
+        if chain_result.thermostat is not None:
+            sample_stats["thermostat"] = np.asarray(chain_result.thermostat)
+        if chain_result.momentum_norm is not None:
+            sample_stats["momentum_norm"] = np.asarray(chain_result.momentum_norm)
+        posterior_attributes = {
+            "phydrax_algorithm": chain_result.algorithm,
+            "phydrax_approximation": chain_result.approximation,
+            "phydrax_chain_method": chain_result.chain_method,
+            "phydrax_step_size": chain_result.step_size,
+            "phydrax_batch_fraction": chain_result.batch_fraction,
+            "phydrax_source_fingerprint": chain_result.source_fingerprint,
+            "phydrax_control_variate": chain_result.control_variate is not None,
+        }
+    else:
+        sample_stats = {
+            "lp": np.asarray(chain_result.log_density),
+            "acceptance_rate": np.asarray(chain_result.acceptance_rate),
+            "diverging": np.asarray(chain_result.divergent),
+            "energy": np.asarray(chain_result.energy),
+            "n_steps": np.asarray(chain_result.num_integration_steps),
+            "tree_depth": np.asarray(chain_result.num_trajectory_expansions),
+        }
+        posterior_attributes = {
+            "phydrax_algorithm": chain_result.algorithm,
+            "phydrax_chain_method": chain_result.chain_method,
+        }
+        if isinstance(result, FlowNUTSResult):
+            sample_stats.update(
+                {
+                    "flow_acceptance_rate": np.asarray(
+                        result.global_acceptance_rate
+                    ),
+                    "flow_accepted_count": np.asarray(result.global_accepted_count),
+                    "flow_mean_log_acceptance_ratio": np.asarray(
+                        result.global_mean_log_acceptance_ratio
+                    ),
+                    "flow_nonfinite_count": np.asarray(
+                        result.global_nonfinite_count
+                    ),
+                }
+            )
+            posterior_attributes["phydrax_flow_nuts_config"] = json.dumps(
+                result.config.as_dict(),
+                sort_keys=True,
+                separators=(",", ":"),
+            )
     return az.from_dict(
         {
             "posterior": posterior,
@@ -336,6 +364,102 @@ def _adapt_result(result, arrays, fields, trees):
         }
         return "ensemble_kalman_inversion", metadata, ("problem",)
 
+    if isinstance(result, SGMCMCResult):
+        _put_tree(trees, arrays, "samples", result.samples)
+        _put_tree(
+            trees,
+            arrays,
+            "unconstrained_samples",
+            result.unconstrained_samples,
+        )
+        _put_tree(trees, arrays, "final_states", result.final_states)
+        _put_tree(trees, arrays, "burnin_states", result.burnin_states)
+        _put_tree(trees, arrays, "diagnostics.rhat", result.diagnostics.rhat)
+        _put_tree(
+            trees,
+            arrays,
+            "diagnostics.bulk_ess",
+            result.diagnostics.bulk_ess,
+        )
+        _put_tree(
+            trees,
+            arrays,
+            "diagnostics.tail_ess",
+            result.diagnostics.tail_ess,
+        )
+        _put_tree(trees, arrays, "diagnostics.mean", result.diagnostics.mean)
+        _put_tree(
+            trees,
+            arrays,
+            "diagnostics.standard_deviation",
+            result.diagnostics.standard_deviation,
+        )
+        _put_field(fields, arrays, "gradient_norm", result.gradient_norm)
+        _put_field(fields, arrays, "chain_keys", result.chain_keys)
+        _put_field(fields, arrays, "root_key", jr.key_data(result.root_key))
+        if result.log_density is not None:
+            _put_field(fields, arrays, "log_density", result.log_density)
+        if result.thermostat is not None:
+            _put_field(fields, arrays, "thermostat", result.thermostat)
+        if result.momentum_norm is not None:
+            _put_field(fields, arrays, "momentum_norm", result.momentum_norm)
+        control_metadata = None
+        if result.control_variate is not None:
+            _put_tree(
+                trees,
+                arrays,
+                "control_variate.center",
+                result.control_variate.center,
+            )
+            _put_tree(
+                trees,
+                arrays,
+                "control_variate.full_gradient",
+                result.control_variate.full_gradient,
+            )
+            control_metadata = {
+                "fingerprint": result.control_variate.fingerprint,
+                "construction_duration_seconds": (
+                    result.control_variate.construction_duration_seconds
+                ),
+                "construction_gradient_evaluations": (
+                    result.control_variate.construction_gradient_evaluations
+                ),
+            }
+        metadata = {
+            "algorithm": result.algorithm,
+            "approximation": result.approximation,
+            "chain_method": result.chain_method,
+            "num_chains": result.num_chains,
+            "num_draws": result.num_draws,
+            "num_burnin": result.num_burnin,
+            "steps_per_sample": result.steps_per_sample,
+            "num_updates": result.num_updates,
+            "num_gradient_evaluations": result.num_gradient_evaluations,
+            "step_size": result.step_size,
+            "diffusion": result.diffusion,
+            "initial_thermostat": result.initial_thermostat,
+            "source_num_factors": result.source_num_factors,
+            "batch_capacity": result.batch_capacity,
+            "batch_fraction": result.batch_fraction,
+            "source_fingerprint": result.source_fingerprint,
+            "source_configuration": result.source_configuration,
+            "control_variate": control_metadata,
+            "compilation_duration_seconds": result.compilation_duration_seconds,
+            "burnin_duration_seconds": result.burnin_duration_seconds,
+            "sampling_duration_seconds": result.sampling_duration_seconds,
+            "duration_seconds": result.duration_seconds,
+            "samples_per_second": result.samples_per_second,
+            "updates_per_second": result.updates_per_second,
+            "gradient_evaluations_per_second": (
+                result.gradient_evaluations_per_second
+            ),
+            "sample_memory_bytes": result.sample_memory_bytes,
+            "mean_update_gradient_norm": result.mean_update_gradient_norm,
+            "max_update_gradient_norm": result.max_update_gradient_norm,
+        }
+        return "sgmcmc", metadata, ("problem",)
+
     if isinstance(result, FlowNUTSResult):
         mcmc = result.mcmc
         _put_tree(trees, arrays, "samples", result.samples)
@@ -458,6 +582,27 @@ def _adapt_result(result, arrays, fields, trees):
             ],
         }
         return "mcmc", metadata, ("problem",)
+
+    if isinstance(result, SGMCMCMixingReport):
+        for name, value in (
+            ("max_rhat", result.max_rhat),
+            ("min_bulk_ess", result.min_bulk_ess),
+            ("min_tail_ess", result.min_tail_ess),
+            ("max_gradient_norm", result.max_gradient_norm),
+        ):
+            _put_field(fields, arrays, name, value)
+        metadata = result.as_dict()
+        metadata["thresholds"] = {
+            "max_rhat": result.thresholds.max_rhat,
+            "min_bulk_ess": result.thresholds.min_bulk_ess,
+            "min_tail_ess": result.thresholds.min_tail_ess,
+            "allow_nonfinite_updates": (
+                result.thresholds.allow_nonfinite_updates
+            ),
+        }
+        for name in fields:
+            metadata.pop(name, None)
+        return "sgmcmc_mixing_report", metadata, ()
 
     if isinstance(result, MCMCConvergenceReport):
         for name in (

--- a/phydrax/uq/_sgmcmc.py
+++ b/phydrax/uq/_sgmcmc.py
@@ -1,0 +1,1437 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from pathlib import Path
+from typing import Any, cast, Literal
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+from blackjax.sgmcmc import diffusions
+from blackjax.sgmcmc.sgnht import init as init_sgnht, SGNHTState
+from jaxtyping import Array, PyTree
+
+from .._frozendict import frozendict
+from .._strict import StrictModule
+from ._chain import (
+    _prepare_chain_positions,
+    _split_chain_keys,
+    _stack_trees,
+    _tree_nbytes,
+    _unstack_tree,
+    _validate_chain_method,
+    ChainMethod,
+)
+from ._checkpoint import (
+    array_tree_fingerprint,
+    CheckpointCompatibilityError,
+    CheckpointCorruptionError,
+    pack_array_tree,
+    read_checkpoint_archive,
+    tree_signature,
+    unpack_array_tree,
+    write_checkpoint_archive,
+)
+from ._minibatch_posterior import (
+    LikelihoodBatch,
+    MinibatchPosteriorProblem,
+    MinibatchSource,
+)
+from ._posterior_predictive import (
+    predict_from_position_samples,
+    sample_observations_from_position_samples,
+)
+from ._predictive import PredictiveField
+from ._sgmcmc_diagnostics import (
+    sgmcmc_diagnostics,
+    SGMCMCDiagnostics,
+    SGMCMCMixingReport,
+    SGMCMCMixingThresholds,
+)
+
+
+SGMCMCAlgorithm = Literal["sgld", "sgnht"]
+_APPROXIMATION = "unadjusted_fixed_step"
+_INITIALIZATION_TAG = 0
+_TRANSITION_TAG = 1
+_CHECKPOINT_KIND = "sgmcmc"
+
+
+class SGMCMCControlVariate(StrictModule):
+    """Full-gradient reference used by a minibatch difference estimator."""
+
+    center: PyTree[Array]
+    full_gradient: PyTree[Array]
+    problem_fingerprint: str = eqx.field(static=True)
+    source_fingerprint: str = eqx.field(static=True)
+    fingerprint: str = eqx.field(static=True)
+    construction_duration_seconds: float = eqx.field(static=True)
+    construction_gradient_evaluations: int = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        center: PyTree[Array],
+        full_gradient: PyTree[Array],
+        problem_fingerprint: str,
+        source_fingerprint: str,
+        construction_duration_seconds: float,
+        construction_gradient_evaluations: int,
+    ):
+        payload = {
+            "center": array_tree_fingerprint(center),
+            "full_gradient": array_tree_fingerprint(full_gradient),
+            "problem_fingerprint": str(problem_fingerprint),
+            "source_fingerprint": str(source_fingerprint),
+        }
+        canonical = json.dumps(payload, separators=(",", ":"), sort_keys=True)
+        self.center = center
+        self.full_gradient = full_gradient
+        self.problem_fingerprint = str(problem_fingerprint)
+        self.source_fingerprint = str(source_fingerprint)
+        self.fingerprint = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+        self.construction_duration_seconds = float(construction_duration_seconds)
+        self.construction_gradient_evaluations = int(
+            construction_gradient_evaluations
+        )
+
+
+class SGMCMCResult(StrictModule):
+    """Chain-preserving fixed-step SG-MCMC draws and honest mixing evidence."""
+
+    problem: MinibatchPosteriorProblem
+    samples: PyTree[Array]
+    unconstrained_samples: PyTree[Array]
+    final_states: Any
+    burnin_states: Any
+    diagnostics: SGMCMCDiagnostics
+    gradient_norm: Array
+    log_density: Array | None
+    thermostat: Array | None
+    momentum_norm: Array | None
+    root_key: Array
+    chain_keys: Array
+    control_variate: SGMCMCControlVariate | None
+    algorithm: SGMCMCAlgorithm = eqx.field(static=True)
+    approximation: str = eqx.field(static=True)
+    step_size: float = eqx.field(static=True)
+    diffusion: float | None = eqx.field(static=True)
+    initial_thermostat: float | None = eqx.field(static=True)
+    num_burnin: int = eqx.field(static=True)
+    num_samples: int = eqx.field(static=True)
+    steps_per_sample: int = eqx.field(static=True)
+    num_updates: int = eqx.field(static=True)
+    num_gradient_evaluations: int = eqx.field(static=True)
+    source_num_factors: int = eqx.field(static=True)
+    batch_capacity: int = eqx.field(static=True)
+    source_fingerprint: str = eqx.field(static=True)
+    _source_configuration_json: str = eqx.field(static=True)
+    chain_method: ChainMethod = eqx.field(static=True)
+    compilation_duration_seconds: float = eqx.field(static=True)
+    burnin_duration_seconds: float = eqx.field(static=True)
+    sampling_duration_seconds: float = eqx.field(static=True)
+    duration_seconds: float = eqx.field(static=True)
+    samples_per_second: float = eqx.field(static=True)
+    updates_per_second: float = eqx.field(static=True)
+    gradient_evaluations_per_second: float = eqx.field(static=True)
+    sample_memory_bytes: int = eqx.field(static=True)
+    mean_update_gradient_norm: float = eqx.field(static=True)
+    max_update_gradient_norm: float = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        problem: MinibatchPosteriorProblem,
+        samples: PyTree[Array],
+        unconstrained_samples: PyTree[Array],
+        final_states: Any,
+        burnin_states: Any,
+        diagnostics: SGMCMCDiagnostics,
+        gradient_norm: Array,
+        log_density: Array | None,
+        thermostat: Array | None,
+        momentum_norm: Array | None,
+        root_key: Array,
+        chain_keys: Array,
+        control_variate: SGMCMCControlVariate | None,
+        algorithm: SGMCMCAlgorithm,
+        step_size: float,
+        diffusion: float | None,
+        initial_thermostat: float | None,
+        num_burnin: int,
+        num_samples: int,
+        steps_per_sample: int,
+        num_updates: int,
+        num_gradient_evaluations: int,
+        source_num_factors: int,
+        batch_capacity: int,
+        source_fingerprint: str,
+        source_configuration_json: str,
+        chain_method: ChainMethod,
+        compilation_duration_seconds: float,
+        burnin_duration_seconds: float,
+        sampling_duration_seconds: float,
+        mean_update_gradient_norm: float,
+        max_update_gradient_norm: float,
+    ):
+        total_duration = (
+            float(compilation_duration_seconds)
+            + float(burnin_duration_seconds)
+            + float(sampling_duration_seconds)
+            + (
+                0.0
+                if control_variate is None
+                else control_variate.construction_duration_seconds
+            )
+        )
+        retained = int(num_samples) * int(chain_keys.shape[0])
+        update_count = int(num_updates) * int(chain_keys.shape[0])
+        gradient_count = int(num_gradient_evaluations)
+        self.problem = problem
+        self.samples = samples
+        self.unconstrained_samples = unconstrained_samples
+        self.final_states = final_states
+        self.burnin_states = burnin_states
+        self.diagnostics = diagnostics
+        self.gradient_norm = jnp.asarray(gradient_norm)
+        self.log_density = None if log_density is None else jnp.asarray(log_density)
+        self.thermostat = None if thermostat is None else jnp.asarray(thermostat)
+        self.momentum_norm = (
+            None if momentum_norm is None else jnp.asarray(momentum_norm)
+        )
+        self.root_key = jnp.asarray(root_key)
+        self.chain_keys = jnp.asarray(chain_keys)
+        self.control_variate = control_variate
+        self.algorithm = algorithm
+        self.approximation = _APPROXIMATION
+        self.step_size = float(step_size)
+        self.diffusion = None if diffusion is None else float(diffusion)
+        self.initial_thermostat = (
+            None if initial_thermostat is None else float(initial_thermostat)
+        )
+        self.num_burnin = int(num_burnin)
+        self.num_samples = int(num_samples)
+        self.steps_per_sample = int(steps_per_sample)
+        self.num_updates = int(num_updates)
+        self.num_gradient_evaluations = gradient_count
+        self.source_num_factors = int(source_num_factors)
+        self.batch_capacity = int(batch_capacity)
+        self.source_fingerprint = str(source_fingerprint)
+        self._source_configuration_json = str(source_configuration_json)
+        self.chain_method = chain_method
+        self.compilation_duration_seconds = float(compilation_duration_seconds)
+        self.burnin_duration_seconds = float(burnin_duration_seconds)
+        self.sampling_duration_seconds = float(sampling_duration_seconds)
+        self.duration_seconds = total_duration
+        self.samples_per_second = retained / max(total_duration, 1e-12)
+        self.updates_per_second = update_count / max(total_duration, 1e-12)
+        self.gradient_evaluations_per_second = gradient_count / max(
+            total_duration, 1e-12
+        )
+        self.sample_memory_bytes = (
+            _tree_nbytes(samples)
+            + _tree_nbytes(unconstrained_samples)
+            + int(self.gradient_norm.nbytes)
+            + (0 if self.thermostat is None else int(self.thermostat.nbytes))
+            + (0 if self.momentum_norm is None else int(self.momentum_norm.nbytes))
+            + (0 if self.log_density is None else int(self.log_density.nbytes))
+        )
+        self.mean_update_gradient_norm = float(mean_update_gradient_norm)
+        self.max_update_gradient_norm = float(max_update_gradient_norm)
+
+    @property
+    def num_chains(self) -> int:
+        return int(self.chain_keys.shape[0])
+
+    @property
+    def num_draws(self) -> int:
+        return self.num_samples
+
+    @property
+    def batch_fraction(self) -> float:
+        return self.batch_capacity / self.source_num_factors
+
+    @property
+    def source_configuration(self) -> dict[str, Any]:
+        return json.loads(self._source_configuration_json)
+
+    def predict(
+        self,
+        *args: Any,
+        batch_size: int | None = None,
+        valid_policy: Literal["record", "raise"] = "record",
+        chain_dim: str = "__phydra_uq_chain",
+        draw_dim: str = "__phydra_uq_draw",
+        **kwargs: Any,
+    ) -> PredictiveField | frozendict[str, PredictiveField]:
+        return predict_from_position_samples(
+            self.problem,
+            self.unconstrained_samples,
+            *args,
+            sample_dims=(chain_dim, draw_dim),
+            sample_sources=("epistemic", "epistemic"),
+            batch_size=batch_size,
+            valid_policy=valid_policy,
+            **kwargs,
+        )
+
+    def predict_observations(
+        self,
+        key: Array,
+        /,
+        *args: Any,
+        num_observation_samples: int,
+        batch_size: int | None = None,
+        valid_policy: Literal["record", "raise"] = "record",
+        chain_dim: str = "__phydra_uq_chain",
+        draw_dim: str = "__phydra_uq_draw",
+        observation_dim: str = "__phydra_uq_observation",
+        **kwargs: Any,
+    ) -> PredictiveField | frozendict[str, PredictiveField]:
+        return sample_observations_from_position_samples(
+            self.problem,
+            key,
+            self.unconstrained_samples,
+            *args,
+            num_observation_samples=num_observation_samples,
+            sample_dims=(chain_dim, draw_dim),
+            sample_sources=("epistemic", "epistemic"),
+            observation_dim=observation_dim,
+            batch_size=batch_size,
+            valid_policy=valid_policy,
+            **kwargs,
+        )
+
+    def mixing_report(
+        self,
+        *,
+        max_rhat: float = 1.01,
+        min_bulk_ess: float = 400.0,
+        min_tail_ess: float = 400.0,
+        allow_nonfinite_updates: bool = False,
+    ) -> SGMCMCMixingReport:
+        thresholds = SGMCMCMixingThresholds(
+            max_rhat=max_rhat,
+            min_bulk_ess=min_bulk_ess,
+            min_tail_ess=min_tail_ess,
+            allow_nonfinite_updates=allow_nonfinite_updates,
+        )
+        return SGMCMCMixingReport(
+            diagnostics=self.diagnostics,
+            thresholds=thresholds,
+            algorithm=self.algorithm,
+            approximation=self.approximation,
+            num_chains=self.num_chains,
+            num_draws=self.num_draws,
+            step_size=self.step_size,
+            batch_fraction=self.batch_fraction,
+            sample_memory_bytes=self.sample_memory_bytes,
+            duration_seconds=self.duration_seconds,
+            samples_per_second=self.samples_per_second,
+        )
+
+
+def build_sgmcmc_control_variate(
+    problem: MinibatchPosteriorProblem,
+    source: MinibatchSource,
+    center: PyTree[Any],
+    /,
+) -> SGMCMCControlVariate:
+    """Build an exact full-gradient reference from one complete source epoch."""
+    source_configuration_json, batches = _validate_problem_source(problem, source)
+    del source_configuration_json
+    center_position, _ = _prepare_chain_positions(
+        problem.initial_position,
+        num_chains=1,
+        initial_position=center,
+    )
+    problem.parameter_space.constrain(center_position)
+    started = time.perf_counter()
+    prior_gradient = jax.grad(problem.parameter_space.unconstrained_log_prior)(
+        center_position
+    )
+    likelihood_gradient = jax.tree_util.tree_map(jnp.zeros_like, center_position)
+
+    def batch_log_likelihood(position, batch):
+        physical = problem.parameter_space.constrain(position)
+        return jnp.sum(problem.log_likelihood_factors(physical, batch))
+
+    gradient_fn = eqx.filter_jit(
+        lambda current, current_batch: jax.grad(batch_log_likelihood)(
+            current, current_batch
+        )
+    )
+    for batch in batches:
+        batch_gradient = gradient_fn(center_position, batch)
+        likelihood_gradient = jax.tree_util.tree_map(
+            lambda total, value: total + value,
+            likelihood_gradient,
+            batch_gradient,
+        )
+    full_gradient = jax.tree_util.tree_map(
+        lambda prior, likelihood: prior + likelihood,
+        prior_gradient,
+        likelihood_gradient,
+    )
+    jax.block_until_ready(full_gradient)
+    duration = time.perf_counter() - started
+    problem_fingerprint = _problem_fingerprint(problem, batches[0])
+    return SGMCMCControlVariate(
+        center=center_position,
+        full_gradient=full_gradient,
+        problem_fingerprint=problem_fingerprint,
+        source_fingerprint=source.fingerprint,
+        construction_duration_seconds=duration,
+        construction_gradient_evaluations=len(batches) + 2,
+    )
+
+
+def sample_sgld(
+    problem: MinibatchPosteriorProblem,
+    source: MinibatchSource,
+    /,
+    *,
+    key: Array,
+    step_size: float,
+    num_chains: int = 4,
+    num_burnin: int = 1000,
+    num_samples: int = 1000,
+    steps_per_sample: int = 1,
+    initial_position: PyTree[Any] | None = None,
+    initial_positions: PyTree[Any] | None = None,
+    chain_method: ChainMethod = "vectorized",
+    control_variate: SGMCMCControlVariate | None = None,
+    checkpoint_path: str | Path | None = None,
+    checkpoint_every: int | None = None,
+    checkpoint_id: str | None = None,
+    resume_from: str | Path | None = None,
+) -> SGMCMCResult:
+    """Run fixed-step stochastic-gradient Langevin dynamics."""
+    return _sample_sgmcmc(
+        problem,
+        source,
+        key=key,
+        algorithm="sgld",
+        step_size=step_size,
+        diffusion=None,
+        initial_thermostat=None,
+        num_chains=num_chains,
+        num_burnin=num_burnin,
+        num_samples=num_samples,
+        steps_per_sample=steps_per_sample,
+        initial_position=initial_position,
+        initial_positions=initial_positions,
+        chain_method=chain_method,
+        control_variate=control_variate,
+        checkpoint_path=checkpoint_path,
+        checkpoint_every=checkpoint_every,
+        checkpoint_id=checkpoint_id,
+        resume_from=resume_from,
+    )
+
+
+def sample_sgnht(
+    problem: MinibatchPosteriorProblem,
+    source: MinibatchSource,
+    /,
+    *,
+    key: Array,
+    step_size: float,
+    diffusion: float = 0.01,
+    initial_thermostat: float | None = None,
+    num_chains: int = 4,
+    num_burnin: int = 1000,
+    num_samples: int = 1000,
+    steps_per_sample: int = 1,
+    initial_position: PyTree[Any] | None = None,
+    initial_positions: PyTree[Any] | None = None,
+    chain_method: ChainMethod = "vectorized",
+    control_variate: SGMCMCControlVariate | None = None,
+    checkpoint_path: str | Path | None = None,
+    checkpoint_every: int | None = None,
+    checkpoint_id: str | None = None,
+    resume_from: str | Path | None = None,
+) -> SGMCMCResult:
+    """Run fixed-step stochastic-gradient Nosé-Hoover thermostat dynamics."""
+    diffusion_value = float(diffusion)
+    thermostat = (
+        diffusion_value if initial_thermostat is None else float(initial_thermostat)
+    )
+    return _sample_sgmcmc(
+        problem,
+        source,
+        key=key,
+        algorithm="sgnht",
+        step_size=step_size,
+        diffusion=diffusion_value,
+        initial_thermostat=thermostat,
+        num_chains=num_chains,
+        num_burnin=num_burnin,
+        num_samples=num_samples,
+        steps_per_sample=steps_per_sample,
+        initial_position=initial_position,
+        initial_positions=initial_positions,
+        chain_method=chain_method,
+        control_variate=control_variate,
+        checkpoint_path=checkpoint_path,
+        checkpoint_every=checkpoint_every,
+        checkpoint_id=checkpoint_id,
+        resume_from=resume_from,
+    )
+
+
+def _sample_sgmcmc(
+    problem: MinibatchPosteriorProblem,
+    source: MinibatchSource,
+    /,
+    *,
+    key: Array,
+    algorithm: SGMCMCAlgorithm,
+    step_size: float,
+    diffusion: float | None,
+    initial_thermostat: float | None,
+    num_chains: int,
+    num_burnin: int,
+    num_samples: int,
+    steps_per_sample: int,
+    initial_position: PyTree[Any] | None,
+    initial_positions: PyTree[Any] | None,
+    chain_method: ChainMethod,
+    control_variate: SGMCMCControlVariate | None,
+    checkpoint_path: str | Path | None,
+    checkpoint_every: int | None,
+    checkpoint_id: str | None,
+    resume_from: str | Path | None,
+) -> SGMCMCResult:
+    source_configuration_json, initial_batches = _validate_problem_source(
+        problem, source
+    )
+    chains = int(num_chains)
+    burnin = int(num_burnin)
+    draws = int(num_samples)
+    thinning = int(steps_per_sample)
+    if chains < 2:
+        raise ValueError("num_chains must be at least two for mixing diagnostics.")
+    if burnin <= 0:
+        raise ValueError("num_burnin must be positive.")
+    if draws < 4:
+        raise ValueError("num_samples must be at least four.")
+    if thinning <= 0:
+        raise ValueError("steps_per_sample must be positive.")
+    step = float(step_size)
+    if not jnp.isfinite(step) or step <= 0.0:
+        raise ValueError("step_size must be positive and finite.")
+    if algorithm == "sgnht":
+        if diffusion is None or not jnp.isfinite(diffusion) or diffusion <= 0.0:
+            raise ValueError("diffusion must be positive and finite.")
+        if initial_thermostat is None or not jnp.isfinite(initial_thermostat):
+            raise ValueError("initial_thermostat must be finite.")
+    method = _validate_chain_method(chain_method)
+    if control_variate is not None and not isinstance(
+        control_variate, SGMCMCControlVariate
+    ):
+        raise TypeError("control_variate must be an SGMCMCControlVariate or None.")
+    if resume_from is not None and (
+        initial_position is not None or initial_positions is not None
+    ):
+        raise ValueError(
+            "initial_position and initial_positions cannot be supplied when resuming."
+        )
+
+    destination = (
+        Path(checkpoint_path)
+        if checkpoint_path is not None
+        else (Path(resume_from) if resume_from is not None else None)
+    )
+    if checkpoint_every is not None and destination is None:
+        raise ValueError("checkpoint_every requires checkpoint_path or resume_from.")
+    total_updates = burnin + draws * thinning
+    interval = min(100, total_updates) if checkpoint_every is None else int(
+        checkpoint_every
+    )
+    if interval <= 0:
+        raise ValueError("checkpoint_every must be positive.")
+    if destination is not None and (checkpoint_id is None or not str(checkpoint_id)):
+        raise ValueError("checkpoint_id is required for SG-MCMC checkpointing.")
+
+    position, chain_positions = _prepare_chain_positions(
+        problem.initial_position,
+        num_chains=chains,
+        initial_position=initial_position,
+        initial_positions=initial_positions,
+    )
+    problem.parameter_space.constrain(position)
+    root_key, chain_keys = _split_chain_keys(key, chains)
+    problem_fingerprint = _problem_fingerprint(problem, initial_batches[0])
+    if control_variate is not None:
+        if control_variate.source_fingerprint != source.fingerprint:
+            raise ValueError("control_variate was built for a different source.")
+        if control_variate.problem_fingerprint != problem_fingerprint:
+            raise ValueError("control_variate was built for a different problem.")
+        _prepare_chain_positions(
+            problem.initial_position,
+            num_chains=1,
+            initial_position=control_variate.center,
+        )
+
+    settings = {
+        "algorithm": algorithm,
+        "num_chains": chains,
+        "num_burnin": burnin,
+        "step_size": step,
+        "steps_per_sample": thinning,
+        "chain_method": method,
+        "diffusion": diffusion,
+        "initial_thermostat": initial_thermostat,
+        "control_variate_fingerprint": (
+            None if control_variate is None else control_variate.fingerprint
+        ),
+        "root_key": [int(value) for value in jr.key_data(root_key).reshape(-1)],
+    }
+    compatibility = (
+        {
+            "checkpoint_id": str(checkpoint_id),
+            "source_type": f"{type(source).__module__}.{type(source).__qualname__}",
+            "source_fingerprint": source.fingerprint,
+            "source_configuration": json.loads(source_configuration_json),
+            "problem_type": f"{type(problem).__module__}.{type(problem).__qualname__}",
+            "parameter_tree": tree_signature(problem.initial_position),
+            "problem_fingerprint": problem_fingerprint,
+            "settings": settings,
+        }
+        if destination is not None
+        else None
+    )
+    gradient_fn = _gradient_estimator(problem, control_variate)
+    state_template = _initialize_states(
+        algorithm,
+        chain_positions,
+        chain_keys,
+        initial_thermostat=initial_thermostat,
+        chain_method=method,
+    )
+
+    if resume_from is None:
+        values = jax.vmap(
+            lambda current: problem.log_density_estimate(
+                current, initial_batches[0]
+            )
+        )(chain_positions)
+        gradients = jax.vmap(
+            lambda current: gradient_fn(current, initial_batches[0])
+        )(chain_positions)
+        invalid_value_chains = tuple(
+            int(index)
+            for index in jnp.argwhere(~jnp.isfinite(values)).reshape(-1)
+        )
+        invalid_gradient_locations = _invalid_chain_locations(gradients, chains)
+        if invalid_value_chains or invalid_gradient_locations:
+            raise FloatingPointError(
+                "Initial SG-MCMC evaluation is nonfinite; "
+                f"log-density chains={invalid_value_chains}, "
+                f"gradient locations={invalid_gradient_locations}."
+            )
+        current_states = state_template
+        burnin_states = None
+        stored_samples = _empty_sample_tree(position, chains)
+        retained_gradient_norm = jnp.empty((chains, 0), dtype=float)
+        retained_thermostat = (
+            jnp.empty((chains, 0), dtype=float) if algorithm == "sgnht" else None
+        )
+        retained_momentum_norm = (
+            jnp.empty((chains, 0), dtype=float) if algorithm == "sgnht" else None
+        )
+        completed_updates = 0
+        completed_draws = 0
+        compilation_duration = 0.0
+        burnin_duration = 0.0
+        sampling_duration = 0.0
+        gradient_evaluations = 1 + chains * (
+            2 if control_variate is not None else 1
+        )
+        if control_variate is not None:
+            gradient_evaluations += control_variate.construction_gradient_evaluations
+        gradient_norm_sum = 0.0
+        gradient_norm_count = 0
+        gradient_norm_max = 0.0
+        min_active_factors = problem.num_factors
+        max_active_factors = 0
+        nonfinite_update_count = 0
+    else:
+        if compatibility is None:
+            raise RuntimeError("SG-MCMC resume compatibility was not constructed.")
+        checkpoint_state, arrays = read_checkpoint_archive(
+            resume_from,
+            kind=_CHECKPOINT_KIND,
+            compatibility=compatibility,
+        )
+        restored = _read_sgmcmc_checkpoint(
+            checkpoint_state,
+            arrays,
+            algorithm=algorithm,
+            state_template=state_template,
+            position_template=position,
+            num_chains=chains,
+            num_burnin=burnin,
+            num_samples=draws,
+            steps_per_sample=thinning,
+        )
+        current_states = restored["current_states"]
+        burnin_states = restored["burnin_states"]
+        stored_samples = restored["samples"]
+        retained_gradient_norm = restored["gradient_norm"]
+        retained_thermostat = restored["thermostat"]
+        retained_momentum_norm = restored["momentum_norm"]
+        completed_updates = restored["completed_updates"]
+        completed_draws = restored["completed_draws"]
+        compilation_duration = restored["compilation_duration_seconds"]
+        burnin_duration = restored["burnin_duration_seconds"]
+        sampling_duration = restored["sampling_duration_seconds"]
+        gradient_evaluations = restored["gradient_evaluations"]
+        gradient_evaluations += 1
+        gradient_norm_sum = restored["gradient_norm_sum"]
+        gradient_norm_count = restored["gradient_norm_count"]
+        gradient_norm_max = restored["gradient_norm_max"]
+        min_active_factors = restored["min_active_factors"]
+        max_active_factors = restored["max_active_factors"]
+        nonfinite_update_count = restored["nonfinite_update_count"]
+
+    transition = _compile_transition(
+        algorithm,
+        problem,
+        control_variate,
+        step_size=step,
+        diffusion=diffusion,
+        chain_method=method,
+        states=current_states,
+        chain_keys=chain_keys,
+        batch=initial_batches[0],
+    )
+    compilation_duration += transition[1]
+    advance = transition[0]
+    new_samples: list[PyTree[Array]] = []
+    new_gradient_norms: list[Array] = []
+    new_thermostats: list[Array] = []
+    new_momentum_norms: list[Array] = []
+    cached_epoch = -1
+    epoch_batches: tuple[LikelihoodBatch, ...] = ()
+
+    for update in range(completed_updates, total_updates):
+        epoch = update // int(source.batches_per_epoch)
+        if epoch != cached_epoch:
+            epoch_batches = _materialize_source_epoch(source, epoch)
+            cached_epoch = epoch
+        batch = epoch_batches[update % int(source.batches_per_epoch)]
+        transition_keys = _transition_keys(chain_keys, update)
+        update_started = time.perf_counter()
+        new_states, gradient_norm = advance(current_states, transition_keys, batch)
+        jax.block_until_ready(new_states)
+        update_duration = time.perf_counter() - update_started
+        invalid_state_locations = _invalid_chain_locations(new_states, chains)
+        invalid_gradient_locations = tuple(
+            f"chain[{int(index)}].gradient_norm"
+            for index in jnp.argwhere(~jnp.isfinite(gradient_norm)).reshape(-1)
+        )
+        if invalid_state_locations or invalid_gradient_locations:
+            raise FloatingPointError(
+                "Nonfinite SG-MCMC transition at logical update "
+                f"{update}; state locations={invalid_state_locations}, "
+                f"gradient locations={invalid_gradient_locations}."
+            )
+        current_states = new_states
+        completed_updates = update + 1
+        if completed_updates <= burnin:
+            burnin_duration += update_duration
+        else:
+            sampling_duration += update_duration
+        active_factors = int(batch.factor_count)
+        min_active_factors = min(min_active_factors, active_factors)
+        max_active_factors = max(max_active_factors, active_factors)
+        gradient_norm_sum += float(jnp.sum(gradient_norm))
+        gradient_norm_count += chains
+        gradient_norm_max = max(gradient_norm_max, float(jnp.max(gradient_norm)))
+        gradient_evaluations += chains * (2 if control_variate is not None else 1)
+
+        if completed_updates == burnin:
+            burnin_states = current_states
+        if completed_updates > burnin and (completed_updates - burnin) % thinning == 0:
+            new_samples.append(_state_position(algorithm, current_states))
+            new_gradient_norms.append(gradient_norm)
+            if algorithm == "sgnht":
+                new_thermostats.append(current_states.xi)
+                new_momentum_norms.append(_batched_tree_norm(current_states.momentum))
+            completed_draws += 1
+
+        if destination is not None and (
+            completed_updates % interval == 0 or completed_updates == total_updates
+        ):
+            stored_samples = _combine_sample_trees(stored_samples, new_samples)
+            retained_gradient_norm = _combine_statistic(
+                retained_gradient_norm, new_gradient_norms
+            )
+            if algorithm == "sgnht":
+                retained_thermostat = _combine_statistic(
+                    retained_thermostat, new_thermostats
+                )
+                retained_momentum_norm = _combine_statistic(
+                    retained_momentum_norm, new_momentum_norms
+                )
+            new_samples.clear()
+            new_gradient_norms.clear()
+            new_thermostats.clear()
+            new_momentum_norms.clear()
+            if compatibility is None:
+                raise RuntimeError("SG-MCMC checkpoint compatibility is unavailable.")
+            _write_sgmcmc_checkpoint(
+                destination,
+                compatibility=compatibility,
+                algorithm=algorithm,
+                completed_updates=completed_updates,
+                completed_draws=completed_draws,
+                current_states=current_states,
+                burnin_states=burnin_states,
+                samples=stored_samples,
+                gradient_norm=retained_gradient_norm,
+                thermostat=retained_thermostat,
+                momentum_norm=retained_momentum_norm,
+                compilation_duration_seconds=compilation_duration,
+                burnin_duration_seconds=burnin_duration,
+                sampling_duration_seconds=sampling_duration,
+                gradient_evaluations=gradient_evaluations,
+                gradient_norm_sum=gradient_norm_sum,
+                gradient_norm_count=gradient_norm_count,
+                gradient_norm_max=gradient_norm_max,
+                min_active_factors=min_active_factors,
+                max_active_factors=max_active_factors,
+                nonfinite_update_count=nonfinite_update_count,
+            )
+
+    stored_samples = _combine_sample_trees(stored_samples, new_samples)
+    retained_gradient_norm = _combine_statistic(
+        retained_gradient_norm, new_gradient_norms
+    )
+    if algorithm == "sgnht":
+        retained_thermostat = _combine_statistic(
+            retained_thermostat, new_thermostats
+        )
+        retained_momentum_norm = _combine_statistic(
+            retained_momentum_norm, new_momentum_norms
+        )
+    if completed_draws != draws:
+        raise RuntimeError("SG-MCMC retained an unexpected number of draws.")
+    if burnin_states is None:
+        raise RuntimeError("SG-MCMC did not preserve its burn-in terminal state.")
+    unconstrained_samples = stored_samples
+    samples = problem.parameter_space.constrain(unconstrained_samples)
+    log_density = (
+        None
+        if problem.full_log_likelihood_fn is None
+        else _evaluate_full_log_density(problem, unconstrained_samples)
+    )
+    diagnostics = sgmcmc_diagnostics(
+        samples,
+        gradient_norm=retained_gradient_norm,
+        min_active_factors=min_active_factors,
+        max_active_factors=max_active_factors,
+        nonfinite_update_count=nonfinite_update_count,
+    )
+    jax.block_until_ready(diagnostics.max_rhat)
+    mean_update_gradient_norm = gradient_norm_sum / max(gradient_norm_count, 1)
+    return SGMCMCResult(
+        problem=problem,
+        samples=samples,
+        unconstrained_samples=unconstrained_samples,
+        final_states=current_states,
+        burnin_states=burnin_states,
+        diagnostics=diagnostics,
+        gradient_norm=retained_gradient_norm,
+        log_density=log_density,
+        thermostat=retained_thermostat,
+        momentum_norm=retained_momentum_norm,
+        root_key=root_key,
+        chain_keys=chain_keys,
+        control_variate=control_variate,
+        algorithm=algorithm,
+        step_size=step,
+        diffusion=diffusion,
+        initial_thermostat=initial_thermostat,
+        num_burnin=burnin,
+        num_samples=draws,
+        steps_per_sample=thinning,
+        num_updates=total_updates,
+        num_gradient_evaluations=gradient_evaluations,
+        source_num_factors=problem.num_factors,
+        batch_capacity=int(source.batch_capacity),
+        source_fingerprint=source.fingerprint,
+        source_configuration_json=source_configuration_json,
+        chain_method=method,
+        compilation_duration_seconds=compilation_duration,
+        burnin_duration_seconds=burnin_duration,
+        sampling_duration_seconds=sampling_duration,
+        mean_update_gradient_norm=mean_update_gradient_norm,
+        max_update_gradient_norm=gradient_norm_max,
+    )
+
+
+def _gradient_estimator(
+    problem: MinibatchPosteriorProblem,
+    control_variate: SGMCMCControlVariate | None,
+):
+    ordinary_gradient = jax.grad(problem.log_density_estimate)
+    if control_variate is None:
+        return ordinary_gradient
+
+    def control_variate_gradient(position, batch):
+        gradient = ordinary_gradient(position, batch)
+        center_gradient = ordinary_gradient(control_variate.center, batch)
+        return jax.tree_util.tree_map(
+            lambda full, current, center: full + current - center,
+            control_variate.full_gradient,
+            gradient,
+            center_gradient,
+        )
+
+    return control_variate_gradient
+
+
+def _compile_transition(
+    algorithm: SGMCMCAlgorithm,
+    problem: MinibatchPosteriorProblem,
+    control_variate: SGMCMCControlVariate | None,
+    *,
+    step_size: float,
+    diffusion: float | None,
+    chain_method: ChainMethod,
+    states: Any,
+    chain_keys: Array,
+    batch: LikelihoodBatch,
+):
+    gradient_fn = _gradient_estimator(problem, control_variate)
+    if algorithm == "sgld":
+        integrator = diffusions.overdamped_langevin()
+
+        def one_step(step_key, state, minibatch):
+            gradient = gradient_fn(state, minibatch)
+            return (
+                integrator(step_key, state, gradient, step_size, 1.0),
+                _tree_norm(gradient),
+            )
+
+    else:
+        if diffusion is None:
+            raise ValueError("diffusion is required for SGNHT transitions.")
+        integrator = diffusions.sgnht(float(diffusion), 0.0)
+
+        def one_step(step_key, state, minibatch):
+            gradient = gradient_fn(state.position, minibatch)
+            position, momentum, xi = integrator(
+                step_key,
+                state.position,
+                state.momentum,
+                state.xi,
+                gradient,
+                step_size,
+                1.0,
+            )
+            return SGNHTState(position, momentum, xi), _tree_norm(gradient)
+
+    compile_started = time.perf_counter()
+    if chain_method == "vectorized":
+        vectorized_transition = cast(
+            Any,
+            eqx.filter_jit(
+                lambda current_states, keys, minibatch: jax.vmap(
+                    lambda state, step_key: one_step(step_key, state, minibatch)
+                )(current_states, keys)
+            ),
+        )
+        compiled = vectorized_transition.lower(
+            states, chain_keys, batch
+        ).compile()
+
+        def advance(current_states, keys, minibatch):
+            return compiled(current_states, keys, minibatch)
+
+    else:
+        state_values = _unstack_tree(states, int(chain_keys.shape[0]))
+        sequential_transition = cast(Any, eqx.filter_jit(one_step))
+        compiled = sequential_transition.lower(
+            chain_keys[0], state_values[0], batch
+        ).compile()
+
+        def advance(current_states, keys, minibatch):
+            current_values = _unstack_tree(current_states, int(keys.shape[0]))
+            next_states = []
+            gradient_norms = []
+            for state, step_key in zip(current_values, keys, strict=True):
+                next_state, gradient_norm = compiled(step_key, state, minibatch)
+                next_states.append(next_state)
+                gradient_norms.append(gradient_norm)
+            return _stack_trees(next_states), jnp.stack(gradient_norms)
+
+    compilation_duration = time.perf_counter() - compile_started
+    return advance, compilation_duration
+
+
+def _initialize_states(
+    algorithm: SGMCMCAlgorithm,
+    positions: PyTree[Array],
+    chain_keys: Array,
+    *,
+    initial_thermostat: float | None,
+    chain_method: ChainMethod,
+):
+    if algorithm == "sgld":
+        return positions
+    if initial_thermostat is None:
+        raise ValueError("initial_thermostat is required for SGNHT states.")
+    initialization_keys = jax.vmap(
+        lambda chain_key: jr.fold_in(chain_key, _INITIALIZATION_TAG)
+    )(chain_keys)
+    initialize = lambda position, init_key: init_sgnht(
+        position, init_key, float(initial_thermostat)
+    )
+    if chain_method == "vectorized":
+        return jax.jit(jax.vmap(initialize))(positions, initialization_keys)
+    position_values = _unstack_tree(positions, int(chain_keys.shape[0]))
+    return _stack_trees(
+        [
+            initialize(position, init_key)
+            for position, init_key in zip(
+                position_values, initialization_keys, strict=True
+            )
+        ]
+    )
+
+
+
+
+def _transition_keys(chain_keys: Array, update: int, /) -> Array:
+    return jax.vmap(
+        lambda chain_key: jr.fold_in(
+            jr.fold_in(chain_key, _TRANSITION_TAG), int(update)
+        )
+    )(chain_keys)
+
+
+def _state_position(algorithm: SGMCMCAlgorithm, states: Any, /):
+    return states if algorithm == "sgld" else states.position
+
+
+def _tree_norm(tree: PyTree[Any], /) -> Array:
+    return jnp.sqrt(
+        sum(
+            (
+                jnp.sum(jnp.asarray(leaf, dtype=float) ** 2)
+                for leaf in jax.tree_util.tree_leaves(tree)
+            ),
+            jnp.zeros((), dtype=float),
+        )
+    )
+
+
+def _batched_tree_norm(tree: PyTree[Any], /) -> Array:
+    leaves = jax.tree_util.tree_leaves(tree)
+    squared = sum(
+        (
+            jnp.sum(
+                jnp.asarray(leaf, dtype=float).reshape((leaf.shape[0], -1)) ** 2,
+                axis=1,
+            )
+            for leaf in leaves
+        ),
+        jnp.zeros((leaves[0].shape[0],), dtype=float),
+    )
+    return jnp.sqrt(squared)
+
+
+def _invalid_chain_locations(
+    tree: PyTree[Any],
+    num_chains: int,
+    /,
+) -> tuple[str, ...]:
+    locations: list[str] = []
+    for path, leaf in jax.tree_util.tree_flatten_with_path(tree)[0]:
+        array = jnp.asarray(leaf)
+        path_name = jax.tree_util.keystr(path)
+        if array.ndim == 0 or int(array.shape[0]) != num_chains:
+            locations.append(
+                f"{path_name or '<root>'}: expected leading chain axis "
+                f"of length {num_chains}"
+            )
+            continue
+        for index in jnp.argwhere(~jnp.isfinite(array)):
+            chain = int(index[0])
+            trailing = tuple(int(value) for value in index[1:])
+            suffix = (
+                ""
+                if not trailing
+                else "[" + ",".join(str(value) for value in trailing) + "]"
+            )
+            locations.append(f"chain[{chain}]{path_name}{suffix}")
+    return tuple(locations)
+
+
+def _invalid_chain_indices(tree: PyTree[Any], num_chains: int, /) -> tuple[int, ...]:
+    valid = jnp.ones((num_chains,), dtype=bool)
+    for leaf in jax.tree_util.tree_leaves(tree):
+        array = jnp.asarray(leaf)
+        if array.ndim == 0 or int(array.shape[0]) != num_chains:
+            return tuple(range(num_chains))
+        valid = valid & jnp.all(
+            jnp.isfinite(array).reshape((num_chains, -1)), axis=1
+        )
+    return tuple(int(index) for index in jnp.argwhere(~valid).reshape(-1))
+
+
+def _empty_sample_tree(position: PyTree[Any], chains: int, /):
+    return jax.tree_util.tree_map(
+        lambda value: jnp.empty((chains, 0, *value.shape), dtype=value.dtype),
+        position,
+    )
+
+
+def _combine_sample_trees(stored, additions):
+    if not additions:
+        return stored
+    added = jax.tree_util.tree_map(
+        lambda *leaves: jnp.stack(leaves, axis=1), *additions
+    )
+    return jax.tree_util.tree_map(
+        lambda previous, current: jnp.concatenate((previous, current), axis=1),
+        stored,
+        added,
+    )
+
+
+def _combine_statistic(stored, additions):
+    if stored is None:
+        return None
+    if not additions:
+        return stored
+    return jnp.concatenate((stored, jnp.stack(additions, axis=1)), axis=1)
+
+
+def _evaluate_full_log_density(problem, samples):
+    leaves = jax.tree_util.tree_leaves(samples)
+    chains, draws = int(leaves[0].shape[0]), int(leaves[0].shape[1])
+    flattened = jax.tree_util.tree_map(
+        lambda value: value.reshape((chains * draws, *value.shape[2:])), samples
+    )
+    values = jax.vmap(problem.full_log_density)(flattened)
+    if not bool(jnp.all(jnp.isfinite(values))):
+        raise FloatingPointError("Full log density is nonfinite at retained SG-MCMC draws.")
+    return values.reshape((chains, draws))
+
+
+def _validate_problem_source(problem, source):
+    if not isinstance(problem, MinibatchPosteriorProblem):
+        raise TypeError("problem must be a MinibatchPosteriorProblem.")
+    if not isinstance(source, MinibatchSource):
+        raise TypeError("source must implement MinibatchSource.")
+    if int(source.num_factors) != problem.num_factors:
+        raise ValueError("source num_factors does not match the posterior problem.")
+    if int(source.batch_capacity) <= 0 or int(source.batches_per_epoch) <= 0:
+        raise ValueError("source batch capacity and epoch length must be positive.")
+    if not source.fingerprint:
+        raise ValueError("source fingerprint must be non-empty.")
+    configuration_json = json.dumps(
+        source.configuration(),
+        allow_nan=False,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    batches = _materialize_source_epoch(source, 0)
+    return configuration_json, batches
+
+
+def _materialize_source_epoch(
+    source: MinibatchSource, epoch: int, /
+) -> tuple[LikelihoodBatch, ...]:
+    batches = tuple(source.epoch(epoch))
+    if len(batches) != int(source.batches_per_epoch):
+        raise ValueError("source epoch length does not match batches_per_epoch.")
+    if not batches:
+        raise ValueError("source epochs must contain at least one batch.")
+    for batch in batches:
+        if not isinstance(batch, LikelihoodBatch):
+            raise TypeError("source epochs must emit LikelihoodBatch objects.")
+        if batch.capacity != int(source.batch_capacity):
+            raise ValueError("source emitted a batch with incompatible capacity.")
+    if sum(int(batch.factor_count) for batch in batches) != int(source.num_factors):
+        raise ValueError("source epoch active-factor count does not match num_factors.")
+    return batches
+
+
+def _problem_fingerprint(
+    problem: MinibatchPosteriorProblem,
+    batch: LikelihoodBatch,
+    /,
+) -> str:
+    probe, gradient = jax.value_and_grad(problem.log_density_estimate)(
+        problem.initial_position,
+        batch,
+    )
+    jax.block_until_ready((probe, gradient))
+    payload = {
+        "problem_arrays": array_tree_fingerprint(problem)["sha256"],
+        "initial_position": array_tree_fingerprint(problem.initial_position),
+        "initial_probe": array_tree_fingerprint(
+            {"value": probe, "gradient": gradient}
+        ),
+        "num_factors": problem.num_factors,
+    }
+    canonical = json.dumps(payload, separators=(",", ":"), sort_keys=True)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _write_sgmcmc_checkpoint(
+    destination,
+    *,
+    compatibility,
+    algorithm,
+    completed_updates,
+    completed_draws,
+    current_states,
+    burnin_states,
+    samples,
+    gradient_norm,
+    thermostat,
+    momentum_norm,
+    compilation_duration_seconds,
+    burnin_duration_seconds,
+    sampling_duration_seconds,
+    gradient_evaluations,
+    gradient_norm_sum,
+    gradient_norm_count,
+    gradient_norm_max,
+    min_active_factors,
+    max_active_factors,
+    nonfinite_update_count,
+):
+    arrays: dict[str, Any] = {
+        "gradient_norm": gradient_norm,
+    }
+    if thermostat is not None:
+        arrays["thermostat"] = thermostat
+    if momentum_norm is not None:
+        arrays["momentum_norm"] = momentum_norm
+    state = {
+        "algorithm": algorithm,
+        "completed_updates": int(completed_updates),
+        "completed_draws": int(completed_draws),
+        "current_state_tree": pack_array_tree(
+            "current_state", current_states, arrays
+        ),
+        "burnin_state_tree": (
+            None
+            if burnin_states is None
+            else pack_array_tree("burnin_state", burnin_states, arrays)
+        ),
+        "sample_tree": pack_array_tree("samples", samples, arrays),
+        "gradient_norm_array": "gradient_norm",
+        "thermostat_array": None if thermostat is None else "thermostat",
+        "momentum_norm_array": None if momentum_norm is None else "momentum_norm",
+        "compilation_duration_seconds": float(compilation_duration_seconds),
+        "burnin_duration_seconds": float(burnin_duration_seconds),
+        "sampling_duration_seconds": float(sampling_duration_seconds),
+        "gradient_evaluations": int(gradient_evaluations),
+        "gradient_norm_sum": float(gradient_norm_sum),
+        "gradient_norm_count": int(gradient_norm_count),
+        "gradient_norm_max": float(gradient_norm_max),
+        "min_active_factors": int(min_active_factors),
+        "max_active_factors": int(max_active_factors),
+        "nonfinite_update_count": int(nonfinite_update_count),
+    }
+    write_checkpoint_archive(
+        destination,
+        kind=_CHECKPOINT_KIND,
+        compatibility=compatibility,
+        state=state,
+        arrays=arrays,
+    )
+
+
+def _read_sgmcmc_checkpoint(
+    state,
+    arrays,
+    *,
+    algorithm,
+    state_template,
+    position_template,
+    num_chains,
+    num_burnin,
+    num_samples,
+    steps_per_sample,
+):
+    if state.get("algorithm") != algorithm:
+        raise CheckpointCompatibilityError(
+            "Checkpoint algorithm does not match the requested SG-MCMC method."
+        )
+    completed_updates = _checkpoint_int(
+        state, "completed_updates", minimum=0
+    )
+    completed_draws = _checkpoint_int(state, "completed_draws", minimum=0)
+    maximum_updates = num_burnin + num_samples * steps_per_sample
+    if completed_updates > maximum_updates or completed_draws > num_samples:
+        raise CheckpointCompatibilityError(
+            "Checkpoint contains more progress than the requested sample count."
+        )
+    expected_draws = max(0, completed_updates - num_burnin) // steps_per_sample
+    if completed_draws != expected_draws:
+        raise CheckpointCorruptionError(
+            "Checkpoint update and retained-draw progress are inconsistent."
+        )
+    current_spec = state.get("current_state_tree")
+    sample_spec = state.get("sample_tree")
+    if not isinstance(current_spec, dict) or not isinstance(sample_spec, dict):
+        raise CheckpointCorruptionError("Checkpoint state tree metadata is invalid.")
+    current_states = unpack_array_tree(
+        current_spec, arrays, state_template
+    )
+    sample_template = jax.tree_util.tree_map(
+        lambda value: jnp.empty(
+            (num_chains, completed_draws, *value.shape), dtype=value.dtype
+        ),
+        position_template,
+    )
+    samples = unpack_array_tree(sample_spec, arrays, sample_template)
+    burnin_spec = state.get("burnin_state_tree")
+    if completed_updates < num_burnin:
+        if burnin_spec is not None:
+            raise CheckpointCorruptionError(
+                "Checkpoint contains burn-in states before burn-in completion."
+            )
+        burnin_states = None
+    else:
+        if not isinstance(burnin_spec, dict):
+            raise CheckpointCorruptionError(
+                "Checkpoint is missing completed burn-in states."
+            )
+        burnin_states = unpack_array_tree(
+            burnin_spec, arrays, state_template
+        )
+    gradient_norm = _checkpoint_array(
+        arrays,
+        state.get("gradient_norm_array"),
+        shape=(num_chains, completed_draws),
+    )
+    if algorithm == "sgnht":
+        thermostat = _checkpoint_array(
+            arrays,
+            state.get("thermostat_array"),
+            shape=(num_chains, completed_draws),
+        )
+        momentum_norm = _checkpoint_array(
+            arrays,
+            state.get("momentum_norm_array"),
+            shape=(num_chains, completed_draws),
+        )
+    else:
+        if state.get("thermostat_array") is not None or state.get(
+            "momentum_norm_array"
+        ) is not None:
+            raise CheckpointCorruptionError(
+                "SGLD checkpoint contains thermostat statistics."
+            )
+        thermostat = None
+        momentum_norm = None
+    invalid = _invalid_chain_indices(current_states, num_chains)
+    if invalid:
+        raise CheckpointCorruptionError(
+            f"Checkpoint current states are nonfinite for chains {invalid}."
+        )
+    return {
+        "current_states": current_states,
+        "burnin_states": burnin_states,
+        "samples": samples,
+        "gradient_norm": gradient_norm,
+        "thermostat": thermostat,
+        "momentum_norm": momentum_norm,
+        "completed_updates": completed_updates,
+        "completed_draws": completed_draws,
+        "compilation_duration_seconds": _checkpoint_float(
+            state, "compilation_duration_seconds", minimum=0.0
+        ),
+        "burnin_duration_seconds": _checkpoint_float(
+            state, "burnin_duration_seconds", minimum=0.0
+        ),
+        "sampling_duration_seconds": _checkpoint_float(
+            state, "sampling_duration_seconds", minimum=0.0
+        ),
+        "gradient_evaluations": _checkpoint_int(
+            state, "gradient_evaluations", minimum=0
+        ),
+        "gradient_norm_sum": _checkpoint_float(
+            state, "gradient_norm_sum", minimum=0.0
+        ),
+        "gradient_norm_count": _checkpoint_int(
+            state, "gradient_norm_count", minimum=0
+        ),
+        "gradient_norm_max": _checkpoint_float(
+            state, "gradient_norm_max", minimum=0.0
+        ),
+        "min_active_factors": _checkpoint_int(
+            state, "min_active_factors", minimum=1
+        ),
+        "max_active_factors": _checkpoint_int(
+            state, "max_active_factors", minimum=1
+        ),
+        "nonfinite_update_count": _checkpoint_int(
+            state, "nonfinite_update_count", minimum=0
+        ),
+    }
+
+
+def _checkpoint_array(arrays, name, *, shape):
+    if not isinstance(name, str) or name not in arrays:
+        raise CheckpointCorruptionError("Checkpoint statistic array is missing.")
+    value = jnp.asarray(arrays[name])
+    if value.shape != shape:
+        raise CheckpointCorruptionError(
+            f"Checkpoint array {name!r} has an invalid shape."
+        )
+    return value
+
+
+def _checkpoint_int(state, name, *, minimum):
+    value = state.get(name)
+    if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+        raise CheckpointCorruptionError(
+            f"Checkpoint field {name!r} is invalid."
+        )
+    return int(value)
+
+
+def _checkpoint_float(state, name, *, minimum):
+    value = state.get(name)
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        raise CheckpointCorruptionError(
+            f"Checkpoint field {name!r} is invalid."
+        )
+    result = float(value)
+    if not jnp.isfinite(result) or result < minimum:
+        raise CheckpointCorruptionError(
+            f"Checkpoint field {name!r} is invalid."
+        )
+    return result
+
+
+__all__ = [
+    "build_sgmcmc_control_variate",
+    "sample_sgld",
+    "sample_sgnht",
+    "SGMCMCControlVariate",
+    "SGMCMCDiagnostics",
+    "SGMCMCMixingReport",
+    "SGMCMCMixingThresholds",
+    "SGMCMCResult",
+]

--- a/phydrax/uq/_sgmcmc_diagnostics.py
+++ b/phydrax/uq/_sgmcmc_diagnostics.py
@@ -1,0 +1,298 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from typing import Any
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array, PyTree
+
+from .._strict import StrictModule
+
+
+class SGMCMCDiagnostics(StrictModule):
+    """Rank mixing and stochastic-gradient summaries for fixed-step chains."""
+
+    rhat: PyTree[Array]
+    bulk_ess: PyTree[Array]
+    tail_ess: PyTree[Array]
+    mean: PyTree[Array]
+    standard_deviation: PyTree[Array]
+    minimum: PyTree[Array]
+    maximum: PyTree[Array]
+    max_rhat: Array
+    min_bulk_ess: Array
+    min_tail_ess: Array
+    mean_gradient_norm: Array
+    standard_deviation_gradient_norm: Array
+    max_gradient_norm: Array
+    min_active_factors: int = eqx.field(static=True)
+    max_active_factors: int = eqx.field(static=True)
+    nonfinite_update_count: int = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        rhat: PyTree[Array],
+        bulk_ess: PyTree[Array],
+        tail_ess: PyTree[Array],
+        mean: PyTree[Array],
+        standard_deviation: PyTree[Array],
+        minimum: PyTree[Array],
+        maximum: PyTree[Array],
+        gradient_norm: Array,
+        min_active_factors: int,
+        max_active_factors: int,
+        nonfinite_update_count: int,
+    ):
+        gradient_values = jnp.asarray(gradient_norm, dtype=float)
+        self.rhat = rhat
+        self.bulk_ess = bulk_ess
+        self.tail_ess = tail_ess
+        self.mean = mean
+        self.standard_deviation = standard_deviation
+        self.minimum = minimum
+        self.maximum = maximum
+        self.max_rhat = _tree_extreme(rhat, maximum=True)
+        self.min_bulk_ess = _tree_extreme(bulk_ess, maximum=False)
+        self.min_tail_ess = _tree_extreme(tail_ess, maximum=False)
+        self.mean_gradient_norm = jnp.mean(gradient_values)
+        self.standard_deviation_gradient_norm = jnp.std(gradient_values)
+        self.max_gradient_norm = jnp.max(gradient_values)
+        self.min_active_factors = int(min_active_factors)
+        self.max_active_factors = int(max_active_factors)
+        self.nonfinite_update_count = int(nonfinite_update_count)
+
+
+class SGMCMCMixingThresholds(StrictModule):
+    """Caller-controlled mixing gates for a fixed-step production window."""
+
+    max_rhat: float = eqx.field(static=True)
+    min_bulk_ess: float = eqx.field(static=True)
+    min_tail_ess: float = eqx.field(static=True)
+    allow_nonfinite_updates: bool = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        max_rhat: float = 1.01,
+        min_bulk_ess: float = 400.0,
+        min_tail_ess: float = 400.0,
+        allow_nonfinite_updates: bool = False,
+    ):
+        maximum = float(max_rhat)
+        minimum_bulk = float(min_bulk_ess)
+        minimum_tail = float(min_tail_ess)
+        if not jnp.isfinite(maximum) or maximum < 1.0:
+            raise ValueError("max_rhat must be finite and at least one.")
+        if not jnp.isfinite(minimum_bulk) or minimum_bulk <= 0.0:
+            raise ValueError("min_bulk_ess must be finite and positive.")
+        if not jnp.isfinite(minimum_tail) or minimum_tail <= 0.0:
+            raise ValueError("min_tail_ess must be finite and positive.")
+        self.max_rhat = maximum
+        self.min_bulk_ess = minimum_bulk
+        self.min_tail_ess = minimum_tail
+        self.allow_nonfinite_updates = bool(allow_nonfinite_updates)
+
+
+class SGMCMCMixingReport(StrictModule):
+    """Serializable mixing decision for an explicitly approximate chain."""
+
+    thresholds: SGMCMCMixingThresholds
+    passed: bool = eqx.field(static=True)
+    failures: tuple[str, ...] = eqx.field(static=True)
+    rhat_failures: tuple[str, ...] = eqx.field(static=True)
+    bulk_ess_failures: tuple[str, ...] = eqx.field(static=True)
+    tail_ess_failures: tuple[str, ...] = eqx.field(static=True)
+    max_rhat: Array
+    min_bulk_ess: Array
+    min_tail_ess: Array
+    max_gradient_norm: Array
+    algorithm: str = eqx.field(static=True)
+    approximation: str = eqx.field(static=True)
+    num_chains: int = eqx.field(static=True)
+    num_draws: int = eqx.field(static=True)
+    step_size: float = eqx.field(static=True)
+    batch_fraction: float = eqx.field(static=True)
+    sample_memory_bytes: int = eqx.field(static=True)
+    duration_seconds: float = eqx.field(static=True)
+    samples_per_second: float = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        diagnostics: SGMCMCDiagnostics,
+        thresholds: SGMCMCMixingThresholds,
+        algorithm: str,
+        approximation: str,
+        num_chains: int,
+        num_draws: int,
+        step_size: float,
+        batch_fraction: float,
+        sample_memory_bytes: int,
+        duration_seconds: float,
+        samples_per_second: float,
+    ):
+        rhat_failures = _failing_locations(
+            diagnostics.rhat,
+            lambda value: ~jnp.isfinite(value) | (value > thresholds.max_rhat),
+        )
+        bulk_failures = _failing_locations(
+            diagnostics.bulk_ess,
+            lambda value: ~jnp.isfinite(value) | (value < thresholds.min_bulk_ess),
+        )
+        tail_failures = _failing_locations(
+            diagnostics.tail_ess,
+            lambda value: ~jnp.isfinite(value) | (value < thresholds.min_tail_ess),
+        )
+        failures: list[str] = []
+        if rhat_failures:
+            failures.append("rhat")
+        if bulk_failures:
+            failures.append("bulk_ess")
+        if tail_failures:
+            failures.append("tail_ess")
+        if diagnostics.nonfinite_update_count and not thresholds.allow_nonfinite_updates:
+            failures.append("nonfinite_updates")
+        self.thresholds = thresholds
+        self.passed = not failures
+        self.failures = tuple(failures)
+        self.rhat_failures = rhat_failures
+        self.bulk_ess_failures = bulk_failures
+        self.tail_ess_failures = tail_failures
+        self.max_rhat = diagnostics.max_rhat
+        self.min_bulk_ess = diagnostics.min_bulk_ess
+        self.min_tail_ess = diagnostics.min_tail_ess
+        self.max_gradient_norm = diagnostics.max_gradient_norm
+        self.algorithm = str(algorithm)
+        self.approximation = str(approximation)
+        self.num_chains = int(num_chains)
+        self.num_draws = int(num_draws)
+        self.step_size = float(step_size)
+        self.batch_fraction = float(batch_fraction)
+        self.sample_memory_bytes = int(sample_memory_bytes)
+        self.duration_seconds = float(duration_seconds)
+        self.samples_per_second = float(samples_per_second)
+
+    def raise_for_failure(self) -> None:
+        if not self.passed:
+            raise SGMCMCMixingError(self)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "passed": self.passed,
+            "failures": self.failures,
+            "rhat_failures": self.rhat_failures,
+            "bulk_ess_failures": self.bulk_ess_failures,
+            "tail_ess_failures": self.tail_ess_failures,
+            "max_rhat": float(self.max_rhat),
+            "min_bulk_ess": float(self.min_bulk_ess),
+            "min_tail_ess": float(self.min_tail_ess),
+            "max_gradient_norm": float(self.max_gradient_norm),
+            "algorithm": self.algorithm,
+            "approximation": self.approximation,
+            "num_chains": self.num_chains,
+            "num_draws": self.num_draws,
+            "step_size": self.step_size,
+            "batch_fraction": self.batch_fraction,
+            "sample_memory_bytes": self.sample_memory_bytes,
+            "duration_seconds": self.duration_seconds,
+            "samples_per_second": self.samples_per_second,
+        }
+
+
+class SGMCMCMixingError(RuntimeError):
+    """Raised when a fixed-step SG-MCMC mixing report fails its gates."""
+
+    report: SGMCMCMixingReport
+
+    def __init__(self, report: SGMCMCMixingReport):
+        self.report = report
+        super().__init__("SG-MCMC mixing gates failed: " + ", ".join(report.failures) + ".")
+
+
+def sgmcmc_diagnostics(
+    samples: PyTree[Array],
+    /,
+    *,
+    gradient_norm: Array,
+    min_active_factors: int,
+    max_active_factors: int,
+    nonfinite_update_count: int = 0,
+) -> SGMCMCDiagnostics:
+    """Compute rank diagnostics without fabricating HMC transition statistics."""
+    import blackjax.diagnostics as diagnostics
+
+    leaves = jax.tree_util.tree_leaves(samples)
+    if not leaves:
+        raise ValueError("SG-MCMC samples must contain array leaves.")
+    for leaf in leaves:
+        array = jnp.asarray(leaf)
+        if array.ndim < 2 or int(array.shape[0]) < 2 or int(array.shape[1]) < 4:
+            raise ValueError(
+                "SG-MCMC diagnostics require at least two chains and four draws."
+            )
+    rhat = jax.tree_util.tree_map(
+        lambda value: diagnostics.rhat(value, chain_axis=0, sample_axis=1),
+        samples,
+    )
+    bulk_ess = jax.tree_util.tree_map(
+        lambda value: diagnostics.ess_bulk(value, chain_axis=0, sample_axis=1),
+        samples,
+    )
+    tail_ess = jax.tree_util.tree_map(
+        lambda value: diagnostics.ess_tail(value, chain_axis=0, sample_axis=1),
+        samples,
+    )
+    return SGMCMCDiagnostics(
+        rhat=rhat,
+        bulk_ess=bulk_ess,
+        tail_ess=tail_ess,
+        mean=jax.tree_util.tree_map(lambda value: jnp.mean(value, axis=(0, 1)), samples),
+        standard_deviation=jax.tree_util.tree_map(
+            lambda value: jnp.std(value, axis=(0, 1)), samples
+        ),
+        minimum=jax.tree_util.tree_map(
+            lambda value: jnp.min(value, axis=(0, 1)), samples
+        ),
+        maximum=jax.tree_util.tree_map(
+            lambda value: jnp.max(value, axis=(0, 1)), samples
+        ),
+        gradient_norm=gradient_norm,
+        min_active_factors=min_active_factors,
+        max_active_factors=max_active_factors,
+        nonfinite_update_count=nonfinite_update_count,
+    )
+
+
+def _failing_locations(tree: PyTree[Any], predicate: Any, /) -> tuple[str, ...]:
+    locations: list[str] = []
+    for path, leaf in jax.tree_util.tree_flatten_with_path(tree)[0]:
+        array = jnp.asarray(leaf, dtype=float)
+        base = jax.tree_util.keystr(path) or "<root>"
+        for index in jnp.argwhere(predicate(array)):
+            suffix = ""
+            if array.ndim:
+                suffix = "[" + ",".join(str(int(value)) for value in index) + "]"
+            locations.append(base + suffix)
+    return tuple(locations)
+
+
+def _tree_extreme(tree: PyTree[Any], /, *, maximum: bool) -> Array:
+    values = jnp.concatenate(
+        [jnp.ravel(jnp.asarray(leaf, dtype=float)) for leaf in jax.tree_util.tree_leaves(tree)]
+    )
+    return jnp.max(values) if maximum else jnp.min(values)
+
+
+__all__ = [
+    "SGMCMCDiagnostics",
+    "SGMCMCMixingError",
+    "SGMCMCMixingReport",
+    "SGMCMCMixingThresholds",
+    "sgmcmc_diagnostics",
+]

--- a/tests/integration/test_uq_benchmark_matrix.py
+++ b/tests/integration/test_uq_benchmark_matrix.py
@@ -24,7 +24,7 @@ def test_complete_uq_benchmark_matrix_passes_and_writes_machine_report(tmp_path)
     assert report.passed
     assert tuple(scenario.name for scenario in report.scenarios) == tuple(SCENARIOS)
     assert "schema_version" not in payload
-    assert payload["summary"]["scenario_count"] == 7
+    assert payload["summary"]["scenario_count"] == 8
     assert payload["summary"]["scenarios_failed"] == 0
     assert all(
         category["failed"] == 0

--- a/tests/integration/test_uq_sgmcmc.py
+++ b/tests/integration/test_uq_sgmcmc.py
@@ -1,0 +1,126 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax.numpy as jnp
+import jax.random as jr
+
+import phydrax as phx
+
+
+def _conjugate_normal_problem():
+    observations = 1.2 + jnp.linspace(-0.3, 0.3, 64)
+    prior_scale = 2.0
+    source = phx.uq.ArrayMinibatchSource(
+        observations,
+        batch_size=8,
+        seed=101,
+    )
+    parameter_space = phx.uq.ParameterSpace(
+        jnp.asarray(0.0),
+        priors=phx.uq.Normal(0.0, prior_scale),
+    )
+
+    def factors(parameter, batch):
+        return -0.5 * (batch.data - parameter) ** 2
+
+    def full_likelihood(parameter):
+        return jnp.sum(-0.5 * (observations - parameter) ** 2)
+
+    minibatch_problem = phx.uq.MinibatchPosteriorProblem(
+        parameter_space,
+        factors,
+        num_factors=source.num_factors,
+        full_log_likelihood=full_likelihood,
+    )
+    exact_problem = phx.uq.PosteriorProblem(parameter_space, full_likelihood)
+    precision = observations.shape[0] + 1.0 / prior_scale**2
+    posterior_mean = jnp.sum(observations) / precision
+    posterior_variance = 1.0 / precision
+    return (
+        minibatch_problem,
+        exact_problem,
+        source,
+        posterior_mean,
+        posterior_variance,
+    )
+
+
+def test_sgld_recovers_conjugate_posterior_and_step_refinement_reduces_bias():
+    problem, exact_problem, source, expected_mean, expected_variance = (
+        _conjugate_normal_problem()
+    )
+    control = phx.uq.build_sgmcmc_control_variate(
+        problem,
+        source,
+        expected_mean,
+    )
+    coarse = phx.uq.sample_sgld(
+        problem,
+        source,
+        key=jr.key(501),
+        step_size=1.0e-2,
+        num_chains=4,
+        num_burnin=300,
+        num_samples=800,
+        control_variate=control,
+    )
+    refined = phx.uq.sample_sgld(
+        problem,
+        source,
+        key=jr.key(502),
+        step_size=2.0e-3,
+        num_chains=4,
+        num_burnin=500,
+        num_samples=1200,
+        control_variate=control,
+    )
+    nuts = phx.uq.sample_nuts(
+        exact_problem,
+        key=jr.key(506),
+        num_chains=4,
+        num_warmup=200,
+        num_samples=400,
+        initial_step_size=0.1,
+        max_num_doublings=6,
+    )
+    laplace = phx.uq.fit_laplace(exact_problem, expected_mean)
+
+    coarse_variance_error = jnp.abs(jnp.var(coarse.samples) - expected_variance)
+    refined_variance_error = jnp.abs(jnp.var(refined.samples) - expected_variance)
+    assert refined_variance_error < coarse_variance_error
+    assert jnp.abs(jnp.mean(refined.samples) - expected_mean) < 0.03
+    assert refined_variance_error / expected_variance < 0.15
+    assert jnp.abs(jnp.mean(nuts.samples) - expected_mean) < 0.03
+    assert jnp.abs(jnp.var(nuts.samples) - expected_variance) / expected_variance < 0.2
+    assert jnp.allclose(laplace.map_parameters, expected_mean, atol=1.0e-10)
+    assert jnp.allclose(laplace.covariance[0, 0], expected_variance, rtol=1.0e-10)
+
+
+def test_sgnht_recovers_conjugate_posterior_with_thermostat_diagnostics():
+    problem, _, source, expected_mean, expected_variance = (
+        _conjugate_normal_problem()
+    )
+    control = phx.uq.build_sgmcmc_control_variate(
+        problem,
+        source,
+        expected_mean,
+    )
+    result = phx.uq.sample_sgnht(
+        problem,
+        source,
+        key=jr.key(505),
+        step_size=5.0e-3,
+        diffusion=0.01,
+        num_chains=4,
+        num_burnin=2000,
+        num_samples=5000,
+        control_variate=control,
+    )
+
+    assert jnp.abs(jnp.mean(result.samples) - expected_mean) < 0.03
+    assert jnp.abs(jnp.var(result.samples) - expected_variance) / expected_variance < 0.25
+    assert result.diagnostics.max_rhat < 1.1
+    assert result.thermostat.shape == (4, 5000)
+    assert result.momentum_norm.shape == (4, 5000)
+    assert jnp.all(jnp.isfinite(result.thermostat))

--- a/tests/unit/uq/test_benchmark_report.py
+++ b/tests/unit/uq/test_benchmark_report.py
@@ -114,3 +114,16 @@ def test_runner_records_scenario_exceptions_without_losing_the_report(monkeypatc
     assert report.scenarios[0].error_type == "RuntimeError"
     assert report.scenarios[0].failures == ("scenario_error",)
     assert "failure for smoke" in report.scenarios[0].error_message
+
+
+def test_stochastic_gradient_benchmark_controls_are_profiled_and_registered():
+    smoke = runner.get_configuration("smoke")
+    standard = runner.get_configuration("standard")
+
+    assert tuple(runner.SCENARIOS)[-1] == "stochastic_gradient_regression"
+    assert smoke.sgmcmc_burnin > 0
+    assert smoke.sgmcmc_draws > 0
+    assert smoke.sgmcmc_batch_size > 0
+    assert smoke.sgmcmc_steps_per_sample > 0
+    assert standard.sgmcmc_burnin >= smoke.sgmcmc_burnin
+    assert standard.sgmcmc_draws >= smoke.sgmcmc_draws

--- a/tests/unit/uq/test_minibatch_posterior.py
+++ b/tests/unit/uq/test_minibatch_posterior.py
@@ -1,0 +1,173 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+import phydrax as phx
+
+
+def _problem(data, *, num_factors=None, full_shift=0.0):
+    values = jnp.asarray(data)
+    count = int(values.shape[0]) if num_factors is None else int(num_factors)
+    space = phx.uq.ParameterSpace(
+        jnp.log(jnp.asarray(1.5)),
+        priors=phx.uq.LogNormal(0.0, 1.0),
+        bijectors=phx.uq.ExpBijector(),
+    )
+
+    def factors(parameter, batch):
+        return -0.5 * (batch.data - parameter) ** 2
+
+    return phx.uq.MinibatchPosteriorProblem(
+        space,
+        factors,
+        num_factors=count,
+        full_log_likelihood=lambda parameter: (
+            jnp.sum(-0.5 * (values - parameter) ** 2) + full_shift
+        ),
+        predict=lambda parameter, scale: scale * parameter,
+        observation_variance=lambda parameter: jnp.ones_like(parameter) * 0.25,
+        sample_observation=lambda key, parameter: parameter
+        + 0.5 * jax.random.normal(key),
+    )
+
+
+def _active_values(source, epoch):
+    return jnp.concatenate(
+        [batch.data[batch.factor_mask] for batch in source.epoch(epoch)]
+    )
+
+
+def test_array_minibatch_source_is_deterministic_complete_and_padded():
+    data = jnp.arange(7)
+    source = phx.uq.ArrayMinibatchSource(data, batch_size=3, seed=11)
+    duplicate = phx.uq.ArrayMinibatchSource(data, batch_size=3, seed=11)
+
+    first = tuple(source.epoch(2))
+    second = tuple(duplicate.epoch(2))
+
+    assert source.num_factors == 7
+    assert source.batch_capacity == 3
+    assert source.batches_per_epoch == 3
+    assert [int(batch.factor_count) for batch in first] == [3, 3, 1]
+    assert all(batch.capacity == 3 for batch in first)
+    assert jnp.array_equal(jnp.sort(_active_values(source, 2)), data)
+    assert all(
+        jnp.array_equal(left.data, right.data)
+        and jnp.array_equal(left.factor_mask, right.factor_mask)
+        for left, right in zip(first, second, strict=True)
+    )
+    assert source.fingerprint == duplicate.fingerprint
+    assert not jnp.array_equal(_active_values(source, 2), _active_values(source, 3))
+    assert first[-1].data[-1] == first[-1].data[0]
+    assert not bool(first[-1].factor_mask[-1])
+
+
+def test_array_minibatch_source_fingerprint_covers_data_and_configuration():
+    baseline = phx.uq.ArrayMinibatchSource(jnp.arange(6), batch_size=4, seed=2)
+    changed_data = phx.uq.ArrayMinibatchSource(
+        jnp.arange(6).at[0].set(9), batch_size=4, seed=2
+    )
+    changed_batch = phx.uq.ArrayMinibatchSource(jnp.arange(6), batch_size=3, seed=2)
+    changed_seed = phx.uq.ArrayMinibatchSource(jnp.arange(6), batch_size=4, seed=3)
+
+    assert len({
+        baseline.fingerprint,
+        changed_data.fingerprint,
+        changed_batch.fingerprint,
+        changed_seed.fingerprint,
+    }) == 4
+    assert baseline.configuration()["data"]["sha256"]
+
+
+@pytest.mark.parametrize(
+    ("data", "batch_size", "message"),
+    [
+        (jnp.asarray(1.0), 2, "positive leading axis"),
+        ({"x": jnp.ones((3,)), "y": jnp.ones((2,))}, 2, "share"),
+        (jnp.ones((3,)), 0, "batch_size"),
+    ],
+)
+def test_array_minibatch_source_rejects_invalid_contracts(data, batch_size, message):
+    with pytest.raises(ValueError, match=message):
+        phx.uq.ArrayMinibatchSource(data, batch_size=batch_size)
+
+
+def test_likelihood_batch_requires_a_nonempty_boolean_factor_mask():
+    with pytest.raises(ValueError, match="one-dimensional"):
+        phx.uq.LikelihoodBatch(jnp.ones((2,)), jnp.ones((1, 2), dtype=bool))
+    with pytest.raises(TypeError, match="boolean"):
+        phx.uq.LikelihoodBatch(jnp.ones((2,)), jnp.ones((2,)))
+    with pytest.raises(ValueError, match="active factor"):
+        phx.uq.LikelihoodBatch(jnp.ones((2,)), jnp.zeros((2,), dtype=bool))
+
+
+def test_minibatch_posterior_scales_only_active_likelihood_factors():
+    data = jnp.asarray([0.5, 1.0, 2.0, 4.0, 8.0])
+    problem = _problem(data)
+    batch = phx.uq.LikelihoodBatch(
+        jnp.asarray([0.5, 2.0, 1.0e20]),
+        jnp.asarray([True, True, False]),
+    )
+    position = problem.initial_position
+    physical = problem.parameter_space.constrain(position)
+    factors = -0.5 * (batch.data[:2] - physical) ** 2
+    expected_likelihood = data.shape[0] / 2 * jnp.sum(factors)
+    expected = (
+        expected_likelihood
+        + problem.parameter_space.log_prior(physical)
+        + problem.parameter_space.log_abs_det_jacobian(position)
+    )
+
+    assert jnp.allclose(problem.log_likelihood_estimate(physical, batch), expected_likelihood)
+    assert jnp.allclose(problem.log_density_estimate(position, batch), expected)
+    assert problem.predict(position, 3.0) == 3.0 * physical
+    assert problem.conditional_observation_variance(position) == 0.25
+    assert jnp.isfinite(problem.sample_observation(jax.random.key(1), position))
+
+
+def test_minibatch_posterior_rejects_wrong_factor_shapes():
+    space = phx.uq.ParameterSpace(jnp.asarray(0.0), priors=phx.uq.Normal(0.0, 1.0))
+    batch = phx.uq.LikelihoodBatch(jnp.ones((3,)), jnp.ones((3,), dtype=bool))
+    scalar_problem = phx.uq.MinibatchPosteriorProblem(
+        space, lambda parameter, current: jnp.asarray(0.0), num_factors=3
+    )
+    short_problem = phx.uq.MinibatchPosteriorProblem(
+        space, lambda parameter, current: jnp.ones((2,)), num_factors=3
+    )
+
+    with pytest.raises(ValueError, match="one scalar"):
+        scalar_problem.log_density_estimate(space.initial, batch)
+    with pytest.raises(ValueError, match="one scalar"):
+        short_problem.log_density_estimate(space.initial, batch)
+
+
+def test_minibatch_diagnostics_reconstruct_full_density_and_gradient():
+    data = jnp.linspace(0.2, 1.4, 7)
+    source = phx.uq.ArrayMinibatchSource(data, batch_size=3, seed=4)
+    diagnostics = phx.uq.diagnose_minibatch_posterior(_problem(data), source)
+
+    assert diagnostics.passed
+    assert diagnostics.epoch_active_factor_count == data.shape[0]
+    assert diagnostics.repeated_evaluation_matches
+    assert diagnostics.jit_evaluation_matches
+    assert diagnostics.full_log_density_matches
+    assert diagnostics.full_gradient_matches
+    assert diagnostics.capabilities.prediction
+    assert diagnostics.capabilities.control_variates
+
+
+def test_minibatch_diagnostics_report_population_and_full_density_mismatches():
+    data = jnp.linspace(-1.0, 1.0, 5)
+    source = phx.uq.ArrayMinibatchSource(data, batch_size=2, seed=5)
+    diagnostics = phx.uq.diagnose_minibatch_posterior(
+        _problem(data, num_factors=6, full_shift=1.0), source
+    )
+
+    assert not diagnostics.passed
+    assert "source_population_mismatch" in diagnostics.failures
+    assert "epoch_factor_count_mismatch" in diagnostics.failures
+    assert "full_log_density_mismatch" in diagnostics.failures

--- a/tests/unit/uq/test_operator_likelihood.py
+++ b/tests/unit/uq/test_operator_likelihood.py
@@ -5,6 +5,7 @@
 import equinox as eqx
 import jax
 import jax.numpy as jnp
+import jax.random as jr
 import pytest
 
 import phydrax as phx
@@ -238,3 +239,224 @@ def test_operator_likelihood_rejects_empty_cases_and_contract_mismatches():
     )
     with pytest.raises(ValueError, match="fixed batch contract"):
         term.log_prob({"level": jnp.asarray(0.0)})
+
+
+def _operator_dataset(cases=5, resolution=4):
+    axis = phx.nn.OperatorAxis("x", jnp.linspace(0.0, 1.0, resolution))
+    values = jnp.arange(cases, dtype=float)[:, None] + axis.nodes[None, :]
+    return phx.nn.operator_dataset_from_arrays(
+        {"state": values},
+        {"solution": 2.0 * values},
+        source_axes={"state": (axis,)},
+        query_axes=(axis,),
+    )
+
+
+def _dynamic_prediction(parameter, batch):
+    return phx.nn.OperatorPrediction.from_field(
+        "solution",
+        parameter * batch.input("state").values,
+        "query",
+        batch.query("query"),
+        spec=phx.nn.OperatorOutputSpec(),
+        case_axes=batch.case_axes,
+        case_shape=batch.case_shape,
+    )
+
+
+def test_dynamic_operator_likelihood_matches_fixed_full_batch_and_is_jittable():
+    dataset = _operator_dataset()
+    target_field = dataset.targets.field("solution")
+    dynamic = phx.uq.OperatorBatchObservationLikelihood(
+        _dynamic_prediction,
+        phx.uq.GaussianLikelihood(0.2),
+    )
+    data = phx.uq.OperatorLikelihoodData(
+        dataset.batch,
+        target_field.values,
+        output_spec=target_field.spec,
+        field_name="solution",
+        query_name=target_field.query_name,
+    )
+    fixed = phx.uq.FixedOperatorObservationLikelihood(
+        lambda parameter: _dynamic_prediction(parameter, dataset.batch),
+        dataset.batch,
+        target_field.values,
+        phx.uq.GaussianLikelihood(0.2),
+        output_spec=target_field.spec,
+        field_name="solution",
+        query_name=target_field.query_name,
+    )
+    parameter = jnp.asarray(1.7)
+
+    assert jnp.allclose(
+        dynamic.per_case_log_prob(parameter, data),
+        fixed.per_case_log_prob(parameter),
+    )
+    likelihood_batch = phx.uq.LikelihoodBatch(
+        data,
+        jnp.asarray([True, True, True, True, False]),
+    )
+    compiled = eqx.filter_jit(
+        lambda value, batch: dynamic(value, batch)
+    )(parameter, likelihood_batch)
+    assert compiled.shape == (5,)
+    assert compiled[-1] == 0.0
+
+
+def test_operator_minibatch_source_is_complete_padded_and_content_addressed():
+    dataset = _operator_dataset()
+    loader = phx.nn.OperatorBatchLoader(
+        dataset,
+        batch_size=2,
+        shuffle=True,
+        seed=6,
+        drop_last=False,
+        prefetch=1,
+    )
+    source = phx.uq.OperatorMinibatchSource(loader, field_name="solution")
+    batches = tuple(source.epoch(0))
+    case_ids = jnp.concatenate(
+        [
+            batch.data.batch.input("state").values[:, 0][batch.factor_mask]
+            for batch in batches
+        ]
+    )
+
+    assert source.num_factors == 5
+    assert source.batch_capacity == 2
+    assert source.batches_per_epoch == 3
+    assert [int(batch.factor_count) for batch in batches] == [2, 2, 1]
+    assert jnp.array_equal(jnp.sort(case_ids), jnp.arange(5.0))
+    assert batches[-1].data.target.shape == (2, 4)
+    assert not bool(batches[-1].factor_mask[-1])
+    assert (
+        source.configuration()["loader_source_fingerprint"]
+        == loader.source_fingerprint()
+    )
+
+    changed_seed = phx.uq.OperatorMinibatchSource(
+        phx.nn.OperatorBatchLoader(
+            dataset,
+            batch_size=2,
+            shuffle=True,
+            seed=7,
+            drop_last=False,
+            prefetch=1,
+        ),
+        field_name="solution",
+    )
+    changed_data = phx.uq.OperatorMinibatchSource(
+        phx.nn.OperatorBatchLoader(
+            _operator_dataset(cases=6),
+            batch_size=2,
+            shuffle=True,
+            seed=6,
+            drop_last=False,
+            prefetch=1,
+        ),
+        field_name="solution",
+    )
+    assert source.fingerprint != changed_seed.fingerprint
+    assert source.fingerprint != changed_data.fingerprint
+
+
+def test_operator_minibatch_source_rejects_lossy_loader_policies():
+    dataset = _operator_dataset()
+    with pytest.raises(ValueError, match="drop_last=True"):
+        phx.uq.OperatorMinibatchSource(
+            phx.nn.OperatorBatchLoader(
+                dataset,
+                batch_size=2,
+                shuffle=True,
+                seed=1,
+                drop_last=True,
+            ),
+            field_name="solution",
+        )
+    with pytest.raises(ValueError, match="shuffle=True"):
+        phx.uq.OperatorMinibatchSource(
+            phx.nn.OperatorBatchLoader(
+                dataset,
+                batch_size=2,
+                shuffle=False,
+                seed=1,
+                drop_last=False,
+            ),
+            field_name="solution",
+        )
+
+
+def test_operator_sgmcmc_supports_selected_parameter_subspaces_and_predictions():
+    dataset = _operator_dataset()
+    source = phx.uq.OperatorMinibatchSource(
+        phx.nn.OperatorBatchLoader(
+            dataset,
+            batch_size=2,
+            shuffle=True,
+            seed=8,
+            drop_last=False,
+            prefetch=1,
+        ),
+        field_name="solution",
+    )
+    model = {"frozen": jnp.asarray(11.0), "weight": jnp.asarray(1.8)}
+    subspace = phx.uq.ParameterSubspace.from_leaf_paths(model, ("['weight']",))
+    parameter_space = phx.uq.ParameterSpace(
+        subspace.initial,
+        priors={"frozen": None, "weight": phx.uq.Normal(0.0, 3.0)},
+    )
+
+    def predict(selected, batch):
+        parameters = subspace.reconstruct(selected)
+        return _dynamic_prediction(parameters["weight"], batch)
+
+    likelihood = phx.uq.OperatorBatchObservationLikelihood(
+        predict,
+        phx.uq.GaussianLikelihood(0.2),
+    )
+    target_field = dataset.targets.field("solution")
+    full_data = phx.uq.OperatorLikelihoodData(
+        dataset.batch,
+        target_field.values,
+        output_spec=target_field.spec,
+        field_name="solution",
+        query_name=target_field.query_name,
+    )
+    problem = phx.uq.MinibatchPosteriorProblem(
+        parameter_space,
+        likelihood,
+        num_factors=source.num_factors,
+        full_log_likelihood=lambda selected: jnp.sum(
+            likelihood.per_case_log_prob(selected, full_data)
+        ),
+        predict=lambda selected: phx.uq.operator_prediction_field(
+            predict(selected, dataset.batch),
+            field_name="solution",
+        ),
+    )
+    result = phx.uq.sample_sgld(
+        problem,
+        source,
+        key=jr.key(40),
+        step_size=1.0e-6,
+        num_chains=2,
+        num_burnin=2,
+        num_samples=4,
+    )
+    prediction = result.predict()
+
+    assert result.samples["weight"].shape == (2, 4)
+    assert result.samples["frozen"] is None
+    selected_draw = {
+        "frozen": None,
+        "weight": result.samples["weight"][0, 0],
+    }
+    assert subspace.reconstruct(selected_draw)["frozen"] == 11.0
+    assert prediction.samples.dims == (
+        "__phydra_uq_chain",
+        "__phydra_uq_draw",
+        "case",
+        "x",
+    )
+    assert prediction.samples.shape == (2, 4, 5, 4)

--- a/tests/unit/uq/test_result_export.py
+++ b/tests/unit/uq/test_result_export.py
@@ -207,3 +207,85 @@ def test_result_archive_reader_rejects_truncated_archives(tmp_path):
 
     with pytest.raises(phx.uq.CheckpointCorruptionError, match="Cannot read"):
         phx.uq.read_result_archive(destination)
+
+
+def _sgmcmc_result():
+    data = jnp.linspace(-1.0, 1.0, 7)
+    source = phx.uq.ArrayMinibatchSource(data, batch_size=3, seed=12)
+    problem = phx.uq.MinibatchPosteriorProblem(
+        phx.uq.ParameterSpace(
+            jnp.asarray(0.0),
+            priors=phx.uq.Normal(0.0, 2.0),
+        ),
+        lambda parameter, batch: -0.5 * (batch.data - parameter) ** 2,
+        num_factors=source.num_factors,
+        full_log_likelihood=lambda parameter: jnp.sum(
+            -0.5 * (data - parameter) ** 2
+        ),
+    )
+    control = phx.uq.build_sgmcmc_control_variate(
+        problem,
+        source,
+        jnp.asarray(0.0),
+    )
+    return phx.uq.sample_sgnht(
+        problem,
+        source,
+        key=jr.key(950),
+        step_size=1.0e-4,
+        diffusion=0.01,
+        num_chains=2,
+        num_burnin=2,
+        num_samples=4,
+        control_variate=control,
+    )
+
+
+def test_sgmcmc_result_and_mixing_report_have_portable_archives(tmp_path):
+    result = _sgmcmc_result()
+    report = result.mixing_report(
+        max_rhat=2.0,
+        min_bulk_ess=1.0,
+        min_tail_ess=1.0,
+    )
+
+    result_archive = _assert_archive_matches_adapter(
+        result,
+        tmp_path / "sgmcmc.phxuq",
+    )
+    report_archive = _assert_archive_matches_adapter(
+        report,
+        tmp_path / "sgmcmc-report.phxuq",
+    )
+
+    assert result_archive.kind == "sgmcmc"
+    assert result_archive.metadata["approximation"] == "unadjusted_fixed_step"
+    assert result_archive.metadata["control_variate"]["fingerprint"]
+    assert "thermostat" in result_archive.fields
+    assert "momentum_norm" in result_archive.fields
+    assert "control_variate.center" in result_archive.trees
+    assert report_archive.kind == "sgmcmc_mixing_report"
+    assert report_archive.metadata["approximation"] == "unadjusted_fixed_step"
+
+
+def test_sgmcmc_arviz_export_preserves_approximation_and_thermostat_semantics():
+    result = _sgmcmc_result()
+    inference_data = phx.uq.to_arviz(result)
+    posterior = inference_data["posterior"].dataset
+    sample_stats = inference_data["sample_stats"].dataset
+
+    assert posterior.sizes["chain"] == 2
+    assert posterior.sizes["draw"] == 4
+    assert posterior.attrs["phydrax_algorithm"] == "sgnht"
+    assert posterior.attrs["phydrax_approximation"] == "unadjusted_fixed_step"
+    assert posterior.attrs["phydrax_control_variate"]
+    assert set(sample_stats.data_vars) == {
+        "stochastic_gradient_norm",
+        "lp",
+        "thermostat",
+        "momentum_norm",
+    }
+    assert all(
+        sample_stats[name].dims == ("chain", "draw")
+        for name in sample_stats.data_vars
+    )

--- a/tests/unit/uq/test_sgmcmc.py
+++ b/tests/unit/uq/test_sgmcmc.py
@@ -1,0 +1,277 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import coordax as cx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+from blackjax.sgmcmc import diffusions
+from blackjax.sgmcmc.sgnht import init as init_sgnht
+
+import phydrax as phx
+import phydrax.uq._sgmcmc as sgmcmc_module
+
+
+def _regression_problem(*, batch_size=3, seed=7):
+    inputs = jnp.linspace(-1.5, 1.5, 8)
+    targets = 0.4 + 1.7 * inputs
+    data = {"input": inputs, "target": targets}
+    source = phx.uq.ArrayMinibatchSource(data, batch_size=batch_size, seed=seed)
+    space = phx.uq.ParameterSpace(
+        jnp.asarray([0.0, 0.0]),
+        priors=phx.uq.Normal(0.0, 3.0),
+    )
+
+    def factors(parameters, batch):
+        prediction = parameters[0] + parameters[1] * batch.data["input"]
+        return -0.5 * ((batch.data["target"] - prediction) / 0.5) ** 2
+
+    def full_likelihood(parameters):
+        prediction = parameters[0] + parameters[1] * inputs
+        return jnp.sum(-0.5 * ((targets - prediction) / 0.5) ** 2)
+
+    problem = phx.uq.MinibatchPosteriorProblem(
+        space,
+        factors,
+        num_factors=source.num_factors,
+        full_log_likelihood=full_likelihood,
+        predict=lambda parameters, values: parameters[0] + parameters[1] * values,
+    )
+    return problem, source
+
+
+def _assert_tree_equal(left, right):
+    comparisons = jax.tree_util.tree_map(jnp.array_equal, left, right)
+    assert all(jax.tree_util.tree_leaves(comparisons))
+
+
+def _transition_keys(chain_keys, update):
+    return jax.vmap(
+        lambda key: jr.fold_in(jr.fold_in(key, 1), update)
+    )(chain_keys)
+
+
+def test_sgld_first_update_matches_blackjax_diffusion_convention():
+    problem, source = _regression_problem()
+    initial = jnp.asarray([[-0.3, 0.2], [0.4, -0.1]])
+    step_size = 2.0e-4
+    result = phx.uq.sample_sgld(
+        problem,
+        source,
+        key=jr.key(20),
+        step_size=step_size,
+        num_chains=2,
+        num_burnin=1,
+        num_samples=4,
+        initial_positions=initial,
+    )
+    batch = next(source.epoch(0))
+    gradients = jax.vmap(
+        lambda position: jax.grad(problem.log_density_estimate)(position, batch)
+    )(initial)
+    keys = _transition_keys(result.chain_keys, 0)
+    integrator = diffusions.overdamped_langevin()
+    expected = jax.vmap(
+        lambda key, position, gradient: integrator(
+            key, position, gradient, step_size, 1.0
+        )
+    )(keys, initial, gradients)
+
+    assert jnp.array_equal(result.burnin_states, expected)
+
+
+def test_sgnht_first_update_matches_blackjax_diffusion_convention():
+    problem, source = _regression_problem()
+    initial = jnp.asarray([[-0.2, 0.3], [0.25, -0.15]])
+    step_size = 1.0e-4
+    diffusion = 0.02
+    thermostat = 0.03
+    result = phx.uq.sample_sgnht(
+        problem,
+        source,
+        key=jr.key(21),
+        step_size=step_size,
+        diffusion=diffusion,
+        initial_thermostat=thermostat,
+        num_chains=2,
+        num_burnin=1,
+        num_samples=4,
+        initial_positions=initial,
+    )
+    initialization_keys = jax.vmap(lambda key: jr.fold_in(key, 0))(result.chain_keys)
+    states = jax.vmap(
+        lambda position, key: init_sgnht(position, key, thermostat)
+    )(initial, initialization_keys)
+    batch = next(source.epoch(0))
+    gradients = jax.vmap(
+        lambda position: jax.grad(problem.log_density_estimate)(position, batch)
+    )(states.position)
+    keys = _transition_keys(result.chain_keys, 0)
+    integrator = diffusions.sgnht(diffusion, 0.0)
+    position, momentum, xi = jax.vmap(
+        lambda key, state_position, state_momentum, state_xi, gradient: integrator(
+            key,
+            state_position,
+            state_momentum,
+            state_xi,
+            gradient,
+            step_size,
+            1.0,
+        )
+    )(keys, states.position, states.momentum, states.xi, gradients)
+
+    assert jnp.array_equal(result.burnin_states.position, position)
+    assert jnp.array_equal(result.burnin_states.momentum, momentum)
+    assert jnp.array_equal(result.burnin_states.xi, xi)
+
+
+@pytest.mark.parametrize("sample", [phx.uq.sample_sgld, phx.uq.sample_sgnht])
+def test_sgmcmc_sequential_and_vectorized_chains_replay_exactly(sample):
+    problem, source = _regression_problem(batch_size=4)
+    common = {
+        "key": jr.key(22),
+        "step_size": 1.0e-4,
+        "num_chains": 2,
+        "num_burnin": 3,
+        "num_samples": 6,
+        "steps_per_sample": 2,
+        "initial_positions": jnp.asarray([[-0.4, 0.1], [0.5, -0.2]]),
+    }
+    vectorized = sample(problem, source, **common, chain_method="vectorized")
+    sequential = sample(problem, source, **common, chain_method="sequential")
+
+    _assert_tree_equal(vectorized.samples, sequential.samples)
+    _assert_tree_equal(vectorized.final_states, sequential.final_states)
+    assert jnp.array_equal(vectorized.gradient_norm, sequential.gradient_norm)
+    assert not jnp.array_equal(vectorized.samples[0], vectorized.samples[1])
+
+
+def test_control_variate_is_exact_at_center_and_rejects_other_sources():
+    problem, source = _regression_problem(batch_size=3)
+    center = jnp.asarray([0.2, 1.5])
+    control = phx.uq.build_sgmcmc_control_variate(problem, source, center)
+    expected = jax.grad(problem.full_log_density)(center)
+    estimator = sgmcmc_module._gradient_estimator(problem, control)
+    ordinary = jax.grad(problem.log_density_estimate)
+    batches = tuple(source.epoch(0))
+    controlled = jnp.stack([estimator(center, batch) for batch in batches])
+    uncontrolled = jnp.stack([ordinary(center, batch) for batch in batches])
+
+    assert jnp.allclose(control.full_gradient, expected)
+    assert jnp.allclose(controlled, jnp.broadcast_to(expected, controlled.shape))
+    assert jnp.max(jnp.var(controlled, axis=0)) < jnp.max(jnp.var(uncontrolled, axis=0))
+    assert control.construction_gradient_evaluations == source.batches_per_epoch + 2
+
+    incompatible_source = phx.uq.ArrayMinibatchSource(
+        source.data, batch_size=3, seed=source.configuration()["seed"] + 1
+    )
+    with pytest.raises(ValueError, match="different source"):
+        phx.uq.sample_sgld(
+            problem,
+            incompatible_source,
+            key=jr.key(23),
+            step_size=1.0e-4,
+            num_chains=2,
+            num_burnin=1,
+            num_samples=4,
+            control_variate=control,
+        )
+
+
+def test_sgmcmc_preserves_nested_constrained_parameter_samples():
+    values = jnp.linspace(-1.0, 1.0, 6)
+    source = phx.uq.ArrayMinibatchSource(values, batch_size=4, seed=9)
+    space = phx.uq.ParameterSpace(
+        {"location": jnp.asarray(0.0), "scale": jnp.asarray(0.0)},
+        priors={
+            "location": phx.uq.Normal(0.0, 2.0),
+            "scale": phx.uq.LogNormal(0.0, 0.5),
+        },
+        bijectors={
+            "location": phx.uq.IdentityBijector(),
+            "scale": phx.uq.ExpBijector(),
+        },
+    )
+
+    def factors(parameters, batch):
+        return -0.5 * ((batch.data - parameters["location"]) / parameters["scale"]) ** 2
+
+    problem = phx.uq.MinibatchPosteriorProblem(
+        space,
+        factors,
+        num_factors=source.num_factors,
+        predict=lambda parameters, x: cx.Field(
+            parameters["location"] + parameters["scale"] * x,
+            dims=("point",),
+        ),
+    )
+    result = phx.uq.sample_sgld(
+        problem,
+        source,
+        key=jr.key(24),
+        step_size=1.0e-5,
+        num_chains=2,
+        num_burnin=2,
+        num_samples=4,
+    )
+
+    assert result.samples["location"].shape == (2, 4)
+    assert result.samples["scale"].shape == (2, 4)
+    assert jnp.all(result.samples["scale"] > 0.0)
+    prediction = result.predict(jnp.asarray([1.0, 2.0]))
+    assert prediction.samples.shape == (2, 4, 2)
+
+
+def test_sgmcmc_result_exposes_honest_diagnostics_and_mixing_gates():
+    problem, source = _regression_problem(batch_size=3)
+    result = phx.uq.sample_sgld(
+        problem,
+        source,
+        key=jr.key(25),
+        step_size=1.0e-4,
+        num_chains=2,
+        num_burnin=3,
+        num_samples=8,
+    )
+    report = result.mixing_report(
+        max_rhat=2.0,
+        min_bulk_ess=1.0e9,
+        min_tail_ess=1.0e9,
+    )
+
+    assert result.approximation == "unadjusted_fixed_step"
+    assert result.log_density.shape == (2, 8)
+    assert result.thermostat is None
+    assert result.momentum_norm is None
+    assert result.diagnostics.min_active_factors == 2
+    assert result.diagnostics.max_active_factors == 3
+    assert "bulk_ess" in report.failures
+    assert report.as_dict()["approximation"] == "unadjusted_fixed_step"
+    with pytest.raises(phx.uq.SGMCMCMixingError):
+        report.raise_for_failure()
+
+
+def test_sgmcmc_rejects_invalid_controls_and_reports_nonfinite_locations():
+    problem, source = _regression_problem()
+    common = {
+        "key": jr.key(26),
+        "step_size": 1.0e-4,
+        "num_chains": 2,
+        "num_burnin": 1,
+        "num_samples": 4,
+    }
+    with pytest.raises(ValueError, match="step_size"):
+        phx.uq.sample_sgld(problem, source, **(common | {"step_size": 0.0}))
+    with pytest.raises(ValueError, match="num_chains"):
+        phx.uq.sample_sgld(problem, source, **(common | {"num_chains": 1}))
+    with pytest.raises(ValueError, match="num_samples"):
+        phx.uq.sample_sgld(problem, source, **(common | {"num_samples": 3}))
+    with pytest.raises(FloatingPointError, match=r"chain\[1\]"):
+        phx.uq.sample_sgld(
+            problem,
+            source,
+            **common,
+            initial_positions=jnp.asarray([[0.0, 0.0], [jnp.nan, 0.0]]),
+        )

--- a/tests/unit/uq/test_sgmcmc_checkpoint.py
+++ b/tests/unit/uq/test_sgmcmc_checkpoint.py
@@ -1,0 +1,256 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+import phydrax as phx
+import phydrax.uq._sgmcmc as sgmcmc_module
+
+
+def _problem_source(*, seed=17, batch_size=3):
+    data = jnp.linspace(-1.0, 1.0, 7)
+    source = phx.uq.ArrayMinibatchSource(data, batch_size=batch_size, seed=seed)
+    problem = phx.uq.MinibatchPosteriorProblem(
+        phx.uq.ParameterSpace(
+            jnp.asarray(0.0),
+            priors=phx.uq.Normal(0.0, 2.0),
+        ),
+        lambda parameter, batch: -0.5 * (batch.data - parameter) ** 2,
+        num_factors=source.num_factors,
+        full_log_likelihood=lambda parameter: jnp.sum(
+            -0.5 * (data - parameter) ** 2
+        ),
+    )
+    return problem, source
+
+
+def _assert_tree_equal(left, right):
+    comparisons = jax.tree_util.tree_map(jnp.array_equal, left, right)
+    assert all(jax.tree_util.tree_leaves(comparisons))
+
+
+def _assert_exact_result(left, right):
+    _assert_tree_equal(left.samples, right.samples)
+    _assert_tree_equal(left.unconstrained_samples, right.unconstrained_samples)
+    _assert_tree_equal(left.final_states, right.final_states)
+    _assert_tree_equal(left.burnin_states, right.burnin_states)
+    _assert_tree_equal(left.diagnostics.rhat, right.diagnostics.rhat)
+    _assert_tree_equal(left.diagnostics.bulk_ess, right.diagnostics.bulk_ess)
+    _assert_tree_equal(left.diagnostics.tail_ess, right.diagnostics.tail_ess)
+    assert jnp.array_equal(left.gradient_norm, right.gradient_norm)
+    assert jnp.array_equal(left.log_density, right.log_density)
+    if left.thermostat is None:
+        assert right.thermostat is None
+        assert right.momentum_norm is None
+    else:
+        assert jnp.array_equal(left.thermostat, right.thermostat)
+        assert jnp.array_equal(left.momentum_norm, right.momentum_norm)
+    assert left.num_gradient_evaluations == right.num_gradient_evaluations + 1
+    assert left.mean_update_gradient_norm == right.mean_update_gradient_norm
+    assert left.max_update_gradient_norm == right.max_update_gradient_norm
+
+
+@pytest.mark.parametrize("interrupt_update", [2, 4, 5, 6])
+def test_sgld_resume_is_exact_across_lifecycle_boundaries(
+    tmp_path,
+    monkeypatch,
+    interrupt_update,
+):
+    problem, source = _problem_source()
+    common = {
+        "key": jr.key(30),
+        "step_size": 1.0e-4,
+        "num_chains": 2,
+        "num_burnin": 4,
+        "num_samples": 6,
+        "steps_per_sample": 2,
+        "checkpoint_id": f"sgld-boundary-{interrupt_update}",
+    }
+    direct = phx.uq.sample_sgld(problem, source, **common)
+    checkpoint = tmp_path / f"sgld-{interrupt_update}.phxckpt"
+    original_write = sgmcmc_module._write_sgmcmc_checkpoint
+
+    def interrupting_write(destination, **kwargs):
+        original_write(destination, **kwargs)
+        if kwargs["completed_updates"] == interrupt_update:
+            raise RuntimeError("simulated interruption")
+
+    monkeypatch.setattr(
+        sgmcmc_module,
+        "_write_sgmcmc_checkpoint",
+        interrupting_write,
+    )
+    with pytest.raises(RuntimeError, match="simulated interruption"):
+        phx.uq.sample_sgld(
+            problem,
+            source,
+            **common,
+            checkpoint_path=checkpoint,
+            checkpoint_every=1,
+        )
+    monkeypatch.setattr(
+        sgmcmc_module,
+        "_write_sgmcmc_checkpoint",
+        original_write,
+    )
+    resumed = phx.uq.sample_sgld(
+        problem,
+        source,
+        **common,
+        resume_from=checkpoint,
+        checkpoint_every=1,
+    )
+
+    _assert_exact_result(resumed, direct)
+
+
+def test_sgnht_resume_preserves_momentum_thermostat_and_samples(tmp_path, monkeypatch):
+    problem, source = _problem_source(seed=18)
+    common = {
+        "key": jr.key(31),
+        "step_size": 5.0e-5,
+        "diffusion": 0.02,
+        "initial_thermostat": 0.03,
+        "num_chains": 2,
+        "num_burnin": 3,
+        "num_samples": 5,
+        "steps_per_sample": 2,
+        "checkpoint_id": "sgnht-exact",
+    }
+    direct = phx.uq.sample_sgnht(problem, source, **common)
+    checkpoint = tmp_path / "sgnht.phxckpt"
+    original_write = sgmcmc_module._write_sgmcmc_checkpoint
+
+    def interrupting_write(destination, **kwargs):
+        original_write(destination, **kwargs)
+        if kwargs["completed_updates"] == 4:
+            raise RuntimeError("simulated interruption")
+
+    monkeypatch.setattr(
+        sgmcmc_module,
+        "_write_sgmcmc_checkpoint",
+        interrupting_write,
+    )
+    with pytest.raises(RuntimeError, match="simulated interruption"):
+        phx.uq.sample_sgnht(
+            problem,
+            source,
+            **common,
+            checkpoint_path=checkpoint,
+            checkpoint_every=1,
+        )
+    monkeypatch.setattr(
+        sgmcmc_module,
+        "_write_sgmcmc_checkpoint",
+        original_write,
+    )
+    resumed = phx.uq.sample_sgnht(
+        problem,
+        source,
+        **common,
+        resume_from=checkpoint,
+        checkpoint_every=1,
+    )
+
+    _assert_exact_result(resumed, direct)
+
+
+def test_completed_sgmcmc_checkpoint_extends_without_restarting(tmp_path):
+    problem, source = _problem_source(seed=19)
+    checkpoint = tmp_path / "extend.phxckpt"
+    common = {
+        "key": jr.key(32),
+        "step_size": 1.0e-4,
+        "num_chains": 2,
+        "num_burnin": 3,
+        "steps_per_sample": 2,
+        "checkpoint_id": "extend",
+    }
+    first = phx.uq.sample_sgld(
+        problem,
+        source,
+        **common,
+        num_samples=4,
+        checkpoint_path=checkpoint,
+        checkpoint_every=2,
+    )
+    extended = phx.uq.sample_sgld(
+        problem,
+        source,
+        **common,
+        num_samples=7,
+        resume_from=checkpoint,
+        checkpoint_every=2,
+    )
+    direct = phx.uq.sample_sgld(
+        problem,
+        source,
+        **common,
+        num_samples=7,
+    )
+
+    assert first.samples.shape == (2, 4)
+    _assert_exact_result(extended, direct)
+    with pytest.raises(phx.uq.CheckpointCompatibilityError, match="more progress"):
+        phx.uq.sample_sgld(
+            problem,
+            source,
+            **common,
+            num_samples=4,
+            resume_from=checkpoint,
+        )
+
+
+def test_sgmcmc_checkpoint_rejects_identity_source_settings_and_corruption(tmp_path):
+    problem, source = _problem_source(seed=20)
+    checkpoint = tmp_path / "compatibility.phxckpt"
+    common = {
+        "key": jr.key(33),
+        "step_size": 1.0e-4,
+        "num_chains": 2,
+        "num_burnin": 2,
+        "num_samples": 4,
+        "checkpoint_id": "compatible",
+    }
+    phx.uq.sample_sgld(
+        problem,
+        source,
+        **common,
+        checkpoint_path=checkpoint,
+        checkpoint_every=2,
+    )
+
+    with pytest.raises(phx.uq.CheckpointCompatibilityError, match="checkpoint id"):
+        phx.uq.sample_sgld(
+            problem,
+            source,
+            **(common | {"checkpoint_id": "other"}),
+            resume_from=checkpoint,
+        )
+    with pytest.raises(phx.uq.CheckpointCompatibilityError, match="source"):
+        phx.uq.sample_sgld(
+            problem,
+            phx.uq.ArrayMinibatchSource(source.data, batch_size=3, seed=21),
+            **common,
+            resume_from=checkpoint,
+        )
+    with pytest.raises(phx.uq.CheckpointCompatibilityError, match="settings"):
+        phx.uq.sample_sgld(
+            problem,
+            source,
+            **(common | {"step_size": 2.0e-4}),
+            resume_from=checkpoint,
+        )
+
+    checkpoint.write_bytes(checkpoint.read_bytes()[:64])
+    with pytest.raises(phx.uq.CheckpointCorruptionError, match="Cannot read"):
+        phx.uq.sample_sgld(
+            problem,
+            source,
+            **common,
+            resume_from=checkpoint,
+        )

--- a/tools/uq_benchmarks/configuration.py
+++ b/tools/uq_benchmarks/configuration.py
@@ -19,6 +19,10 @@ class BenchmarkConfiguration:
     num_chains: int
     num_warmup: int
     num_draws: int
+    sgmcmc_burnin: int
+    sgmcmc_draws: int
+    sgmcmc_batch_size: int
+    sgmcmc_steps_per_sample: int
     pathfinder_samples: int
     smc_particles: int
     posterior_prediction_samples: int
@@ -43,6 +47,10 @@ PROFILES: dict[ProfileName, BenchmarkConfiguration] = {
         num_chains=4,
         num_warmup=100,
         num_draws=150,
+        sgmcmc_burnin=1_000,
+        sgmcmc_draws=1_000,
+        sgmcmc_batch_size=16,
+        sgmcmc_steps_per_sample=4,
         pathfinder_samples=768,
         smc_particles=800,
         posterior_prediction_samples=1_024,
@@ -66,6 +74,10 @@ PROFILES: dict[ProfileName, BenchmarkConfiguration] = {
         smc_particles=4_000,
         posterior_prediction_samples=8_192,
         calibration_cases=2_048,
+        sgmcmc_burnin=3_000,
+        sgmcmc_draws=5_000,
+        sgmcmc_batch_size=32,
+        sgmcmc_steps_per_sample=2,
         gp_repeats=12,
         jit_warm_repetitions=10,
         flow_adaptation_rounds=4,

--- a/tools/uq_benchmarks/scenarios.py
+++ b/tools/uq_benchmarks/scenarios.py
@@ -15,6 +15,7 @@ import jax
 import jax.numpy as jnp
 import jax.random as jr
 import jax.scipy as jsp
+import optax
 
 import phydrax as phx
 
@@ -1642,6 +1643,629 @@ def correlated_vector_discrepancy(
     )
 
 
+def _small_deep_ensemble_predictions(
+    train_inputs: jax.Array,
+    train_targets: jax.Array,
+    prediction_inputs: jax.Array,
+    /,
+    *,
+    key: jax.Array,
+    num_members: int,
+    num_steps: int,
+) -> jax.Array:
+    """Fit independent bootstrapped nonlinear regressors for a robust baseline."""
+    optimizer = optax.adam(1.0e-2)
+
+    def predict(parameters, inputs):
+        hidden = jnp.tanh(
+            inputs[:, None] * parameters["input_weight"][None, :]
+            + parameters["hidden_bias"][None, :]
+        )
+        return hidden @ parameters["output_weight"] + parameters["output_bias"]
+
+    def loss(parameters, inputs, targets):
+        residual = predict(parameters, inputs) - targets
+        return jnp.mean(residual**2)
+
+    @jax.jit
+    def train_step(parameters, optimizer_state, inputs, targets):
+        gradients = jax.grad(loss)(parameters, inputs, targets)
+        updates, next_optimizer_state = optimizer.update(
+            gradients,
+            optimizer_state,
+            parameters,
+        )
+        return (
+            optax.apply_updates(parameters, updates),
+            next_optimizer_state,
+        )
+
+    predictions = []
+    member_keys = jr.split(key, int(num_members))
+    for member_key in member_keys:
+        bootstrap_key, input_key, output_key = jr.split(member_key, 3)
+        bootstrap = jr.randint(
+            bootstrap_key,
+            train_inputs.shape,
+            0,
+            train_inputs.shape[0],
+        )
+        member_inputs = train_inputs[bootstrap]
+        member_targets = train_targets[bootstrap]
+        parameters = {
+            "input_weight": 0.25 * jr.normal(input_key, (8,)),
+            "hidden_bias": jnp.zeros((8,)),
+            "output_weight": 0.25 * jr.normal(output_key, (8,)),
+            "output_bias": jnp.asarray(0.0),
+        }
+        optimizer_state = optimizer.init(parameters)
+        for _ in range(int(num_steps)):
+            parameters, optimizer_state = train_step(
+                parameters,
+                optimizer_state,
+                member_inputs,
+                member_targets,
+            )
+        predictions.append(predict(parameters, prediction_inputs))
+    return jnp.stack(predictions)
+
+
+def stochastic_gradient_regression(
+    configuration: BenchmarkConfiguration,
+    seed: int,
+) -> ScenarioResult:
+    """Benchmark fixed-step SG-MCMC against exact Gaussian and ensemble references."""
+    started = time.perf_counter()
+    root_key = jr.key(seed)
+    observation_key = jr.fold_in(root_key, 1)
+    num_factors = 128
+    inputs = jnp.linspace(-1.5, 1.5, num_factors)
+    design = jnp.stack((jnp.ones_like(inputs), inputs), axis=1)
+    true_position = jnp.asarray([0.4, -0.7])
+    observation_scale = 0.6
+    observations = (
+        design @ true_position
+        + observation_scale * jr.normal(observation_key, (num_factors,))
+    )
+    prior_scale = 2.0
+    precision = (
+        jnp.eye(2) / prior_scale**2
+        + design.T @ design / observation_scale**2
+    )
+    analytic_covariance = jnp.linalg.inv(precision)
+    analytic_mean = analytic_covariance @ (
+        design.T @ observations / observation_scale**2
+    )
+    analytic_scale = jnp.sqrt(jnp.diag(analytic_covariance))
+
+    def position_from_vector(vector):
+        return {
+            "offset": vector[0],
+            "nested": {"positive_rate": vector[1]},
+        }
+
+    def vector_from_physical(parameters):
+        return jnp.stack(
+            (
+                parameters["offset"],
+                jnp.log(parameters["nested"]["positive_rate"]),
+            )
+        )
+
+    parameter_space = phx.uq.ParameterSpace(
+        position_from_vector(jnp.zeros((2,))),
+        priors={
+            "offset": phx.uq.Normal(0.0, prior_scale),
+            "nested": {
+                "positive_rate": phx.uq.LogNormal(0.0, prior_scale)
+            },
+        },
+        bijectors={
+            "offset": phx.uq.IdentityBijector(),
+            "nested": {"positive_rate": phx.uq.ExpBijector()},
+        },
+    )
+    source = phx.uq.ArrayMinibatchSource(
+        {"input": inputs, "target": observations},
+        batch_size=configuration.sgmcmc_batch_size,
+        seed=seed + 1,
+    )
+
+    def likelihood_factors(parameters, batch):
+        vector = vector_from_physical(parameters)
+        prediction = vector[0] + vector[1] * batch.data["input"]
+        return -0.5 * (
+            (batch.data["target"] - prediction) / observation_scale
+        ) ** 2
+
+    def full_log_likelihood(parameters):
+        vector = vector_from_physical(parameters)
+        return jnp.sum(
+            -0.5
+            * ((observations - design @ vector) / observation_scale) ** 2
+        )
+
+    problem = phx.uq.MinibatchPosteriorProblem(
+        parameter_space,
+        likelihood_factors,
+        num_factors=num_factors,
+        full_log_likelihood=full_log_likelihood,
+    )
+    exact_problem = phx.uq.PosteriorProblem(
+        parameter_space,
+        full_log_likelihood,
+    )
+    diagnostics = phx.uq.diagnose_minibatch_posterior(problem, source)
+    center = position_from_vector(analytic_mean)
+    control, control_seconds = _timed_call(
+        lambda: phx.uq.build_sgmcmc_control_variate(
+            problem,
+            source,
+            center,
+        )
+    )
+    first_batch = next(source.epoch(0))
+    cold, compile_seconds, execute = _jit_timings(
+        lambda position, batch: jax.value_and_grad(
+            problem.log_density_estimate
+        )(position, batch),
+        problem.initial_position,
+        first_batch,
+        repetitions=configuration.jit_warm_repetitions,
+    )
+
+    step_size = 5.0e-4
+    sgld, sgld_seconds = _timed_call(
+        lambda: phx.uq.sample_sgld(
+            problem,
+            source,
+            key=jr.fold_in(root_key, 2),
+            step_size=step_size,
+            num_chains=configuration.num_chains,
+            num_burnin=configuration.sgmcmc_burnin,
+            num_samples=configuration.sgmcmc_draws,
+            steps_per_sample=configuration.sgmcmc_steps_per_sample,
+            chain_method="vectorized",
+        )
+    )
+    refined, refined_seconds = _timed_call(
+        lambda: phx.uq.sample_sgld(
+            problem,
+            source,
+            key=jr.fold_in(root_key, 3),
+            step_size=step_size / 2.0,
+            num_chains=configuration.num_chains,
+            num_burnin=configuration.sgmcmc_burnin,
+            num_samples=configuration.sgmcmc_draws,
+            steps_per_sample=configuration.sgmcmc_steps_per_sample,
+            chain_method="vectorized",
+        )
+    )
+    controlled, controlled_seconds = _timed_call(
+        lambda: phx.uq.sample_sgld(
+            problem,
+            source,
+            key=jr.fold_in(root_key, 4),
+            step_size=step_size / 2.0,
+            control_variate=control,
+            num_chains=configuration.num_chains,
+            num_burnin=configuration.sgmcmc_burnin,
+            num_samples=configuration.sgmcmc_draws,
+            steps_per_sample=configuration.sgmcmc_steps_per_sample,
+            chain_method="vectorized",
+        )
+    )
+    sgnht, sgnht_seconds = _timed_call(
+        lambda: phx.uq.sample_sgnht(
+            problem,
+            source,
+            key=jr.fold_in(root_key, 5),
+            step_size=5.0e-3,
+            diffusion=0.1,
+            control_variate=control,
+            num_chains=configuration.num_chains,
+            num_burnin=configuration.sgmcmc_burnin,
+            num_samples=configuration.sgmcmc_draws,
+            steps_per_sample=configuration.sgmcmc_steps_per_sample,
+            chain_method="vectorized",
+        )
+    )
+    nuts, nuts_seconds = _timed_call(
+        lambda: phx.uq.sample_nuts(
+            exact_problem,
+            key=jr.fold_in(root_key, 6),
+            num_chains=configuration.num_chains,
+            num_warmup=configuration.num_warmup,
+            num_samples=configuration.num_draws,
+            initial_step_size=0.05,
+            target_acceptance_rate=0.9,
+            max_num_doublings=7,
+            chain_method="vectorized",
+        )
+    )
+    laplace, laplace_seconds = _timed_call(
+        lambda: phx.uq.fit_laplace(
+            exact_problem,
+            center,
+            stationarity_tolerance=1.0e-6,
+        )
+    )
+
+    prediction_inputs = jnp.linspace(-1.75, 1.75, 81)
+    prediction_design = jnp.stack(
+        (jnp.ones_like(prediction_inputs), prediction_inputs),
+        axis=1,
+    )
+    analytic_prediction_mean = prediction_design @ analytic_mean
+    analytic_prediction_variance = jnp.einsum(
+        "ni,ij,nj->n",
+        prediction_design,
+        analytic_covariance,
+        prediction_design,
+    )
+    ensemble_members = 4 if configuration.profile == "smoke" else 8
+    ensemble_steps = 300 if configuration.profile == "smoke" else 800
+    ensemble_predictions, ensemble_seconds = _timed_call(
+        lambda: _small_deep_ensemble_predictions(
+            inputs,
+            observations,
+            prediction_inputs,
+            key=jr.fold_in(root_key, 7),
+            num_members=ensemble_members,
+            num_steps=ensemble_steps,
+        )
+    )
+
+    def sample_matrix(result):
+        return jnp.stack(
+            (
+                result.unconstrained_samples["offset"].reshape(-1),
+                result.unconstrained_samples["nested"][
+                    "positive_rate"
+                ].reshape(-1),
+            ),
+            axis=1,
+        )
+
+    matrices = {
+        "sgld": sample_matrix(sgld),
+        "sgld_refined": sample_matrix(refined),
+        "sgld_control_variate": sample_matrix(controlled),
+        "sgnht": sample_matrix(sgnht),
+        "nuts": sample_matrix(nuts),
+    }
+    sample_means = {
+        name: jnp.mean(values, axis=0)
+        for name, values in matrices.items()
+    }
+    sample_covariances = {
+        name: jnp.cov(values, rowvar=False)
+        for name, values in matrices.items()
+    }
+
+    max_rhat, min_ess = _convergence_limits(configuration)
+    metrics: dict[str, Metric] = {
+        "full_density_reconstruction": metric(
+            int(
+                diagnostics.full_log_density_matches is True
+                and diagnostics.full_gradient_matches is True
+            ),
+            "diagnostic",
+            minimum=1.0,
+        ),
+        "source_epoch_factor_fraction": metric(
+            diagnostics.epoch_active_factor_count / num_factors,
+            "diagnostic",
+            minimum=1.0,
+            maximum=1.0,
+        ),
+        "control_variate_construction_seconds": metric(
+            control_seconds,
+            "performance",
+            unit="s",
+        ),
+        "control_variate_gradient_evaluations": metric(
+            control.construction_gradient_evaluations,
+            "performance",
+        ),
+        "sgld_seconds": metric(sgld_seconds, "performance", unit="s"),
+        "sgld_refined_seconds": metric(
+            refined_seconds,
+            "performance",
+            unit="s",
+        ),
+        "sgld_control_variate_seconds": metric(
+            controlled_seconds,
+            "performance",
+            unit="s",
+        ),
+        "sgnht_seconds": metric(sgnht_seconds, "performance", unit="s"),
+        "nuts_seconds": metric(nuts_seconds, "performance", unit="s"),
+        "laplace_seconds": metric(laplace_seconds, "performance", unit="s"),
+        "deep_ensemble_seconds": metric(
+            ensemble_seconds,
+            "performance",
+            unit="s",
+        ),
+        "sgld_samples_per_second": metric(
+            sgld.samples_per_second,
+            "performance",
+            unit="sample/s",
+        ),
+        "sgld_updates_per_second": metric(
+            sgld.updates_per_second,
+            "performance",
+            unit="update/s",
+        ),
+        "sgnht_samples_per_second": metric(
+            sgnht.samples_per_second,
+            "performance",
+            unit="sample/s",
+        ),
+        "sgld_gradient_evaluations_per_second": metric(
+            sgld.gradient_evaluations_per_second,
+            "performance",
+            unit="gradient/s",
+        ),
+        "sgld_sample_memory_bytes": metric(
+            sgld.sample_memory_bytes,
+            "performance",
+            unit="byte",
+        ),
+        "sgnht_sample_memory_bytes": metric(
+            sgnht.sample_memory_bytes,
+            "performance",
+            unit="byte",
+        ),
+        "batch_memory_fraction": metric(
+            sum(
+                int(jnp.asarray(leaf).nbytes)
+                for leaf in jax.tree_util.tree_leaves(first_batch.data)
+            )
+            / sum(
+                int(jnp.asarray(leaf).nbytes)
+                for leaf in jax.tree_util.tree_leaves(source.data)
+            ),
+            "performance",
+        ),
+    }
+
+    accuracy_gates = {
+        "sgld": (0.75, 0.75),
+        "sgld_refined": (0.65, 0.65),
+        "sgld_control_variate": (0.65, 0.65),
+        "sgnht": (0.65, 0.75),
+        "nuts": (0.55, 0.55),
+    }
+    chain_results = {
+        "sgld": sgld,
+        "sgld_refined": refined,
+        "sgld_control_variate": controlled,
+        "sgnht": sgnht,
+    }
+    covariance_norm = jnp.linalg.norm(analytic_covariance)
+    for name, values in matrices.items():
+        mean_error = jnp.sqrt(
+            jnp.mean(
+                ((sample_means[name] - analytic_mean) / analytic_scale) ** 2
+            )
+        )
+        covariance_error = (
+            jnp.linalg.norm(
+                sample_covariances[name] - analytic_covariance
+            )
+            / covariance_norm
+        )
+        prediction_mean = prediction_design @ sample_means[name]
+        prediction_variance = jnp.einsum(
+            "ni,ij,nj->n",
+            prediction_design,
+            sample_covariances[name],
+            prediction_design,
+        )
+        mean_gate, covariance_gate = accuracy_gates[name]
+        metrics[f"{name}_posterior_mean_standardized_rmse"] = metric(
+            mean_error,
+            "accuracy",
+            maximum=mean_gate,
+        )
+        metrics[f"{name}_covariance_relative_error"] = metric(
+            covariance_error,
+            "accuracy",
+            maximum=covariance_gate,
+        )
+        metrics[f"{name}_predictive_mean_rmse"] = metric(
+            jnp.sqrt(
+                jnp.mean(
+                    (prediction_mean - analytic_prediction_mean) ** 2
+                )
+            ),
+            "accuracy",
+            maximum=0.08,
+        )
+        metrics[f"{name}_predictive_variance_relative_rmse"] = metric(
+            jnp.sqrt(
+                jnp.mean(
+                    (
+                        prediction_variance
+                        - analytic_prediction_variance
+                    )
+                    ** 2
+                )
+            )
+            / jnp.mean(analytic_prediction_variance),
+            "accuracy",
+            maximum=0.8,
+        )
+        if name in chain_results:
+            result = chain_results[name]
+            metrics[f"{name}_max_rhat"] = metric(
+                result.diagnostics.max_rhat,
+                "convergence",
+                maximum=(
+                    1.12
+                    if name == "sgnht" and configuration.profile == "smoke"
+                    else (1.05 if name == "sgnht" else max_rhat)
+                ),
+            )
+            metrics[f"{name}_min_ess"] = metric(
+                jnp.minimum(
+                    result.diagnostics.min_bulk_ess,
+                    result.diagnostics.min_tail_ess,
+                ),
+                "convergence",
+                minimum=min_ess,
+            )
+            metrics[f"{name}_ess_per_second"] = metric(
+                jnp.minimum(
+                    result.diagnostics.min_bulk_ess,
+                    result.diagnostics.min_tail_ess,
+                )
+                / max(result.sampling_duration_seconds, 1.0e-12),
+                "performance",
+                unit="ESS/s",
+            )
+
+    ordinary_gradient = jax.grad(problem.log_density_estimate)
+    probe = position_from_vector(
+        analytic_mean + jnp.asarray([0.2, -0.2]) * analytic_scale
+    )
+    epoch_batches = tuple(source.epoch(0))
+
+    def gradient_vector(gradient):
+        return jnp.stack(
+            (
+                gradient["offset"],
+                gradient["nested"]["positive_rate"],
+            )
+        )
+
+    ordinary_gradients = jnp.stack(
+        [
+            gradient_vector(ordinary_gradient(probe, batch))
+            for batch in epoch_batches
+        ]
+    )
+    controlled_gradients = jnp.stack(
+        [
+            gradient_vector(
+                jax.tree_util.tree_map(
+                    lambda full, current, at_center: (
+                        full + current - at_center
+                    ),
+                    control.full_gradient,
+                    ordinary_gradient(probe, batch),
+                    ordinary_gradient(control.center, batch),
+                )
+            )
+            for batch in epoch_batches
+        ]
+    )
+    ordinary_variance = jnp.sum(jnp.var(ordinary_gradients, axis=0))
+    controlled_variance = jnp.sum(jnp.var(controlled_gradients, axis=0))
+    metrics["control_variate_gradient_variance_reduction"] = metric(
+        ordinary_variance
+        / jnp.maximum(controlled_variance, jnp.finfo(float).eps),
+        "diagnostic",
+        minimum=10.0,
+    )
+    metrics["step_halving_mean_discrepancy"] = metric(
+        jnp.linalg.norm(sample_means["sgld"] - sample_means["sgld_refined"])
+        / jnp.linalg.norm(analytic_scale),
+        "diagnostic",
+    )
+    metrics["step_halving_covariance_discrepancy"] = metric(
+        jnp.linalg.norm(
+            sample_covariances["sgld"]
+            - sample_covariances["sgld_refined"]
+        )
+        / covariance_norm,
+        "diagnostic",
+    )
+    metrics["laplace_mean_error"] = metric(
+        jnp.linalg.norm(
+            jnp.asarray(
+                [
+                    laplace.map_position["offset"],
+                    laplace.map_position["nested"]["positive_rate"],
+                ]
+            )
+            - analytic_mean
+        ),
+        "accuracy",
+        maximum=1.0e-8,
+    )
+    laplace_order = jnp.asarray([1, 0])
+    laplace_covariance = laplace.covariance[
+        jnp.ix_(laplace_order, laplace_order)
+    ]
+    metrics["laplace_covariance_relative_error"] = metric(
+        jnp.linalg.norm(laplace_covariance - analytic_covariance)
+        / covariance_norm,
+        "accuracy",
+        maximum=1.0e-8,
+    )
+    ensemble_mean = jnp.mean(ensemble_predictions, axis=0)
+    ensemble_variance = jnp.var(ensemble_predictions, axis=0)
+    metrics["deep_ensemble_predictive_mean_rmse"] = metric(
+        jnp.sqrt(
+            jnp.mean((ensemble_mean - analytic_prediction_mean) ** 2)
+        ),
+        "accuracy",
+        maximum=0.2,
+    )
+    metrics["deep_ensemble_predictive_variance_relative_rmse"] = metric(
+        jnp.sqrt(
+            jnp.mean(
+                (
+                    ensemble_variance
+                    - analytic_prediction_variance
+                )
+                ** 2
+            )
+        )
+        / jnp.mean(analytic_prediction_variance),
+        "accuracy",
+    )
+    metrics.update(
+        _performance_metrics(
+            wall_seconds=time.perf_counter() - started,
+            cold_seconds=cold,
+            compile_seconds=compile_seconds,
+            execution_seconds=execute,
+            sample_memory_bytes=sum(
+                result.sample_memory_bytes
+                for result in (sgld, refined, controlled, sgnht)
+            ),
+        )
+    )
+    return ScenarioResult(
+        name="stochastic_gradient_regression",
+        description=stochastic_gradient_regression.__doc__ or "",
+        seed=seed,
+        metrics=metrics,
+        metadata={
+            "profile": configuration.profile,
+            "num_factors": num_factors,
+            "batch_size": configuration.sgmcmc_batch_size,
+            "num_chains": configuration.num_chains,
+            "num_burnin": configuration.sgmcmc_burnin,
+            "num_draws": configuration.sgmcmc_draws,
+            "steps_per_sample": configuration.sgmcmc_steps_per_sample,
+            "sgld_step_size": step_size,
+            "sgnht_step_size": 5.0e-3,
+            "sgnht_diffusion": 0.1,
+            "approximation": "unadjusted_fixed_step",
+            "source_fingerprint": source.fingerprint,
+            "analytic_mean": analytic_mean.tolist(),
+            "analytic_covariance": analytic_covariance.tolist(),
+            "parameter_structure": "nested_with_positive_log_coordinate",
+            "deep_ensemble_members": ensemble_members,
+            "deep_ensemble_steps": ensemble_steps,
+        },
+    )
+
+
 SCENARIOS: dict[str, Scenario] = {
     "elliptic_coefficient_inverse": elliptic_coefficient_inverse,
     "nonlinear_transformed_ode": nonlinear_transformed_ode,
@@ -1650,6 +2274,7 @@ SCENARIOS: dict[str, Scenario] = {
     "misspecified_pde_discrepancy": misspecified_pde_discrepancy,
     "correlated_vector_discrepancy": correlated_vector_discrepancy,
     "flow_assisted_multimodal": flow_assisted_multimodal,
+    "stochastic_gradient_regression": stochastic_gradient_regression,
 }
 
 


### PR DESCRIPTION
## Summary

Adds a native stochastic-gradient MCMC stack to `phydrax.uq`, centered on explicit factorized-likelihood and deterministic minibatch-source contracts.

The change introduces fixed-step SGLD and SGNHT using BlackJAX transition components while keeping Phydrax ownership of posterior semantics, PyTree handling, chain execution, diagnostics, checkpointing, prediction, operator integration, and result interchange.

## Motivation

Exact NUTS/HMC remains the preferred reference when a full-data transition is tractable. Large scientific likelihoods and neural-operator datasets need a separate execution contract: statistical factors must be explicit, minibatch scaling must be auditable, prior and transform terms must be applied exactly once, and the source schedule must be reproducible across chains and checkpoint resumes.

This PR adds that substrate without weakening `PosteriorProblem` or silently routing stochastic likelihoods through exact MCMC APIs.

## Architecture

### Factorized posterior contract

- Adds `LikelihoodBatch`, containing fixed-capacity factor data and an authoritative active-factor mask.
- Adds the runtime-checkable `MinibatchSource` protocol with population size, batch capacity, complete-epoch count, stable configuration, content fingerprint, and deterministic epoch iteration.
- Adds `ArrayMinibatchSource` for reproducibly shuffled array PyTrees with padded final batches.
- Adds `MinibatchPosteriorProblem` for one normalized likelihood contribution per statistical factor.
- The likelihood estimate scales the active-factor mean by the declared population size, then adds the physical prior and bijector Jacobian exactly once.
- An optional full log likelihood enables exact complete-epoch reconstruction checks and tractable reference comparisons.

### Contract diagnostics

- Adds `diagnose_minibatch_posterior` and structured capability/diagnostic results.
- Checks initial stochastic value and gradient finiteness, source/problem population compatibility, complete-epoch factor accounting, and optional full-density and full-gradient reconstruction.
- Reports exact nonfinite PyTree locations and whether prediction, observation variance, observation sampling, full-density, and control-variate primitives are available.

### Shared chain runtime

- Extracts chain-method validation, initial-position handling, deterministic per-chain key derivation, PyTree stacking/unstacking, and memory accounting into `phydrax/uq/_chain.py`.
- Migrates NUTS/HMC and Flow-NUTS to the shared private runtime rather than creating a second chain convention.
- Preserves separate chain and draw axes and independent sequential/vectorized execution semantics.

### SGLD and SGNHT

- Adds `sample_sgld` using BlackJAX overdamped-Langevin transitions.
- Adds `sample_sgnht` using BlackJAX SGNHT state initialization and diffusion transitions.
- Both samplers support arbitrary nested parameter PyTrees, physical-space bijectors, independent chains, burn-in, fixed update thinning, deterministic indexed source/transition keys, and optional explicit initial positions.
- A shared execution engine owns batch scheduling, state retention, timing, gradient accounting, nonfinite transition validation, and checkpoint lifecycle behavior.

### Control variates

- Adds `build_sgmcmc_control_variate` for an exact-center difference estimator.
- Constructs the reference gradient from one validated complete source epoch.
- Records construction cost and fingerprints the problem/source/control identity.
- Sampling rejects a control variate created for a different problem or source instead of accepting a structurally compatible but semantically unrelated reference.

### Diagnostics and result semantics

- Adds `SGMCMCDiagnostics`, `SGMCMCMixingThresholds`, `SGMCMCMixingReport`, and `SGMCMCMixingError`.
- Retains rank-normalized R-hat, bulk/tail ESS, posterior moments, stochastic-gradient norms, maximum update-gradient norm, active-factor accounting, full-gradient agreement evidence, and exact nonfinite-update locations.
- SGNHT results additionally retain thermostat and momentum-norm traces.
- `SGMCMCResult` exposes constrained and unconstrained samples, source configuration, source/problem fingerprints, chain keys, throughput, gradient/update counts, timing decomposition, memory use, prediction, observation prediction, and caller-controlled mixing gates.

### Checkpointing and replay

- Extends the portable checkpoint archive to SG-MCMC without pickle or Python object arrays.
- Persists current states, completed production draws, burn-in state, diagnostic accumulators, source settings, control-variate identity, and deterministic key lineage.
- Resume validates archive checksums, runtime versions, algorithm and approximation identity, problem/source fingerprints, PyTree signatures, chain configuration, and all fixed-step settings.
- The indexed schedule preserves uninterrupted-versus-resumed execution on the same backend without replaying burn-in.

### Neural-operator likelihoods

- Adds `OperatorLikelihoodData` and `OperatorBatchObservationLikelihood` for normalized dynamically supplied operator observations.
- Adds `OperatorMinibatchSource` as a deterministic adapter over `OperatorBatchLoader`.
- Defines one complete physical case as one factor; query points, channels, geometry, masks, quadrature, and observed values remain coupled inside that factor.
- Rejects lossy loader policies such as dropped final batches or disabled deterministic shuffling.
- Extends operator-source fingerprints through dataset content, case provenance, loader configuration, normalization, dtype, and sharding semantics.
- Supports explicit `ParameterSubspace` inference while preserving the frozen complement of the model PyTree.

### Prediction and result interchange

- Generalizes posterior predictive helpers across exact and minibatch posterior problems.
- Extends portable UQ result archives with SG-MCMC samples, diagnostics, source/control metadata, and SGNHT state summaries.
- Extends ArviZ conversion with separate chain/draw posterior variables and SG-MCMC sample statistics while retaining algorithm and approximation attributes.

### Benchmarks and documentation

- Adds profile controls for SG-MCMC burn-in, draws, batch size, and updates per retained draw.
- Adds the `stochastic_gradient_regression` scenario with analytic Gaussian, NUTS, dense Laplace, step-halving, control-variate, and bootstrapped deep-ensemble references.
- Extends the inference API reference, operator UQ API, uncertainty guide, general UQ cookbook, operator UQ cookbook, and capability overview.
- Documents factor boundaries, source requirements, fixed-step bias, reference-comparison requirements, and method-selection guidance.

## Public API additions

- `LikelihoodBatch`
- `MinibatchSource`
- `ArrayMinibatchSource`
- `MinibatchPosteriorProblem`
- `MinibatchPosteriorCapabilities`
- `MinibatchPosteriorDiagnostics`
- `diagnose_minibatch_posterior`
- `sample_sgld`
- `sample_sgnht`
- `build_sgmcmc_control_variate`
- `SGMCMCControlVariate`
- `SGMCMCResult`
- `SGMCMCDiagnostics`
- `SGMCMCMixingThresholds`
- `SGMCMCMixingReport`
- `SGMCMCMixingError`
- `OperatorLikelihoodData`
- `OperatorBatchObservationLikelihood`
- `OperatorMinibatchSource`

## Scientific semantics and boundaries

Returned SGLD and SGNHT draws are explicitly labeled `unadjusted_fixed_step`. Burn-in discards early states but does not imply adaptation, and rank diagnostics assess mixing rather than stationary discretization bias.

The documented workflow requires step-size halving and comparison against NUTS or Laplace on a tractable full-data or reduced reference problem. The implementation intentionally does not claim decreasing-step stochastic approximation, automatic step-size adaptation, SGHMC, pSGLD/RMSProp geometry, query-anchor subsampling, likelihood-dependent sampling, online gradient-noise covariance estimation, or multi-host source execution.

## Compatibility

- Existing `PosteriorProblem`, NUTS/HMC, and Flow-NUTS public APIs remain intact.
- Existing exact-chain semantics use the extracted private runtime rather than compatibility shims.
- Stochastic likelihoods remain a separate explicit problem type and cannot be passed accidentally to exact MCMC entry points.
- Existing operator fixed-observation likelihood behavior remains available alongside the new dynamic case-minibatch path.

## Reviewer guide

1. Start with `phydrax/uq/_minibatch_posterior.py` and `_minibatch_diagnostics.py` for the statistical contract.
2. Review `phydrax/uq/_chain.py` for shared chain semantics.
3. Review `phydrax/uq/_sgmcmc.py` and `_sgmcmc_diagnostics.py` for execution, replay, and result invariants.
4. Review `phydrax/uq/_operator_likelihood.py` and the operator loader fingerprint changes for geometry-aware factorization.
5. Review `_result_export.py` for portable archive and ArviZ integration.
6. Review `tools/uq_benchmarks/scenarios.py` for the exact-reference and fixed-step comparison design.
7. Review the UQ guide and cookbooks for the exposed scientific boundaries and recommended usage.