### PR TITLE
Add bounded differential evolution for geometry design

### DIFF
--- a/docs/api/geometry.md
+++ b/docs/api/geometry.md
@@ -151,6 +151,77 @@ particular representation. Available constraints include parameter targets and
 equalities, point distances, interior/exterior clearance, measure and boundary
 measure targets, boundary-point conditions, and B-Rep seam compatibility.
 
+## Bounded global design search
+
+`DifferentialEvolutionSearch` is intended for low-dimensional geometry design
+problems whose residual objective is nonsmooth, multimodal, or poorly served by a
+single local initialization. It searches the squared residual from
+`DesignConstraintSystem` over an explicit finite box. Differential evolution is a
+stochastic global heuristic: convergence reports population-fitness dispersion, not
+a proof of global optimality or coverage of every basin.
+
+Search bounds and physical schema bounds have different roles. `ParameterSpec.bounds`
+describe physical admissibility and may be one-sided or absent. `search(..., bounds=...)`
+defines the finite algorithmic box. Every trainable degree of freedom must have finite
+lower and upper search limits, and those limits must remain inside any finite physical
+schema bounds. Scalar limits broadcast across a parameter; array limits must match its
+declared shape.
+
+The root PRNG key is required. The initial population uses the typed
+`phydrax.sampling` design substrate; Latin hypercube is the default, while scrambled
+Sobol and the other supported reference designs may be selected explicitly. The
+current state is inserted into the first population member. Generated candidates are
+reflected into the box before both evaluation and storage.
+
+```python
+import jax.random as jr
+import phydrax as phx
+
+geometry = phx.geometry.Sphere(
+    center=(0.0, 0.0, 0.0),
+    radius=1.0,
+    feature_id="body",
+).compile()
+center = phx.geometry.ParameterId("body", "center")
+radius = phx.geometry.ParameterId("body", "radius")
+
+system = phx.geometry.DesignConstraintSystem(
+    geometry,
+    (phx.geometry.ParameterTarget(radius, 1.5),),
+)
+search = phx.geometry.DifferentialEvolutionSearch(
+    32,
+    100,
+    design=phx.sampling.SobolDesign(scrambled=True),
+)
+global_result = system.search(
+    search,
+    key=jr.key(0),
+    bounds={
+        center: ((-0.25, -0.25, -0.25), (0.25, 0.25, 0.25)),
+        radius: (0.25, 2.5),
+    },
+)
+
+# Local refinement is a separate, explicit phase.
+local_result = system.solve(initial_state=global_result.state)
+optimized_geometry = geometry.with_state(local_result.state)
+domain = phx.domain.GeometryDomain(optimized_geometry)
+```
+
+`DesignSearchResult` preserves the final population and objectives, best-objective
+history, exact generation and objective-evaluation counts, invalid-evaluation count,
+resolved bounds, root key, design signature, and termination reason. Its global
+`converged` flag is independent of `ConstraintSolveResult.converged` from the optional
+local phase. Keeping the phases separate makes extra evaluations and failure modes
+observable.
+
+Global search currently requires
+`geometry.field_certificate.validity_region == "all_space"`. Restricted regions such
+as fixed-topology B-Rep validity cannot yet provide an executable per-candidate
+validity predicate, so search fails before objective evaluation rather than silently
+crossing an uncertified region.
+
 ## Reconstruction with provenance
 
 Point-cloud, planar, terrain, and LiDAR reconstruction are explicit pipelines:
@@ -197,6 +268,14 @@ a primitive constructor.
 ---
 
 ::: phydrax.geometry.DesignConstraintSystem
+
+---
+
+::: phydrax.geometry.DifferentialEvolutionSearch
+
+---
+
+::: phydrax.geometry.DesignSearchResult
 
 ---
 

--- a/docs/api/solver/functional_solver.md
+++ b/docs/api/solver/functional_solver.md
@@ -14,7 +14,9 @@ For a conceptual overview (loss evaluation, enforced pipelines, training loop be
     - `objectives` may contain signed terms such as `IntegralFunctional`; their values
       are added directly and are not squared.
     - `partition_functions()` exposes the trainable/non-trainable state split used by `solve(...)`.
-    - `solve(...)` updates parameters inside `functions` using Optax or evosax optimizers.
+    - `solve(...)` accepts standard and line-search Optax transformations, plus
+      Evosax distribution-based algorithms. Population-based Evosax algorithms
+      require a separate finite search-space contract and are rejected.
     - `solve(..., evaluation_parameters=...)` keeps optimizer updates on raw training
       parameters while using the optimizer-prescribed view for diagnostics, selection,
       and returned functions.

--- a/docs/guides_solver.md
+++ b/docs/guides_solver.md
@@ -281,8 +281,15 @@ shape.
 `optim=` can be:
 
 - an Optax `GradientTransformation` (standard first-order optimizers),
-- an Optax `GradientTransformationExtraArgs` (line-search style optimizers),
-- an evosax algorithm instance (evolutionary strategies).
+- an Optax `GradientTransformationExtraArgs` (line-search style optimizers), or
+- an Evosax distribution-based algorithm.
+
+Evosax population-based algorithms are not accepted by `FunctionalSolver`. They
+require an explicit initial population, finite search bounds, and selection semantics
+that a general neural-network parameter PyTree does not provide. Low-dimensional
+geometry design uses
+[`DesignConstraintSystem.search`](api/geometry.md#bounded-global-design-search),
+which supplies those contracts explicitly.
 
 ### Optimizer evaluation parameters
 
@@ -557,9 +564,10 @@ loss1 = solver.loss(key=jr.key(1))
 print(loss0, loss1)
 ```
 
-## EvoSax example (gradient-free)
+## Evosax example (gradient-free)
 
-To use evolutionary strategies, pass an evosax algorithm instance as `optim=...`:
+`Open_ES` is an Evosax distribution-based algorithm, so it can optimize the
+trainable parameter PyTree managed by `FunctionalSolver`:
 
 ```python
 import equinox as eqx

--- a/docs/guides_uncertainty.md
+++ b/docs/guides_uncertainty.md
@@ -1557,6 +1557,9 @@ VJP actions, and applies \(J C_x J^\mathrm{H}\) without constructing a
 Jacobian.
 
 ```python
+def forward(diffusivity, source):
+    return diffusivity + source
+
 center = {
     "diffusivity": jnp.asarray(0.2),
     "source": jnp.asarray([0.9, 1.0, 1.1]),
@@ -1610,9 +1613,6 @@ integration. String shorthands such as `"sobol_scrambled"` and typed
 reproducibility, and capability contract.
 
 ```python
-def forward(diffusivity, source):
-    return diffusivity + source
-
 inputs = phx.uq.sample_joint(
     {
         "diffusivity": phx.uq.LogNormal(-2.0, 0.25),

--- a/phydrax/domain/_components.py
+++ b/phydrax/domain/_components.py
@@ -294,8 +294,8 @@ class DomainComponent(StrictModule):
         domain: Domain,
         spec: SelectionSpec | None = None,
         where: Mapping[str, Callable] | None = None,
-        where_all: DomainFunction | None = None,
-        weight_all: DomainFunction | None = None,
+        where_all: DomainFunction | Callable | None = None,
+        weight_all: DomainFunction | Callable | None = None,
         density_normalized: bool = False,
     ):
         self.domain = domain
@@ -314,27 +314,17 @@ class DomainComponent(StrictModule):
             )
             for factor in self.domain.joint_factors
         )
-        self.where = frozendict(where or {})
-        self.where_all = where_all
-        self.weight_all = weight_all
-        self.density_normalized = bool(density_normalized)
+        where_all_ = where_all
+        if where_all_ is not None and not isinstance(where_all_, DomainFunction):
+            where_all_ = self.domain.Function(*self.domain.labels)(where_all_)
+        weight_all_ = weight_all
+        if weight_all_ is not None and not isinstance(weight_all_, DomainFunction):
+            weight_all_ = self.domain.Function(*self.domain.labels)(weight_all_)
 
-        if self.where_all is not None and not isinstance(self.where_all, DomainFunction):
-            self.where_all = DomainFunction(
-                domain=self.domain,
-                deps=self.domain.labels,
-                func=self.where_all,
-                metadata={},
-            )
-        if self.weight_all is not None and not isinstance(
-            self.weight_all, DomainFunction
-        ):
-            self.weight_all = DomainFunction(
-                domain=self.domain,
-                deps=self.domain.labels,
-                func=self.weight_all,
-                metadata={},
-            )
+        self.where = frozendict(where or {})
+        self.where_all = where_all_
+        self.weight_all = weight_all_
+        self.density_normalized = bool(density_normalized)
 
     def factor_component(self, label: str, /) -> FactorComponent:
         """Return the bound joint-factor component that owns ``label``."""

--- a/phydrax/domain/_evaluation.py
+++ b/phydrax/domain/_evaluation.py
@@ -37,9 +37,7 @@ class FunctionBinding:
         kwargs: Mapping[str, Any],
     ) -> Any:
         call_kwargs = kwargs
-        if (self.pass_key and key is not None) or (
-            self.pass_iter and iter_ is not None
-        ):
+        if (self.pass_key and key is not None) or (self.pass_iter and iter_ is not None):
             call_kwargs = dict(kwargs)
             if self.pass_key and key is not None:
                 call_kwargs["key"] = key
@@ -299,9 +297,7 @@ def complete_batch_axes(
         out = field
         for label in domain_labels:
             coord_axes = (
-                None
-                if coord_axes_by_label is None
-                else coord_axes_by_label.get(label)
+                None if coord_axes_by_label is None else coord_axes_by_label.get(label)
             )
             if coord_axes is not None:
                 for axis in coord_axes:
@@ -378,9 +374,7 @@ def try_blockwise_evaluation(
             return None, "GridBatch.dense_structure must be canonicalized."
         for dep in deps:
             dep_axes = (
-                None
-                if coord_axes_by_label is None
-                else coord_axes_by_label.get(dep)
+                None if coord_axes_by_label is None else coord_axes_by_label.get(dep)
             )
             arg = _as_blockwise_arg(points[dep])
             if arg is None:
@@ -401,9 +395,14 @@ def try_blockwise_evaluation(
 
     axes = _dedupe_axes(axis_order)
     values = jnp.asarray(evaluator(*args, key=key, **kwargs))
-    if values.ndim < len(axes):
-        return None, "model output rank is smaller than its blockwise axis rank."
-    return cx.Field(values, dims=axes + (None,) * (values.ndim - len(axes))), None
+    used_axes = _mapped_axis_prefix(values, axes, points)
+    return (
+        cx.Field(
+            values,
+            dims=used_axes + (None,) * (values.ndim - len(used_axes)),
+        ),
+        None,
+    )
 
 
 def evaluate_pointwise_callable(
@@ -428,10 +427,7 @@ def evaluate_pointwise_callable(
             for block in dense_structure.blocks
             if any(label in deps for label in block)
         )
-        mapped_axes = tuple(
-            dense_structure.axis_for(block[0])
-            for block in mapped_blocks
-        )
+        mapped_axes = tuple(dense_structure.axis_for(block[0]) for block in mapped_blocks)
         if any(axis is None for axis in mapped_axes):
             raise ValueError("GridBatch dense axes must be canonicalized.")
 

--- a/phydrax/geometry/__init__.py
+++ b/phydrax/geometry/__init__.py
@@ -108,6 +108,7 @@ from .design._schema import (
     ParameterSchema,
     ParameterSpec,
 )
+from .design._search import DesignSearchResult, DifferentialEvolutionSearch
 from .design._sketch import (
     Coincident,
     EqualLength,
@@ -195,9 +196,11 @@ __all__ = [
     "Coincident",
     "ConstraintSolveResult",
     "DesignConstraintSystem",
+    "DesignSearchResult",
     "Cone",
     "DDGOperators",
     "DesignState",
+    "DifferentialEvolutionSearch",
     "DistanceSemantics",
     "Cylinder",
     "Difference",

--- a/phydrax/geometry/design/__init__.py
+++ b/phydrax/geometry/design/__init__.py
@@ -26,6 +26,12 @@ _CONSTRAINT_EXPORTS = frozenset(
         "ParameterTarget",
     }
 )
+_SEARCH_EXPORTS = frozenset(
+    {
+        "DesignSearchResult",
+        "DifferentialEvolutionSearch",
+    }
+)
 _SKETCH_EXPORTS = frozenset(
     {
         "AbstractSketchConstraint",
@@ -55,6 +61,8 @@ def __getattr__(name: str):
 
     if name in _CONSTRAINT_EXPORTS:
         from . import _constraints as module
+    elif name in _SEARCH_EXPORTS:
+        from . import _search as module
     elif name in _SKETCH_EXPORTS:
         from . import _sketch as module
     else:
@@ -73,8 +81,10 @@ __all__ = [
     "Coincident",
     "ConstraintSolveResult",
     "DesignConstraintSystem",
+    "DesignSearchResult",
     "DesignState",
     "EqualLength",
+    "DifferentialEvolutionSearch",
     "ExteriorClearance",
     "FixedPoint",
     "Horizontal",

--- a/phydrax/geometry/design/_constraints.py
+++ b/phydrax/geometry/design/_constraints.py
@@ -5,13 +5,14 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING
 
 import equinox as eqx
 import jax
 import jax.numpy as jnp
 import numpy as np
-from jaxtyping import Array
+from jaxtyping import Array, ArrayLike, Key
 
 from ..._strict import StrictModule
 from .._capabilities import (
@@ -20,6 +21,10 @@ from .._capabilities import (
 )
 from .._contracts import CompiledGeometry, GeometryKernel
 from ._schema import DesignState, ParameterId, ParameterSchema
+
+
+if TYPE_CHECKING:
+    from ._search import DesignSearchResult, DifferentialEvolutionSearch
 
 
 class AbstractDesignConstraint(StrictModule):
@@ -367,13 +372,24 @@ class DesignConstraintSystem(StrictModule):
             tuple(state.values[index].reshape((-1,)) for index in self.trainable_indices)
         )
 
-    def unpack(self, vector: Array, /) -> DesignState:
+    def unpack(
+        self,
+        vector: Array,
+        /,
+        *,
+        base_state: DesignState | None = None,
+    ) -> DesignState:
         vector_ = jnp.asarray(vector, dtype=float).reshape((-1,))
         if vector_.shape != self.lower_bounds.shape:
             raise ValueError(
                 "vector has the wrong number of trainable degrees of freedom."
             )
-        values = list(self.geometry.state.values)
+        state = self.geometry.state if base_state is None else base_state
+        if not isinstance(state, DesignState):
+            raise TypeError("base_state must be a DesignState or None.")
+        if state.schema != self.geometry.schema:
+            raise ValueError("base_state schema does not match the constraint system.")
+        values = list(state.values)
         for index, (start, stop, shape) in zip(
             self.trainable_indices, self.slices, strict=True
         ):
@@ -391,9 +407,30 @@ class DesignConstraintSystem(StrictModule):
         )
         return jnp.concatenate(values)
 
+    def search(
+        self,
+        search: DifferentialEvolutionSearch,
+        /,
+        *,
+        key: Key[Array, ""],
+        bounds: Mapping[ParameterId, tuple[ArrayLike, ArrayLike]] | None = None,
+        initial_state: DesignState | None = None,
+    ) -> DesignSearchResult:
+        """Search globally over a finite box of trainable geometry parameters."""
+        from ._search import search_design_constraints
+
+        return search_design_constraints(
+            self,
+            search,
+            key=key,
+            bounds=bounds,
+            initial_state=initial_state,
+        )
+
     def solve(
         self,
         *,
+        initial_state: DesignState | None = None,
         max_iterations: int = 32,
         tolerance: float = 1e-9,
         damping: float = 1e-8,
@@ -403,10 +440,13 @@ class DesignConstraintSystem(StrictModule):
             raise ValueError("iteration counts must be positive.")
         if tolerance <= 0.0 or damping <= 0.0:
             raise ValueError("tolerance and damping must be positive.")
-        initial = self.pack(self.geometry.state)
+        state = self.geometry.state if initial_state is None else initial_state
+        if not isinstance(state, DesignState):
+            raise TypeError("initial_state must be a DesignState or None.")
+        initial = self.pack(state)
 
         def residual_vector(vector):
-            return self.residual(self.unpack(vector))
+            return self.residual(self.unpack(vector, base_state=state))
 
         initial_norm = jnp.linalg.norm(residual_vector(initial))
         loop_state = (
@@ -463,7 +503,7 @@ class DesignConstraintSystem(StrictModule):
         vector, converged, iterations = jax.lax.fori_loop(
             0, max_iterations, iteration, loop_state
         )
-        state = self.unpack(vector)
+        state = self.unpack(vector, base_state=state)
         residual = self.residual(state)
         return ConstraintSolveResult(
             state=state,

--- a/phydrax/geometry/design/_search.py
+++ b/phydrax/geometry/design/_search.py
@@ -1,0 +1,509 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import replace
+from functools import lru_cache
+from typing import Any, Literal
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import numpy as np
+from evosax.algorithms import DifferentialEvolution
+from jaxtyping import Array, ArrayLike, Key
+
+from ..._sampling import (
+    design_signature,
+    DesignLike,
+    LatinHypercubeDesign,
+    materialize_design,
+    resolve_design,
+)
+from ..._strict import StrictModule
+from ._constraints import DesignConstraintSystem
+from ._schema import DesignState, ParameterId
+
+
+SearchStrategy = Literal["best1bin", "rand1bin"]
+SearchBounds = Mapping[ParameterId, tuple[ArrayLike, ArrayLike]]
+
+
+class DifferentialEvolutionSearch(StrictModule):
+    """Validated bounded differential-evolution search configuration."""
+
+    population_size: int = eqx.field(static=True)
+    max_generations: int = eqx.field(static=True)
+    strategy: SearchStrategy = eqx.field(static=True)
+    differential_weight: float = eqx.field(static=True)
+    crossover_rate: float = eqx.field(static=True)
+    relative_tolerance: float = eqx.field(static=True)
+    absolute_tolerance: float = eqx.field(static=True)
+    design: Any
+
+    def __init__(
+        self,
+        population_size: int,
+        max_generations: int,
+        /,
+        *,
+        strategy: SearchStrategy = "best1bin",
+        differential_weight: float = 0.8,
+        crossover_rate: float = 0.9,
+        relative_tolerance: float = 0.01,
+        absolute_tolerance: float = 0.0,
+        design: DesignLike = LatinHypercubeDesign(),
+    ):
+        population_size_ = int(population_size)
+        generations_ = int(max_generations)
+        weight_ = float(differential_weight)
+        crossover_ = float(crossover_rate)
+        relative_ = float(relative_tolerance)
+        absolute_ = float(absolute_tolerance)
+        if population_size_ < 4:
+            raise ValueError(
+                "population_size must be at least 4 for differential evolution."
+            )
+        if generations_ < 0:
+            raise ValueError("max_generations must be non-negative.")
+        if strategy not in ("best1bin", "rand1bin"):
+            raise ValueError("strategy must be 'best1bin' or 'rand1bin'.")
+        if not np.isfinite(weight_) or weight_ < 0.0 or weight_ >= 2.0:
+            raise ValueError("differential_weight must be finite and lie in [0, 2).")
+        if not np.isfinite(crossover_) or crossover_ < 0.0 or crossover_ > 1.0:
+            raise ValueError("crossover_rate must be finite and lie in [0, 1].")
+        if not np.isfinite(relative_) or relative_ < 0.0:
+            raise ValueError("relative_tolerance must be finite and non-negative.")
+        if not np.isfinite(absolute_) or absolute_ < 0.0:
+            raise ValueError("absolute_tolerance must be finite and non-negative.")
+        self.population_size = population_size_
+        self.max_generations = generations_
+        self.strategy = strategy
+        self.differential_weight = weight_
+        self.crossover_rate = crossover_
+        self.relative_tolerance = relative_
+        self.absolute_tolerance = absolute_
+        self.design = resolve_design(design)
+
+
+class DesignSearchResult(StrictModule):
+    """Best design state and convergence evidence from a bounded global search."""
+
+    state: DesignState
+    residual: Array
+    residual_norm: Array
+    objective: Array
+    population_vectors: Array
+    population_objectives: Array
+    best_objective_history: Array
+    lower_bounds: Array
+    upper_bounds: Array
+    key: Key[Array, ""]
+    search: DifferentialEvolutionSearch
+    converged: bool = eqx.field(static=True)
+    termination_reason: str = eqx.field(static=True)
+    generations: int = eqx.field(static=True)
+    objective_evaluations: int = eqx.field(static=True)
+    invalid_evaluations: int = eqx.field(static=True)
+    design_signature: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        state: DesignState,
+        residual: Array,
+        objective: Array,
+        population_vectors: Array,
+        population_objectives: Array,
+        best_objective_history: Array,
+        lower_bounds: Array,
+        upper_bounds: Array,
+        key: Key[Array, ""],
+        search: DifferentialEvolutionSearch,
+        converged: bool,
+        termination_reason: str,
+        generations: int,
+        objective_evaluations: int,
+        invalid_evaluations: int,
+        design_signature: str,
+    ):
+        residual_ = jnp.asarray(residual, dtype=float).reshape((-1,))
+        self.state = state
+        self.residual = residual_
+        self.residual_norm = jnp.linalg.norm(residual_)
+        self.objective = jnp.asarray(objective, dtype=float).reshape(())
+        self.population_vectors = jnp.asarray(population_vectors, dtype=float)
+        self.population_objectives = jnp.asarray(population_objectives, dtype=float)
+        self.best_objective_history = jnp.asarray(best_objective_history, dtype=float)
+        self.lower_bounds = jnp.asarray(lower_bounds, dtype=float)
+        self.upper_bounds = jnp.asarray(upper_bounds, dtype=float)
+        self.key = key
+        self.search = search
+        self.converged = bool(converged)
+        self.termination_reason = str(termination_reason)
+        self.generations = int(generations)
+        self.objective_evaluations = int(objective_evaluations)
+        self.invalid_evaluations = int(invalid_evaluations)
+        self.design_signature = str(design_signature)
+
+
+def _parameter_bound(
+    value: ArrayLike,
+    shape: tuple[int, ...],
+    /,
+    *,
+    parameter_id: ParameterId,
+    side: str,
+) -> np.ndarray:
+    array = np.asarray(value, dtype=float)
+    if array.shape == ():
+        return np.full(shape, float(array), dtype=float).reshape((-1,))
+    if array.shape != shape:
+        raise ValueError(
+            f"{side} search bound for {parameter_id} must be scalar or have shape "
+            f"{shape}, got {array.shape}."
+        )
+    return array.reshape((-1,))
+
+
+def _resolve_search_bounds(
+    system: DesignConstraintSystem,
+    bounds: SearchBounds | None,
+    initial_state: DesignState,
+    /,
+) -> tuple[Array, Array, Array]:
+    if bounds is not None and not isinstance(bounds, Mapping):
+        raise TypeError("bounds must be a mapping from ParameterId to (lower, upper).")
+    overrides = {} if bounds is None else dict(bounds)
+    schema = system.geometry.schema
+    index_by_id = {spec.parameter_id: index for index, spec in enumerate(schema.specs)}
+    slices_by_index = {
+        index: slice_info
+        for index, slice_info in zip(
+            system.trainable_indices,
+            system.slices,
+            strict=True,
+        )
+    }
+    lower = np.asarray(system.lower_bounds, dtype=float).copy()
+    upper = np.asarray(system.upper_bounds, dtype=float).copy()
+
+    for parameter_id, pair in overrides.items():
+        if not isinstance(parameter_id, ParameterId):
+            raise TypeError("Every search-bound key must be a ParameterId.")
+        if parameter_id not in index_by_id:
+            raise KeyError(f"Unknown geometry parameter {parameter_id}.")
+        index = index_by_id[parameter_id]
+        if index not in slices_by_index:
+            raise ValueError(
+                f"Search bounds were provided for non-trainable {parameter_id}."
+            )
+        if not isinstance(pair, tuple) or len(pair) != 2:
+            raise TypeError(
+                f"Search bounds for {parameter_id} must be a (lower, upper) tuple."
+            )
+        start, stop, shape = slices_by_index[index]
+        lower_ = _parameter_bound(pair[0], shape, parameter_id=parameter_id, side="Lower")
+        upper_ = _parameter_bound(pair[1], shape, parameter_id=parameter_id, side="Upper")
+        if not np.all(np.isfinite(lower_)) or not np.all(np.isfinite(upper_)):
+            raise ValueError(f"Search bounds for {parameter_id} must be finite.")
+        if np.any(lower_ >= upper_):
+            raise ValueError(
+                f"Every lower search bound for {parameter_id} must be smaller "
+                "than its upper bound."
+            )
+        physical_lower, physical_upper = schema.specs[index].bounds
+        if physical_lower is not None and np.any(lower_ < physical_lower):
+            raise ValueError(
+                f"Search bounds for {parameter_id} extend below the physical lower "
+                f"bound {physical_lower}."
+            )
+        if physical_upper is not None and np.any(upper_ > physical_upper):
+            raise ValueError(
+                f"Search bounds for {parameter_id} extend above the physical upper "
+                f"bound {physical_upper}."
+            )
+        lower[start:stop] = lower_
+        upper[start:stop] = upper_
+
+    missing = []
+    for index, (start, stop, _shape) in slices_by_index.items():
+        if np.any(~np.isfinite(lower[start:stop])) or np.any(
+            ~np.isfinite(upper[start:stop])
+        ):
+            missing.append(str(schema.specs[index].parameter_id))
+    if missing:
+        names = ", ".join(missing)
+        raise ValueError(f"Finite search bounds are required for: {names}.")
+    if np.any(lower >= upper):
+        raise ValueError("Every lower search bound must be smaller than its upper bound.")
+
+    initial = np.asarray(system.pack(initial_state), dtype=float)
+    outside = (initial < lower) | (initial > upper)
+    if np.any(outside):
+        raise ValueError("The initial design state lies outside the search bounds.")
+    initial_unit = (initial - lower) / (upper - lower)
+    return (
+        jnp.asarray(lower, dtype=float),
+        jnp.asarray(upper, dtype=float),
+        jnp.asarray(initial_unit, dtype=float),
+    )
+
+
+def _reflect_unit_box(population: Array, /) -> Array:
+    folded = jnp.mod(population, 2.0)
+    return jnp.where(folded <= 1.0, folded, 2.0 - folded)
+
+
+def _population_objectives(
+    population: Array,
+    system: DesignConstraintSystem,
+    base_state: DesignState,
+    lower_bounds: Array,
+    upper_bounds: Array,
+    /,
+) -> Array:
+    def objective(unit_vector):
+        vector = lower_bounds + unit_vector * (upper_bounds - lower_bounds)
+        residual = system.residual(system.unpack(vector, base_state=base_state))
+        return jnp.sum(residual * residual)
+
+    return jax.vmap(objective)(population)
+
+
+def _fitness_converged(
+    fitness: Array,
+    /,
+    *,
+    relative_tolerance: float,
+    absolute_tolerance: float,
+) -> Array:
+    return jnp.all(jnp.isfinite(fitness)) & (
+        jnp.std(fitness)
+        <= absolute_tolerance + relative_tolerance * jnp.abs(jnp.mean(fitness))
+    )
+
+
+@lru_cache(maxsize=128)
+def _differential_evolution_algorithm(
+    population_size: int,
+    dimension: int,
+    dtype_name: str,
+    /,
+) -> DifferentialEvolution:
+    return DifferentialEvolution(
+        population_size=population_size,
+        solution=jnp.zeros((dimension,), dtype=np.dtype(dtype_name)),
+    )
+
+
+@eqx.filter_jit
+def _run_search(
+    system: DesignConstraintSystem,
+    base_state: DesignState,
+    algorithm: Any,
+    algorithm_params: Any,
+    initial_population: Array,
+    lower_bounds: Array,
+    upper_bounds: Array,
+    key: Key[Array, ""],
+    *,
+    max_generations: int,
+    relative_tolerance: float,
+    absolute_tolerance: float,
+):
+    initial_raw_fitness = _population_objectives(
+        initial_population,
+        system,
+        base_state,
+        lower_bounds,
+        upper_bounds,
+    )
+    initial_finite = jnp.isfinite(initial_raw_fitness)
+    initial_fitness = jnp.where(initial_finite, initial_raw_fitness, jnp.inf)
+    key, init_key = jr.split(key)
+    algorithm_state = algorithm.init(
+        init_key,
+        initial_population,
+        initial_fitness,
+        algorithm_params,
+    )
+    history = jnp.full((max_generations + 1,), jnp.inf, dtype=initial_fitness.dtype)
+    history = history.at[0].set(jnp.min(initial_fitness))
+    loop_state = (
+        jnp.asarray(0, dtype=jnp.int32),
+        algorithm_state,
+        key,
+        jnp.sum(~initial_finite, dtype=jnp.int32),
+        history,
+    )
+
+    def condition(carry):
+        generation, state, _key, _invalid, _history = carry
+        return (
+            (generation < max_generations)
+            & jnp.any(jnp.isfinite(state.fitness))
+            & ~_fitness_converged(
+                state.fitness,
+                relative_tolerance=relative_tolerance,
+                absolute_tolerance=absolute_tolerance,
+            )
+        )
+
+    def generation_step(carry):
+        generation, state, key_, invalid, history_ = carry
+        key_, ask_key, tell_key = jr.split(key_, 3)
+        population, state = algorithm.ask(ask_key, state, algorithm_params)
+        population = _reflect_unit_box(population)
+        raw_fitness = _population_objectives(
+            population,
+            system,
+            base_state,
+            lower_bounds,
+            upper_bounds,
+        )
+        finite = jnp.isfinite(raw_fitness)
+        fitness = jnp.where(finite, raw_fitness, jnp.inf)
+        state, _metrics = algorithm.tell(
+            tell_key,
+            population,
+            fitness,
+            state,
+            algorithm_params,
+        )
+        next_generation = generation + 1
+        history_ = history_.at[next_generation].set(jnp.min(state.fitness))
+        return (
+            next_generation,
+            state,
+            key_,
+            invalid + jnp.sum(~finite, dtype=jnp.int32),
+            history_,
+        )
+
+    generation, state, _key, invalid, history = jax.lax.while_loop(
+        condition,
+        generation_step,
+        loop_state,
+    )
+    population = algorithm.get_population(state)
+    best = algorithm.get_best_solution(state)
+    converged = _fitness_converged(
+        state.fitness,
+        relative_tolerance=relative_tolerance,
+        absolute_tolerance=absolute_tolerance,
+    )
+    return generation, population, state.fitness, best, history, invalid, converged
+
+
+def search_design_constraints(
+    system: DesignConstraintSystem,
+    search: DifferentialEvolutionSearch,
+    /,
+    *,
+    key: Key[Array, ""],
+    bounds: SearchBounds | None = None,
+    initial_state: DesignState | None = None,
+) -> DesignSearchResult:
+    """Run bounded differential evolution over a compiled geometry design state."""
+    if not isinstance(system, DesignConstraintSystem):
+        raise TypeError("system must be a DesignConstraintSystem.")
+    if not isinstance(search, DifferentialEvolutionSearch):
+        raise TypeError("search must be a DifferentialEvolutionSearch.")
+    if system.geometry.field_certificate.validity_region != "all_space":
+        raise NotImplementedError(
+            "Global design search requires a geometry validity region of 'all_space'; "
+            f"got {system.geometry.field_certificate.validity_region!r}."
+        )
+    state = system.geometry.state if initial_state is None else initial_state
+    if not isinstance(state, DesignState):
+        raise TypeError("initial_state must be a DesignState or None.")
+    lower, upper, initial_unit = _resolve_search_bounds(system, bounds, state)
+    dimension = int(lower.shape[0])
+    design_key = jr.fold_in(key, 0)
+    evolution_key = jr.fold_in(key, 1)
+    population = materialize_design(
+        search.design,
+        count=search.population_size,
+        dimension=dimension,
+        key=design_key,
+    )
+    population = population.at[0].set(initial_unit)
+
+    algorithm = _differential_evolution_algorithm(
+        search.population_size,
+        dimension,
+        str(lower.dtype),
+    )
+    algorithm_params = replace(
+        algorithm.default_params,
+        elitism=search.strategy == "best1bin",
+        crossover_rate=search.crossover_rate,
+        differential_weight=search.differential_weight,
+    )
+    (
+        generations,
+        unit_population,
+        population_objectives,
+        best_unit,
+        history,
+        invalid_evaluations,
+        converged,
+    ) = _run_search(
+        system,
+        state,
+        algorithm,
+        algorithm_params,
+        population,
+        lower,
+        upper,
+        evolution_key,
+        max_generations=search.max_generations,
+        relative_tolerance=search.relative_tolerance,
+        absolute_tolerance=search.absolute_tolerance,
+    )
+    generations_ = int(generations)
+    population_vectors = lower + unit_population * (upper - lower)
+    best_vector = lower + best_unit * (upper - lower)
+    best_state = system.unpack(best_vector, base_state=state)
+    residual = system.residual(best_state)
+    objective = jnp.sum(residual * residual)
+    finite_population = bool(jnp.any(jnp.isfinite(population_objectives)))
+    converged_ = bool(converged)
+    if not finite_population:
+        termination_reason = "no_finite_candidates"
+    elif converged_ and generations_ == 0:
+        termination_reason = "initial_population_converged"
+    elif converged_:
+        termination_reason = "fitness_tolerance"
+    else:
+        termination_reason = "max_generations"
+
+    return DesignSearchResult(
+        state=best_state,
+        residual=residual,
+        objective=objective,
+        population_vectors=population_vectors,
+        population_objectives=population_objectives,
+        best_objective_history=history[: generations_ + 1],
+        lower_bounds=lower,
+        upper_bounds=upper,
+        key=key,
+        search=search,
+        converged=converged_,
+        termination_reason=termination_reason,
+        generations=generations_,
+        objective_evaluations=search.population_size * (generations_ + 1),
+        invalid_evaluations=int(invalid_evaluations),
+        design_signature=design_signature(search.design),
+    )
+
+
+__all__ = [
+    "DesignSearchResult",
+    "DifferentialEvolutionSearch",
+]

--- a/phydrax/operators/differential/_domain_ops.py
+++ b/phydrax/operators/differential/_domain_ops.py
@@ -8,21 +8,27 @@ import operator
 from collections.abc import Callable, Mapping, Sequence
 from typing import Any, Literal
 
+import coordax as cx
 import jax
 import jax.core as jax_core
 import jax.numpy as jnp
 import opt_einsum as oe
-from jaxtyping import ArrayLike
+from jaxtyping import Array, ArrayLike, Key
 
 from phydrax.domain import (
+    BatchEvaluator,
     BinaryFieldEvaluator,
     ConcatenatedModelEvaluator,
     CoordinateSpec,
     DomainFunction,
+    GridBatch,
     SwapAxesFieldEvaluator,
     UnaryFieldEvaluator,
 )
 
+from ..._doc import DOC_KEY0
+from ..._strict import StrictModule
+from ...domain._evaluation import evaluate_pointwise_callable
 from ...nn._utils import _get_size
 from ._array_ops import (
     _basis_nth_derivative,
@@ -40,6 +46,94 @@ from ._runtime import get_partial_eval_cache
 _ADEngine = Literal["auto", "reverse", "forward", "jvp"]
 
 
+class _DiscreteDerivativeEvaluator(StrictModule, BatchEvaluator):
+    """Preserve coordinate-separable batches for finite and basis derivatives."""
+
+    source: DomainFunction
+    pointwise: Callable
+    variable: str
+    coordinate_axis: int
+    order: int
+    backend: Literal["fd", "basis"]
+    basis: Literal["poly", "fourier", "sine", "cosine"]
+    periodic: bool
+
+    def __init__(
+        self,
+        source: DomainFunction,
+        pointwise: Callable,
+        /,
+        *,
+        variable: str,
+        coordinate_axis: int,
+        order: int,
+        backend: Literal["fd", "basis"],
+        basis: Literal["poly", "fourier", "sine", "cosine"],
+        periodic: bool,
+    ):
+        self.source = source
+        self.pointwise = pointwise
+        self.variable = str(variable)
+        self.coordinate_axis = int(coordinate_axis)
+        self.order = int(order)
+        self.backend = backend
+        self.basis = basis
+        self.periodic = bool(periodic)
+
+    def __call__(self, *args, key=None, **kwargs):
+        return self.pointwise(*args, key=key, **kwargs)
+
+    def __call_batch__(
+        self,
+        batch: Any,
+        /,
+        *,
+        key: Key[Array, ""] = DOC_KEY0,
+        **kwargs: Any,
+    ) -> cx.Field:
+        if isinstance(batch, GridBatch) and self.variable in batch.coord_axes_by_label:
+            coordinate_fields = batch.points[self.variable]
+            if not isinstance(coordinate_fields, tuple):
+                raise TypeError(
+                    "Coordinate-separable derivative inputs must be tuples of fields."
+                )
+            axis_names = batch.coord_axes_by_label[self.variable]
+            coordinate_field = coordinate_fields[self.coordinate_axis]
+            coordinate = jnp.asarray(coordinate_field.data)
+            source = self.source(batch, key=key, **kwargs)
+            axis = source.dims.index(axis_names[self.coordinate_axis])
+            if self.backend == "fd":
+                spacing = (
+                    coordinate[1] - coordinate[0]
+                    if coordinate.shape[0] > 1
+                    else jnp.asarray(1.0, dtype=coordinate.dtype)
+                )
+                values = _fd_nth_derivative(
+                    jnp.asarray(source.data),
+                    dx=spacing,
+                    axis=axis,
+                    order=self.order,
+                    periodic=self.periodic,
+                )
+            else:
+                values = _basis_nth_derivative(
+                    jnp.asarray(source.data),
+                    coordinate,
+                    axis=axis,
+                    order=self.order,
+                    basis=self.basis,
+                )
+            return cx.Field(values, dims=source.dims)
+        return evaluate_pointwise_callable(
+            self,
+            deps=self.source.deps,
+            domain_labels=self.source.domain.labels,
+            points=batch,
+            key=key,
+            kwargs=kwargs,
+        )
+
+
 def _unwrap_factor(factor: object, /) -> object:
     return factor
 
@@ -51,9 +145,7 @@ def _resolve_var(u: DomainFunction, var: str | None, /) -> str:
         return var
 
     differentiable = tuple(
-        label
-        for label in u.domain.labels
-        if u.domain.coordinate(label).differentiable
+        label for label in u.domain.labels if u.domain.coordinate(label).differentiable
     )
 
     if len(differentiable) != 1:
@@ -139,8 +231,6 @@ def _latent_model_from_domain_function(
     if isinstance(raw_model, LatentContractionModel):
         return raw_model, u.func
     return None
-
-
 
 
 def _const_scalar(fn: DomainFunction, /) -> float | None:
@@ -280,8 +370,6 @@ def _try_derivative_rule(
     if out is not None and not isinstance(out, DomainFunction):
         raise TypeError("DerivativeRule.derive must return a DomainFunction or None.")
     return out
-
-
 
 
 def _emit_latent_fallback_warning(u: DomainFunction, reason: str, /) -> None:
@@ -2114,14 +2202,16 @@ def partial(
 
     use_jvp = ad_engine == "jvp"
     if not use_jvp:
-        hooked = _try_derivative_rule(u,
-        var=var,
-        axis=axis,
-        order=1,
-        mode=mode_eff,
-        backend="ad",
-        basis="poly",
-        periodic=False,)
+        hooked = _try_derivative_rule(
+            u,
+            var=var,
+            axis=axis,
+            order=1,
+            mode=mode_eff,
+            backend="ad",
+            basis="poly",
+            periodic=False,
+        )
         if hooked is not None:
             return hooked
 
@@ -2327,14 +2417,16 @@ def partial_n(
             raise ValueError(f"axis must be in [0,{int(var_dim)}), got {axis_i}.")
 
     if backend == "ad" or backend == "jet":
-        hooked = _try_derivative_rule(u,
-        var=var,
-        axis=axis,
-        order=order_i,
-        mode=mode_eff,
-        backend=backend,
-        basis=basis,
-        periodic=periodic,)
+        hooked = _try_derivative_rule(
+            u,
+            var=var,
+            axis=axis,
+            order=order_i,
+            mode=mode_eff,
+            backend=backend,
+            basis=basis,
+            periodic=periodic,
+        )
         if hooked is not None:
             return hooked
         structured = _try_structured_partial_n(
@@ -2450,7 +2542,26 @@ def partial_n(
             v = jnp.zeros_like(x).at[..., axis_i].set(1.0)
         return _return(jet_dn(f, x, v, n=order_i))
 
-    return DomainFunction(domain=u.domain, deps=u.deps, func=_nth, metadata=out_metadata)
+    evaluator = (
+        _DiscreteDerivativeEvaluator(
+            u,
+            _nth,
+            variable=var,
+            coordinate_axis=axis_i,
+            order=order_i,
+            backend=backend,
+            basis=basis,
+            periodic=periodic,
+        )
+        if backend in ("fd", "basis")
+        else _nth
+    )
+    return DomainFunction(
+        domain=u.domain,
+        deps=u.deps,
+        func=evaluator,
+        metadata=out_metadata,
+    )
 
 
 def partial_x(

--- a/phydrax/solver/_functional_solver.py
+++ b/phydrax/solver/_functional_solver.py
@@ -11,6 +11,7 @@ from typing import Any
 import jax.numpy as jnp
 import jax.random as jr
 import optax
+from evosax.algorithms.distribution_based.base import DistributionBasedAlgorithm
 from jaxtyping import Array, Key
 
 from phydrax.domain import DomainFunction, EnforcementGateMethod
@@ -307,7 +308,7 @@ class FunctionalSolver(StrictModule):
         num_iter: int,
         optim: optax.GradientTransformation
         | optax.GradientTransformationExtraArgs
-        | Any
+        | DistributionBasedAlgorithm
         | None = None,
         evaluation_parameters: EvaluationParametersFn | None = None,
         seed: int = 0,
@@ -327,9 +328,11 @@ class FunctionalSolver(StrictModule):
         The optimization updates trainable inexact-array leaves of `self.functions`.
         Domains and fixed observed-data state are kept non-trainable.
 
-        - If `optim` is an Optax `GradientTransformation`, a standard gradient step is used.
-        - If `optim` is an Optax `GradientTransformationExtraArgs`, a line-search style update is used.
-        - Otherwise, `optim` is treated as an evosax algorithm instance.
+        - Standard and extra-argument Optax transformations are accepted.
+        - Evosax distribution-based algorithms are accepted.
+        - Evosax population-based algorithms require an explicit search-space contract
+          and are therefore rejected; bounded geometry design uses
+          `DesignConstraintSystem.search(...)`.
         - `evaluation_parameters`, when provided, maps optimizer state and raw training
           parameters to the parameter view used for diagnostics, model selection, and
           the returned solver. This supports optimizers such as Optax schedule-free

--- a/phydrax/solver/_functional_train.py
+++ b/phydrax/solver/_functional_train.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import inspect
 import time
 from contextlib import nullcontext
 from pathlib import Path
@@ -16,6 +15,8 @@ import jax.numpy as jnp
 import jax.random as jr
 import numpy as np
 import optax
+from evosax.algorithms.distribution_based.base import DistributionBasedAlgorithm
+from evosax.algorithms.population_based.base import PopulationBasedAlgorithm
 from jax import core as jcore
 
 from .._frozendict import frozendict
@@ -51,6 +52,7 @@ class _SupportsDataMetrics(Protocol):
         key: Any,
         **kwargs: Any,
     ) -> dict[str, Any]: ...
+
 
 def _sample_objective_batches(objectives: tuple[Any, ...], /, *, key: Any):
     keys = jr.split(key, len(objectives))
@@ -473,7 +475,7 @@ def solve(
     if isinstance(optim, str):
         raise TypeError(
             "optim must be an optimizer object (e.g. optax.adam(...), optax.lbfgs(...), "
-            "or an evosax algorithm instance), not a string."
+            "or an evosax distribution-based algorithm instance), not a string."
         )
 
     _opt_linesearch: optax.GradientTransformationExtraArgs | None = None
@@ -483,12 +485,23 @@ def solve(
         _opt_linesearch = optim
     elif isinstance(optim, optax.GradientTransformation):
         _opt_standard = optim
-    else:
+    elif isinstance(optim, PopulationBasedAlgorithm):
         if evaluation_parameters is not None:
             raise ValueError(
                 "evaluation_parameters is supported only for Optax optimizers."
             )
-        return _solve_evosax(
+        raise NotImplementedError(
+            "FunctionalSolver does not accept Evosax population-based algorithms: "
+            "they require an explicit initial population and finite search-space "
+            "semantics. For bounded geometry design, use "
+            "DesignConstraintSystem.search(...)."
+        )
+    elif isinstance(optim, DistributionBasedAlgorithm):
+        if evaluation_parameters is not None:
+            raise ValueError(
+                "evaluation_parameters is supported only for Optax optimizers."
+            )
+        return _solve_evosax_distribution(
             self,
             num_iter=num_iter,
             algo=optim,
@@ -503,6 +516,11 @@ def solve(
             tensorboard_flush_every=tensorboard_flush_every,
             profile_adaptive=profile_adaptive,
             train_constraint_sample_size=train_constraint_sample_size,
+        )
+    else:
+        raise TypeError(
+            "optim must be an Optax transformation or an Evosax distribution-based "
+            "algorithm instance."
         )
 
     log_ctx = (
@@ -1113,11 +1131,11 @@ def solve(
         return eqx.tree_at(lambda s: s.training_diagnostics, result, diagnostics)
 
 
-def _solve_evosax(
+def _solve_evosax_distribution(
     self: "FunctionalSolver",
     *,
     num_iter: int,
-    algo: Any,
+    algo: DistributionBasedAlgorithm,
     seed: int,
     jit: bool,
     keep_best: bool,
@@ -1322,17 +1340,7 @@ def _solve_evosax(
     terms_fn = eqx.filter_jit(_terms_for_params) if jit else _terms_for_params
 
     key = jr.key(seed)
-    init_sig = inspect.signature(algo.init)
-    init_params = init_sig.parameters
-    accepts_var_kwargs = any(
-        p.kind == inspect.Parameter.VAR_KEYWORD for p in init_params.values()
-    )
-    init_kwargs = {}
-    if accepts_var_kwargs or ("params" in init_params):
-        init_kwargs["params"] = algo_params
-    if accepts_var_kwargs or ("mean" in init_params):
-        init_kwargs["mean"] = params
-    evo_state = algo.init(key, **init_kwargs)
+    evo_state = algo.init(key, mean=params, params=algo_params)
 
     control = TrainingController(
         total_steps=int(num_iter),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "coordax==0.2.3",
     "diffrax>=0.7.2,<0.8",
     "equinox==0.13.2",
-    "evosax>=0.2.0",
+    "evosax>=0.2.0,<0.3",
     "flowjax>=19.1.1,<20",
     "jax>=0.8.2,<0.10",
     "jax2onnx>=0.14.0",

--- a/tests/unit/geometry/test_design_global_search.py
+++ b/tests/unit/geometry/test_design_global_search.py
@@ -1,0 +1,229 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from dataclasses import replace
+
+import jax.numpy as jnp
+import jax.random as jr
+import numpy as np
+import pytest
+
+import phydrax as phx
+from phydrax.geometry.design import AbstractDesignConstraint
+from phydrax.geometry.design._search import _reflect_unit_box
+
+
+class _ConstantConstraint(AbstractDesignConstraint):
+    def residual(self, kernel, schema, state, /):
+        del kernel, schema, state
+        return self._weighted(jnp.ones((1,)))
+
+
+class _InvalidConstraint(AbstractDesignConstraint):
+    def residual(self, kernel, schema, state, /):
+        del kernel, schema, state
+        return self._weighted(jnp.full((1,), jnp.nan))
+
+
+def _sphere_problem(*, constraint=None):
+    geometry = phx.geometry.Sphere((0.0, 0.0, 0.0), 1.0).compile()
+    parameter_ids = {
+        parameter_id.name: parameter_id for parameter_id in geometry.schema.parameter_ids
+    }
+    if constraint is None:
+        constraint = phx.geometry.ParameterTarget(parameter_ids["radius"], 1.5)
+    system = phx.geometry.DesignConstraintSystem(geometry, (constraint,))
+    bounds = {
+        parameter_ids["center"]: (-0.5, 0.5),
+        parameter_ids["radius"]: (0.25, 2.5),
+    }
+    return geometry, system, parameter_ids, bounds
+
+
+def test_configuration_validation():
+    with pytest.raises(ValueError, match="at least 4"):
+        phx.geometry.DifferentialEvolutionSearch(3, 4)
+    with pytest.raises(ValueError, match="non-negative"):
+        phx.geometry.DifferentialEvolutionSearch(4, -1)
+    with pytest.raises(ValueError, match="strategy"):
+        phx.geometry.DifferentialEvolutionSearch(4, 1, strategy="invalid")
+    with pytest.raises(ValueError, match="differential_weight"):
+        phx.geometry.DifferentialEvolutionSearch(4, 1, differential_weight=2.0)
+    with pytest.raises(ValueError, match="crossover_rate"):
+        phx.geometry.DifferentialEvolutionSearch(4, 1, crossover_rate=1.1)
+    with pytest.raises(ValueError, match="relative_tolerance"):
+        phx.geometry.DifferentialEvolutionSearch(4, 1, relative_tolerance=-1.0)
+    with pytest.raises(ValueError, match="absolute_tolerance"):
+        phx.geometry.DifferentialEvolutionSearch(4, 1, absolute_tolerance=jnp.nan)
+    with pytest.raises(ValueError, match="design must be one of"):
+        phx.geometry.DifferentialEvolutionSearch(4, 1, design="unknown")
+
+
+def test_search_bounds_are_complete_finite_and_physically_admissible():
+    geometry, system, parameter_ids, bounds = _sphere_problem()
+    search = phx.geometry.DifferentialEvolutionSearch(4, 0)
+
+    with pytest.raises(ValueError, match="center"):
+        system.search(
+            search,
+            key=jr.key(0),
+            bounds={parameter_ids["radius"]: (0.25, 2.5)},
+        )
+    with pytest.raises(KeyError, match="Unknown geometry parameter"):
+        system.search(
+            search,
+            key=jr.key(0),
+            bounds={
+                **bounds,
+                phx.geometry.ParameterId("unknown", "parameter"): (0.0, 1.0),
+            },
+        )
+    with pytest.raises(ValueError, match="shape"):
+        system.search(
+            search,
+            key=jr.key(0),
+            bounds={**bounds, parameter_ids["center"]: (jnp.zeros((2,)), 0.5)},
+        )
+    with pytest.raises(ValueError, match="smaller"):
+        system.search(
+            search,
+            key=jr.key(0),
+            bounds={**bounds, parameter_ids["radius"]: (2.0, 1.0)},
+        )
+    with pytest.raises(ValueError, match="finite"):
+        system.search(
+            search,
+            key=jr.key(0),
+            bounds={**bounds, parameter_ids["radius"]: (0.25, jnp.inf)},
+        )
+    with pytest.raises(ValueError, match="physical lower"):
+        system.search(
+            search,
+            key=jr.key(0),
+            bounds={**bounds, parameter_ids["radius"]: (-0.25, 2.5)},
+        )
+
+    outside = geometry.state.updated({parameter_ids["radius"]: jnp.asarray(3.0)})
+    with pytest.raises(ValueError, match="outside"):
+        system.search(
+            search,
+            key=jr.key(0),
+            bounds=bounds,
+            initial_state=outside,
+        )
+
+
+def test_search_is_reproducible_bounded_and_exactly_accounted():
+    geometry, system, _parameter_ids, bounds = _sphere_problem()
+    search = phx.geometry.DifferentialEvolutionSearch(
+        8,
+        4,
+        strategy="rand1bin",
+        relative_tolerance=0.0,
+        absolute_tolerance=0.0,
+        design=phx.sampling.SobolDesign(scrambled=True),
+    )
+
+    result = system.search(search, key=jr.key(42), bounds=bounds)
+    replay = system.search(search, key=jr.key(42), bounds=bounds)
+    different = system.search(search, key=jr.key(43), bounds=bounds)
+
+    assert result.generations == 4
+    assert result.objective_evaluations == 8 * 5
+    assert result.invalid_evaluations == 0
+    assert result.termination_reason == "max_generations"
+    assert result.best_objective_history.shape == (5,)
+    assert np.all(np.diff(np.asarray(result.best_objective_history)) <= 0.0)
+    assert np.all(
+        np.asarray(result.population_vectors) >= np.asarray(result.lower_bounds)
+    )
+    assert np.all(
+        np.asarray(result.population_vectors) <= np.asarray(result.upper_bounds)
+    )
+    assert float(result.objective) == pytest.approx(
+        float(jnp.sum(result.residual * result.residual))
+    )
+    assert float(result.objective) == pytest.approx(
+        float(jnp.min(result.population_objectives))
+    )
+    assert result.design_signature == phx.sampling.design_signature(search.design)
+
+    np.testing.assert_array_equal(result.population_vectors, replay.population_vectors)
+    np.testing.assert_array_equal(
+        result.population_objectives, replay.population_objectives
+    )
+    np.testing.assert_array_equal(
+        result.best_objective_history, replay.best_objective_history
+    )
+    for left, right in zip(result.state.values, replay.state.values, strict=True):
+        np.testing.assert_array_equal(left, right)
+    assert not np.array_equal(result.population_vectors, different.population_vectors)
+
+    local = system.solve(initial_state=result.state)
+    assert bool(local.converged)
+    assert float(jnp.sum(local.residual * local.residual)) <= float(result.objective)
+    optimized = geometry.with_state(local.state)
+    domain = phx.domain.GeometryDomain(optimized)
+    assert domain.geometry.equivalent(optimized)
+
+
+def test_initial_population_convergence_and_invalid_objectives_are_explicit():
+    _geometry, constant_system, _parameter_ids, bounds = _sphere_problem(
+        constraint=_ConstantConstraint()
+    )
+    converged = constant_system.search(
+        phx.geometry.DifferentialEvolutionSearch(4, 10),
+        key=jr.key(0),
+        bounds=bounds,
+    )
+    assert converged.converged
+    assert converged.generations == 0
+    assert converged.objective_evaluations == 4
+    assert converged.termination_reason == "initial_population_converged"
+    np.testing.assert_array_equal(converged.best_objective_history, jnp.asarray([1.0]))
+
+    _geometry, invalid_system, _parameter_ids, bounds = _sphere_problem(
+        constraint=_InvalidConstraint()
+    )
+    invalid = invalid_system.search(
+        phx.geometry.DifferentialEvolutionSearch(4, 10),
+        key=jr.key(0),
+        bounds=bounds,
+    )
+    assert not invalid.converged
+    assert invalid.generations == 0
+    assert invalid.objective_evaluations == 4
+    assert invalid.invalid_evaluations == 4
+    assert invalid.termination_reason == "no_finite_candidates"
+    assert np.all(np.isinf(np.asarray(invalid.population_objectives)))
+    assert bool(jnp.isnan(invalid.objective))
+
+
+def test_repair_reflects_arbitrary_overshoot_into_unit_box():
+    candidates = jnp.asarray([-4.2, -1.2, -0.2, 0.2, 1.2, 2.2, 5.2])
+    repaired = _reflect_unit_box(candidates)
+    np.testing.assert_allclose(
+        repaired,
+        jnp.asarray([0.2, 0.8, 0.2, 0.2, 0.8, 0.2, 0.8]),
+        atol=1e-12,
+    )
+    assert np.all(np.asarray(repaired) >= 0.0)
+    assert np.all(np.asarray(repaired) <= 1.0)
+
+
+def test_restricted_geometry_validity_region_fails_before_evaluation(monkeypatch):
+    geometry, system, _parameter_ids, bounds = _sphere_problem()
+    restricted = replace(geometry.field_certificate, validity_region="fixed_topology")
+    monkeypatch.setattr(
+        type(geometry.kernel),
+        "field_certificate",
+        property(lambda _self: restricted),
+    )
+
+    with pytest.raises(NotImplementedError, match="validity region"):
+        system.search(
+            phx.geometry.DifferentialEvolutionSearch(4, 1),
+            key=jr.key(0),
+            bounds=bounds,
+        )

--- a/tests/unit/geometry/test_geometry_full_substrate.py
+++ b/tests/unit/geometry/test_geometry_full_substrate.py
@@ -239,16 +239,37 @@ def test_sketch_and_design_constraint_solvers_lower_to_geometry():
         sphere,
         (phx.geometry.MeasureTarget(target_volume),),
     )
-    design_solution = system.solve()
     radius_id = next(
         parameter_id
         for parameter_id in sphere.schema.parameter_ids
         if parameter_id.name == "radius"
     )
+    center_id = next(
+        parameter_id
+        for parameter_id in sphere.schema.parameter_ids
+        if parameter_id.name == "center"
+    )
+    global_solution = system.search(
+        phx.geometry.DifferentialEvolutionSearch(
+            8,
+            4,
+            relative_tolerance=0.0,
+            absolute_tolerance=0.0,
+        ),
+        key=jax.random.key(12),
+        bounds={
+            center_id: (-0.25, 0.25),
+            radius_id: (0.25, 2.5),
+        },
+    )
+    design_solution = system.solve(initial_state=global_solution.state)
     assert bool(design_solution.converged)
     assert float(design_solution.state.values[sphere.schema.index(radius_id)]) == (
         pytest.approx(target_radius)
     )
+    optimized = sphere.with_state(design_solution.state)
+    domain = phx.domain.GeometryDomain(optimized)
+    assert float(domain.measure) == pytest.approx(target_volume)
 
 
 def test_affine_geometry_preserves_boundary_tags_and_exact_atlas_measure():

--- a/tests/unit/solver/test_evosax_dispatch.py
+++ b/tests/unit/solver/test_evosax_dispatch.py
@@ -1,0 +1,48 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from typing import cast
+
+import jax.numpy as jnp
+import pytest
+from evosax.algorithms import DifferentialEvolution, Open_ES
+
+from phydrax.solver import FunctionalSolver
+from phydrax.solver._functional_train import solve
+
+
+_DUMMY_SOLVER = cast(FunctionalSolver, object())
+
+
+def test_population_based_evosax_is_rejected_with_search_space_guidance():
+    algorithm = DifferentialEvolution(
+        population_size=4,
+        solution=jnp.zeros((2,)),
+    )
+
+    with pytest.raises(
+        NotImplementedError,
+        match=r"initial population.*DesignConstraintSystem\.search",
+    ):
+        solve(_DUMMY_SOLVER, num_iter=1, optim=algorithm)
+
+
+def test_unrelated_optimizer_object_is_rejected_before_training():
+    with pytest.raises(TypeError, match="Optax transformation"):
+        solve(_DUMMY_SOLVER, num_iter=1, optim=object())
+
+
+def test_evaluation_parameters_remains_optax_only_for_evosax():
+    algorithm = Open_ES(
+        population_size=8,
+        solution=jnp.zeros((2,)),
+    )
+
+    with pytest.raises(ValueError, match="only for Optax"):
+        solve(
+            _DUMMY_SOLVER,
+            num_iter=1,
+            optim=algorithm,
+            evaluation_parameters=lambda state, parameters: parameters,
+        )


### PR DESCRIPTION
## Summary

Adds a bounded, JAX-native differential evolution workflow for low-dimensional geometry design. The new API searches a `DesignConstraintSystem` over explicit finite parameter bounds, returns the complete population and convergence evidence, and composes cleanly with the existing deterministic local solver.

This also tightens the optimizer boundary in `FunctionalSolver` and preserves structured domain evaluation through global predicates, blockwise models, and discrete derivatives.

## Motivation

Geometry design problems can be nonsmooth, multimodal, or sensitive to initialization. The existing damped Gauss–Newton solver is an effective local method, but it is not a global optimizer and should not silently inherit an implicit search space.

The new workflow makes the missing contracts explicit:

- the optimized degrees of freedom come from the compiled `ParameterSchema`;
- the stochastic search region is a finite box supplied by `ParameterId`;
- initialization uses the shared typed `phydrax.sampling` design substrate;
- global search and local refinement remain separate, observable phases;
- restricted geometry-validity regions fail before candidate evaluation rather than being crossed without a certificate.

## Public API

### `DifferentialEvolutionSearch`

An immutable, validated configuration containing:

- population size and maximum generations;
- `best1bin` or `rand1bin` strategy selection;
- differential weight and crossover rate;
- relative and absolute population-fitness tolerances;
- a typed sampling design, defaulting to Latin hypercube sampling.

### `DesignConstraintSystem.search(...)`

Runs the bounded stochastic phase:

```python
import jax.random as jr
import phydrax as phx

geometry = phx.geometry.Sphere(
    center=(0.0, 0.0, 0.0),
    radius=1.0,
    feature_id="body",
).compile()

center = phx.geometry.ParameterId("body", "center")
radius = phx.geometry.ParameterId("body", "radius")

system = phx.geometry.DesignConstraintSystem(
    geometry,
    (phx.geometry.ParameterTarget(radius, 1.5),),
)

search = phx.geometry.DifferentialEvolutionSearch(
    32,
    100,
    design=phx.sampling.SobolDesign(scrambled=True),
)

global_result = system.search(
    search,
    key=jr.key(0),
    bounds={
        center: ((-0.25, -0.25, -0.25), (0.25, 0.25, 0.25)),
        radius: (0.25, 2.5),
    },
)

local_result = system.solve(initial_state=global_result.state)
optimized = geometry.with_state(local_result.state)
```

### `DesignSearchResult`

Returns the best `DesignState` together with:

- residual, residual norm, and squared-residual objective;
- final population vectors and objectives;
- monotone best-objective history;
- resolved lower and upper bounds;
- convergence status and explicit termination reason;
- exact generation, objective-evaluation, and invalid-evaluation counts;
- root PRNG key and sampling-design signature.

## Search semantics

### Bounds

Search bounds are distinct from physical schema bounds:

- every trainable degree of freedom must resolve to finite lower and upper search limits;
- scalar bounds broadcast over a parameter, while array bounds must match its declared shape;
- unknown and non-trainable `ParameterId` entries are rejected;
- search bounds must remain inside any finite physical bounds in `ParameterSpec`;
- an initial state outside the resolved search box is rejected.

This keeps algorithmic exploration limits explicit without mutating the compiled geometry schema or inventing bounds from physical scale.

### Initialization and reproducibility

- The initial unit-cube population is generated by `phydrax.sampling.materialize_design(...)`.
- Latin hypercube, Sobol, Halton, Hammersley, IID, and other canonical design objects therefore share the existing capability and reproducibility contract.
- The current geometry state is inserted as the first population member.
- Stable folded PRNG subkeys separate design generation from evolution.

### Evolution and repair

- Evosax `DifferentialEvolution` supplies the population-based ask/tell implementation.
- `best1bin` enables elitism; `rand1bin` disables it.
- Candidate populations are evaluated with `jax.vmap` inside an `eqx.filter_jit`-compiled JAX control-flow loop.
- Arbitrary candidate overshoot is repaired by repeated reflection into the unit box rather than clipping.
- Non-finite candidate objectives become positive infinity for selection and are counted explicitly.

### Convergence and accounting

Population convergence uses the configured absolute-plus-relative fitness-dispersion criterion and requires every active fitness value to be finite. Termination distinguishes:

- `initial_population_converged`;
- `fitness_tolerance`;
- `max_generations`;
- `no_finite_candidates`.

The initial population is an evaluated population, so objective accounting is exactly `population_size × (completed_generations + 1)`. Result history includes that initial evaluation and is trimmed to the completed generation count.

### Geometry validity and reconstruction

Global search currently requires `field_certificate.validity_region == "all_space"`. Fixed-topology B-Rep and other restricted validity regions do not yet expose an executable per-candidate validity predicate, so they are rejected before any objective evaluation.

The selected vector is unpacked into a complete `DesignState`. Callers reconstruct through the existing canonical path, `CompiledGeometry.with_state(...)`, preserving geometry capabilities, provenance, and domain interoperability.

## Global and local composition

Local polishing is intentionally explicit:

1. `DesignConstraintSystem.search(...)` explores the bounded global box.
2. The caller may inspect the global population and termination evidence.
3. `DesignConstraintSystem.solve(initial_state=global_result.state)` optionally performs deterministic local refinement.

There is no hidden local objective evaluation, callback, or phase ambiguity, and nonsmooth users may skip local differentiation entirely.

## Optimizer contract cleanup

`FunctionalSolver.solve(...)` now describes and enforces the supported optimizer families directly:

- standard and line-search Optax transformations remain supported;
- Evosax distribution-based algorithms remain supported for trainable neural parameter PyTrees;
- Evosax population-based algorithms are rejected with guidance to `DesignConstraintSystem.search(...)`, because they require an explicit initial population and finite search-space semantics;
- unrelated optimizer objects fail with a focused `TypeError` rather than reaching training internals;
- the Evosax dependency range is constrained to the compatible 0.2 release line.

## Structured domain evaluation fixes

The branch also resolves structured-evaluation regressions exposed against current `dev`:

- raw component-level `where_all` and `weight_all` callables are bound through `Domain.Function(...)`, preserving canonical key and iteration forwarding;
- finite-difference and basis derivatives retain `GridBatch` structure and differentiate batch-evaluated fields along named coordinate axes;
- blockwise callable outputs infer the axes they preserve, allowing intentionally reduced axes to be restored by `complete_batch_axes`;
- FNO and other blockwise models therefore retain coordinate-separable grids through basis Laplacians instead of falling back to pointwise execution;
- the uncertainty guide defines its reusable `forward(...)` map before the first example that invokes it.

## Documentation

Updates the geometry API and solver documentation with:

- the bounded-search public API and complete example;
- the distinction between physical admissibility and finite search bounds;
- stochastic convergence and global-optimality limitations;
- explicit global-then-local composition;
- optimizer-family guidance for Optax and Evosax;
- result accounting, geometry reconstruction, and validity-region constraints.

## Scope and limitations

- This is a heuristic global optimizer, not a certificate of global optimality.
- It is intended for low-dimensional trainable geometry parameter spaces, not unconstrained full-network parameter PyTrees.
- Search requires finite explicit bounds for every trainable geometry degree of freedom.
- Population sharding, callbacks, vectorized objective switches, custom evolutionary strategies, and implicit local polishing are intentionally outside this API.
- Restricted geometry-validity regions remain unavailable until they provide an executable state-validity contract.