### PR TITLE
Add matrix-free linearized uncertainty propagation

### DIFF
--- a/docs/all-of-phydrax.md
+++ b/docs/all-of-phydrax.md
@@ -88,8 +88,11 @@ The enforced route is staged as boundary → initial → interior data. See:
 `phydrax.uq` keeps epistemic, uncertain-input, observation, stochastic-process,
 and numerical axes explicit in named `PredictiveField` results. NUTS/HMC, Laplace
 approximation, deep ensembles, and Gaussian-process discrepancy models produce
-coherent epistemic draws; probability domains, static random fields, and joint
-QMC propagate uncertain inputs. Global Wiener, Poisson-clock, composite, and
+coherent epistemic draws. Matrix-free JVP/VJP propagation transports diagonal,
+dense, low-rank, or operator-valued covariance through scientific maps; normalized
+errors-in-variables likelihoods account jointly for uncertain predictors and
+observations. Probability domains, static random fields, and joint QMC propagate
+full uncertain-input distributions. Global Wiener, Poisson-clock, composite, and
 coefficient-process realizations provide replayable process paths.
 Complete-field Gaussian or conditional-flow operators define transition
 marginals; typed Wiener/jump operator adapters define pathwise or composite

--- a/docs/api/uq/index.md
+++ b/docs/api/uq/index.md
@@ -5,7 +5,8 @@ optimization, BlackJAX NUTS/HMC, fixed-step SGLD/SGNHT with control variates,
 flow-assisted NUTS, Pathfinder, adaptive tempered SMC, dense and structured Laplace
 approximations, exact/sparse/correlated-output Gaussian-process model discrepancy,
 predictive fields, coherent stochastic models, likelihoods and proper scores,
-conformal calibration, uncertain-input propagation, and global sensitivity.
+matrix-free first-order covariance propagation, normalized errors-in-variables
+inference, conformal calibration, uncertain-input propagation, and global sensitivity.
 
 Stochastic-gradient samplers consume deterministic, content-addressed minibatch
 sources and preserve chain/draw structure, replay state, throughput, and mixing

--- a/docs/api/uq/inference.md
+++ b/docs/api/uq/inference.md
@@ -177,6 +177,44 @@ as independent observations.
             - __init__
             - log_prob
 
+
+### Linearized errors in variables
+
+`LinearizedGaussianMeasurementLikelihood` is a normalized joint Gaussian
+likelihood for uncertain predictors and uncertain observations. For case \(i\),
+it evaluates the physical prediction \(f(\theta, x_i)\), pushes the declared
+input covariance through the local input derivative \(J_i\), and uses
+
+\[
+\Sigma_i(\theta)
+= \Sigma_{y,i}(\theta)
++ J_i(\theta)\Sigma_{x,i}(\theta)J_i(\theta)^\mathsf{T}.
+\]
+
+The log determinant of \(\Sigma_i(\theta)\) is part of every factor. Omitting it
+changes the posterior whenever the effective covariance depends on parameters.
+Input and observation covariance may be fixed arrays or parameter-dependent
+callbacks. Both shared and explicit per-case batching are supported. Output
+events are intentionally bounded by `max_output_dimension`, because normalized
+dense Gaussian factors require a Cholesky factorization.
+
+`log_prob_cases(...)` evaluates the same term on an external deterministic
+minibatch. Put measured inputs, targets, and original case indices in an
+`ArrayMinibatchSource`; use `log_prob_cases` as the
+`MinibatchPosteriorProblem` factor callable. This reuses the full-data
+likelihood exactly rather than defining a second stochastic objective.
+
+::: phydrax.uq.LinearizedGaussianMeasurementLikelihood
+    options:
+        members:
+            - __init__
+            - per_case_log_prob
+            - log_prob_cases
+            - log_prob
+
+---
+
+
 ## MAP estimation
 
 ::: phydrax.uq.find_map
@@ -343,6 +381,7 @@ on a tractable reference before interpreting these draws quantitatively.
             - sample_unconstrained
             - sample
             - predict
+            - linearized_predict
             - physical_covariance
             - physical_correlation
             - predict_observations
@@ -357,6 +396,7 @@ on a tractable reference before interpreting these draws quantitatively.
             - sample_unconstrained
             - sample
             - predict
+            - linearized_predict
             - predict_observations
 
 ---

--- a/docs/api/uq/operator.md
+++ b/docs/api/uq/operator.md
@@ -59,6 +59,23 @@ invalid whole-function draw or raises immediately according to `valid_policy`.
 
 ::: phydrax.uq.sample_operator_predictive
 
+## Linearized source covariance
+
+`propagate_operator_linearized` consumes the physical source-to-field
+`OperatorLinearization` returned by `phydrax.nn.linearize_operator`. The result
+retains case axes, output query dimensions, masks, and output-channel metadata.
+It exposes \(J C_x J^\mathrm{H}\) through the common matrix-free propagation
+result rather than flattening an operator field into an anonymous tensor API.
+
+Use `geometry="discrete"` when covariance is defined on the finite nodal values.
+Pointwise variance and guarded dense materialization are then meaningful. Use
+`geometry="hilbert"` only when source and output geometries both declare
+physical quadrature. Its pullback is the quadrature-aware operator adjoint;
+only covariance-vector products are exposed because a continuous
+function-space covariance has no canonical nodal diagonal.
+
+::: phydrax.uq.propagate_operator_linearized
+
 ## Geometry-aware operator uncertainty
 
 `OperatorPredictiveField` is architecture-independent: predictions from `GINO`,

--- a/docs/api/uq/propagation.md
+++ b/docs/api/uq/propagation.md
@@ -77,3 +77,90 @@
 ---
 
 ::: phydrax.uq.propagate
+
+
+## Matrix-free linearized covariance
+
+`propagate_linearized` evaluates the nominal output once, retains a JVP
+pushforward and Hermitian VJP pullback, and represents the first-order output
+covariance as the action \(J C_x J^\mathrm{H}\). It never materializes a Jacobian.
+Choose the input covariance representation deliberately:
+
+- `DiagonalCovariance` for independent coordinate variances;
+- `DenseCovariance` for a small explicit Hermitian positive-semidefinite matrix;
+- `FactorCovariance` for \(C_x=B B^\mathrm{H}\), with factor rank on the leading
+  axis of every PyTree leaf;
+- `CovarianceOperator` for a caller-supplied matrix-free action.
+
+`exact_variance()` is exact under the declared first-order model for diagonal,
+dense, and factor inputs. `estimate_variance(...)` is a keyed Hutchinson
+estimate, reports its Monte Carlo standard error, and is the only diagonal path
+for a generic covariance operator. `materialize_covariance(...)` is guarded by
+an explicit output-dimension ceiling. It is a diagnostic for small outputs, not
+the default representation.
+
+Real-valued PyTrees and `coordax.Field` outputs retain their structure and named
+dimensions. Complex propagation requires `complex_linear=True` and uses the
+Hermitian adjoint. Non-holomorphic models must instead expose real and imaginary
+coordinates explicitly.
+
+::: phydrax.uq.DiagonalCovariance
+    options:
+        members:
+            - __init__
+
+---
+
+::: phydrax.uq.DenseCovariance
+    options:
+        members:
+            - __init__
+
+---
+
+::: phydrax.uq.FactorCovariance
+    options:
+        members:
+            - __init__
+
+---
+
+::: phydrax.uq.CovarianceOperator
+    options:
+        members:
+            - __init__
+
+---
+
+::: phydrax.uq.covariance_representation
+
+---
+
+::: phydrax.uq.propagate_linearized
+
+---
+
+::: phydrax.uq.propagate_linearized_map
+
+---
+
+::: phydrax.uq.LinearizedPropagationResult
+    options:
+        members:
+            - pushforward
+            - pullback
+            - covariance_vector_product
+            - exact_variance
+            - estimate_variance
+            - materialize_covariance
+
+---
+
+::: phydrax.uq.LinearizedVarianceEstimate
+
+---
+
+::: phydrax.uq.LinearizedDenseCovariance
+    options:
+        members:
+            - covariance_vector_product

--- a/docs/cookbook/operator_uncertainty.md
+++ b/docs/cookbook/operator_uncertainty.md
@@ -238,6 +238,42 @@ ensemble-member axes when both sources matter, and inspect
 conformal coverage remains an in-distribution statement over complete physical
 cases; it does not become a geometry-extrapolation guarantee.
 
+### 4b. Propagate local source covariance without flattening the field
+
+```python
+operator_linearization = phx.nn.linearize_operator(
+    members[0],
+    test_batch,
+    "state",
+    field_name="output",
+    key=jr.key(5),
+)
+source_covariance = phx.uq.DiagonalCovariance(
+    jnp.full_like(operator_linearization.base_input, 0.03**2)
+)
+local_operator_prediction = phx.uq.propagate_operator_linearized(
+    operator_linearization,
+    source_covariance,
+    geometry="discrete",
+)
+local_field_variance = local_operator_prediction.exact_variance()
+
+assert local_field_variance.dims == ("case", "x")
+```
+
+The result retains the operator query dimensions and uses the same matrix-free
+JVP/VJP covariance engine as any other physical map. `geometry="discrete"`
+means covariance of the finite nodal values, so pointwise variance and guarded
+dense materialization are well-defined.
+
+For a continuous function-space covariance, use `geometry="hilbert"` only when
+both source and output geometries carry explicit physical quadrature, as this
+recipe does. The pullback then uses the quadrature-aware Hilbert adjoint.
+Only `covariance_vector_product(...)` is exposed: a continuum covariance has no
+canonical pointwise diagonal until a Riesz-coordinate representation is
+declared.
+
+
 ## 5. Define a normalized operator observation likelihood
 
 An operator training loss is not automatically a posterior likelihood. A finite

--- a/docs/cookbook/uncertainty_quantification.md
+++ b/docs/cookbook/uncertainty_quantification.md
@@ -132,6 +132,36 @@ input_prediction = phx.uq.propagate(
 The resulting source is `"input"`, distinct from ensemble epistemic variation. Keep
 these axes separate when both are present.
 
+### 5a. Use a local covariance when full draws are unnecessary
+
+```python
+local_center = {
+    "coefficient": jnp.asarray(0.4),
+    "forcing": jnp.asarray([0.8, 1.0, 1.2]),
+}
+local_covariance = phx.uq.FactorCovariance(
+    {
+        "coefficient": jnp.asarray([0.05, 0.00]),
+        "forcing": jnp.asarray(
+            [[0.02, 0.02, 0.02], [0.01, -0.01, 0.00]]
+        ),
+    }
+)
+local_prediction = phx.uq.propagate_linearized(
+    lambda value: solve_forward(value["coefficient"], value["forcing"]),
+    local_center,
+    local_covariance,
+)
+local_variance = local_prediction.exact_variance(batch_size=1)
+```
+
+The leading axis of every factor leaf is the shared covariance rank. This path
+uses JVP/VJP actions and never materializes a Jacobian. Validate it against the
+joint-QMC workflow above at several shrinking covariance scales before relying
+on a nonlinear model.
+
+
+
 ## 6. Rank global effects
 
 ```python
@@ -221,6 +251,8 @@ structured_laplace = phx.uq.fit_laplace(
     curvature="diagonal",
 )
 ```
+laplace_linearized = dense_laplace.linearized_predict(posterior_query)
+laplace_local_variance = laplace_linearized.exact_variance()
 
 The MCMC result preserves distinct chain and draw dimensions and includes split
 rank-normalized $\hat R$, bulk/tail ESS, acceptance, divergence, energy, depth, and
@@ -244,6 +276,39 @@ path to `ParameterSubspace.from_subtree_paths(...)`; this includes all arrays in
 those modules and avoids accidentally selecting only the last coordinate factor.
 See the posterior-contract section of the UQ guide for the complete separable
 selection pattern and its nonlinear joint-posterior interpretation.
+
+
+### 7a. Infer with uncertain predictors and responses
+
+```python
+measured_inputs = jnp.linspace(0.2, 1.4, 20)[:, None]
+measured_targets = 1.7 * measured_inputs[:, 0]
+
+measurement_term = phx.uq.LinearizedGaussianMeasurementLikelihood(
+    lambda parameters, value: parameters["slope"] * value[0],
+    measured_inputs,
+    measured_targets,
+    input_covariance=jnp.asarray([[0.04**2]]),
+    observation_covariance=jnp.asarray([[0.02**2]]),
+)
+measurement_space = phx.uq.ParameterSpace(
+    {"slope": jnp.asarray(1.5)},
+    priors={"slope": phx.uq.Normal(0.0, 3.0)},
+)
+measurement_problem = phx.uq.PosteriorProblem.from_terms(
+    measurement_space,
+    (measurement_term,),
+)
+measurement_map = phx.uq.find_map(measurement_problem)
+```
+
+The likelihood includes the parameter-dependent log determinant of the
+effective covariance. For a stochastic-gradient run, put `inputs`, `targets`,
+and `case_indices` in one `ArrayMinibatchSource` and call
+`measurement_term.log_prob_cases(...)` from the factor function. Compare the
+result against an explicit latent-input model when the predictor uncertainty is
+not small enough for a local linearization.
+
 
 ## 8. Scale a factorized likelihood with fixed-step SG-MCMC
 

--- a/docs/guides_uncertainty.md
+++ b/docs/guides_uncertainty.md
@@ -780,6 +780,54 @@ width. `GaussianScaleCalibrator.fit` estimates one positive multiplier by the
 closed-form held-out Gaussian-NLL optimum. It calibrates scale under a Gaussian
 likelihood; it does not provide a finite-sample coverage guarantee.
 
+## Uncertain predictors and normalized measurement error
+
+When both a measured predictor \(x_i\) and response \(y_i\) are uncertain, an
+observation-only residual model is generally wrong. For a smooth prediction
+\(f(\theta, x_i)\), `LinearizedGaussianMeasurementLikelihood` uses the local
+input Jacobian \(J_i\) and normalized effective covariance
+
+\[
+\Sigma_i(\theta)
+= \Sigma_{y,i}(\theta)
++ J_i(\theta)\Sigma_{x,i}(\theta)J_i(\theta)^\mathsf{T}.
+\]
+
+```python
+measured_x = jnp.linspace(0.1, 1.0, 24)[:, None]
+measured_y = 1.8 * measured_x[:, 0]
+
+measurement_term = phx.uq.LinearizedGaussianMeasurementLikelihood(
+    lambda parameters, x: parameters["slope"] * x[0],
+    measured_x,
+    measured_y,
+    input_covariance=jnp.asarray([[0.03**2]]),
+    observation_covariance=jnp.asarray([[0.02**2]]),
+)
+measurement_space = phx.uq.ParameterSpace(
+    {"slope": jnp.asarray(1.5)},
+    priors={"slope": phx.uq.Normal(0.0, 3.0)},
+)
+measurement_posterior = phx.uq.PosteriorProblem.from_terms(
+    measurement_space,
+    (measurement_term,),
+)
+```
+
+The quadratic residual and `log(det(Sigma_i))` terms are both mandatory. The
+normalization changes with \(\theta\) whenever the model sensitivity or a
+covariance callback changes; dropping it defines a different objective.
+Covariances may be shared or explicitly `per_case`, and may be fixed arrays or
+functions of physical parameters. No covariance shape is inferred from array
+rank.
+
+This likelihood is intentionally local and Gaussian. Use it for small or
+moderate output events with differentiable predictors. Compare against an
+explicit latent-input model when nonlinear input effects are material. Use
+`log_prob_cases(...)` with an `ArrayMinibatchSource` containing measured inputs,
+targets, and original case indices to reuse this exact term under SG-MCMC.
+
+
 ## Posterior contract
 
 Bayesian inference starts from one explicit `PosteriorProblem`. It owns:
@@ -1188,6 +1236,24 @@ approximate_prediction = laplace.predict(
 )
 ```
 
+For cheap local prediction moments, propagate the Laplace covariance without
+drawing:
+
+```python
+linearized_prediction = laplace.linearized_predict(
+    jnp.linspace(0.0, 1.0, 65)
+)
+linearized_variance = linearized_prediction.exact_variance()
+```
+
+`linearized_predict` differentiates the complete prediction path from
+unconstrained parameters, so parameter bijectors are included automatically.
+Dense Laplace supports exact first-order diagonals. Structured Laplace retains
+its covariance-vector product and can materialize only a caller-bounded small
+output covariance or estimate its diagonal with keyed Hutchinson probes.
+Continue to use `predict(...)` when nonlinear posterior-predictive shape,
+mean shifts, skewness, or tails matter.
+
 For larger subspaces, the same entry point dispatches to a Phydrax adapter around
 Laplax:
 
@@ -1480,6 +1546,49 @@ All calibrators use the exact finite-sample rank
 $k=\lceil(n+1)(1-\alpha)\rceil$. If $k>n$, Phydrax rejects the requested interval
 instead of silently clamping the rank. Coverage requires exchangeable calibration
 and test cases. Pointwise and simultaneous coverage are separate contracts.
+
+## Local covariance propagation
+
+`propagate_linearized` is the matrix-free first-order path for a smooth
+scientific map. It evaluates the nominal output once, keeps JVP and Hermitian
+VJP actions, and applies \(J C_x J^\mathrm{H}\) without constructing a
+Jacobian.
+
+```python
+center = {
+    "diffusivity": jnp.asarray(0.2),
+    "source": jnp.asarray([0.9, 1.0, 1.1]),
+}
+covariance = phx.uq.DiagonalCovariance(
+    {
+        "diffusivity": jnp.asarray(0.01),
+        "source": jnp.full((3,), 0.02),
+    }
+)
+local = phx.uq.propagate_linearized(
+    lambda value: forward(value["diffusivity"], value["source"]),
+    center,
+    covariance,
+)
+output_variance = local.exact_variance()
+```
+
+| Situation | First method | Escalation |
+| --- | --- | --- |
+| Smooth map, small perturbations, cheap moments | `propagate_linearized` | QMC or Monte Carlo validation |
+| Dense small input covariance | `DenseCovariance` | Factorize if repeatedly reused |
+| Low-rank prior or empirical modes | `FactorCovariance` | Increase retained rank |
+| Matrix-free covariance or PDE inverse action | `CovarianceOperator` | Keyed Hutchinson diagonal |
+| Small output diagnostic | Guarded `materialize_covariance` | Keep covariance-vector products for large fields |
+| Strong nonlinearity, discontinuity, threshold, or multimodality | Joint QMC or posterior draws | Explicit latent/reference model |
+
+`exact_variance()` means exact under the first-order approximation, not exact
+for the nonlinear model. `estimate_variance(...)` additionally carries
+Hutchinson Monte Carlo error. Preserve `coordax.Field` dimensions and uncertainty
+source labels in downstream summaries. Complex maps must be genuinely
+complex-linear and request `complex_linear=True`; otherwise represent real and
+imaginary parts explicitly.
+
 
 ## Uncertain inputs and joint QMC
 

--- a/phydrax/nn/operator_training/_linearization.py
+++ b/phydrax/nn/operator_training/_linearization.py
@@ -14,7 +14,12 @@ from jaxtyping import Array, Key
 
 from ..._doc import DOC_KEY0
 from ..models.core._base import _AbstractOperatorModel
-from ..models.core._operator import FunctionSamples, OperatorBatch, OperatorPrediction
+from ..models.core._operator import (
+    FunctionSamples,
+    OperatorBatch,
+    OperatorOutputSpec,
+    OperatorPrediction,
+)
 from ._physics import operator_hilbert_inner_product
 from ._trained_operator import TrainedOperator
 
@@ -146,6 +151,7 @@ class OperatorLinearization:
     base_input: Array
     base_output: Array
     output_query: FunctionSamples
+    output_spec: OperatorOutputSpec
 
     @property
     def source_samples(self) -> FunctionSamples:
@@ -288,6 +294,7 @@ def linearize_operator(
         output_query=prediction.query_geometry(
             prediction.field(resolved_field).query_name
         ),
+        output_spec=prediction.field(resolved_field).spec,
     )
 
 

--- a/phydrax/uq/__init__.py
+++ b/phydrax/uq/__init__.py
@@ -10,6 +10,14 @@ from ._checkpoint import (
     CheckpointError,
 )
 from ._conformal import FunctionalConformal, NormalizedConformal, SplitConformal
+from ._covariance import (
+    AbstractCovariance,
+    covariance_representation,
+    CovarianceOperator,
+    DenseCovariance,
+    DiagonalCovariance,
+    FactorCovariance,
+)
 from ._diagnostics import (
     MCMCConvergenceError,
     MCMCConvergenceReport,
@@ -137,6 +145,13 @@ from ._likelihoods import (
     GaussianLocationScaleLikelihood,
     StudentTLikelihood,
 )
+from ._linearized import (
+    LinearizedDenseCovariance,
+    LinearizedPropagationResult,
+    LinearizedVarianceEstimate,
+    propagate_linearized,
+    propagate_linearized_map,
+)
 from ._map import find_map, MAPConvergenceError, MAPResult
 from ._martingale import (
     jump_compensator_diagnostics,
@@ -149,6 +164,10 @@ from ._martingale import (
     QuadraticVariationDiagnostics,
 )
 from ._mcmc import MCMCChainWarmup, MCMCResult, sample_hmc, sample_nuts
+from ._measurement_likelihood import (
+    CovarianceBatching,
+    LinearizedGaussianMeasurementLikelihood,
+)
 from ._metrics import (
     calibration_error,
     energy_distance,
@@ -180,6 +199,7 @@ from ._operator import (
     operator_predictive_from_samples,
     OperatorPredictionInterval,
     OperatorPredictiveField,
+    propagate_operator_linearized,
     sample_operator_predictive,
 )
 from ._operator_conformal import OperatorFunctionalConformal
@@ -495,6 +515,8 @@ __all__ = [
     "GaussianLikelihood",
     "GaussianLocationScaleLikelihood",
     "StudentTLikelihood",
+    "CovarianceBatching",
+    "LinearizedGaussianMeasurementLikelihood",
     "GaussianScaleCalibrator",
     "calibration_error",
     "energy_distance",
@@ -575,6 +597,7 @@ __all__ = [
     "OperatorMinibatchSource",
     "operator_input_predictive",
     "operator_prediction_field",
+    "propagate_operator_linearized",
     "OperatorPredictionInterval",
     "OperatorPredictiveField",
     "operator_predictive_from_samples",
@@ -596,6 +619,17 @@ __all__ = [
     "diagnose_minibatch_posterior",
     "MinibatchPosteriorCapabilities",
     "MinibatchPosteriorDiagnostics",
+    "AbstractCovariance",
+    "CovarianceOperator",
+    "DenseCovariance",
+    "DiagonalCovariance",
+    "FactorCovariance",
+    "covariance_representation",
+    "LinearizedDenseCovariance",
+    "LinearizedPropagationResult",
+    "LinearizedVarianceEstimate",
+    "propagate_linearized",
+    "propagate_linearized_map",
     "GaussianPriorWhitening",
     "AbstractPosteriorTerm",
     "CompositePosteriorLikelihood",

--- a/phydrax/uq/_covariance.py
+++ b/phydrax/uq/_covariance.py
@@ -1,0 +1,280 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, Literal
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jax.flatten_util import ravel_pytree
+from jaxtyping import Array, ArrayLike, PyTree
+
+from .._strict import StrictModule
+
+
+CovarianceRepresentation = Literal["diagonal", "dense", "factor", "operator"]
+
+
+class AbstractCovariance(StrictModule):
+    """Explicit representation of a covariance on an array PyTree."""
+
+
+class DiagonalCovariance(AbstractCovariance):
+    """Independent variances with the same PyTree structure as an uncertain value."""
+
+    variance: PyTree[Array]
+
+    def __init__(self, variance: PyTree[ArrayLike], /):
+        arrays = jax.tree_util.tree_map(jnp.asarray, variance)
+        leaves = jax.tree_util.tree_leaves(arrays)
+        if not leaves or any(not eqx.is_inexact_array(leaf) for leaf in leaves):
+            raise TypeError("Diagonal covariance must contain inexact array leaves.")
+        for leaf in leaves:
+            if jnp.issubdtype(leaf.dtype, jnp.complexfloating):
+                raise TypeError("Diagonal covariance variances must be real-valued.")
+            if bool(jnp.any(~jnp.isfinite(leaf))) or bool(jnp.any(leaf < 0.0)):
+                raise ValueError(
+                    "Diagonal covariance variances must be finite and nonnegative."
+                )
+        self.variance = arrays
+
+
+class DenseCovariance(AbstractCovariance):
+    """Dense Hermitian positive-semidefinite covariance in flattened PyTree order."""
+
+    matrix: Array
+
+    def __init__(self, matrix: ArrayLike, /):
+        value = jnp.asarray(matrix)
+        if not eqx.is_inexact_array(value):
+            raise TypeError("Dense covariance must be an inexact array.")
+        if value.ndim != 2 or value.shape[0] == 0 or value.shape[0] != value.shape[1]:
+            raise ValueError("Dense covariance must be a non-empty square matrix.")
+        if bool(jnp.any(~jnp.isfinite(value))):
+            raise ValueError("Dense covariance must be finite.")
+        tolerance = _matrix_tolerance(value)
+        hermitian_error = jnp.max(jnp.abs(value - jnp.conj(value.T)))
+        if bool(hermitian_error > tolerance):
+            raise ValueError("Dense covariance must be Hermitian within tolerance.")
+        hermitian = 0.5 * (value + jnp.conj(value.T))
+        eigenvalues = jnp.linalg.eigvalsh(hermitian)
+        if bool(jnp.min(eigenvalues) < -tolerance):
+            raise ValueError("Dense covariance must be positive semidefinite.")
+        self.matrix = hermitian
+
+
+class FactorCovariance(AbstractCovariance):
+    """Covariance ``B Bᴴ`` stored as leading-rank PyTree factor directions."""
+
+    factors: PyTree[Array]
+    rank: int = eqx.field(static=True)
+
+    def __init__(self, factors: PyTree[ArrayLike], /):
+        arrays = jax.tree_util.tree_map(jnp.asarray, factors)
+        leaves = jax.tree_util.tree_leaves(arrays)
+        if not leaves or any(not eqx.is_inexact_array(leaf) for leaf in leaves):
+            raise TypeError("Covariance factors must contain inexact array leaves.")
+        if any(leaf.ndim == 0 for leaf in leaves):
+            raise ValueError("Every covariance-factor leaf needs a leading rank axis.")
+        rank = int(leaves[0].shape[0])
+        if rank <= 0 or any(int(leaf.shape[0]) != rank for leaf in leaves):
+            raise ValueError(
+                "Covariance-factor leaves must share one positive leading rank axis."
+            )
+        if any(bool(jnp.any(~jnp.isfinite(leaf))) for leaf in leaves):
+            raise ValueError("Covariance factors must be finite.")
+        self.factors = arrays
+        self.rank = rank
+
+
+class CovarianceOperator(AbstractCovariance):
+    """Caller-supplied self-adjoint positive-semidefinite covariance action."""
+
+    matvec_fn: Callable[[PyTree[Array]], PyTree[Array]] = eqx.field(static=True)
+
+    def __init__(self, matvec: Callable[[PyTree[Array]], PyTree[Array]], /):
+        if not callable(matvec):
+            raise TypeError("CovarianceOperator matvec must be callable.")
+        self.matvec_fn = matvec
+
+    def __call__(self, vector: PyTree[Array], /) -> PyTree[Array]:
+        return self.matvec_fn(vector)
+
+
+def covariance_representation(
+    covariance: AbstractCovariance,
+    /,
+) -> CovarianceRepresentation:
+    """Return the explicit storage representation of one covariance."""
+    if isinstance(covariance, DiagonalCovariance):
+        return "diagonal"
+    if isinstance(covariance, DenseCovariance):
+        return "dense"
+    if isinstance(covariance, FactorCovariance):
+        return "factor"
+    if isinstance(covariance, CovarianceOperator):
+        return "operator"
+    raise TypeError("covariance must implement AbstractCovariance.")
+
+
+def _validate_covariance_template(
+    covariance: AbstractCovariance,
+    template: PyTree[Array],
+    /,
+) -> tuple[int, Any]:
+    flat_template, unravel = ravel_pytree(template)
+    dimension = int(flat_template.size)
+    if dimension <= 0:
+        raise ValueError("Covariance templates must contain at least one scalar.")
+    template_structure = jax.tree_util.tree_structure(template)
+    template_leaves = jax.tree_util.tree_leaves(template)
+
+    if isinstance(covariance, DiagonalCovariance):
+        _validate_tree_shapes(
+            covariance.variance,
+            template_structure,
+            tuple(leaf.shape for leaf in template_leaves),
+            owner="Diagonal covariance",
+        )
+    elif isinstance(covariance, DenseCovariance):
+        if covariance.matrix.shape != (dimension, dimension):
+            raise ValueError(
+                "Dense covariance shape must match the flattened uncertain value; "
+                f"expected {(dimension, dimension)}, got {covariance.matrix.shape}."
+            )
+        if (
+            jnp.issubdtype(covariance.matrix.dtype, jnp.complexfloating)
+            and not jnp.issubdtype(flat_template.dtype, jnp.complexfloating)
+        ):
+            raise TypeError(
+                "Complex dense covariance requires a complex uncertain value."
+            )
+    elif isinstance(covariance, FactorCovariance):
+        factor_shapes = tuple((covariance.rank, *leaf.shape) for leaf in template_leaves)
+        _validate_tree_shapes(
+            covariance.factors,
+            template_structure,
+            factor_shapes,
+            owner="Factor covariance",
+        )
+        for factor, template_leaf in zip(
+            jax.tree_util.tree_leaves(covariance.factors),
+            template_leaves,
+            strict=True,
+        ):
+            if (
+                jnp.issubdtype(factor.dtype, jnp.complexfloating)
+                and not jnp.issubdtype(template_leaf.dtype, jnp.complexfloating)
+            ):
+                raise TypeError(
+                    "Complex covariance factors require complex uncertain values."
+                )
+    elif isinstance(covariance, CovarianceOperator):
+        probe = jax.tree_util.tree_map(jnp.ones_like, template)
+        output = covariance(probe)
+        _validate_tree_shapes(
+            output,
+            template_structure,
+            tuple(leaf.shape for leaf in template_leaves),
+            owner="Covariance operator output",
+        )
+        if any(
+            bool(jnp.any(~jnp.isfinite(jnp.asarray(leaf))))
+            for leaf in jax.tree_util.tree_leaves(output)
+        ):
+            raise FloatingPointError("Covariance operator probe output must be finite.")
+    else:
+        raise TypeError("covariance must implement AbstractCovariance.")
+    return dimension, unravel
+
+
+def _apply_covariance(
+    covariance: AbstractCovariance,
+    vector: PyTree[Array],
+    /,
+    *,
+    unravel: Any,
+) -> PyTree[Array]:
+    if isinstance(covariance, DiagonalCovariance):
+        return jax.tree_util.tree_map(
+            lambda variance, value: variance * value,
+            covariance.variance,
+            vector,
+        )
+    if isinstance(covariance, DenseCovariance):
+        flat_vector, _ = ravel_pytree(vector)
+        return unravel(covariance.matrix @ flat_vector)
+    if isinstance(covariance, FactorCovariance):
+        vector_leaves = jax.tree_util.tree_leaves(vector)
+        factor_leaves = jax.tree_util.tree_leaves(covariance.factors)
+        coefficients = jnp.zeros(
+            (covariance.rank,),
+            dtype=jnp.result_type(
+                *(leaf.dtype for leaf in (*vector_leaves, *factor_leaves))
+            ),
+        )
+        for factor, value in zip(factor_leaves, vector_leaves, strict=True):
+            axes = tuple(range(1, factor.ndim))
+            coefficients = coefficients + jnp.sum(
+                jnp.conj(factor) * value[None, ...],
+                axis=axes,
+            )
+        return jax.tree_util.tree_map(
+            lambda factor: jnp.tensordot(coefficients, factor, axes=((0,), (0,))),
+            covariance.factors,
+        )
+    if isinstance(covariance, CovarianceOperator):
+        return covariance(vector)
+    raise TypeError("covariance must implement AbstractCovariance.")
+
+
+def _dense_factor_directions(
+    covariance: DenseCovariance,
+    /,
+    *,
+    unravel: Any,
+) -> PyTree[Array]:
+    eigenvalues, eigenvectors = jnp.linalg.eigh(covariance.matrix)
+    clipped = jnp.maximum(eigenvalues, jnp.zeros((), dtype=eigenvalues.dtype))
+    flat_factors = jnp.sqrt(clipped)[:, None] * jnp.swapaxes(eigenvectors, 0, 1)
+    return jax.vmap(unravel)(flat_factors)
+
+
+def _validate_tree_shapes(
+    value: PyTree[Any],
+    expected_structure: Any,
+    expected_shapes: tuple[tuple[int, ...], ...],
+    /,
+    *,
+    owner: str,
+) -> None:
+    if jax.tree_util.tree_structure(value) != expected_structure:
+        raise ValueError(f"{owner} must match the uncertain value PyTree structure.")
+    leaves = jax.tree_util.tree_leaves(value)
+    observed_shapes = tuple(tuple(int(size) for size in leaf.shape) for leaf in leaves)
+    if observed_shapes != expected_shapes:
+        raise ValueError(
+            f"{owner} leaf shapes must be {expected_shapes}; got {observed_shapes}."
+        )
+
+
+def _matrix_tolerance(matrix: Array, /) -> Array:
+    real_dtype = jnp.asarray(jnp.real(matrix)).dtype
+    epsilon = jnp.finfo(real_dtype).eps
+    scale = jnp.maximum(jnp.max(jnp.abs(matrix)), jnp.ones((), dtype=real_dtype))
+    return 100.0 * int(matrix.shape[0]) * epsilon * scale
+
+
+__all__ = [
+    "AbstractCovariance",
+    "CovarianceOperator",
+    "CovarianceRepresentation",
+    "DenseCovariance",
+    "DiagonalCovariance",
+    "FactorCovariance",
+    "covariance_representation",
+]

--- a/phydrax/uq/_laplace.py
+++ b/phydrax/uq/_laplace.py
@@ -16,6 +16,8 @@ from jaxtyping import Array, PyTree
 
 from .._frozendict import frozendict
 from .._strict import StrictModule
+from ._covariance import DenseCovariance
+from ._linearized import LinearizedPropagationResult, propagate_linearized
 from ._posterior import PosteriorProblem
 
 
@@ -87,13 +89,15 @@ class LaplaceResult(StrictModule):
 
     def physical_covariance(self) -> Array:
         """Return delta-method covariance after parameter bijectors."""
-
-        def constrain_flat(flat_position):
-            physical = self.problem.parameter_space.constrain(self.unravel(flat_position))
-            return ravel_pytree(physical)[0]
-
-        jacobian = jax.jacrev(constrain_flat)(self.flat_map_position)
-        return jacobian @ self.covariance @ jacobian.T
+        propagation = propagate_linearized(
+            self.problem.parameter_space.constrain,
+            self.map_position,
+            DenseCovariance(self.covariance),
+            source="epistemic",
+        )
+        return propagation.materialize_covariance(
+            max_dimension=propagation.output_dimension
+        ).matrix
 
     def physical_correlation(self) -> Array:
         """Return delta-method physical-parameter correlations."""
@@ -135,6 +139,20 @@ class LaplaceResult(StrictModule):
         """Draw transformed physical-parameter samples."""
         unconstrained = self.sample_unconstrained(key, num_samples=num_samples)
         return self.problem.parameter_space.constrain(unconstrained)
+    def linearized_predict(
+        self,
+        /,
+        *args: Any,
+        **kwargs: Any,
+    ) -> LinearizedPropagationResult:
+        """Propagate dense Laplace covariance through one local prediction map."""
+        return propagate_linearized(
+            lambda position: self.problem.predict(position, *args, **kwargs),
+            self.map_position,
+            DenseCovariance(self.covariance),
+            source="epistemic",
+        )
+
 
     def predict(
         self,

--- a/phydrax/uq/_laplax_backend.py
+++ b/phydrax/uq/_laplax_backend.py
@@ -18,6 +18,8 @@ from laplax.enums import CurvApprox
 
 from .._frozendict import frozendict
 from .._strict import StrictModule
+from ._covariance import CovarianceOperator
+from ._linearized import LinearizedPropagationResult, propagate_linearized
 from ._posterior import AbstractBijector, IdentityBijector, PosteriorProblem
 from ._posterior_predictive import (
     predict_from_position_samples,
@@ -95,15 +97,13 @@ class StructuredLaplaceResult(StrictModule):
         self, vector: PyTree[Array], /
     ) -> PyTree[Array]:
         """Apply delta-method covariance in transformed physical coordinates."""
-        constrain = self.problem.parameter_space.constrain
-        _, pullback = jax.vjp(constrain, self.map_position)
-        unconstrained_vector = pullback(vector)[0]
-        covariance_vector = self.covariance_mv(unconstrained_vector)
-        return jax.jvp(
-            constrain,
-            (self.map_position,),
-            (covariance_vector,),
-        )[1]
+        propagation = propagate_linearized(
+            self.problem.parameter_space.constrain,
+            self.map_position,
+            CovarianceOperator(self.covariance_mv),
+            source="epistemic",
+        )
+        return propagation.covariance_vector_product(vector)
 
     def sample_unconstrained(
         self,
@@ -140,6 +140,20 @@ class StructuredLaplaceResult(StrictModule):
         """Draw transformed physical parameters."""
         positions = self.sample_unconstrained(key, num_samples=num_samples)
         return self.problem.parameter_space.constrain(positions)
+    def linearized_predict(
+        self,
+        /,
+        *args: Any,
+        **kwargs: Any,
+    ) -> LinearizedPropagationResult:
+        """Propagate structured Laplace covariance through a local prediction map."""
+        return propagate_linearized(
+            lambda position: self.problem.predict(position, *args, **kwargs),
+            self.map_position,
+            CovarianceOperator(self.covariance_mv),
+            source="epistemic",
+        )
+
 
     def predict(
         self,

--- a/phydrax/uq/_linearized.py
+++ b/phydrax/uq/_linearized.py
@@ -1,0 +1,577 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+from jax.flatten_util import ravel_pytree
+from jaxtyping import Array, PyTree
+
+from .._strict import StrictModule
+from .._uncertainty import UncertaintySource, validate_uncertainty_source
+from ._covariance import (
+    _apply_covariance,
+    _dense_factor_directions,
+    _matrix_tolerance,
+    _validate_covariance_template,
+    _validate_tree_shapes,
+    AbstractCovariance,
+    covariance_representation,
+    CovarianceOperator,
+    DenseCovariance,
+    DiagonalCovariance,
+    FactorCovariance,
+)
+
+
+class LinearizedVarianceEstimate(StrictModule):
+    """Hutchinson estimate of a first-order output-covariance diagonal."""
+
+    variance: PyTree[Array]
+    standard_error: PyTree[Array]
+    num_probes: int = eqx.field(static=True)
+    probe_distribution: str = eqx.field(static=True)
+    exact: bool = eqx.field(static=True)
+    approximation: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        variance: PyTree[Array],
+        standard_error: PyTree[Array],
+        /,
+        *,
+        num_probes: int,
+        probe_distribution: str,
+    ):
+        self.variance = variance
+        self.standard_error = standard_error
+        self.num_probes = int(num_probes)
+        self.probe_distribution = str(probe_distribution)
+        self.exact = False
+        self.approximation = "first_order_hutchinson"
+
+
+class LinearizedDenseCovariance(StrictModule):
+    """Guarded dense output covariance with a deterministic PyTree layout."""
+
+    matrix: Array
+    hermitian_defect: Array
+    leaf_paths: tuple[str, ...] = eqx.field(static=True)
+    leaf_shapes: tuple[tuple[int, ...], ...] = eqx.field(static=True)
+    dimension: int = eqx.field(static=True)
+    unravel: Any = eqx.field(static=True)
+
+    def __init__(
+        self,
+        matrix: Array,
+        hermitian_defect: Array,
+        /,
+        *,
+        output_template: PyTree[Array],
+        unravel: Any,
+    ):
+        path_leaves = jax.tree_util.tree_flatten_with_path(output_template)[0]
+        self.matrix = jnp.asarray(matrix)
+        self.hermitian_defect = jnp.asarray(hermitian_defect)
+        self.leaf_paths = tuple(
+            jax.tree_util.keystr(path) or "<root>" for path, _ in path_leaves
+        )
+        self.leaf_shapes = tuple(
+            tuple(int(size) for size in leaf.shape) for _, leaf in path_leaves
+        )
+        self.dimension = int(self.matrix.shape[0])
+        self.unravel = unravel
+
+    def covariance_vector_product(
+        self,
+        vector: PyTree[Array],
+        /,
+    ) -> PyTree[Array]:
+        """Apply the materialized covariance and restore the output PyTree."""
+        flat_vector, _ = ravel_pytree(vector)
+        if flat_vector.shape != (self.dimension,):
+            raise ValueError(
+                "Dense covariance vector has incompatible flattened dimension; "
+                f"expected {self.dimension}, got {flat_vector.size}."
+            )
+        return self.unravel(self.matrix @ flat_vector)
+
+
+class LinearizedPropagationResult(StrictModule):
+    """Matrix-free first-order moments around one nominal scientific input."""
+
+    mean: PyTree[Array]
+    input_template: PyTree[Array]
+    covariance: AbstractCovariance
+    pushforward_fn: Callable[[PyTree[Array]], PyTree[Array]]
+    pullback_fn: Callable[[PyTree[Array]], PyTree[Array]]
+    input_unravel: Any = eqx.field(static=True)
+    output_unravel: Any = eqx.field(static=True)
+    source: UncertaintySource = eqx.field(static=True)
+    input_covariance_representation: str = eqx.field(static=True)
+    approximation: str = eqx.field(static=True)
+    input_dimension: int = eqx.field(static=True)
+    output_dimension: int = eqx.field(static=True)
+    coordinate_covariance: bool = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        mean: PyTree[Array],
+        input_template: PyTree[Array],
+        covariance: AbstractCovariance,
+        pushforward: Callable[[PyTree[Array]], PyTree[Array]],
+        pullback: Callable[[PyTree[Array]], PyTree[Array]],
+        source: UncertaintySource,
+        coordinate_covariance: bool = True,
+    ):
+        _validate_array_tree(input_template, owner="Linearized input", finite=True)
+        _validate_array_tree(mean, owner="Linearized output", finite=True)
+        input_dimension, input_unravel = _validate_covariance_template(
+            covariance,
+            input_template,
+        )
+        flat_output, output_unravel = ravel_pytree(mean)
+        output_dimension = int(flat_output.size)
+        if output_dimension <= 0:
+            raise ValueError("Linearized outputs must contain at least one scalar.")
+
+        input_structure = jax.tree_util.tree_structure(input_template)
+        input_shapes = tuple(
+            tuple(int(size) for size in leaf.shape)
+            for leaf in jax.tree_util.tree_leaves(input_template)
+        )
+        output_structure = jax.tree_util.tree_structure(mean)
+        output_shapes = tuple(
+            tuple(int(size) for size in leaf.shape)
+            for leaf in jax.tree_util.tree_leaves(mean)
+        )
+        input_probe = jax.tree_util.tree_map(jnp.ones_like, input_template)
+        output_probe = jax.tree_util.tree_map(jnp.ones_like, mean)
+        _validate_tree_shapes(
+            pushforward(input_probe),
+            output_structure,
+            output_shapes,
+            owner="Linearized pushforward output",
+        )
+        _validate_tree_shapes(
+            pullback(output_probe),
+            input_structure,
+            input_shapes,
+            owner="Linearized pullback output",
+        )
+
+        self.mean = mean
+        self.input_template = input_template
+        self.covariance = covariance
+        self.pushforward_fn = pushforward
+        self.pullback_fn = pullback
+        self.input_unravel = input_unravel
+        self.output_unravel = output_unravel
+        self.source = validate_uncertainty_source(
+            source,
+            owner="LinearizedPropagationResult.source",
+        )
+        self.input_covariance_representation = covariance_representation(covariance)
+        self.approximation = "first_order"
+        self.input_dimension = input_dimension
+        self.output_dimension = output_dimension
+        self.coordinate_covariance = bool(coordinate_covariance)
+
+    def pushforward(self, tangent: PyTree[Array], /) -> PyTree[Array]:
+        """Apply the local derivative to an input tangent."""
+        _validate_like(tangent, self.input_template, owner="Input tangent")
+        return self.pushforward_fn(tangent)
+
+    def pullback(self, cotangent: PyTree[Array], /) -> PyTree[Array]:
+        """Apply the local Euclidean or Hermitian pullback."""
+        _validate_like(cotangent, self.mean, owner="Output cotangent")
+        return self.pullback_fn(cotangent)
+
+    def covariance_vector_product(
+        self,
+        vector: PyTree[Array],
+        /,
+    ) -> PyTree[Array]:
+        """Apply ``J Cₓ Jᴴ`` without materializing either Jacobian or covariance."""
+        input_covector = self.pullback(vector)
+        covariance_vector = _apply_covariance(
+            self.covariance,
+            input_covector,
+            unravel=self.input_unravel,
+        )
+        return self.pushforward(covariance_vector)
+
+    def exact_variance(
+        self,
+        *,
+        batch_size: int | None = None,
+    ) -> PyTree[Array]:
+        """Return the exact output diagonal under the first-order approximation."""
+        if not self.coordinate_covariance:
+            raise ValueError(
+                "Pointwise variance requires a coordinate covariance; "
+                "Hilbert-operator covariance supports only vector products."
+            )
+        if isinstance(self.covariance, CovarianceOperator):
+            raise ValueError(
+                "Exact variance requires diagonal, dense, or factor input covariance; "
+                "use estimate_variance for a covariance operator."
+            )
+        chunk = _batch_size(batch_size, self.input_dimension)
+        accumulator = jax.tree_util.tree_map(
+            lambda value: jnp.zeros_like(jnp.real(value)),
+            self.mean,
+        )
+        if isinstance(self.covariance, DiagonalCovariance):
+            directions = None
+            rank = self.input_dimension
+        else:
+            directions, rank = self._factor_directions()
+        for start in range(0, rank, chunk):
+            stop = min(start + chunk, rank)
+            if directions is None:
+                selected = self._diagonal_directions(start, stop)
+            else:
+                selected = jax.tree_util.tree_map(
+                    lambda value: value[start:stop],
+                    directions,
+                )
+            propagated = jax.vmap(self.pushforward_fn)(selected)
+            contribution = jax.tree_util.tree_map(
+                lambda value: jnp.sum(jnp.abs(value) ** 2, axis=0),
+                propagated,
+            )
+            accumulator = jax.tree_util.tree_map(
+                lambda total, value: total + value,
+                accumulator,
+                contribution,
+            )
+        return accumulator
+
+    def estimate_variance(
+        self,
+        key: Array,
+        /,
+        *,
+        num_probes: int,
+        batch_size: int | None = None,
+    ) -> LinearizedVarianceEstimate:
+        """Estimate the output diagonal with keyed Hutchinson probes."""
+        if not self.coordinate_covariance:
+            raise ValueError(
+                "Variance estimation requires a coordinate covariance; "
+                "Hilbert-operator covariance supports only vector products."
+            )
+        count = int(num_probes)
+        if count < 2:
+            raise ValueError("num_probes must be at least two to estimate uncertainty.")
+        chunk = _batch_size(batch_size, count)
+        flat_mean, _ = ravel_pytree(self.mean)
+        real_dtype = jnp.asarray(jnp.real(flat_mean)).dtype
+        sample_sum = jnp.zeros((self.output_dimension,), dtype=real_dtype)
+        sample_square_sum = jnp.zeros_like(sample_sum)
+        complex_output = jnp.issubdtype(flat_mean.dtype, jnp.complexfloating)
+        distribution = "complex_phase" if complex_output else "rademacher"
+
+        for start in range(0, count, chunk):
+            size = min(chunk, count - start)
+            probes = _flat_probes(
+                key,
+                start,
+                size,
+                self.output_dimension,
+                dtype=flat_mean.dtype,
+                complex_output=complex_output,
+            )
+            probe_trees = jax.vmap(self.output_unravel)(probes)
+            applied_trees = jax.vmap(self.covariance_vector_product)(probe_trees)
+            applied = jax.vmap(lambda value: ravel_pytree(value)[0])(applied_trees)
+            samples = jnp.real(jnp.conj(probes) * applied)
+            sample_sum = sample_sum + jnp.sum(samples, axis=0)
+            sample_square_sum = sample_square_sum + jnp.sum(samples**2, axis=0)
+
+        estimate = sample_sum / count
+        sample_variance = (
+            sample_square_sum - sample_sum**2 / count
+        ) / (count - 1)
+        standard_error = jnp.sqrt(jnp.maximum(sample_variance, 0.0) / count)
+        return LinearizedVarianceEstimate(
+            self.output_unravel(estimate),
+            self.output_unravel(standard_error),
+            num_probes=count,
+            probe_distribution=distribution,
+        )
+
+    def materialize_covariance(
+        self,
+        *,
+        max_dimension: int = 256,
+        batch_size: int | None = None,
+    ) -> LinearizedDenseCovariance:
+        """Materialize a guarded dense output covariance in flattened output order."""
+        if not self.coordinate_covariance:
+            raise ValueError(
+                "Dense materialization requires a coordinate covariance; "
+                "Hilbert-operator covariance supports only vector products."
+            )
+        maximum = int(max_dimension)
+        if maximum <= 0:
+            raise ValueError("max_dimension must be positive.")
+        if self.output_dimension > maximum:
+            raise ValueError(
+                "Dense output covariance exceeds max_dimension; "
+                f"got {self.output_dimension} > {maximum}."
+            )
+        chunk = _batch_size(batch_size, self.output_dimension)
+        flat_mean, _ = ravel_pytree(self.mean)
+        columns: list[Array] = []
+        for start in range(0, self.output_dimension, chunk):
+            stop = min(start + chunk, self.output_dimension)
+            probes = jnp.eye(
+                self.output_dimension,
+                dtype=flat_mean.dtype,
+            )[start:stop]
+            probe_trees = jax.vmap(self.output_unravel)(probes)
+            applied_trees = jax.vmap(self.covariance_vector_product)(probe_trees)
+            applied = jax.vmap(lambda value: ravel_pytree(value)[0])(applied_trees)
+            columns.append(jnp.swapaxes(applied, 0, 1))
+        matrix = jnp.concatenate(tuple(columns), axis=1)
+        adjoint = jnp.conj(matrix.T)
+        scale = jnp.maximum(jnp.linalg.norm(matrix), jnp.finfo(jnp.real(matrix).dtype).eps)
+        defect = jnp.linalg.norm(matrix - adjoint) / scale
+        tolerance = _matrix_tolerance(matrix) / jnp.maximum(
+            jnp.max(jnp.abs(matrix)),
+            jnp.ones((), dtype=jnp.real(matrix).dtype),
+        )
+        if bool(defect > tolerance):
+            raise ValueError(
+                "Materialized output covariance is not Hermitian within tolerance; "
+                f"relative defect={float(defect):.3e}."
+            )
+        hermitian = 0.5 * (matrix + adjoint)
+        return LinearizedDenseCovariance(
+            hermitian,
+            defect,
+            output_template=self.mean,
+            unravel=self.output_unravel,
+        )
+
+    def _diagonal_directions(
+        self,
+        start: int,
+        stop: int,
+        /,
+    ) -> PyTree[Array]:
+        covariance = self.covariance
+        if not isinstance(covariance, DiagonalCovariance):
+            raise TypeError("Diagonal directions require diagonal input covariance.")
+        flat_variance, _ = ravel_pytree(covariance.variance)
+        flat_template, _ = ravel_pytree(self.input_template)
+        size = stop - start
+        indices = jnp.arange(start, stop)
+        flat_directions = jnp.zeros(
+            (size, self.input_dimension),
+            dtype=jnp.result_type(flat_template.dtype, flat_variance.dtype),
+        )
+        flat_directions = flat_directions.at[jnp.arange(size), indices].set(
+            jnp.sqrt(flat_variance[indices])
+        )
+        directions = jax.vmap(self.input_unravel)(flat_directions)
+        return jax.tree_util.tree_map(
+            lambda value, template: value.astype(template.dtype),
+            directions,
+            self.input_template,
+        )
+
+
+    def _factor_directions(self) -> tuple[PyTree[Array], int]:
+        def input_dtype(directions):
+            return jax.tree_util.tree_map(
+                lambda value, template: value.astype(template.dtype),
+                directions,
+                self.input_template,
+            )
+
+        if isinstance(self.covariance, FactorCovariance):
+            return input_dtype(self.covariance.factors), self.covariance.rank
+        if isinstance(self.covariance, DenseCovariance):
+            directions = _dense_factor_directions(
+                self.covariance,
+                unravel=self.input_unravel,
+            )
+            return input_dtype(directions), self.input_dimension
+        raise TypeError("Covariance operators do not expose factor directions.")
+
+
+def propagate_linearized(
+    forward: Callable[[PyTree[Array]], PyTree[Array]],
+    center: PyTree[Array],
+    covariance: AbstractCovariance,
+    /,
+    *,
+    source: UncertaintySource = "input",
+    complex_linear: bool = False,
+) -> LinearizedPropagationResult:
+    """Propagate covariance through a local JAX linearization without a Jacobian."""
+    if not callable(forward):
+        raise TypeError("forward must be callable.")
+    _validate_array_tree(center, owner="Linearization center", finite=True)
+    if not isinstance(covariance, AbstractCovariance):
+        raise TypeError("covariance must implement AbstractCovariance.")
+    mean, pushforward = jax.linearize(forward, center)
+    _validate_array_tree(mean, owner="Linearized forward output", finite=True)
+    complex_values = _tree_is_complex(center) or _tree_is_complex(mean)
+    if complex_values and not complex_linear:
+        raise ValueError(
+            "Complex linearized propagation requires complex_linear=True; represent "
+            "non-holomorphic models with explicit real and imaginary coordinates."
+        )
+    transpose = jax.linear_transpose(pushforward, center)
+
+    pullback = jax.tree_util.Partial(
+        _complex_pullback if complex_values else _real_pullback,
+        transpose,
+    )
+
+    return LinearizedPropagationResult(
+        mean=mean,
+        input_template=center,
+        covariance=covariance,
+        pushforward=pushforward,
+        pullback=pullback,
+        source=source,
+    )
+
+
+def propagate_linearized_map(
+    mean: PyTree[Array],
+    input_template: PyTree[Array],
+    covariance: AbstractCovariance,
+    /,
+    *,
+    pushforward: Callable[[PyTree[Array]], PyTree[Array]],
+    pullback: Callable[[PyTree[Array]], PyTree[Array]],
+    source: UncertaintySource = "input",
+    coordinate_covariance: bool = True,
+) -> LinearizedPropagationResult:
+    """Propagate covariance through caller-supplied tangent and adjoint actions."""
+    if not callable(pushforward) or not callable(pullback):
+        raise TypeError("pushforward and pullback must be callable.")
+    if not isinstance(covariance, AbstractCovariance):
+        raise TypeError("covariance must implement AbstractCovariance.")
+    return LinearizedPropagationResult(
+        mean=mean,
+        input_template=input_template,
+        covariance=covariance,
+        pushforward=pushforward,
+        pullback=pullback,
+        source=source,
+        coordinate_covariance=coordinate_covariance,
+    )
+
+
+def _validate_array_tree(
+    value: PyTree[Any],
+    /,
+    *,
+    owner: str,
+    finite: bool,
+) -> None:
+    leaves = jax.tree_util.tree_leaves(value)
+    if not leaves or any(not eqx.is_inexact_array(leaf) for leaf in leaves):
+        raise TypeError(f"{owner} must be a non-empty PyTree of inexact arrays.")
+    if finite and any(bool(jnp.any(~jnp.isfinite(leaf))) for leaf in leaves):
+        raise ValueError(f"{owner} must be finite.")
+
+
+def _validate_like(
+    value: PyTree[Array],
+    template: PyTree[Array],
+    /,
+    *,
+    owner: str,
+) -> None:
+    _validate_tree_shapes(
+        value,
+        jax.tree_util.tree_structure(template),
+        tuple(
+            tuple(int(size) for size in leaf.shape)
+            for leaf in jax.tree_util.tree_leaves(template)
+        ),
+        owner=owner,
+    )
+def _real_pullback(transpose: Callable[..., Any], cotangent: PyTree[Array], /):
+    return transpose(cotangent)[0]
+
+
+def _complex_pullback(transpose: Callable[..., Any], cotangent: PyTree[Array], /):
+    return _conjugate_tree(transpose(_conjugate_tree(cotangent))[0])
+
+
+
+
+def _tree_is_complex(value: PyTree[Array], /) -> bool:
+    return any(
+        jnp.issubdtype(leaf.dtype, jnp.complexfloating)
+        for leaf in jax.tree_util.tree_leaves(value)
+    )
+
+
+def _conjugate_tree(value: PyTree[Array], /) -> PyTree[Array]:
+    return jax.tree_util.tree_map(jnp.conj, value)
+
+
+def _flat_probes(
+    key: Array,
+    start: int,
+    count: int,
+    dimension: int,
+    /,
+    *,
+    dtype: Any,
+    complex_output: bool,
+) -> Array:
+    indices = jnp.arange(start, start + count, dtype=jnp.uint32)
+    keys = jax.vmap(lambda index: jr.fold_in(key, index))(indices)
+    if complex_output:
+        phase_indices = jax.vmap(lambda probe_key: jr.randint(
+            probe_key,
+            (dimension,),
+            0,
+            4,
+        ))(keys)
+        phases = jnp.asarray((1.0, 1.0j, -1.0, -1.0j), dtype=dtype)
+        return phases[phase_indices]
+    return jax.vmap(
+        lambda probe_key: jr.rademacher(
+            probe_key,
+            (dimension,),
+            dtype=dtype,
+        )
+    )(keys)
+
+
+def _batch_size(value: int | None, total: int, /) -> int:
+    if value is None:
+        return total
+    size = int(value)
+    if size <= 0:
+        raise ValueError("batch_size must be positive or None.")
+    return min(size, total)
+
+
+__all__ = [
+    "LinearizedDenseCovariance",
+    "LinearizedPropagationResult",
+    "LinearizedVarianceEstimate",
+    "propagate_linearized",
+    "propagate_linearized_map",
+]

--- a/phydrax/uq/_measurement_likelihood.py
+++ b/phydrax/uq/_measurement_likelihood.py
@@ -1,0 +1,472 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from math import prod
+from typing import Any, cast, Literal
+
+import coordax as cx
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.scipy as jsp
+from jax.flatten_util import ravel_pytree
+from jaxtyping import Array, ArrayLike, PyTree
+
+from ._posterior_terms import AbstractPosteriorTerm
+
+
+CovarianceBatching = Literal["shared", "per_case"]
+CovarianceValue = ArrayLike | Callable[[PyTree[Any]], ArrayLike]
+
+
+class LinearizedGaussianMeasurementLikelihood(AbstractPosteriorTerm):
+    """Normalized Gaussian errors-in-variables likelihood linearized per case.
+
+    The prediction callable receives physical parameters and one measured input case.
+    Input uncertainty is pushed through that local input derivative and added to the
+    declared observation covariance before evaluating one joint Gaussian factor.
+    """
+
+    inputs: PyTree[Array]
+    targets: Array
+    input_covariance: Array | None
+    observation_covariance: Array | None
+    predict_fn: Callable[[PyTree[Any], PyTree[Array]], ArrayLike | cx.Field] = (
+        eqx.field(static=True)
+    )
+    input_covariance_fn: Callable[[PyTree[Any]], ArrayLike] | None = eqx.field(
+        static=True
+    )
+    observation_covariance_fn: Callable[[PyTree[Any]], ArrayLike] | None = eqx.field(
+        static=True
+    )
+    input_covariance_batching: CovarianceBatching = eqx.field(static=True)
+    observation_covariance_batching: CovarianceBatching = eqx.field(static=True)
+    num_cases: int = eqx.field(static=True)
+    input_dimension: int = eqx.field(static=True)
+    output_dimension: int = eqx.field(static=True)
+    stabilization: float = eqx.field(static=True)
+    max_output_dimension: int = eqx.field(static=True)
+
+    def __init__(
+        self,
+        predict_case: Callable[[PyTree[Any], PyTree[Array]], ArrayLike | cx.Field],
+        measured_inputs: PyTree[ArrayLike],
+        measured_targets: ArrayLike | cx.Field,
+        /,
+        *,
+        input_covariance: CovarianceValue,
+        observation_covariance: CovarianceValue,
+        input_covariance_batching: CovarianceBatching = "shared",
+        observation_covariance_batching: CovarianceBatching = "shared",
+        stabilization: float = 0.0,
+        max_output_dimension: int = 256,
+        label: str = "measurement_error",
+    ):
+        if not callable(predict_case):
+            raise TypeError("predict_case must be callable.")
+        inputs = jax.tree_util.tree_map(jnp.asarray, measured_inputs)
+        num_cases = _validate_case_tree(inputs, owner="Measured inputs", finite=True)
+        targets = _field_data(measured_targets)
+        if targets.ndim == 0 or int(targets.shape[0]) != num_cases:
+            raise ValueError(
+                "Measured targets must have the same non-empty leading case axis as "
+                "measured inputs."
+            )
+        if jnp.issubdtype(targets.dtype, jnp.complexfloating):
+            raise TypeError("Measurement likelihood targets must be real-valued.")
+        if bool(jnp.any(~jnp.isfinite(targets))):
+            raise ValueError("Measured targets must be finite.")
+
+        one_input = jax.tree_util.tree_map(lambda value: value[0], inputs)
+        flat_input, _ = ravel_pytree(one_input)
+        input_dimension = int(flat_input.size)
+        output_dimension = int(prod(targets.shape[1:])) if targets.ndim > 1 else 1
+        maximum = int(max_output_dimension)
+        if maximum <= 0:
+            raise ValueError("max_output_dimension must be positive.")
+        if output_dimension > maximum:
+            raise ValueError(
+                "Measurement output event exceeds max_output_dimension; "
+                f"got {output_dimension} > {maximum}."
+            )
+        input_batching = _validate_batching(
+            input_covariance_batching,
+            owner="input_covariance_batching",
+        )
+        observation_batching = _validate_batching(
+            observation_covariance_batching,
+            owner="observation_covariance_batching",
+        )
+        regularization = float(stabilization)
+        if not jnp.isfinite(regularization) or regularization < 0.0:
+            raise ValueError("stabilization must be finite and nonnegative.")
+
+        input_value, input_fn = _split_covariance(input_covariance, owner="input")
+        observation_value, observation_fn = _split_covariance(
+            observation_covariance,
+            owner="observation",
+        )
+        if input_value is not None:
+            input_value = _validate_fixed_covariance(
+                input_value,
+                batching=input_batching,
+                num_cases=num_cases,
+                dimension=input_dimension,
+                positive_definite=False,
+                stabilization=0.0,
+                owner="Input covariance",
+            )
+        if observation_value is not None:
+            observation_value = _validate_fixed_covariance(
+                observation_value,
+                batching=observation_batching,
+                num_cases=num_cases,
+                dimension=output_dimension,
+                positive_definite=True,
+                stabilization=regularization,
+                owner="Observation covariance",
+            )
+
+        self.predict_fn = predict_case
+        self.inputs = inputs
+        self.targets = targets
+        self.input_covariance = input_value
+        self.observation_covariance = observation_value
+        self.input_covariance_fn = input_fn
+        self.observation_covariance_fn = observation_fn
+        self.input_covariance_batching = input_batching
+        self.observation_covariance_batching = observation_batching
+        self.num_cases = num_cases
+        self.input_dimension = input_dimension
+        self.output_dimension = output_dimension
+        self.stabilization = regularization
+        self.max_output_dimension = maximum
+        self.label = _label(label)
+
+    def per_case_log_prob(self, parameters: PyTree[Any], /) -> Array:
+        """Return one normalized joint Gaussian contribution per stored case."""
+        return self.log_prob_cases(
+            parameters,
+            self.inputs,
+            self.targets,
+            case_indices=jnp.arange(self.num_cases, dtype=jnp.int32),
+        )
+
+    def log_prob_cases(
+        self,
+        parameters: PyTree[Any],
+        inputs: PyTree[ArrayLike],
+        targets: ArrayLike | cx.Field,
+        /,
+        *,
+        case_indices: ArrayLike | None = None,
+    ) -> Array:
+        """Evaluate external case batches for deterministic minibatch inference."""
+        input_arrays = jax.tree_util.tree_map(jnp.asarray, inputs)
+        batch_size = _validate_case_tree(
+            input_arrays,
+            owner="Measurement batch inputs",
+            finite=False,
+        )
+        target_array = _field_data(targets)
+        if target_array.ndim == 0 or int(target_array.shape[0]) != batch_size:
+            raise ValueError(
+                "Measurement batch targets must share the input leading case axis."
+            )
+        observed_dimension = (
+            int(prod(target_array.shape[1:])) if target_array.ndim > 1 else 1
+        )
+        if observed_dimension != self.output_dimension:
+            raise ValueError(
+                "Measurement batch target event dimension changed; "
+                f"expected {self.output_dimension}, got {observed_dimension}."
+            )
+        indices = _case_indices(case_indices, batch_size, self.num_cases)
+        input_covariances = self._resolved_covariance(
+            parameters,
+            fixed=self.input_covariance,
+            callback=self.input_covariance_fn,
+            batching=self.input_covariance_batching,
+            dimension=self.input_dimension,
+            case_indices=indices,
+            batch_size=batch_size,
+            owner="Input covariance",
+        )
+        observation_covariances = self._resolved_covariance(
+            parameters,
+            fixed=self.observation_covariance,
+            callback=self.observation_covariance_fn,
+            batching=self.observation_covariance_batching,
+            dimension=self.output_dimension,
+            case_indices=indices,
+            batch_size=batch_size,
+            owner="Observation covariance",
+        )
+        return jax.vmap(
+            lambda input_case, target_case, input_matrix, observation_matrix: (
+                self._case_log_prob(
+                    parameters,
+                    input_case,
+                    target_case,
+                    input_matrix,
+                    observation_matrix,
+                )
+            )
+        )(
+            input_arrays,
+            target_array,
+            input_covariances,
+            observation_covariances,
+        )
+
+    def _resolved_covariance(
+        self,
+        parameters: PyTree[Any],
+        /,
+        *,
+        fixed: Array | None,
+        callback: Callable[[PyTree[Any]], ArrayLike] | None,
+        batching: CovarianceBatching,
+        dimension: int,
+        case_indices: Array,
+        batch_size: int,
+        owner: str,
+    ) -> Array:
+        value = fixed if callback is None else jnp.asarray(callback(parameters))
+        if value is None:
+            raise RuntimeError(f"{owner} has neither a fixed value nor a callback.")
+        if jnp.issubdtype(value.dtype, jnp.complexfloating):
+            raise TypeError(f"{owner} must be real-valued.")
+        if batching == "shared":
+            if value.shape != (dimension, dimension):
+                raise ValueError(
+                    f"{owner} callback must return shape {(dimension, dimension)}; "
+                    f"got {value.shape}."
+                )
+            return jnp.broadcast_to(value, (batch_size, dimension, dimension))
+        expected = (self.num_cases, dimension, dimension)
+        if value.shape != expected:
+            raise ValueError(
+                f"{owner} callback must return per-case shape {expected}; "
+                f"got {value.shape}."
+            )
+        return jnp.take(
+            value,
+            case_indices,
+            axis=0,
+            mode="fill",
+            fill_value=jnp.nan,
+        )
+
+    def _case_log_prob(
+        self,
+        parameters: PyTree[Any],
+        input_case: PyTree[Array],
+        target_case: Array,
+        input_covariance: Array,
+        observation_covariance: Array,
+        /,
+    ) -> Array:
+        flat_input, unravel_input = ravel_pytree(input_case)
+        target = jnp.ravel(jnp.asarray(target_case))
+
+        def predict_flat(value):
+            prediction = _field_data(self.predict_fn(parameters, unravel_input(value)))
+            return jnp.ravel(prediction)
+
+        prediction, pushforward = jax.linearize(predict_flat, flat_input)
+        if prediction.shape != (self.output_dimension,):
+            raise ValueError(
+                "predict_case output event dimension changed; "
+                f"expected {self.output_dimension}, got {prediction.size}."
+            )
+        input_hermitian = 0.5 * (input_covariance + input_covariance.T)
+        input_eigenvalues, input_eigenvectors = jnp.linalg.eigh(input_hermitian)
+        input_factors = (
+            jnp.sqrt(jnp.maximum(input_eigenvalues, 0.0))[:, None]
+            * input_eigenvectors.T
+        )
+        propagated_factors = jax.vmap(pushforward)(input_factors)
+        pushed_covariance = propagated_factors.T @ propagated_factors
+        observation_hermitian = 0.5 * (
+            observation_covariance + observation_covariance.T
+        )
+        effective_covariance = (
+            observation_hermitian
+            + pushed_covariance
+            + self.stabilization * jnp.eye(self.output_dimension)
+        )
+        effective_eigenvalues = jnp.linalg.eigvalsh(effective_covariance)
+        input_tolerance = _covariance_tolerance(input_covariance)
+        observation_tolerance = _covariance_tolerance(observation_covariance)
+        effective_tolerance = _covariance_tolerance(effective_covariance)
+        valid = (
+            jnp.all(jnp.isfinite(prediction))
+            & jnp.all(jnp.isfinite(target))
+            & jnp.all(jnp.isfinite(input_covariance))
+            & jnp.all(jnp.isfinite(observation_covariance))
+            & (
+                jnp.max(jnp.abs(input_covariance - input_covariance.T))
+                <= input_tolerance
+            )
+            & (
+                jnp.max(
+                    jnp.abs(observation_covariance - observation_covariance.T)
+                )
+                <= observation_tolerance
+            )
+            & (jnp.min(input_eigenvalues) >= -input_tolerance)
+            & (jnp.min(effective_eigenvalues) > effective_tolerance)
+        )
+
+        def finite_log_prob(_):
+            cholesky = jnp.linalg.cholesky(effective_covariance)
+            residual = target - prediction
+            standardized = jsp.linalg.solve_triangular(
+                cholesky,
+                residual,
+                lower=True,
+            )
+            quadratic = jnp.vdot(standardized, standardized).real
+            log_determinant = 2.0 * jnp.sum(jnp.log(jnp.diag(cholesky)))
+            normalizer = self.output_dimension * jnp.log(2.0 * jnp.pi)
+            return -0.5 * (quadratic + log_determinant + normalizer)
+
+        return jax.lax.cond(
+            valid,
+            finite_log_prob,
+            lambda _: jnp.asarray(-jnp.inf, dtype=prediction.dtype),
+            operand=None,
+        )
+
+
+def _split_covariance(
+    value: CovarianceValue,
+    /,
+    *,
+    owner: str,
+) -> tuple[Array | None, Callable[[PyTree[Any]], ArrayLike] | None]:
+    if callable(value):
+        return None, cast(Callable[[PyTree[Any]], ArrayLike], value)
+    array = jnp.asarray(value)
+    if not eqx.is_inexact_array(array):
+        raise TypeError(f"{owner}_covariance must be an inexact array or callable.")
+    return array, None
+
+
+def _validate_fixed_covariance(
+    value: Array,
+    /,
+    *,
+    batching: CovarianceBatching,
+    num_cases: int,
+    dimension: int,
+    positive_definite: bool,
+    stabilization: float,
+    owner: str,
+) -> Array:
+    if jnp.issubdtype(value.dtype, jnp.complexfloating):
+        raise TypeError(f"{owner} must be real-valued.")
+    expected = (
+        (dimension, dimension)
+        if batching == "shared"
+        else (num_cases, dimension, dimension)
+    )
+    if value.shape != expected:
+        raise ValueError(f"{owner} must have shape {expected}; got {value.shape}.")
+    matrices = value[None, ...] if batching == "shared" else value
+    if bool(jnp.any(~jnp.isfinite(matrices))):
+        raise ValueError(f"{owner} must be finite.")
+    tolerances = jax.vmap(_covariance_tolerance)(matrices)
+    symmetry_errors = jax.vmap(
+        lambda matrix: jnp.max(jnp.abs(matrix - matrix.T))
+    )(matrices)
+    if bool(jnp.any(symmetry_errors > tolerances)):
+        raise ValueError(f"{owner} must be symmetric within tolerance.")
+    hermitian = 0.5 * (matrices + jnp.swapaxes(matrices, -1, -2))
+    if stabilization:
+        hermitian = hermitian + stabilization * jnp.eye(dimension)[None, ...]
+    eigenvalues = jax.vmap(jnp.linalg.eigvalsh)(hermitian)
+    if positive_definite:
+        if bool(jnp.any(jnp.min(eigenvalues, axis=1) <= tolerances)):
+            raise ValueError(
+                f"{owner} plus explicit stabilization must be positive definite."
+            )
+    elif bool(jnp.any(jnp.min(eigenvalues, axis=1) < -tolerances)):
+        raise ValueError(f"{owner} must be positive semidefinite.")
+    symmetric = 0.5 * (value + jnp.swapaxes(value, -1, -2))
+    return symmetric
+
+
+def _validate_case_tree(
+    value: PyTree[Array],
+    /,
+    *,
+    owner: str,
+    finite: bool,
+) -> int:
+    leaves = jax.tree_util.tree_leaves(value)
+    if not leaves or any(not eqx.is_inexact_array(leaf) for leaf in leaves):
+        raise TypeError(f"{owner} must be a non-empty PyTree of inexact arrays.")
+    if any(leaf.ndim == 0 for leaf in leaves):
+        raise ValueError(f"Every {owner.lower()} leaf needs a leading case axis.")
+    count = int(leaves[0].shape[0])
+    if count <= 0 or any(int(leaf.shape[0]) != count for leaf in leaves):
+        raise ValueError(f"Every {owner.lower()} leaf must share one positive case axis.")
+    if any(jnp.issubdtype(leaf.dtype, jnp.complexfloating) for leaf in leaves):
+        raise TypeError(f"{owner} must be real-valued.")
+    if finite and any(bool(jnp.any(~jnp.isfinite(leaf))) for leaf in leaves):
+        raise ValueError(f"{owner} must be finite.")
+    return count
+
+
+def _case_indices(
+    value: ArrayLike | None,
+    batch_size: int,
+    num_cases: int,
+    /,
+) -> Array:
+    if value is None:
+        if batch_size != num_cases:
+            raise ValueError(
+                "case_indices are required when evaluating a strict subset of cases."
+            )
+        return jnp.arange(num_cases, dtype=jnp.int32)
+    indices = jnp.asarray(value)
+    if indices.shape != (batch_size,) or not jnp.issubdtype(
+        indices.dtype,
+        jnp.integer,
+    ):
+        raise ValueError("case_indices must be one integer index per batch case.")
+    return indices
+
+
+def _field_data(value: ArrayLike | cx.Field, /) -> Array:
+    return jnp.asarray(value.data if isinstance(value, cx.Field) else value)
+
+
+def _validate_batching(value: str, /, *, owner: str) -> CovarianceBatching:
+    if value not in ("shared", "per_case"):
+        raise ValueError(f"{owner} must be 'shared' or 'per_case'.")
+    return value  # type: ignore[return-value]
+
+
+def _label(value: str, /) -> str:
+    label = str(value)
+    if not label:
+        raise ValueError("Measurement likelihood labels must be non-empty.")
+    return label
+
+
+def _covariance_tolerance(matrix: Array, /) -> Array:
+    epsilon = jnp.finfo(matrix.dtype).eps
+    scale = jnp.maximum(jnp.max(jnp.abs(matrix)), jnp.ones((), dtype=matrix.dtype))
+    return 100.0 * int(matrix.shape[-1]) * epsilon * scale
+
+
+__all__ = ["CovarianceBatching", "LinearizedGaussianMeasurementLikelihood"]

--- a/phydrax/uq/_operator.py
+++ b/phydrax/uq/_operator.py
@@ -23,6 +23,9 @@ from ..nn.models.core._operator import (
     OperatorOutputSpec,
     OperatorPrediction,
 )
+from ..nn.operator_training._linearization import OperatorLinearization
+from ._covariance import AbstractCovariance
+from ._linearized import LinearizedPropagationResult, propagate_linearized_map
 from ._predictive import (
     PredictionInterval,
     PredictiveField,
@@ -814,6 +817,87 @@ def operator_input_predictive(
     )
 
 
+def propagate_operator_linearized(
+    linearization: OperatorLinearization,
+    covariance: AbstractCovariance,
+    /,
+    *,
+    geometry: Literal["discrete", "hilbert"] = "discrete",
+    source_channel_metric: Array | None = None,
+    output_channel_metric: Array | None = None,
+) -> LinearizedPropagationResult:
+    """Propagate source covariance through one physical operator linearization."""
+    if not isinstance(linearization, OperatorLinearization):
+        raise TypeError("linearization must be an OperatorLinearization.")
+    if not isinstance(covariance, AbstractCovariance):
+        raise TypeError("covariance must implement AbstractCovariance.")
+    if geometry not in ("discrete", "hilbert"):
+        raise ValueError("geometry must be 'discrete' or 'hilbert'.")
+    if geometry == "discrete" and (
+        source_channel_metric is not None or output_channel_metric is not None
+    ):
+        raise ValueError("Channel metrics are available only for Hilbert geometry.")
+    if geometry == "hilbert" and (
+        not linearization.source_samples.has_physical_quadrature
+        or not linearization.output_query.has_physical_quadrature
+    ):
+        raise ValueError(
+            "Hilbert covariance propagation requires explicit physical quadrature "
+            "for both source and output geometries."
+        )
+
+    dims = _physical_dims(
+        linearization.output_query,
+        linearization.output_spec,
+        linearization.batch.case_axes,
+    )
+    expected = _expected_output_shape(
+        linearization.output_query,
+        linearization.output_spec,
+        linearization.batch.case_shape,
+    )
+    if linearization.base_output.shape != expected:
+        raise ValueError(
+            "Operator linearization output shape does not match its query contract; "
+            f"expected {expected}, got {linearization.base_output.shape}."
+        )
+    mask = _output_mask(
+        linearization.output_query,
+        linearization.output_spec,
+        linearization.batch.case_shape,
+    )
+    mean = cx.Field(
+        jnp.where(mask, linearization.base_output, 0.0),
+        dims=dims,
+    )
+
+    def pushforward(tangent):
+        values = linearization.pushforward(tangent)
+        return cx.Field(jnp.where(mask, values, 0.0), dims=dims)
+
+    def pullback(cotangent):
+        if not isinstance(cotangent, cx.Field):
+            raise TypeError("Operator covariance cotangents must be coordax.Field.")
+        values = jnp.where(mask, jnp.asarray(cotangent.data), 0.0)
+        if geometry == "discrete":
+            return linearization.pullback(values)
+        return linearization.adjoint(
+            values,
+            source_channel_metric=source_channel_metric,
+            output_channel_metric=output_channel_metric,
+        )
+
+    return propagate_linearized_map(
+        mean,
+        linearization.base_input,
+        covariance,
+        pushforward=pushforward,
+        pullback=pullback,
+        source="input",
+        coordinate_covariance=geometry == "discrete",
+    )
+
+
 def sample_operator_predictive(
     model: _AbstractOperatorModel,
     batch: OperatorBatch,
@@ -867,6 +951,7 @@ __all__ = [
     "OperatorPredictiveField",
     "operator_input_predictive",
     "operator_prediction_field",
+    "propagate_operator_linearized",
     "operator_predictive_from_samples",
     "sample_operator_predictive",
 ]

--- a/tests/integration/test_uq_benchmark_matrix.py
+++ b/tests/integration/test_uq_benchmark_matrix.py
@@ -24,7 +24,7 @@ def test_complete_uq_benchmark_matrix_passes_and_writes_machine_report(tmp_path)
     assert report.passed
     assert tuple(scenario.name for scenario in report.scenarios) == tuple(SCENARIOS)
     assert "schema_version" not in payload
-    assert payload["summary"]["scenario_count"] == 8
+    assert payload["summary"]["scenario_count"] == 9
     assert payload["summary"]["scenarios_failed"] == 0
     assert all(
         category["failed"] == 0

--- a/tests/integration/test_uq_linearized_measurement.py
+++ b/tests/integration/test_uq_linearized_measurement.py
@@ -1,0 +1,97 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax.numpy as jnp
+import jax.random as jr
+
+import phydrax as phx
+
+
+def test_linearized_eiv_posterior_matches_explicit_latent_input_nuts_reference():
+    true_slope = 2.0
+    input_scale = 0.5
+    observation_scale = 0.12
+    latent_inputs = jnp.linspace(-2.0, 2.0, 12)
+    input_key, observation_key = jr.split(jr.key(46))
+    measured_inputs = latent_inputs + input_scale * jr.normal(
+        input_key,
+        latent_inputs.shape,
+    )
+    measured_targets = true_slope * latent_inputs + observation_scale * jr.normal(
+        observation_key,
+        latent_inputs.shape,
+    )
+
+    slope_space = phx.uq.ParameterSpace(
+        jnp.asarray(1.8),
+        priors=phx.uq.Normal(0.0, 3.0),
+    )
+    eiv_term = phx.uq.LinearizedGaussianMeasurementLikelihood(
+        lambda slope, value: slope * value[0],
+        measured_inputs[:, None],
+        measured_targets,
+        input_covariance=jnp.asarray([[input_scale**2]]),
+        observation_covariance=jnp.asarray([[observation_scale**2]]),
+    )
+    eiv_problem = phx.uq.PosteriorProblem.from_terms(slope_space, (eiv_term,))
+
+    latent_space = phx.uq.ParameterSpace(
+        {"slope": jnp.asarray(1.8), "input_error": jnp.zeros_like(measured_inputs)},
+        priors={
+            "slope": phx.uq.Normal(0.0, 3.0),
+            "input_error": phx.uq.Normal(0.0, input_scale),
+        },
+    )
+    observation_likelihood = phx.uq.GaussianLikelihood(observation_scale)
+    latent_problem = phx.uq.PosteriorProblem(
+        latent_space,
+        lambda parameters: jnp.sum(
+            observation_likelihood.log_prob(
+                parameters["slope"]
+                * (measured_inputs + parameters["input_error"]),
+                measured_targets,
+            )
+        ),
+    )
+    settings = dict(
+        num_chains=4,
+        num_warmup=300,
+        num_samples=500,
+        initial_step_size=0.15,
+        target_acceptance_rate=0.9,
+        max_num_doublings=8,
+        chain_method="vectorized",
+    )
+    eiv = phx.uq.sample_nuts(eiv_problem, key=jr.key(81), **settings)
+    latent = phx.uq.sample_nuts(latent_problem, key=jr.key(82), **settings)
+    eiv_draws = eiv.samples.reshape((-1,))
+    latent_slope_draws = latent.samples["slope"].reshape((-1,))
+    eiv_mean = jnp.mean(eiv_draws)
+    latent_mean = jnp.mean(latent_slope_draws)
+
+    ordinary_precision = (
+        jnp.sum(measured_inputs**2) / observation_scale**2 + 1.0 / 3.0**2
+    )
+    ordinary_mean = (
+        jnp.sum(measured_inputs * measured_targets) / observation_scale**2
+    ) / ordinary_precision
+
+    assert eiv.convergence_report(
+        max_rhat=1.04,
+        min_bulk_ess=150.0,
+        min_tail_ess=100.0,
+    ).passed
+    assert latent.diagnostics.rhat["slope"] < 1.04
+    assert latent.diagnostics.bulk_ess["slope"] > 150.0
+    assert latent.diagnostics.tail_ess["slope"] > 100.0
+    assert not jnp.any(latent.divergent)
+    assert jnp.abs(eiv_mean - latent_mean) < 0.06
+    assert jnp.abs(ordinary_mean - latent_mean) > 0.25
+    assert jnp.abs(eiv_mean - true_slope) < jnp.abs(ordinary_mean - true_slope)
+    assert jnp.allclose(
+        jnp.var(eiv_draws, ddof=1),
+        jnp.var(latent_slope_draws, ddof=1),
+        rtol=0.20,
+        atol=0.005,
+    )

--- a/tests/unit/uq/test_benchmark_report.py
+++ b/tests/unit/uq/test_benchmark_report.py
@@ -120,10 +120,35 @@ def test_stochastic_gradient_benchmark_controls_are_profiled_and_registered():
     smoke = runner.get_configuration("smoke")
     standard = runner.get_configuration("standard")
 
-    assert tuple(runner.SCENARIOS)[-1] == "stochastic_gradient_regression"
+    assert tuple(runner.SCENARIOS)[-2:] == (
+        "stochastic_gradient_regression",
+        "linearized_uncertainty_propagation",
+    )
     assert smoke.sgmcmc_burnin > 0
     assert smoke.sgmcmc_draws > 0
     assert smoke.sgmcmc_batch_size > 0
     assert smoke.sgmcmc_steps_per_sample > 0
     assert standard.sgmcmc_burnin >= smoke.sgmcmc_burnin
     assert standard.sgmcmc_draws >= smoke.sgmcmc_draws
+    assert smoke.linearized_input_dimension > 0
+    assert smoke.linearized_output_dimension > smoke.linearized_input_dimension
+    assert 0 < smoke.linearized_factor_rank <= smoke.linearized_input_dimension
+    assert smoke.linearized_hutchinson_probes > 1
+    assert smoke.linearized_qmc_samples > 0
+    assert (
+        standard.linearized_input_dimension
+        >= smoke.linearized_input_dimension
+    )
+    assert (
+        standard.linearized_output_dimension
+        >= smoke.linearized_output_dimension
+    )
+    assert (
+        standard.linearized_factor_rank
+        >= smoke.linearized_factor_rank
+    )
+    assert (
+        standard.linearized_hutchinson_probes
+        >= smoke.linearized_hutchinson_probes
+    )
+    assert standard.linearized_qmc_samples >= smoke.linearized_qmc_samples

--- a/tests/unit/uq/test_laplace.py
+++ b/tests/unit/uq/test_laplace.py
@@ -139,3 +139,89 @@ def test_laplace_rejects_nonstationary_centers_and_implicit_regularization():
             prior_precision=1.0,
             stationarity_tolerance=None,
         )
+
+
+
+def test_dense_laplace_linearized_prediction_matches_covariance_and_draws():
+    problem, likelihood_precision = _gaussian_problem()
+    result = phx.uq.fit_laplace(problem, jnp.zeros(6))
+    design = jnp.asarray(
+        [[1.0, -0.5, 0.0, 0.25, 0.0, 0.1], [0.0, 0.2, 1.0, 0.0, -0.4, 0.3]]
+    )
+    expected = design @ result.covariance @ design.T
+
+    linearized = result.linearized_predict(design)
+    sampled = result.predict(
+        jr.key(17),
+        design,
+        num_samples=40_000,
+        batch_size=2_003,
+    )
+
+    assert linearized.mean.dims == ("x",)
+    assert jnp.allclose(linearized.materialize_covariance().matrix, expected)
+    assert jnp.allclose(linearized.exact_variance().data, jnp.diag(expected))
+    assert jnp.allclose(
+        jnp.cov(sampled.samples.data, rowvar=False),
+        expected,
+        rtol=0.03,
+        atol=3e-3,
+    )
+
+
+def test_dense_laplace_transports_covariance_through_parameter_bijectors():
+    center = jnp.log(jnp.asarray(2.0))
+    precision = 999.0
+    space = phx.uq.ParameterSpace(
+        center,
+        priors=phx.uq.LogNormal(center, 1.0),
+        bijectors=phx.uq.ExpBijector(),
+    )
+    problem = phx.uq.PosteriorProblem(
+        space,
+        lambda physical: -0.5 * precision * (jnp.log(physical) - center) ** 2,
+        predict=lambda physical: cx.Field(
+            jnp.atleast_1d(physical**2),
+            dims=("x",),
+        ),
+    )
+    result = phx.uq.fit_laplace(problem, center)
+    prediction = result.linearized_predict()
+
+    assert jnp.allclose(result.covariance, 1.0 / (precision + 1.0))
+    assert jnp.allclose(result.physical_covariance(), 4.0 / (precision + 1.0))
+    assert jnp.allclose(prediction.mean.data, jnp.asarray([4.0]))
+    assert jnp.allclose(prediction.exact_variance().data, 64.0 / (precision + 1.0))
+
+
+def test_structured_laplace_linearized_prediction_stays_matrix_free():
+    problem, likelihood_precision = _gaussian_problem()
+    result = phx.uq.fit_laplace(
+        problem,
+        jnp.zeros(6),
+        curvature="full",
+        prior_precision=1.0,
+    )
+    design = jnp.asarray(
+        [[1.0, 0.0, -0.3, 0.0, 0.2, 0.0], [0.0, 0.5, 0.0, 1.0, 0.0, -0.1]]
+    )
+    expected_parameter_covariance = jnp.linalg.inv(
+        likelihood_precision + jnp.eye(6)
+    )
+    expected = design @ expected_parameter_covariance @ design.T
+    linearized = result.linearized_predict(design)
+
+    assert linearized.input_covariance_representation == "operator"
+    assert jnp.allclose(linearized.materialize_covariance().matrix, expected)
+    assert jnp.allclose(
+        result.physical_covariance_vector_product(jnp.arange(1.0, 7.0)),
+        expected_parameter_covariance @ jnp.arange(1.0, 7.0),
+    )
+    with pytest.raises(ValueError, match="estimate_variance"):
+        linearized.exact_variance()
+    estimate = linearized.estimate_variance(
+        jr.key(18),
+        num_probes=8_192,
+        batch_size=511,
+    )
+    assert jnp.allclose(estimate.variance.data, jnp.diag(expected), atol=0.02)

--- a/tests/unit/uq/test_linearized_propagation.py
+++ b/tests/unit/uq/test_linearized_propagation.py
@@ -1,0 +1,221 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import coordax as cx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+import phydrax as phx
+
+
+def _linear_problem():
+    matrix = jnp.asarray([[1.0, -2.0, 0.5], [0.25, 1.5, -1.0]])
+    covariance = jnp.asarray(
+        [[1.5, 0.2, -0.1], [0.2, 0.8, 0.3], [-0.1, 0.3, 1.2]]
+    )
+    center = jnp.asarray([0.4, -0.2, 0.7])
+    return matrix, covariance, center
+
+
+def test_all_covariance_representations_recover_the_same_affine_pushforward():
+    matrix, covariance, center = _linear_problem()
+    expected = matrix @ covariance @ matrix.T
+    cholesky = jnp.linalg.cholesky(covariance)
+    representations = (
+        phx.uq.DenseCovariance(covariance),
+        phx.uq.FactorCovariance(cholesky.T),
+        phx.uq.CovarianceOperator(lambda vector: covariance @ vector),
+    )
+
+    for declared in representations:
+        result = phx.uq.propagate_linearized(
+            lambda value: matrix @ value + jnp.asarray([1.0, -1.0]),
+            center,
+            declared,
+        )
+        materialized = result.materialize_covariance(max_dimension=2, batch_size=1)
+
+        assert jnp.allclose(result.mean, matrix @ center + jnp.asarray([1.0, -1.0]))
+        assert jnp.allclose(materialized.matrix, expected)
+        assert jnp.allclose(
+            result.covariance_vector_product(jnp.asarray([0.3, -0.8])),
+            expected @ jnp.asarray([0.3, -0.8]),
+        )
+        if not isinstance(declared, phx.uq.CovarianceOperator):
+            assert jnp.allclose(result.exact_variance(batch_size=1), jnp.diag(expected))
+
+
+def test_diagonal_covariance_preserves_nested_pytrees_and_coordax_dimensions():
+    center = {
+        "forcing": jnp.asarray([0.5, -1.0]),
+        "parameter": jnp.asarray(2.0),
+    }
+    variance = {
+        "forcing": jnp.asarray([0.2, 0.4]),
+        "parameter": jnp.asarray(0.3),
+    }
+
+    def forward(value):
+        data = jnp.asarray(
+            [
+                value["forcing"][0] + value["parameter"],
+                2.0 * value["forcing"][1] - value["parameter"],
+            ]
+        )
+        return {
+            "field": cx.Field(data, dims=("component",)),
+            "total": jnp.sum(value["forcing"]),
+        }
+
+    result = phx.uq.propagate_linearized(
+        forward,
+        center,
+        phx.uq.DiagonalCovariance(variance),
+    )
+    exact = result.exact_variance()
+
+    assert result.mean["field"].dims == ("component",)
+    assert exact["field"].dims == ("component",)
+    assert jnp.allclose(exact["field"].data, jnp.asarray([0.5, 1.9]))
+    assert jnp.allclose(exact["total"], 0.6)
+    tangent = jax.tree_util.tree_map(jnp.ones_like, center)
+    cotangent = {
+        "field": cx.Field(jnp.asarray([0.7, -0.3]), dims=("component",)),
+        "total": jnp.asarray(0.2),
+    }
+    pushed = result.pushforward(tangent)
+    pulled = result.pullback(cotangent)
+    left = sum(
+        jnp.vdot(a, b)
+        for a, b in zip(
+            jax.tree_util.tree_leaves(pushed),
+            jax.tree_util.tree_leaves(cotangent),
+            strict=True,
+        )
+    )
+    right = sum(
+        jnp.vdot(a, b)
+        for a, b in zip(
+            jax.tree_util.tree_leaves(tangent),
+            jax.tree_util.tree_leaves(pulled),
+            strict=True,
+        )
+    )
+    assert jnp.allclose(left, right)
+
+
+def test_complex_linear_propagation_uses_the_hermitian_adjoint():
+    multiplier = jnp.asarray(1.0 + 2.0j)
+    center = jnp.asarray([1.0 - 0.5j, -0.2 + 0.3j])
+    result = phx.uq.propagate_linearized(
+        lambda value: multiplier * value,
+        center,
+        phx.uq.DenseCovariance(jnp.eye(2)),
+        complex_linear=True,
+    )
+    cotangent = jnp.asarray([0.4 + 0.7j, -0.1 + 0.2j])
+
+    assert jnp.allclose(result.pullback(cotangent), jnp.conj(multiplier) * cotangent)
+    assert jnp.allclose(result.exact_variance(), jnp.full((2,), 5.0))
+    assert jnp.allclose(
+        result.materialize_covariance().matrix,
+        5.0 * jnp.eye(2),
+    )
+
+    with pytest.raises(ValueError, match="complex_linear=True"):
+        phx.uq.propagate_linearized(
+            lambda value: multiplier * value,
+            center,
+            phx.uq.DiagonalCovariance(jnp.ones(2)),
+        )
+
+
+def test_hutchinson_diagonal_is_keyed_and_reports_sampling_error():
+    covariance = jnp.asarray(
+        [
+            [2.0, 0.4, -0.2, 0.1],
+            [0.4, 1.5, 0.3, -0.2],
+            [-0.2, 0.3, 1.2, 0.25],
+            [0.1, -0.2, 0.25, 0.9],
+        ]
+    )
+    result = phx.uq.propagate_linearized(
+        lambda value: value,
+        jnp.zeros(4),
+        phx.uq.CovarianceOperator(lambda vector: covariance @ vector),
+    )
+
+    estimate = result.estimate_variance(jr.key(8), num_probes=2048, batch_size=127)
+    replay = result.estimate_variance(jr.key(8), num_probes=2048, batch_size=127)
+    repeated = result.estimate_variance(jr.key(8), num_probes=2048, batch_size=503)
+    changed = result.estimate_variance(jr.key(9), num_probes=2048)
+
+    assert estimate.approximation == "first_order_hutchinson"
+    assert estimate.probe_distribution == "rademacher"
+    assert estimate.num_probes == 2048
+    assert not estimate.exact
+    assert jnp.array_equal(estimate.variance, replay.variance)
+    assert jnp.array_equal(estimate.standard_error, replay.standard_error)
+    assert jnp.allclose(estimate.variance, repeated.variance, rtol=1e-14, atol=1e-14)
+    assert jnp.allclose(
+        estimate.standard_error,
+        repeated.standard_error,
+        rtol=1e-14,
+        atol=1e-14,
+    )
+    assert not jnp.array_equal(estimate.variance, changed.variance)
+    assert jnp.allclose(estimate.variance, jnp.diag(covariance), atol=0.04)
+    assert jnp.all(jnp.isfinite(estimate.standard_error))
+    assert jnp.all(estimate.standard_error > 0.0)
+
+
+def test_large_matrix_free_operator_path_rejects_dense_shortcuts():
+    dimension = 20_000
+    center = jnp.linspace(-1.0, 1.0, dimension)
+    result = phx.uq.propagate_linearized(
+        lambda value: 3.0 * value,
+        center,
+        phx.uq.CovarianceOperator(lambda vector: 2.0 * vector),
+    )
+    probe = jnp.ones_like(center)
+
+    assert jnp.allclose(result.covariance_vector_product(probe), 18.0 * probe)
+    with pytest.raises(ValueError, match="estimate_variance"):
+        result.exact_variance()
+    with pytest.raises(ValueError, match="exceeds max_dimension"):
+        result.materialize_covariance(max_dimension=128)
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda: phx.uq.DiagonalCovariance(jnp.asarray([1.0, -0.1])),
+        lambda: phx.uq.DenseCovariance(jnp.asarray([[1.0, 0.5], [0.0, 1.0]])),
+        lambda: phx.uq.DenseCovariance(jnp.asarray([[1.0, 2.0], [2.0, 1.0]])),
+        lambda: phx.uq.FactorCovariance(jnp.ones((0, 2))),
+    ],
+)
+def test_covariance_representations_reject_invalid_declarations(factory):
+    with pytest.raises((TypeError, ValueError)):
+        factory()
+
+
+def test_linearized_propagation_rejects_shape_and_materialization_mismatches():
+    with pytest.raises(ValueError, match="shape must match"):
+        phx.uq.propagate_linearized(
+            lambda value: value,
+            jnp.ones(3),
+            phx.uq.DenseCovariance(jnp.eye(2)),
+        )
+    result = phx.uq.propagate_linearized(
+        lambda value: jnp.concatenate((value, value)),
+        jnp.ones(2),
+        phx.uq.DiagonalCovariance(jnp.ones(2)),
+    )
+    with pytest.raises(ValueError, match="max_dimension"):
+        result.materialize_covariance(max_dimension=0)
+    with pytest.raises(ValueError, match="at least two"):
+        result.estimate_variance(jr.key(0), num_probes=1)

--- a/tests/unit/uq/test_linearized_standards.py
+++ b/tests/unit/uq/test_linearized_standards.py
@@ -1,0 +1,87 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax.numpy as jnp
+import pytest
+
+import phydrax as phx
+
+
+@pytest.mark.parametrize(
+    ("common_variance", "expected_covariance", "expected_correlation"),
+    [
+        (1.0, jnp.asarray([[2.0, 1.0], [1.0, 2.0]]), 0.5),
+        (9.0, jnp.asarray([[10.0, 9.0], [9.0, 10.0]]), 0.9),
+    ],
+)
+def test_jcgm_102_section_9_2_additive_common_effect(
+    common_variance,
+    expected_covariance,
+    expected_correlation,
+):
+    """Reproduce JCGM 102:2011 sections 9.2.2 and 9.2.4 exactly."""
+    input_covariance = jnp.diag(jnp.asarray([1.0, 1.0, common_variance]))
+    result = phx.uq.propagate_linearized(
+        lambda value: jnp.asarray([value[0] + value[2], value[1] + value[2]]),
+        jnp.zeros(3),
+        phx.uq.DenseCovariance(input_covariance),
+    )
+    covariance = result.materialize_covariance().matrix
+    standard_uncertainty = jnp.sqrt(jnp.diag(covariance))
+    correlation = covariance[0, 1] / (
+        standard_uncertainty[0] * standard_uncertainty[1]
+    )
+
+    assert jnp.array_equal(result.mean, jnp.zeros(2))
+    assert jnp.allclose(covariance, expected_covariance)
+    assert jnp.allclose(standard_uncertainty, jnp.sqrt(jnp.diag(expected_covariance)))
+    assert correlation == pytest.approx(expected_correlation)
+
+
+@pytest.mark.parametrize(
+    ("x1", "correlation", "expected_covariance"),
+    [
+        (0.001, 0.0, jnp.asarray([[1.0e-4, 0.0], [0.0, 100.0]])),
+        (0.010, 0.0, jnp.asarray([[1.0e-4, 0.0], [0.0, 1.0]])),
+        (0.100, 0.0, jnp.asarray([[1.0e-4, 0.0], [0.0, 0.01]])),
+        (0.100, 0.9, jnp.asarray([[1.0e-4, 9.0e-4], [9.0e-4, 0.01]])),
+    ],
+)
+def test_jcgm_102_section_9_3_cartesian_to_polar_first_order_covariance(
+    x1,
+    correlation,
+    expected_covariance,
+):
+    """Reproduce the generalized-GUM rows of JCGM 102:2011 section 9.3."""
+    standard_uncertainty = 0.010
+    input_covariance = standard_uncertainty**2 * jnp.asarray(
+        [[1.0, correlation], [correlation, 1.0]]
+    )
+    result = phx.uq.propagate_linearized(
+        lambda value: jnp.asarray(
+            [jnp.hypot(value[0], value[1]), jnp.arctan2(value[1], value[0])]
+        ),
+        jnp.asarray([x1, 0.0]),
+        phx.uq.DenseCovariance(input_covariance),
+    )
+    covariance = result.materialize_covariance().matrix
+
+    assert jnp.allclose(result.mean, jnp.asarray([x1, 0.0]))
+    assert jnp.allclose(covariance, expected_covariance, rtol=1e-12, atol=1e-12)
+
+
+def test_jcgm_near_origin_case_remains_an_explicit_first_order_approximation():
+    """The section 9.3 case must not be disguised as a full polar distribution."""
+    result = phx.uq.propagate_linearized(
+        lambda value: jnp.asarray(
+            [jnp.hypot(value[0], value[1]), jnp.arctan2(value[1], value[0])]
+        ),
+        jnp.asarray([0.001, 0.0]),
+        phx.uq.DiagonalCovariance(jnp.full((2,), 0.010**2)),
+    )
+    angular_standard_uncertainty = jnp.sqrt(result.exact_variance()[1])
+
+    assert result.approximation == "first_order"
+    assert angular_standard_uncertainty == pytest.approx(10.0)
+    assert angular_standard_uncertainty > 2.0 * jnp.pi

--- a/tests/unit/uq/test_measurement_likelihood.py
+++ b/tests/unit/uq/test_measurement_likelihood.py
@@ -1,0 +1,255 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import pytest
+
+import phydrax as phx
+
+
+def _normal_log_density(residual, covariance):
+    sign, log_determinant = jnp.linalg.slogdet(covariance)
+    assert sign > 0.0
+    return -0.5 * (
+        residual @ jnp.linalg.solve(covariance, residual)
+        + log_determinant
+        + residual.size * jnp.log(2.0 * jnp.pi)
+    )
+
+
+def test_affine_measurement_likelihood_matches_normalized_scalar_gaussian():
+    inputs = jnp.asarray([[0.5], [1.0], [2.0]])
+    targets = jnp.asarray([1.4, 2.1, 3.8])
+    parameters = {"intercept": jnp.asarray(0.4), "slope": jnp.asarray(1.8)}
+    input_variance = 0.09
+    observation_variance = 0.04
+    term = phx.uq.LinearizedGaussianMeasurementLikelihood(
+        lambda current, value: current["intercept"] + current["slope"] * value[0],
+        inputs,
+        targets,
+        input_covariance=jnp.asarray([[input_variance]]),
+        observation_covariance=jnp.asarray([[observation_variance]]),
+    )
+    effective_variance = observation_variance + parameters["slope"] ** 2 * input_variance
+    residuals = targets - (
+        parameters["intercept"] + parameters["slope"] * inputs[:, 0]
+    )
+    expected = -0.5 * (
+        residuals**2 / effective_variance
+        + jnp.log(2.0 * jnp.pi * effective_variance)
+    )
+
+    assert jnp.allclose(term.per_case_log_prob(parameters), expected)
+    assert jnp.allclose(term.log_prob(parameters), jnp.sum(expected))
+    assert jnp.allclose(eqx.filter_jit(term.log_prob)(parameters), jnp.sum(expected))
+
+
+def test_multivariate_correlated_measurement_likelihood_matches_dense_reference():
+    matrix = jnp.asarray([[1.2, -0.4], [0.3, 0.8]])
+    inputs = jnp.asarray([[0.2, -0.1], [1.0, 0.5], [-0.4, 0.7]])
+    targets = jnp.asarray([[0.4, -0.2], [0.9, 0.8], [-0.7, 0.3]])
+    input_covariance = jnp.asarray([[0.20, 0.07], [0.07, 0.10]])
+    observation_covariance = jnp.asarray([[0.08, -0.02], [-0.02, 0.12]])
+    offset = jnp.asarray([0.1, -0.2])
+    term = phx.uq.LinearizedGaussianMeasurementLikelihood(
+        lambda parameters, value: parameters["matrix"] @ value
+        + parameters["offset"],
+        inputs,
+        targets,
+        input_covariance=input_covariance,
+        observation_covariance=observation_covariance,
+    )
+    parameters = {"matrix": matrix, "offset": offset}
+    effective_covariance = (
+        observation_covariance + matrix @ input_covariance @ matrix.T
+    )
+    expected = jnp.asarray(
+        [
+            _normal_log_density(target - (matrix @ value + offset), effective_covariance)
+            for value, target in zip(inputs, targets, strict=True)
+        ]
+    )
+
+    assert jnp.allclose(term.per_case_log_prob(parameters), expected)
+    assert jnp.allclose(
+        jax.grad(term.log_prob)(parameters)["matrix"],
+        jax.grad(lambda value: jnp.sum(jnp.asarray([
+            _normal_log_density(
+                target - (value @ measured + offset),
+                observation_covariance + value @ input_covariance @ value.T,
+            )
+            for measured, target in zip(inputs, targets, strict=True)
+        ])))(matrix),
+        rtol=1e-10,
+        atol=1e-10,
+    )
+
+
+def test_parameter_dependent_covariances_are_jittable_and_normalized():
+    inputs = jnp.zeros((4, 1))
+    targets = jnp.zeros((4,))
+    term = phx.uq.LinearizedGaussianMeasurementLikelihood(
+        lambda parameters, value: parameters["slope"] * value[0],
+        inputs,
+        targets,
+        input_covariance=lambda parameters: jnp.asarray(
+            [[parameters["input_scale"] ** 2]]
+        ),
+        observation_covariance=lambda parameters: jnp.asarray(
+            [[parameters["observation_scale"] ** 2]]
+        ),
+    )
+    narrow = {
+        "slope": jnp.asarray(0.5),
+        "input_scale": jnp.asarray(0.2),
+        "observation_scale": jnp.asarray(0.1),
+    }
+    broad = {**narrow, "slope": jnp.asarray(2.0)}
+    narrow_variance = 0.1**2 + 0.5**2 * 0.2**2
+    broad_variance = 0.1**2 + 2.0**2 * 0.2**2
+
+    narrow_value = eqx.filter_jit(term.log_prob)(narrow)
+    broad_value, broad_gradient = jax.value_and_grad(term.log_prob)(broad)
+
+    assert jnp.allclose(
+        narrow_value,
+        -0.5 * inputs.shape[0] * jnp.log(2.0 * jnp.pi * narrow_variance),
+    )
+    assert jnp.allclose(
+        broad_value,
+        -0.5 * inputs.shape[0] * jnp.log(2.0 * jnp.pi * broad_variance),
+    )
+    assert broad_value < narrow_value
+    assert all(
+        bool(jnp.all(jnp.isfinite(value)))
+        for value in jax.tree_util.tree_leaves(broad_gradient)
+    )
+
+
+def test_per_case_covariances_select_the_correct_external_minibatch_cases():
+    inputs = jnp.arange(5.0)[:, None]
+    targets = 1.3 * inputs[:, 0] + jnp.asarray([0.1, -0.2, 0.0, 0.3, -0.1])
+    input_covariances = jnp.asarray([[[value]] for value in jnp.linspace(0.01, 0.05, 5)])
+    observation_covariances = jnp.asarray(
+        [[[value]] for value in jnp.linspace(0.02, 0.06, 5)]
+    )
+    term = phx.uq.LinearizedGaussianMeasurementLikelihood(
+        lambda slope, value: slope * value[0],
+        inputs,
+        targets,
+        input_covariance=input_covariances,
+        observation_covariance=observation_covariances,
+        input_covariance_batching="per_case",
+        observation_covariance_batching="per_case",
+    )
+    full = term.per_case_log_prob(jnp.asarray(1.3))
+    indices = jnp.asarray([4, 1, 3])
+    selected = term.log_prob_cases(
+        jnp.asarray(1.3),
+        inputs[indices],
+        targets[indices],
+        case_indices=indices,
+    )
+
+    assert jnp.allclose(selected, full[indices])
+    invalid = term.log_prob_cases(
+        jnp.asarray(1.3),
+        inputs[:1],
+        targets[:1],
+        case_indices=jnp.asarray([8]),
+    )
+    assert jnp.isneginf(invalid[0])
+
+
+def test_measurement_likelihood_reuses_the_native_minibatch_posterior_contract():
+    inputs = jnp.linspace(0.2, 1.4, 7)[:, None]
+    targets = 1.5 * inputs[:, 0] + 0.1
+    term = phx.uq.LinearizedGaussianMeasurementLikelihood(
+        lambda slope, value: slope * value[0],
+        inputs,
+        targets,
+        input_covariance=jnp.asarray([[0.03]]),
+        observation_covariance=jnp.asarray([[0.02]]),
+    )
+    data = {
+        "inputs": inputs,
+        "targets": targets,
+        "case_indices": jnp.arange(inputs.shape[0]),
+    }
+    source = phx.uq.ArrayMinibatchSource(data, batch_size=3, seed=5)
+
+    def factors(slope, batch):
+        return term.log_prob_cases(
+            slope,
+            batch.data["inputs"],
+            batch.data["targets"],
+            case_indices=batch.data["case_indices"],
+        )
+
+    space = phx.uq.ParameterSpace(
+        jnp.asarray(1.4),
+        priors=phx.uq.Normal(0.0, 2.0),
+    )
+    problem = phx.uq.MinibatchPosteriorProblem(
+        space,
+        factors,
+        num_factors=inputs.shape[0],
+        full_log_likelihood=term.log_prob,
+    )
+    diagnostics = phx.uq.diagnose_minibatch_posterior(problem, source)
+
+    assert diagnostics.passed
+    assert diagnostics.full_log_density_matches
+    assert diagnostics.full_gradient_matches
+
+
+@pytest.mark.parametrize(
+    ("input_covariance", "observation_covariance", "message"),
+    [
+        (jnp.asarray([[-0.1]]), jnp.asarray([[0.1]]), "positive semidefinite"),
+        (jnp.asarray([[0.1]]), jnp.asarray([[0.0]]), "positive definite"),
+        (
+            jnp.asarray([[0.1, 0.0], [0.0, 0.1]]),
+            jnp.asarray([[0.1]]),
+            "shape",
+        ),
+    ],
+)
+def test_measurement_likelihood_rejects_invalid_covariance_contracts(
+    input_covariance,
+    observation_covariance,
+    message,
+):
+    with pytest.raises(ValueError, match=message):
+        phx.uq.LinearizedGaussianMeasurementLikelihood(
+            lambda parameter, value: parameter * value[0],
+            jnp.ones((3, 1)),
+            jnp.ones((3,)),
+            input_covariance=input_covariance,
+            observation_covariance=observation_covariance,
+        )
+
+
+def test_measurement_likelihood_allows_only_explicit_singular_regularization():
+    term = phx.uq.LinearizedGaussianMeasurementLikelihood(
+        lambda parameter, value: parameter * value[0],
+        jnp.ones((2, 1)),
+        jnp.ones((2,)),
+        input_covariance=jnp.asarray([[0.0]]),
+        observation_covariance=jnp.asarray([[0.0]]),
+        stabilization=1.0e-3,
+    )
+
+    assert jnp.all(jnp.isfinite(term.per_case_log_prob(jnp.asarray(1.0))))
+    with pytest.raises(ValueError, match="max_output_dimension"):
+        phx.uq.LinearizedGaussianMeasurementLikelihood(
+            lambda parameter, value: jnp.asarray([parameter, value[0]]),
+            jnp.ones((2, 1)),
+            jnp.ones((2, 2)),
+            input_covariance=jnp.asarray([[0.1]]),
+            observation_covariance=jnp.eye(2),
+            max_output_dimension=1,
+        )

--- a/tests/unit/uq/test_operator_input_propagation.py
+++ b/tests/unit/uq/test_operator_input_propagation.py
@@ -2,8 +2,10 @@
 # Copyright © 2026 PHYDRA, Inc. All rights reserved.
 #
 
+import coordax as cx
 import equinox as eqx
 import jax.numpy as jnp
+import pytest
 
 import phydrax as phx
 from phydrax.nn.models.core._base import _AbstractOperatorModel
@@ -99,3 +101,105 @@ def test_input_function_prediction_matches_explicit_ragged_draw_loop():
         prediction.input_variance().field("output").values[prediction.output_mask()],
         1.0,
     )
+
+
+def _weighted_batch(value: float, *, source_points: int) -> phx.nn.OperatorBatch:
+    query_axis = phx.nn.OperatorAxis(
+        "x",
+        jnp.linspace(0.0, 1.0, 3),
+        quadrature_weights=jnp.asarray([0.25, 0.5, 0.25]),
+    )
+    source_axis = phx.nn.OperatorAxis(
+        "x",
+        jnp.linspace(0.0, 1.0, source_points),
+        quadrature_weights=jnp.full((source_points,), 1.0 / source_points),
+    )
+    query = phx.nn.FunctionSamples(
+        values=None,
+        axes=(query_axis,),
+        mask=jnp.asarray([[True, True, False], [True, True, True]]),
+    )
+    source = phx.nn.FunctionSamples(
+        values=jnp.full((2, source_points), value),
+        axes=(source_axis,),
+    )
+    return phx.nn.OperatorBatch(
+        inputs={"forcing": source},
+        queries={"query": query},
+        case_axes=("case",),
+        case_shape=(2,),
+    )
+
+
+def test_operator_linearized_covariance_preserves_geometry_and_masks():
+    batch = _batch(2.0, source_points=4)
+    linearization = phx.nn.linearize_operator(
+        _MaskedSourceMeanOperator(),
+        batch,
+        "forcing",
+    )
+    source_variance = jnp.full((2, 4), 0.25)
+    result = phx.uq.propagate_operator_linearized(
+        linearization,
+        phx.uq.DiagonalCovariance(source_variance),
+    )
+    mapping = jnp.zeros((6, 8))
+    mapping = mapping.at[0:2, 0:4].set(0.25)
+    mapping = mapping.at[3:6, 4:8].set(0.25)
+    expected_covariance = 0.25 * mapping @ mapping.T
+    mask = jnp.asarray([[True, True, False], [True, True, True]])
+
+    assert result.mean.dims == ("case", "__phydra_operator_point")
+    assert jnp.array_equal(result.mean.data, jnp.where(mask, 2.0, 0.0))
+    assert jnp.allclose(
+        result.materialize_covariance().matrix,
+        expected_covariance,
+    )
+    assert jnp.allclose(
+        result.exact_variance().data,
+        jnp.diag(expected_covariance).reshape((2, 3)),
+    )
+
+
+def test_operator_hilbert_covariance_requires_measure_and_stays_operator_valued():
+    unweighted = phx.nn.linearize_operator(
+        _MaskedSourceMeanOperator(),
+        _batch(1.0, source_points=4),
+        "forcing",
+    )
+    covariance = phx.uq.DiagonalCovariance(jnp.full((2, 4), 0.25))
+    with pytest.raises(ValueError, match="physical quadrature"):
+        phx.uq.propagate_operator_linearized(
+            unweighted,
+            covariance,
+            geometry="hilbert",
+        )
+
+    weighted = phx.nn.linearize_operator(
+        _MaskedSourceMeanOperator(),
+        _weighted_batch(1.0, source_points=4),
+        "forcing",
+    )
+    result = phx.uq.propagate_operator_linearized(
+        weighted,
+        covariance,
+        geometry="hilbert",
+    )
+    mask = jnp.asarray([[True, True, False], [True, True, True]])
+    cotangent = cx.Field(
+        mask.astype(float),
+        dims=result.mean.dims,
+    )
+    expected_input = 0.25 * weighted.adjoint(cotangent.data)
+    expected_output = jnp.where(mask, weighted.pushforward(expected_input), 0.0)
+
+    assert jnp.allclose(
+        result.covariance_vector_product(cotangent).data,
+        expected_output,
+    )
+    with pytest.raises(ValueError, match="only vector products"):
+        result.exact_variance()
+    with pytest.raises(ValueError, match="only vector products"):
+        result.estimate_variance(jnp.asarray([0, 1], dtype=jnp.uint32), num_probes=8)
+    with pytest.raises(ValueError, match="only vector products"):
+        result.materialize_covariance()

--- a/tools/uq_benchmarks/configuration.py
+++ b/tools/uq_benchmarks/configuration.py
@@ -29,6 +29,11 @@ class BenchmarkConfiguration:
     calibration_cases: int
     gp_repeats: int
     jit_warm_repetitions: int
+    linearized_input_dimension: int
+    linearized_output_dimension: int
+    linearized_factor_rank: int
+    linearized_hutchinson_probes: int
+    linearized_qmc_samples: int
     flow_adaptation_rounds: int
     flow_local_adaptation_steps: int
     flow_global_adaptation_steps: int
@@ -57,6 +62,11 @@ PROFILES: dict[ProfileName, BenchmarkConfiguration] = {
         calibration_cases=256,
         gp_repeats=5,
         jit_warm_repetitions=3,
+        linearized_input_dimension=16,
+        linearized_output_dimension=1_024,
+        linearized_factor_rank=4,
+        linearized_hutchinson_probes=256,
+        linearized_qmc_samples=4_096,
         flow_adaptation_rounds=2,
         flow_local_adaptation_steps=40,
         flow_global_adaptation_steps=12,
@@ -80,6 +90,11 @@ PROFILES: dict[ProfileName, BenchmarkConfiguration] = {
         sgmcmc_steps_per_sample=2,
         gp_repeats=12,
         jit_warm_repetitions=10,
+        linearized_input_dimension=32,
+        linearized_output_dimension=4_096,
+        linearized_factor_rank=8,
+        linearized_hutchinson_probes=1_024,
+        linearized_qmc_samples=32_768,
         flow_adaptation_rounds=4,
         flow_local_adaptation_steps=80,
         flow_global_adaptation_steps=20,

--- a/tools/uq_benchmarks/scenarios.py
+++ b/tools/uq_benchmarks/scenarios.py
@@ -2266,6 +2266,363 @@ def stochastic_gradient_regression(
     )
 
 
+def linearized_uncertainty_propagation(
+    configuration: BenchmarkConfiguration,
+    seed: int,
+) -> ScenarioResult:
+    """Validate matrix-free local covariance propagation and normalized EIV inference."""
+    started = time.perf_counter()
+    root_key = jr.key(seed)
+    (
+        affine_key,
+        qmc_key,
+        data_key,
+        low_rank_key,
+        output_key,
+        probe_key,
+    ) = jr.split(root_key, 6)
+
+    affine_input_dimension = 6
+    affine_output_dimension = 4
+    affine_matrix = jr.normal(
+        affine_key,
+        (affine_output_dimension, affine_input_dimension),
+    ) / jnp.sqrt(affine_input_dimension)
+    affine_center = jnp.linspace(-0.4, 0.6, affine_input_dimension)
+    affine_variance = jnp.linspace(0.2, 1.1, affine_input_dimension)
+    affine_covariance = jnp.diag(affine_variance)
+    affine_expected = affine_matrix @ affine_covariance @ affine_matrix.T
+    affine_representations = (
+        phx.uq.DiagonalCovariance(affine_variance),
+        phx.uq.DenseCovariance(affine_covariance),
+        phx.uq.FactorCovariance(jnp.diag(jnp.sqrt(affine_variance))),
+        phx.uq.CovarianceOperator(
+            lambda vector: affine_covariance @ vector
+        ),
+    )
+    affine_results = tuple(
+        phx.uq.propagate_linearized(
+            lambda value: affine_matrix @ value,
+            affine_center,
+            covariance,
+        )
+        for covariance in affine_representations
+    )
+    affine_errors = tuple(
+        jnp.linalg.norm(result.materialize_covariance().matrix - affine_expected)
+        / jnp.linalg.norm(affine_expected)
+        for result in affine_results
+    )
+    affine_hutchinson = affine_results[-1].estimate_variance(
+        jr.fold_in(root_key, 1),
+        num_probes=configuration.linearized_hutchinson_probes,
+        batch_size=min(configuration.linearized_hutchinson_probes, 128),
+    )
+    affine_hutchinson_error = (
+        jnp.linalg.norm(affine_hutchinson.variance - jnp.diag(affine_expected))
+        / jnp.linalg.norm(jnp.diag(affine_expected))
+    )
+
+    common_effect = phx.uq.propagate_linearized(
+        lambda value: jnp.asarray(
+            [value[0] + value[2], value[1] + value[2]]
+        ),
+        jnp.zeros(3),
+        phx.uq.DiagonalCovariance(jnp.asarray([1.0, 1.0, 9.0])),
+    )
+    common_effect_expected = jnp.asarray([[10.0, 9.0], [9.0, 10.0]])
+    common_effect_error = jnp.linalg.norm(
+        common_effect.materialize_covariance().matrix - common_effect_expected
+    ) / jnp.linalg.norm(common_effect_expected)
+
+    nonlinear_center = jnp.asarray([0.6, -0.4])
+    nonlinear_base_covariance = jnp.asarray([[1.0, 0.35], [0.35, 0.8]])
+
+    def nonlinear_map(value):
+        return jnp.asarray(
+            [
+                jnp.sin(value[0]) + 0.1 * value[1] ** 2,
+                jnp.exp(0.2 * value[0] - 0.1 * value[1]),
+                value[0] * value[1],
+            ]
+        )
+
+    unit_design = phx.sampling.materialize_design(
+        phx.sampling.SobolDesign(scrambled=True),
+        count=configuration.linearized_qmc_samples,
+        dimension=2,
+        key=qmc_key,
+    )
+    epsilon = jnp.finfo(unit_design.dtype).eps
+    normal_design = jsp.special.ndtri(jnp.clip(unit_design, epsilon, 1.0 - epsilon))
+    nonlinear_scales = (0.25, 0.125, 0.0625)
+    nonlinear_covariance_errors: list[float] = []
+    nonlinear_mean_errors: list[float] = []
+    for scale in nonlinear_scales:
+        covariance = scale**2 * nonlinear_base_covariance
+        linearized = phx.uq.propagate_linearized(
+            nonlinear_map,
+            nonlinear_center,
+            phx.uq.DenseCovariance(covariance),
+        )
+        samples = nonlinear_center + normal_design @ jnp.linalg.cholesky(covariance).T
+        outputs = jax.vmap(nonlinear_map)(samples)
+        qmc_mean = jnp.mean(outputs, axis=0)
+        qmc_covariance = jnp.cov(outputs, rowvar=False)
+        linearized_covariance = linearized.materialize_covariance().matrix
+        nonlinear_covariance_errors.append(
+            float(
+                jnp.linalg.norm(linearized_covariance - qmc_covariance)
+                / jnp.linalg.norm(qmc_covariance)
+            )
+        )
+        nonlinear_mean_errors.append(
+            float(jnp.linalg.norm(linearized.mean - qmc_mean))
+        )
+
+    true_slope = 2.0
+    input_scale = 0.5
+    observation_scale = 0.12
+    latent_inputs = jnp.linspace(-2.0, 2.0, 12)
+    input_noise_key, observation_noise_key = jr.split(data_key)
+    measured_inputs = latent_inputs + input_scale * jr.normal(
+        input_noise_key,
+        latent_inputs.shape,
+    )
+    measured_targets = true_slope * latent_inputs + observation_scale * jr.normal(
+        observation_noise_key,
+        latent_inputs.shape,
+    )
+    measurement_term = phx.uq.LinearizedGaussianMeasurementLikelihood(
+        lambda slope, value: slope * value[0],
+        measured_inputs[:, None],
+        measured_targets,
+        input_covariance=jnp.asarray([[input_scale**2]]),
+        observation_covariance=jnp.asarray([[observation_scale**2]]),
+    )
+    slope_grid = jnp.linspace(0.5, 3.0, 1_024)
+    eiv_log_likelihood = jax.vmap(measurement_term.log_prob)(slope_grid)
+    def latent_log_likelihood(slope):
+        effective_scale = jnp.sqrt(
+            observation_scale**2 + slope**2 * input_scale**2
+        )
+        residual = measured_targets - slope * measured_inputs
+        return jnp.sum(
+            -0.5 * (residual / effective_scale) ** 2
+            - jnp.log(effective_scale * jnp.sqrt(2.0 * jnp.pi))
+        )
+
+    latent_reference_log_likelihood = jax.vmap(latent_log_likelihood)(slope_grid)
+    prior_log_density = -0.5 * (slope_grid / 3.0) ** 2
+    eiv_weights = jax.nn.softmax(eiv_log_likelihood + prior_log_density)
+    latent_weights = jax.nn.softmax(
+        latent_reference_log_likelihood + prior_log_density
+    )
+    ordinary_log_likelihood = jnp.sum(
+        -0.5
+        * (
+            (
+                measured_targets[None, :]
+                - slope_grid[:, None] * measured_inputs[None, :]
+            )
+            / observation_scale
+        )
+        ** 2,
+        axis=1,
+    )
+    ordinary_weights = jax.nn.softmax(ordinary_log_likelihood + prior_log_density)
+    eiv_mean = jnp.sum(eiv_weights * slope_grid)
+    latent_mean = jnp.sum(latent_weights * slope_grid)
+    ordinary_mean = jnp.sum(ordinary_weights * slope_grid)
+    eiv_variance = jnp.sum(eiv_weights * (slope_grid - eiv_mean) ** 2)
+    latent_variance = jnp.sum(latent_weights * (slope_grid - latent_mean) ** 2)
+
+    input_dimension = configuration.linearized_input_dimension
+    output_dimension = configuration.linearized_output_dimension
+    factor_rank = min(configuration.linearized_factor_rank, input_dimension)
+    factors = jr.normal(low_rank_key, (factor_rank, input_dimension)) / jnp.sqrt(
+        factor_rank
+    )
+    output_matrix = jr.normal(
+        output_key,
+        (output_dimension, input_dimension),
+    ) / jnp.sqrt(input_dimension)
+    low_rank = phx.uq.propagate_linearized(
+        lambda value: output_matrix @ value,
+        jnp.zeros(input_dimension),
+        phx.uq.FactorCovariance(factors),
+    )
+    propagated_factors = output_matrix @ factors.T
+    expected_variance = jnp.sum(propagated_factors**2, axis=1)
+    observed_variance = low_rank.exact_variance(
+        batch_size=max(1, factor_rank // 2)
+    )
+    operator_low_rank = phx.uq.propagate_linearized(
+        lambda value: output_matrix @ value,
+        jnp.zeros(input_dimension),
+        phx.uq.CovarianceOperator(
+            lambda vector: factors.T @ (factors @ vector)
+        ),
+    )
+    output_probe = jr.normal(probe_key, (output_dimension,))
+    expected_action = propagated_factors @ (
+        propagated_factors.T @ output_probe
+    )
+    observed_action = operator_low_rank.covariance_vector_product(output_probe)
+    low_rank_variance_error = (
+        jnp.linalg.norm(observed_variance - expected_variance)
+        / jnp.linalg.norm(expected_variance)
+    )
+    low_rank_action_error = (
+        jnp.linalg.norm(observed_action - expected_action)
+        / jnp.linalg.norm(expected_action)
+    )
+    hutchinson = operator_low_rank.estimate_variance(
+        jr.fold_in(root_key, 2),
+        num_probes=configuration.linearized_hutchinson_probes,
+        batch_size=min(configuration.linearized_hutchinson_probes, 64),
+    )
+    low_rank_hutchinson_error = (
+        jnp.linalg.norm(hutchinson.variance - expected_variance)
+        / jnp.linalg.norm(expected_variance)
+    )
+    low_rank_hutchinson_normalized_error = (
+        jnp.linalg.norm(hutchinson.variance - expected_variance)
+        / jnp.maximum(
+            jnp.linalg.norm(hutchinson.standard_error),
+            jnp.finfo(float).eps,
+        )
+    )
+    cold, compile_seconds, execute = _jit_timings(
+        lambda vector: operator_low_rank.covariance_vector_product(vector),
+        output_probe,
+        repetitions=configuration.jit_warm_repetitions,
+    )
+    represented_memory = int(factors.nbytes)
+    dense_output_memory = (
+        output_dimension * output_dimension * jnp.dtype(float).itemsize
+    )
+
+    metrics = {
+        "affine_representation_relative_error": metric(
+            max(float(value) for value in affine_errors),
+            "accuracy",
+            maximum=1.0e-11,
+        ),
+        "affine_hutchinson_relative_error": metric(
+            affine_hutchinson_error,
+            "accuracy",
+            maximum=0.15,
+        ),
+        "jcgm_common_effect_relative_error": metric(
+            common_effect_error,
+            "accuracy",
+            maximum=1.0e-12,
+        ),
+        "nonlinear_qmc_covariance_relative_error": metric(
+            nonlinear_covariance_errors[-1],
+            "accuracy",
+            maximum=0.08,
+        ),
+        "nonlinear_qmc_error_contraction": metric(
+            nonlinear_covariance_errors[-1] / nonlinear_covariance_errors[0],
+            "diagnostic",
+        ),
+        "eiv_latent_log_likelihood_max_error": metric(
+            jnp.max(
+                jnp.abs(
+                    eiv_log_likelihood - latent_reference_log_likelihood
+                )
+            ),
+            "accuracy",
+            maximum=1.0e-8,
+        ),
+        "eiv_latent_posterior_mean_error": metric(
+            jnp.abs(eiv_mean - latent_mean),
+            "accuracy",
+            maximum=1.0e-8,
+        ),
+        "eiv_latent_posterior_variance_relative_error": metric(
+            jnp.abs(eiv_variance - latent_variance) / latent_variance,
+            "accuracy",
+            maximum=1.0e-7,
+        ),
+        "ordinary_eiv_posterior_mean_discrepancy": metric(
+            jnp.abs(ordinary_mean - latent_mean),
+            "diagnostic",
+        ),
+        "low_rank_variance_relative_error": metric(
+            low_rank_variance_error,
+            "accuracy",
+            maximum=1.0e-11,
+        ),
+        "low_rank_operator_relative_error": metric(
+            low_rank_action_error,
+            "accuracy",
+            maximum=1.0e-11,
+        ),
+        "low_rank_hutchinson_relative_error": metric(
+            low_rank_hutchinson_error,
+            "diagnostic",
+        ),
+        "low_rank_hutchinson_normalized_error": metric(
+            low_rank_hutchinson_normalized_error,
+            "accuracy",
+            maximum=3.0,
+        ),
+        "matrix_free_memory_reduction": metric(
+            dense_output_memory / represented_memory,
+            "diagnostic",
+            minimum=100.0,
+        ),
+        "input_dimension": metric(input_dimension, "diagnostic"),
+        "output_dimension": metric(output_dimension, "diagnostic"),
+        "factor_rank": metric(factor_rank, "diagnostic"),
+        "represented_covariance_memory_bytes": metric(
+            represented_memory,
+            "performance",
+            unit="byte",
+        ),
+        "dense_output_covariance_memory_bytes": metric(
+            dense_output_memory,
+            "diagnostic",
+            unit="byte",
+        ),
+    }
+    metrics.update(
+        _performance_metrics(
+            wall_seconds=time.perf_counter() - started,
+            cold_seconds=cold,
+            compile_seconds=compile_seconds,
+            execution_seconds=execute,
+            sample_memory_bytes=represented_memory,
+        )
+    )
+    return ScenarioResult(
+        name="linearized_uncertainty_propagation",
+        description=linearized_uncertainty_propagation.__doc__ or "",
+        seed=seed,
+        metrics=metrics,
+        metadata={
+            "profile": configuration.profile,
+            "qmc_design": phx.sampling.design_signature("sobol_scrambled"),
+            "qmc_samples": configuration.linearized_qmc_samples,
+            "nonlinear_scales": list(nonlinear_scales),
+            "nonlinear_covariance_relative_errors": nonlinear_covariance_errors,
+            "nonlinear_mean_errors": nonlinear_mean_errors,
+            "input_dimension": input_dimension,
+            "output_dimension": output_dimension,
+            "factor_rank": factor_rank,
+            "hutchinson_probes": configuration.linearized_hutchinson_probes,
+            "represented_covariance_memory_bytes": represented_memory,
+            "dense_output_covariance_memory_bytes": dense_output_memory,
+            "eiv_posterior_mean": float(eiv_mean),
+            "latent_reference_posterior_mean": float(latent_mean),
+            "ordinary_posterior_mean": float(ordinary_mean),
+        },
+    )
+
+
 SCENARIOS: dict[str, Scenario] = {
     "elliptic_coefficient_inverse": elliptic_coefficient_inverse,
     "nonlinear_transformed_ode": nonlinear_transformed_ode,
@@ -2275,6 +2632,7 @@ SCENARIOS: dict[str, Scenario] = {
     "correlated_vector_discrepancy": correlated_vector_discrepancy,
     "flow_assisted_multimodal": flow_assisted_multimodal,
     "stochastic_gradient_regression": stochastic_gradient_regression,
+    "linearized_uncertainty_propagation": linearized_uncertainty_propagation,
 }
 
 


### PR DESCRIPTION
## Summary

Adds a native, matrix-free first-order uncertainty-propagation layer to `phydrax.uq`, then carries that contract through Laplace prediction, neural-operator source uncertainty, and normalized errors-in-variables inference.

The central representation is an output covariance action, `J Cₓ Jᴴ`, rather than a materialized Jacobian or an eagerly constructed output covariance. This keeps the common path compatible with large scientific states, structured parameter PyTrees, named `coordax.Field` outputs, and operator-valued prior covariances.

## Motivation

Phydrax already has the posterior, predictive, stochastic-process, neural-operator, and parameter-space foundations needed for uncertainty quantification. The missing primitive was a reusable local covariance transport that could:

- preserve scientific PyTree and named-field structure;
- distinguish diagonal, dense, low-rank, and matrix-free input covariance;
- expose exact first-order results separately from stochastic diagonal estimates;
- reuse JAX JVP/VJP machinery without allocating a Jacobian;
- compose with existing Laplace and neural-operator APIs; and
- support a normalized measurement-error likelihood when predictors and observations are both uncertain.

This PR adds that primitive directly under `phydrax.uq` without introducing an external inference hierarchy or backend abstraction.

## Public covariance contract

Introduces four explicit covariance representations:

- `DiagonalCovariance`: independent coordinate variances with the same PyTree structure as the uncertain value.
- `DenseCovariance`: a finite Hermitian positive-semidefinite matrix in deterministic flattened PyTree order.
- `FactorCovariance`: a shared leading-rank PyTree factor representing `Cₓ = B Bᴴ`.
- `CovarianceOperator`: a caller-supplied matrix-free covariance action.

Construction validates structure, shapes, finite values, Hermitian symmetry where applicable, and positive-semidefinite semantics within scale-aware numerical tolerances. Representation is always explicit; array rank is never used to guess covariance meaning.

## Matrix-free propagation

Adds `propagate_linearized(...)` for ordinary JAX callables and `propagate_linearized_map(...)` for existing tangent/adjoint implementations.

`LinearizedPropagationResult` retains:

- the nominal output;
- the original input and output PyTree layouts;
- the covariance representation and uncertainty source;
- the local pushforward and pullback actions; and
- input/output dimensions and coordinate-covariance semantics.

Its main operations are:

- `pushforward(...)` for a local tangent action;
- `pullback(...)` for the Euclidean or Hermitian adjoint action;
- `covariance_vector_product(...)` for `J Cₓ Jᴴ v`;
- `exact_variance(...)` for diagonal, dense, and factor input covariance;
- `estimate_variance(...)` for keyed Hutchinson output-diagonal estimation with reported Monte Carlo standard error; and
- `materialize_covariance(...)` for explicitly bounded small-output diagnostics.

Complex propagation is opt-in through `complex_linear=True` and uses the Hermitian pullback. Non-holomorphic models remain an explicit real-coordinate problem rather than receiving an ambiguous complex covariance interpretation.

Exact diagonal propagation is factor-aware and batchable. Diagonal basis directions are constructed by chunk rather than by allocating a full identity matrix when a bounded `batch_size` is requested.

## Laplace integration

Adds `linearized_predict(...)` to both `LaplaceResult` and `StructuredLaplaceResult`.

The method differentiates the complete prediction path from unconstrained posterior coordinates through `ParameterSpace.constrain(...)`, so declared parameter bijectors participate automatically. Dense Laplace covariance exposes exact first-order output diagonals. Structured Laplace delegates through its existing covariance-vector-product contract, retaining matrix-free behavior and guarded output materialization.

Existing `predict(...)`, `physical_covariance()`, and `physical_covariance_vector_product(...)` behavior remains intact. Draw-based prediction continues to serve nonlinear posterior-predictive shape; `linearized_predict(...)` is the explicit local-moment path.

## Neural-operator integration

Extends `OperatorLinearization` to retain the selected `OperatorOutputSpec`, then adds `propagate_operator_linearized(...)` under `phydrax.uq`.

The adapter preserves:

- physical case axes;
- tensor-grid or point-cloud query dimensions;
- query masks;
- output-channel metadata;
- source and output quadrature; and
- the original operator input/output structures.

Two geometries are explicit:

- `geometry="discrete"` interprets covariance on finite nodal coordinates and supports pointwise variance and guarded dense materialization.
- `geometry="hilbert"` uses the quadrature-aware operator adjoint and exposes only covariance-vector products, because a continuous function-space covariance has no canonical nodal diagonal without an additional Riesz-coordinate declaration.

Hilbert propagation requires physical quadrature on both source and output geometries. Padded output queries remain masked throughout the propagated result.

## Normalized errors-in-variables likelihood

Adds `LinearizedGaussianMeasurementLikelihood`, a normalized joint Gaussian posterior term for uncertain predictors and uncertain observations.

For each empirical case, it evaluates the physical prediction, differentiates with respect to the measured input, and forms the effective covariance

`Σᵢ(θ) = Σᵧ,ᵢ(θ) + Jᵢ(θ) Σₓ,ᵢ(θ) Jᵢ(θ)ᵀ`.

The likelihood includes both the quadratic residual and the parameter-dependent log determinant. This avoids the common but incorrect substitution of a weighted residual objective when model sensitivity changes with the inferred parameters.

The contract supports:

- scalar and multivariate output events;
- shared or explicit per-case covariance;
- fixed covariance arrays or parameter-dependent callbacks;
- normalized Cholesky evaluation with an explicit output-dimension ceiling;
- deterministic `per_case_log_prob(...)` and `log_prob(...)`; and
- `log_prob_cases(...)` reuse with `ArrayMinibatchSource` and `MinibatchPosteriorProblem`, including original case indices for per-case covariance selection.

Invalid, non-finite, nonsymmetric, non-positive-semidefinite, singular, or shape-incompatible covariance declarations are rejected rather than silently regularized. Optional stabilization is explicit.

## Scientific references and benchmark assets

Adds a `linearized_uncertainty_propagation` benchmark scenario with profile-controlled input dimension, output dimension, factor rank, Hutchinson probe count, and nonlinear QMC sample count.

The scenario records:

- affine equivalence across diagonal, dense, factor, and operator representations;
- covariance-vector-product agreement;
- JCGM 102 additive and correlated measurement examples;
- nonlinear linearization-versus-QMC behavior across shrinking perturbation scales;
- Hutchinson normalized error and reported standard error;
- errors-in-variables likelihood agreement with an explicit latent-input reference;
- posterior mean and variance effects relative to observation-only inference;
- represented covariance memory; and
- matrix-free memory reduction for large output fields.

The benchmark registry and smoke/standard profiles include the new scenario while preserving stable registry order.

## Documentation

Expands the UQ API reference, uncertainty guide, operator-UQ cookbook, general UQ cookbook, and capability overview with:

- covariance representation selection;
- exact-versus-estimated first-order semantics;
- local propagation decision guidance;
- Laplace linearized prediction;
- discrete-versus-Hilbert operator covariance;
- normalized errors-in-variables inference;
- factor-rank batching; and
- nonlinear/QMC escalation boundaries.

## Compatibility and scope

- Additive public API; existing posterior, predictive, Laplace, and operator entry points remain available.
- No new runtime dependency.
- No generic backend-wrapper or estimator/result hierarchy.
- No implicit covariance inference from shape.
- No claim that first-order moments are exact for nonlinear models.
- No automatic independent-source decomposition when cross-covariances are undeclared.
- No dense Jacobian construction in the propagation path.