### PR TITLE
Add reusable coreset engine and scientific integrations

### DIFF
--- a/docs/api/constraints/core.md
+++ b/docs/api/constraints/core.md
@@ -55,6 +55,16 @@ for estimator semantics, geometry support, and budget comparisons.
 
 ---
 
+::: phydrax.constraints.CoresetCollocationPolicy
+    options:
+        members:
+            - __init__
+            - initialize
+            - refresh
+            - data_metrics
+
+---
+
 
 ::: phydrax.constraints.SeparableCollocationPolicy
     options:

--- a/docs/api/integration.md
+++ b/docs/api/integration.md
@@ -50,6 +50,38 @@ measures, and composed space/time/stochastic reductions.
 
 ::: phydrax.integration.IntegrationRealization
 
+---
+
+::: phydrax.integration.compress
+
+## Measure compression
+
+::: phydrax.coresets.MomentRecombination
+
+---
+
+::: phydrax.coresets.moment_recombine
+
+---
+
+::: phydrax.coresets.KernelHerding
+
+---
+
+::: phydrax.coresets.kernel_herd
+
+---
+
+::: phydrax.coresets.weighted_mmd
+
+---
+
+::: phydrax.integration.MeasureCompressionDiagnostics
+
+---
+
+::: phydrax.integration.CompressedIntegrationDiagnostics
+
 ## Targets
 
 ::: phydrax.integration.over

--- a/docs/api/uq/inference.md
+++ b/docs/api/uq/inference.md
@@ -361,6 +361,22 @@ on a tractable reference before interpreting these draws quantitatively.
             - predict_observations
             - convergence_report
 
+
+### Posterior compression
+
+::: phydrax.uq.thin_posterior
+
+---
+
+::: phydrax.uq.SteinThinning
+
+---
+
+::: phydrax.uq.PosteriorCoreset
+    options:
+        members:
+            - predict
+            - predict_observations
 ---
 
 ::: phydrax.uq.MCMCChainWarmup
@@ -612,6 +628,15 @@ auxiliary randomness.
             - log_probability
             - conditioner
             - condition
+
+
+---
+
+::: phydrax.uq.select_inducing_points
+
+---
+
+::: phydrax.uq.InducingPointSelection
 
 ### Identifiability gates
 

--- a/docs/guides_integrals.md
+++ b/docs/guides_integrals.md
@@ -48,6 +48,7 @@ density mass.
 
 ```python
 import phydrax as phx
+import jax.numpy as jnp
 
 space = phx.domain.ScalarInterval(-1.0, 2.0, label="x")
 
@@ -95,6 +96,44 @@ form.
 An integrand may itself be any nonempty PyTree of `DomainFunction`, callable, or
 array leaves. Reduction preserves that container structure and every leaf dtype in
 `estimate.value`; method diagnostics are returned with the same leaf structure.
+
+## Compress a reusable finite realization
+
+For several expensive integrands over the same finite positive measure, insert
+compression between materialization and reduction:
+
+```python
+samples = jnp.linspace(0.0, 2.0, 25)
+log_weights = jnp.zeros((25,))
+source = phx.integration.materialize(
+    phx.integration.weighted(samples, log_weights)
+)
+compressed = phx.integration.compress(
+    source,
+    phx.coresets.MomentRecombination(),
+    features=jnp.stack((samples, samples**2), axis=1),
+)
+
+estimate_a = phx.integration.reduce(lambda x: jnp.exp(x), compressed)
+estimate_b = phx.integration.reduce(lambda x: jnp.cos(x), compressed)
+```
+
+`MomentRecombination` returns nonnegative weights and preserves the supplied feature
+moments, including mass through its internal constant feature. The result retains at
+most one more active point than the supplied feature count. `KernelHerding(k)` instead
+selects `k` equally weighted points that greedily reduce a blockwise kernel MMD.
+
+Compression currently accepts a finite, one-axis `PointIntegrationBatch` or
+`WeightedSampleBatch`. It rejects signed weights and any stratum, antithetic pair,
+replicate, or component-union structure that cannot yet be preserved exactly. Source
+ancestry, target mass, named sample axes, masks, execution key, and provenance survive
+the reduction. `CompressedIntegrationDiagnostics` keeps selection evidence separate
+from downstream integration diagnostics.
+
+Compression discrepancy is not reported as `IntegrationEstimate.error_estimate`:
+feature-moment residual and MMD are construction diagnostics, not general error bounds
+for an arbitrary later integrand. Amortize compression only when its construction cost
+is repaid across expensive evaluations.
 
 ## Adaptive one-dimensional quadrature
 

--- a/docs/guides_solver.md
+++ b/docs/guides_solver.md
@@ -341,7 +341,8 @@ starting point. Support is declared by `COLLOCATION_POLICY_SUPPORT` and
 
 - **Stable:** fixed scrambled Sobol, periodic replacement, R3, and periodic
   separable sampling.
-- **Conditional:** RAR-D for sufficiently resolved oscillatory residuals and
+- **Conditional:** coreset collocation for residual-weighted, diversity-preserving
+  paired points; RAR-D for sufficiently resolved oscillatory residuals; and
   hierarchical-axis refinement for nested coordinate-separable discretizations.
 
 For production-style adaptive runs, separate proposal generation from solver
@@ -386,11 +387,55 @@ budgets reserve the next validation evaluation before a proposal is admitted, so
 exhausting a candidate or monitor budget cannot leave the final population
 permanently unvalidated.
 
+Use coreset collocation when an underresolved or localized residual repeatedly
+concentrates ordinary residual-only selection. Delay selection until the network
+residual is informative, retain an explicit global-coverage stratum, and validate
+proposals independently:
+
+```python
+policy = phx.constraints.controlled_collocation(
+    phx.constraints.CoresetCollocation(
+        refresh_every=25,
+        start_at=100,
+        sampler="halton_scrambled",
+        candidate_multiplier=8,
+        exponent=0.5,
+        uniform_fraction=0.5,
+        minimum_ess_fraction=0.5,
+        max_fill_distance_ratio=3.0,
+    ),
+    anchors=phx.constraints.CoverageAnchors(0.25),
+)
+```
+
+Each refresh scores `candidate_multiplier × retained_count` points. `exponent=0.5`
+turns the usual squared pointwise residual into residual-magnitude importance. The
+score distribution is normalized before mixing it with the uniform distribution, so
+`uniform_fraction` is dimensionless and does not depend on PDE units. If the mixture
+would have less than `minimum_ess_fraction × candidate_count` effective samples, the
+policy increases the effective uniform fraction and reports the adjustment.
+
+Candidate coordinates are range-normalized on every refresh. With `kernel=None` (the
+default), the radial-kernel length scale is the median nonzero pairwise distance of a
+bounded candidate subsample. Pass an explicit `phx.coresets.RadialKernel(...)` to
+override that scale in normalized-coordinate units. The fill-distance guard rejects a
+proposal whose normalized candidate fill distance exceeds
+`max_fill_distance_ratio` times that of the current population. Selection validity,
+acceptance, MMD, requested and effective mixture fractions, importance ESS, resolved
+kernel scale, fill distances, guard activation, candidate count, and kernel-evaluation
+count are all exposed through solver data metrics.
+
+The policy uses the ordinary `ControlledCollocationPolicy` monitor, rollback, budget,
+and `CoverageAnchors` contracts. Its residual-derived sampling measure intentionally
+changes the effective training distribution, so keep it conditional and compare it
+against fixed low-discrepancy collocation on an untouched monitor and the physical
+quantity of interest.
+
 Choose the population representation first:
 
 | Representation | Policies | Budget unit | Appropriate support |
 | --- | --- | --- | --- |
-| `PointBatch` | `PeriodicCollocation`, `R3`, `RARD` | retained points and residual candidate evaluations | General pointwise PINNs |
+| `PointBatch` | `PeriodicCollocation`, `R3`, `RARD`, `CoresetCollocation` | retained points and residual candidate evaluations | General pointwise PINNs |
 | `GridBatch` | `PeriodicSeparableCollocation`, `HierarchicalAxisCollocation` | axis nodes **and** implied logical evaluations | Separable models and nested axis-aligned structure |
 
 `RARD` is retained for oscillatory or distributed residual structure when the

--- a/docs/guides_uncertainty.md
+++ b/docs/guides_uncertainty.md
@@ -1079,6 +1079,30 @@ Pass `initial_positions` with one leading chain axis when chains must begin at
 different represented modes; `initial_position` retains the replicated-start
 convenience. The two arguments are mutually exclusive.
 
+### Chain-preserving posterior thinning
+
+Thin a completed, convergence-checked MCMC result only as explicit post-processing:
+
+```python
+posterior_coreset = phx.uq.thin_posterior(
+    posterior_draws,
+    phx.uq.SteinThinning(200),
+    key=jr.key(11),
+)
+prediction = posterior_coreset.predict(
+    jnp.linspace(0.0, 1.0, 65),
+    batch_size=64,
+)
+```
+
+`SteinThinning` evaluates the exact transformed-posterior score and greedily minimizes
+an inverse-multiquadric kernel Stein discrepancy inside each chain. The result keeps
+separate chain and retained-draw axes, original chain/draw indices, source convergence
+diagnostics, constrained and unconstrained samples, and the ordinary posterior
+prediction methods. It never recomputes R-hat or effective sample size on the selected
+draws. This is output compression for repeated predictions or storage, not a sampler
+transition and not evidence that an unconverged source chain has converged.
+
 
 Long MCMC runs can checkpoint after a fixed number of completed draws per chain:
 pass `checkpoint_path`, `checkpoint_every`, and a stable caller-owned
@@ -1533,6 +1557,32 @@ matrix-vector product. Factor construction is intended to be amortized over repe
 evaluations. Hyperparameters passed to `factor(...)` are fixed: use
 `log_marginal_likelihood(...)` when amplitude, length scale, or noise remains an
 inferred parameter.
+
+For a fixed sparse-GP kernel geometry, randomized pivoted Cholesky can choose inducing
+inputs from the observed design:
+
+```python
+observation_points = jnp.linspace(0.0, 1.0, 65)[:, None]
+inducing = phx.uq.select_inducing_points(
+    observation_points,
+    32,
+    key=jr.key(12),
+    kernel=phx.coresets.RadialKernel("matern32", length_scale=0.25),
+)
+factor = phx.uq.SparseGaussianProcessFactor(
+    observation_points,
+    inducing.points,
+    amplitude=0.03,
+    length_scale=0.25,
+    noise_scale=0.005,
+    kernel="matern32",
+)
+```
+
+`InducingPointSelection.diagnostics` reports initial and residual kernel trace and the
+explained fraction. Reuse the selection only while its point geometry and kernel scale
+remain fixed; it does not optimize predictive likelihood and does not replace model
+validation.
 
 Conditioned samples are coherent functions over all query points. Latent GP
 variation is an epistemic sample axis; independent measurement noise remains

--- a/phydrax/__init__.py
+++ b/phydrax/__init__.py
@@ -10,6 +10,7 @@ jax.config.update("jax_enable_x64", True)
 
 from . import (
     constraints,
+    coresets,
     data_utils,
     domain,
     equations,
@@ -33,6 +34,7 @@ from . import (
 # Explicit re-exports for star import
 __all__ = [
     "constraints",
+    "coresets",
     "data_utils",
     "domain",
     "equations",

--- a/phydrax/constraints/__init__.py
+++ b/phydrax/constraints/__init__.py
@@ -66,6 +66,7 @@ from ._adaptive_control import (
     RefreshSchedule,
     ResidualMonitor,
 )
+from ._adaptive_coreset import CoresetCollocation, CoresetCollocationPolicy
 from ._adaptive_separable import (
     HierarchicalAxisCollocation,
     HierarchicalAxisPolicy,
@@ -218,6 +219,8 @@ __all__ = [
     "AbstractCollocationPolicy",
     "CollocationPolicy",
     "CollocationPopulation",
+    "CoresetCollocation",
+    "CoresetCollocationPolicy",
     "PeriodicCollocation",
     "R3",
     "RARD",

--- a/phydrax/constraints/_adaptive.py
+++ b/phydrax/constraints/_adaptive.py
@@ -103,6 +103,7 @@ class CollocationPopulation(StrictModule):
     age: cx.Field
     refresh_count: Array
     last_refresh: Array
+    diagnostics: Any | None
 
     def __init__(
         self,
@@ -112,6 +113,7 @@ class CollocationPopulation(StrictModule):
         age: cx.Field | None = None,
         refresh_count: int | Array = 0,
         last_refresh: int | Array = 0,
+        diagnostics: Any | None = None,
     ):
         axis, n = _single_axis_and_size(batch)
         if active is not None:
@@ -125,6 +127,7 @@ class CollocationPopulation(StrictModule):
         self.age = age
         self.refresh_count = jnp.asarray(refresh_count, dtype=jnp.int32)
         self.last_refresh = jnp.asarray(last_refresh, dtype=jnp.int32)
+        self.diagnostics = diagnostics
 
     def loss_weight(self) -> cx.Field | None:
         return self.active

--- a/phydrax/constraints/_adaptive_control.py
+++ b/phydrax/constraints/_adaptive_control.py
@@ -10,6 +10,7 @@ from types import MappingProxyType
 from typing import Any, Literal, TYPE_CHECKING
 
 import coordax as cx
+import equinox as eqx
 import jax
 import jax.numpy as jnp
 import jax.random as jr
@@ -27,6 +28,7 @@ from ._adaptive import (
     CollocationPolicy,
     CollocationPopulation,
 )
+from ._adaptive_coreset import CoresetCollocationPolicy
 from ._adaptive_separable import HierarchicalAxisPolicy, SeparableCollocationPolicy
 
 
@@ -73,6 +75,11 @@ COLLOCATION_POLICY_SUPPORT: Mapping[str, CollocationPolicySupport] = MappingProx
         "rar_d": CollocationPolicySupport(
             "rar_d", "conditional", "Oscillatory or distributed residual structure."
         ),
+        "coreset": CollocationPolicySupport(
+            "coreset",
+            "conditional",
+            "Residual importance with kernel-diverse paired support.",
+        ),
         "periodic_separable": CollocationPolicySupport(
             "periodic_separable", "stable", "Coordinate-separable models."
         ),
@@ -98,6 +105,8 @@ def collocation_policy_support(
         return collocation_policy_support(policy.base_policy)
     elif isinstance(policy, CollocationPolicy):
         name = policy.algorithm
+    elif isinstance(policy, CoresetCollocationPolicy):
+        name = "coreset"
     elif isinstance(policy, HierarchicalAxisPolicy):
         name = "hierarchical_axes"
     elif isinstance(policy, SeparableCollocationPolicy):
@@ -360,11 +369,13 @@ class ControlledCollocationPolicy(AbstractCollocationPolicy):
     ):
         if isinstance(base_policy, ControlledCollocationPolicy):
             raise TypeError("ControlledCollocationPolicy cannot wrap another controller.")
-        schedule = (
-            RefreshSchedule(base_policy.refresh_every)
-            if schedule is None
-            else schedule
-        )
+        if schedule is None:
+            start_at = (
+                base_policy.start_at
+                if isinstance(base_policy, CoresetCollocationPolicy)
+                else 1
+            )
+            schedule = RefreshSchedule(base_policy.refresh_every, start_at=start_at)
         self.base_policy = base_policy
         self.schedule = schedule
         self.monitor = ResidualMonitor() if monitor is None else monitor
@@ -830,13 +841,11 @@ def _inject_collocation_anchors(
         age_data.at[:count].set(reference_age[:count] + 1),
         dims=population.age.dims,
     )
-    return CollocationPopulation(
-        anchored_batch,
-        active=active,
-        age=age,
-        refresh_count=population.refresh_count,
-        last_refresh=population.last_refresh,
-    )
+    anchored = eqx.tree_at(lambda state: state.batch, population, anchored_batch)
+    anchored = eqx.tree_at(lambda state: state.age, anchored, age)
+    if active is not None:
+        anchored = eqx.tree_at(lambda state: state.active, anchored, active)
+    return anchored
 
 
 def _take_first_rows(batch: PointBatch, count: int, /) -> PointBatch:

--- a/phydrax/constraints/_adaptive_coreset.py
+++ b/phydrax/constraints/_adaptive_coreset.py
@@ -1,0 +1,736 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from math import isfinite
+from typing import TYPE_CHECKING
+
+import coordax as cx
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import jax.tree_util as jtu
+from jaxtyping import Array, Key
+
+from phydrax.coresets import (
+    CoresetSelection,
+    kernel_herd,
+    KernelHerding,
+    RadialKernel,
+    weighted_mmd,
+)
+from phydrax.domain import PointBatch, PointSampling
+
+from .._doc import DOC_KEY0
+from .._sampling import DesignLike, resolve_design, UnitDesign
+from .._strict import StrictModule
+from ._adaptive import (
+    _collocation_population_metrics,
+    _concat_batches,
+    _point_sampling,
+    _single_axis_and_size,
+    _take_batch,
+    _validate_axis_field,
+    AbstractCollocationPolicy,
+    CollocationPopulation,
+)
+
+
+if TYPE_CHECKING:
+    from phydrax.domain import DomainFunction
+
+    from ._functional import FunctionalConstraint
+
+class _CoresetCollocationDiagnostics(StrictModule):
+    """Last-refresh importance, kernel, and coverage evidence."""
+
+    selection_valid: Array
+    selection_accepted: Array
+    selection_mmd: Array
+    importance_effective_sample_size: Array
+    effective_uniform_fraction: Array
+    ess_guard_triggered: Array
+    kernel_length_scale_min: Array
+    kernel_length_scale_max: Array
+    coverage_fill_distance: Array
+    coverage_baseline_fill_distance: Array
+    coverage_guard_triggered: Array
+    selection_kernel_evaluations: Array
+
+    def __init__(
+        self,
+        *,
+        selection_valid: bool | Array = False,
+        selection_accepted: bool | Array = False,
+        selection_mmd: float | Array = 0.0,
+        importance_effective_sample_size: float | Array = 0.0,
+        effective_uniform_fraction: float | Array = 0.0,
+        ess_guard_triggered: bool | Array = False,
+        kernel_length_scale_min: float | Array = 0.0,
+        kernel_length_scale_max: float | Array = 0.0,
+        coverage_fill_distance: float | Array = 0.0,
+        coverage_baseline_fill_distance: float | Array = 0.0,
+        coverage_guard_triggered: bool | Array = False,
+        selection_kernel_evaluations: int | Array = 0,
+    ):
+        self.selection_valid = jnp.asarray(selection_valid, dtype=bool)
+        self.selection_accepted = jnp.asarray(selection_accepted, dtype=bool)
+        self.selection_mmd = jnp.asarray(selection_mmd, dtype=float)
+        self.importance_effective_sample_size = jnp.asarray(
+            importance_effective_sample_size,
+            dtype=float,
+        )
+        self.effective_uniform_fraction = jnp.asarray(
+            effective_uniform_fraction,
+            dtype=float,
+        )
+        self.ess_guard_triggered = jnp.asarray(ess_guard_triggered, dtype=bool)
+        self.kernel_length_scale_min = jnp.asarray(
+            kernel_length_scale_min,
+            dtype=float,
+        )
+        self.kernel_length_scale_max = jnp.asarray(
+            kernel_length_scale_max,
+            dtype=float,
+        )
+        self.coverage_fill_distance = jnp.asarray(
+            coverage_fill_distance,
+            dtype=float,
+        )
+        self.coverage_baseline_fill_distance = jnp.asarray(
+            coverage_baseline_fill_distance,
+            dtype=float,
+        )
+        self.coverage_guard_triggered = jnp.asarray(
+            coverage_guard_triggered,
+            dtype=bool,
+        )
+        self.selection_kernel_evaluations = jnp.asarray(
+            selection_kernel_evaluations,
+            dtype=jnp.int64,
+        )
+
+
+def _coreset_diagnostics(
+    population: CollocationPopulation,
+    /,
+) -> _CoresetCollocationDiagnostics:
+    if not isinstance(population.diagnostics, _CoresetCollocationDiagnostics):
+        raise TypeError("CoresetCollocationPolicy requires its initialized population.")
+    return population.diagnostics
+
+
+class CoresetCollocationPolicy(AbstractCollocationPolicy):
+    """Robust residual-weighted kernel herding over refreshed candidates.
+
+    Candidate scores are normalized before mixing with a uniform measure. The
+    effective uniform fraction is raised when needed to enforce the requested
+    importance ESS. Candidate coordinates are range-normalized; omitting ``kernel``
+    selects a median-distance scale on each refresh. A proposal that regresses
+    candidate fill distance too far relative to the retained population is rejected.
+    """
+
+    refresh_every: int
+    start_at: int
+    sampler: UnitDesign
+    candidate_multiplier: int
+    exponent: Array
+    uniform_fraction: Array
+    minimum_ess_fraction: Array
+    max_fill_distance_ratio: Array
+    epsilon: Array
+    kernel: RadialKernel | None
+    kernel_scale_factor: Array
+    block_size: int = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        refresh_every: int = 100,
+        start_at: int | None = None,
+        sampler: DesignLike = "halton_scrambled",
+        candidate_multiplier: int = 10,
+        exponent: float = 0.5,
+        uniform_fraction: float = 0.5,
+        minimum_ess_fraction: float = 0.5,
+        max_fill_distance_ratio: float = 3.0,
+        epsilon: float = 1e-12,
+        kernel: RadialKernel | None = None,
+        kernel_scale_factor: float = 1.0,
+        block_size: int = 256,
+    ):
+        refresh = int(refresh_every)
+        activation = 2 * refresh if start_at is None else int(start_at)
+        multiplier = int(candidate_multiplier)
+        exponent_value = float(exponent)
+        uniform = float(uniform_fraction)
+        minimum_ess = float(minimum_ess_fraction)
+        fill_ratio = float(max_fill_distance_ratio)
+        epsilon_value = float(epsilon)
+        scale_factor = float(kernel_scale_factor)
+        block = int(block_size)
+        if refresh <= 0:
+            raise ValueError("refresh_every must be positive.")
+        if activation <= 0:
+            raise ValueError("start_at must be positive.")
+        if multiplier < 2:
+            raise ValueError("candidate_multiplier must be at least two.")
+        if not isfinite(exponent_value) or exponent_value < 0.0:
+            raise ValueError("exponent must be finite and non-negative.")
+        if not isfinite(uniform) or not 0.0 <= uniform <= 1.0:
+            raise ValueError("uniform_fraction must lie in [0, 1].")
+        if not isfinite(minimum_ess) or not 0.0 < minimum_ess <= 1.0:
+            raise ValueError("minimum_ess_fraction must lie in (0, 1].")
+        if not isfinite(fill_ratio) or fill_ratio < 1.0:
+            raise ValueError("max_fill_distance_ratio must be finite and at least one.")
+        if not isfinite(epsilon_value) or epsilon_value <= 0.0:
+            raise ValueError("epsilon must be finite and strictly positive.")
+        if kernel is not None and not isinstance(kernel, RadialKernel):
+            raise TypeError("kernel must be a RadialKernel or None.")
+        if not isfinite(scale_factor) or scale_factor <= 0.0:
+            raise ValueError("kernel_scale_factor must be finite and strictly positive.")
+        if block <= 0:
+            raise ValueError("block_size must be positive.")
+        self.refresh_every = refresh
+        self.start_at = activation
+        self.sampler = resolve_design(sampler)
+        self.candidate_multiplier = multiplier
+        self.exponent = jnp.asarray(exponent_value, dtype=float)
+        self.uniform_fraction = jnp.asarray(uniform, dtype=float)
+        self.minimum_ess_fraction = jnp.asarray(minimum_ess, dtype=float)
+        self.max_fill_distance_ratio = jnp.asarray(fill_ratio, dtype=float)
+        self.epsilon = jnp.asarray(epsilon_value, dtype=float)
+        self.kernel = kernel
+        self.kernel_scale_factor = jnp.asarray(scale_factor, dtype=float)
+        self.block_size = block
+
+    def initialize(
+        self,
+        constraint: FunctionalConstraint,
+        /,
+        *,
+        key: Key[Array, ""] = DOC_KEY0,
+    ) -> CollocationPopulation:
+        batch = constraint._sample_once(key=key)
+        if not isinstance(batch, PointBatch):
+            raise TypeError("Coreset collocation requires a PointBatch.")
+        _, size = _single_axis_and_size(batch)
+        return CollocationPopulation(
+            batch,
+            diagnostics=_CoresetCollocationDiagnostics(
+                importance_effective_sample_size=size,
+                effective_uniform_fraction=self.uniform_fraction,
+            ),
+        )
+
+    def should_refresh(
+        self,
+        population: CollocationPopulation,
+        iter_: int | Array,
+    ) -> Array:
+        step = jnp.asarray(iter_, dtype=jnp.int32)
+        activated = step >= self.start_at
+        due = (step - population.last_refresh) >= self.refresh_every
+        return activated & due
+
+    def loss_batch_and_weight(
+        self,
+        population: CollocationPopulation,
+        /,
+    ) -> tuple[PointBatch, cx.Field | None]:
+        return population.batch, None
+
+    def data_metrics(
+        self,
+        population: CollocationPopulation,
+        /,
+    ) -> dict[str, Array]:
+        metrics = _collocation_population_metrics(population)
+        _, size = _single_axis_and_size(population.batch)
+        candidate_count = size * self.candidate_multiplier
+        diagnostics = _coreset_diagnostics(population)
+        metrics.update(
+            {
+                "coreset_candidate_count": jnp.asarray(candidate_count, dtype=float),
+                "coreset_candidate_multiplier": jnp.asarray(
+                    self.candidate_multiplier,
+                    dtype=float,
+                ),
+                "coreset_start_at": jnp.asarray(self.start_at, dtype=float),
+                "coreset_score_exponent": jnp.asarray(self.exponent),
+                "coreset_uniform_fraction": jnp.asarray(self.uniform_fraction),
+                "coreset_effective_uniform_fraction": jnp.asarray(
+                    diagnostics.effective_uniform_fraction,
+                    dtype=float,
+                ),
+                "coreset_minimum_ess_fraction": jnp.asarray(
+                    self.minimum_ess_fraction
+                ),
+                "coreset_max_fill_distance_ratio": jnp.asarray(
+                    self.max_fill_distance_ratio
+                ),
+                "coreset_importance_effective_sample_size": jnp.asarray(
+                    diagnostics.importance_effective_sample_size,
+                    dtype=float,
+                ),
+                "coreset_importance_effective_sample_fraction": jnp.asarray(
+                    diagnostics.importance_effective_sample_size / candidate_count,
+                    dtype=float,
+                ),
+                "coreset_ess_guard_triggered": jnp.asarray(
+                    diagnostics.ess_guard_triggered,
+                    dtype=float,
+                ),
+                "coreset_kernel_automatic": jnp.asarray(
+                    self.kernel is None,
+                    dtype=float,
+                ),
+                "coreset_kernel_scale_factor": jnp.asarray(
+                    self.kernel_scale_factor
+                ),
+                "coreset_kernel_length_scale_min": jnp.asarray(
+                    diagnostics.kernel_length_scale_min,
+                    dtype=float,
+                ),
+                "coreset_kernel_length_scale_max": jnp.asarray(
+                    diagnostics.kernel_length_scale_max,
+                    dtype=float,
+                ),
+                "coreset_coverage_fill_distance": jnp.asarray(
+                    diagnostics.coverage_fill_distance,
+                    dtype=float,
+                ),
+                "coreset_coverage_baseline_fill_distance": jnp.asarray(
+                    diagnostics.coverage_baseline_fill_distance,
+                    dtype=float,
+                ),
+                "coreset_coverage_guard_triggered": jnp.asarray(
+                    diagnostics.coverage_guard_triggered,
+                    dtype=float,
+                ),
+                "coreset_selection_kernel_evaluations": jnp.asarray(
+                    diagnostics.selection_kernel_evaluations,
+                    dtype=float,
+                ),
+                "coreset_selection_valid": jnp.asarray(
+                    diagnostics.selection_valid,
+                    dtype=float,
+                ),
+                "coreset_selection_accepted": jnp.asarray(
+                    diagnostics.selection_accepted,
+                    dtype=float,
+                ),
+                "coreset_selection_mmd": jnp.asarray(
+                    diagnostics.selection_mmd,
+                    dtype=float,
+                ),
+            }
+        )
+        return metrics
+
+    def refresh_residual_evaluations(
+        self,
+        population: CollocationPopulation,
+        /,
+    ) -> int:
+        _, size = _single_axis_and_size(population.batch)
+        return size * self.candidate_multiplier
+
+    def refresh(
+        self,
+        constraint: FunctionalConstraint,
+        functions: Mapping[str, DomainFunction],
+        population: CollocationPopulation,
+        /,
+        *,
+        key: Key[Array, ""] = DOC_KEY0,
+        iter_: int | Array,
+    ) -> CollocationPopulation:
+        _coreset_diagnostics(population)
+        sampling = _point_sampling(constraint)
+        axis, size = _single_axis_and_size(population.batch)
+        new_count = size * (self.candidate_multiplier - 1)
+        replacement = constraint.component.sample(
+            PointSampling(
+                new_count,
+                layout=sampling.layout,
+                design=self.sampler,
+            ),
+            key=jr.fold_in(key, 1),
+        )
+        if not isinstance(replacement, PointBatch):
+            raise TypeError("Coreset candidate sampling requires a PointBatch.")
+        candidates = _concat_batches(population.batch, replacement)
+        scores = constraint.pointwise_loss(
+            functions,
+            batch=candidates,
+            key=jr.fold_in(key, 2),
+        )
+        candidate_count = size * self.candidate_multiplier
+        _validate_axis_field(
+            scores,
+            axis=axis,
+            size=candidate_count,
+            name="pointwise loss",
+        )
+        score_values = jax.lax.stop_gradient(jnp.asarray(scores.data, dtype=float))
+        importance, importance_ess, effective_uniform, ess_guard_triggered = (
+            _normalized_importance(
+                score_values,
+                exponent=self.exponent,
+                uniform_fraction=self.uniform_fraction,
+                minimum_ess_fraction=self.minimum_ess_fraction,
+                epsilon=self.epsilon,
+            )
+        )
+        point_features = _point_feature_matrix(candidates, axis, candidate_count)
+        normalized_features = _normalize_point_features(point_features)
+        resolved_kernel = _resolve_selection_kernel(
+            normalized_features,
+            kernel=self.kernel,
+            scale_factor=self.kernel_scale_factor,
+        )
+        selection = _compiled_kernel_herd(
+            normalized_features,
+            KernelHerding(
+                size,
+                kernel=resolved_kernel,
+                block_size=self.block_size,
+                unique=True,
+            ),
+            jnp.log(importance),
+        )
+        baseline_fill_distance = _coverage_fill_distance(
+            normalized_features,
+            normalized_features[:size],
+            block_size=self.block_size,
+        )
+        selection_valid = bool(selection.diagnostics.valid)
+        if selection_valid:
+            proposal_fill_distance = _coverage_fill_distance(
+                normalized_features,
+                normalized_features[selection.indices],
+                block_size=self.block_size,
+            )
+            numerical_slack = jnp.sqrt(jnp.finfo(normalized_features.dtype).eps)
+            coverage_valid = bool(
+                proposal_fill_distance
+                <= self.max_fill_distance_ratio * baseline_fill_distance
+                + numerical_slack
+            )
+        else:
+            proposal_fill_distance = jnp.asarray(jnp.inf, dtype=float)
+            coverage_valid = False
+        selection_accepted = selection_valid and coverage_valid
+        if selection_accepted:
+            selected_indices = selection.indices
+            selection_mmd = selection.diagnostics.mmd
+            fallback_kernel_evaluations = 0
+        else:
+            selected_indices = jnp.arange(size, dtype=jnp.int32)
+            selection_mmd = _compiled_weighted_mmd(
+                normalized_features,
+                normalized_features[:size],
+                jnp.log(importance),
+                resolved_kernel,
+                self.block_size,
+            )
+            fallback_kernel_evaluations = (
+                candidate_count * candidate_count
+                + 2 * candidate_count * size
+                + size * size
+            )
+        selected_batch = _take_batch(candidates, selected_indices)
+        candidate_age = jnp.concatenate(
+            (
+                jnp.asarray(population.age.data, dtype=jnp.int32) + 1,
+                jnp.zeros((new_count,), dtype=jnp.int32),
+            )
+        )
+        age = cx.Field(candidate_age[selected_indices], dims=(axis,))
+        step = jnp.asarray(iter_, dtype=jnp.int32)
+        kernel_evaluations = (
+            2 * candidate_count * candidate_count
+            + 2 * candidate_count * size
+            + size * size
+            + fallback_kernel_evaluations
+        )
+        length_scale = jnp.asarray(resolved_kernel.length_scale, dtype=float)
+        return CollocationPopulation(
+            selected_batch,
+            age=age,
+            refresh_count=population.refresh_count + 1,
+            last_refresh=step,
+            diagnostics=_CoresetCollocationDiagnostics(
+                selection_valid=selection.diagnostics.valid,
+                selection_accepted=selection_accepted,
+                selection_mmd=selection_mmd,
+                importance_effective_sample_size=importance_ess,
+                effective_uniform_fraction=effective_uniform,
+                ess_guard_triggered=ess_guard_triggered,
+                kernel_length_scale_min=jnp.min(length_scale),
+                kernel_length_scale_max=jnp.max(length_scale),
+                coverage_fill_distance=proposal_fill_distance,
+                coverage_baseline_fill_distance=baseline_fill_distance,
+                coverage_guard_triggered=selection_valid and not coverage_valid,
+                selection_kernel_evaluations=kernel_evaluations,
+            ),
+        )
+
+
+@eqx.filter_jit
+def _compiled_kernel_herd(
+    points: Array,
+    method: KernelHerding,
+    log_weights: Array,
+    /,
+) -> CoresetSelection:
+    return kernel_herd(points, method, log_weights=log_weights)
+
+
+@eqx.filter_jit
+def _compiled_weighted_mmd(
+    source_points: Array,
+    comparison_points: Array,
+    source_log_weights: Array,
+    kernel: RadialKernel,
+    block_size: int,
+    /,
+) -> Array:
+    return weighted_mmd(
+        source_points,
+        comparison_points,
+        source_log_weights=source_log_weights,
+        kernel=kernel,
+        block_size=block_size,
+    )
+
+
+@jax.jit
+def _normalized_importance(
+    scores: Array,
+    /,
+    *,
+    exponent: Array,
+    uniform_fraction: Array,
+    minimum_ess_fraction: Array,
+    epsilon: Array,
+) -> tuple[Array, Array, Array, Array]:
+    values = jnp.asarray(scores, dtype=float)
+    count = int(values.shape[0])
+    values = jnp.nan_to_num(
+        values,
+        nan=0.0,
+        posinf=jnp.finfo(values.dtype).max,
+        neginf=0.0,
+    )
+    log_signal = exponent * jnp.log(jnp.maximum(values, 0.0) + epsilon)
+    log_signal = jnp.nan_to_num(
+        log_signal,
+        nan=0.0,
+        posinf=jnp.finfo(values.dtype).max,
+        neginf=-jnp.finfo(values.dtype).max,
+    )
+    signal_probability = jax.nn.softmax(log_signal)
+    uniform_probability = jnp.asarray(1.0 / count, dtype=values.dtype)
+    signal_concentration = jnp.sum(signal_probability * signal_probability)
+    target_ess = jnp.maximum(minimum_ess_fraction * count, 1.0)
+    target_concentration = 1.0 / target_ess
+    excess_signal_concentration = signal_concentration - uniform_probability
+    tolerance = 16.0 * jnp.finfo(values.dtype).eps
+    admissible_signal_fraction_squared = jnp.where(
+        excess_signal_concentration > tolerance,
+        (target_concentration - uniform_probability)
+        / excess_signal_concentration,
+        1.0,
+    )
+    required_uniform_fraction = 1.0 - jnp.sqrt(
+        jnp.clip(admissible_signal_fraction_squared, 0.0, 1.0)
+    )
+    effective_uniform_fraction = jnp.maximum(
+        uniform_fraction,
+        required_uniform_fraction,
+    )
+    importance = (
+        effective_uniform_fraction * uniform_probability
+        + (1.0 - effective_uniform_fraction) * signal_probability
+    )
+    importance_ess = 1.0 / jnp.sum(importance * importance)
+    guard_triggered = effective_uniform_fraction > uniform_fraction + tolerance
+    return (
+        importance,
+        importance_ess,
+        effective_uniform_fraction,
+        guard_triggered,
+    )
+
+
+@jax.jit
+def _normalize_point_features(features: Array, /) -> Array:
+    values = jnp.asarray(features, dtype=float)
+    lower = jnp.min(values, axis=0)
+    extent = jnp.max(values, axis=0) - lower
+    tolerance = jnp.sqrt(jnp.finfo(values.dtype).eps)
+    active = extent > tolerance
+    safe_extent = jnp.where(active, extent, 1.0)
+    normalized = (values - lower) / safe_extent
+    return jnp.where(active, normalized, 0.0)
+
+
+def _resolve_selection_kernel(
+    features: Array,
+    /,
+    *,
+    kernel: RadialKernel | None,
+    scale_factor: Array,
+) -> RadialKernel:
+    coordinate_size = int(features.shape[1])
+    if kernel is not None:
+        length_scale = jnp.asarray(kernel.length_scale)
+        if (
+            length_scale.ndim == 1
+            and length_scale.shape[0] not in (1, coordinate_size)
+        ):
+            raise ValueError(
+                "Explicit coreset kernel length_scale must be scalar or match "
+                "the normalized coordinate size."
+            )
+        return kernel
+    length_scale = scale_factor * _median_pairwise_distance(features)
+    minimum_scale = jnp.sqrt(jnp.finfo(features.dtype).eps)
+    return RadialKernel(length_scale=jnp.maximum(length_scale, minimum_scale))
+
+
+@jax.jit
+def _median_pairwise_distance(features: Array, /) -> Array:
+    point_count = int(features.shape[0])
+    sample_count = min(point_count, 256)
+    if sample_count < 2:
+        return jnp.asarray(1.0, dtype=features.dtype)
+    sample_indices = (
+        jnp.arange(sample_count, dtype=jnp.int32) * (point_count - 1)
+        // (sample_count - 1)
+    )
+    sample = features[sample_indices]
+    left_indices, right_indices = jnp.triu_indices(sample_count, k=1)
+    delta = sample[left_indices] - sample[right_indices]
+    distances = jnp.sqrt(jnp.sum(delta * delta, axis=1))
+    positive = distances > jnp.sqrt(jnp.finfo(distances.dtype).eps)
+    ordered = jnp.sort(jnp.where(positive, distances, jnp.inf))
+    positive_count = jnp.sum(positive, dtype=jnp.int32)
+    median_index = jnp.maximum((positive_count - 1) // 2, 0)
+    return jnp.where(
+        positive_count > 0,
+        ordered[median_index],
+        jnp.asarray(1.0, dtype=features.dtype),
+    )
+
+
+@eqx.filter_jit
+def _coverage_fill_distance(
+    points: Array,
+    support: Array,
+    /,
+    *,
+    block_size: int,
+) -> Array:
+    source = jnp.asarray(points, dtype=float)
+    retained = jnp.asarray(support, dtype=float)
+    if source.ndim != 2 or retained.ndim != 2:
+        raise ValueError("Coverage point arrays must be two-dimensional.")
+    if source.shape[1] != retained.shape[1]:
+        raise ValueError("Coverage point arrays must have equal coordinate size.")
+    source_count, coordinate_size = map(int, source.shape)
+    retained_count = int(retained.shape[0])
+    if source_count == 0 or retained_count == 0:
+        raise ValueError("Coverage point arrays must be non-empty.")
+    block = min(int(block_size), max(source_count, retained_count))
+    source_blocks = (source_count + block - 1) // block
+    retained_blocks = (retained_count + block - 1) // block
+    source_padded = jnp.pad(
+        source,
+        ((0, source_blocks * block - source_count), (0, 0)),
+    )
+    retained_padded = jnp.pad(
+        retained,
+        ((0, retained_blocks * block - retained_count), (0, 0)),
+    )
+    offsets = jnp.arange(block, dtype=jnp.int32)
+
+    def source_body(source_block, maximum_squared_distance):
+        source_start = source_block * block
+        left = jax.lax.dynamic_slice(
+            source_padded,
+            (source_start, 0),
+            (block, coordinate_size),
+        )
+
+        def retained_body(retained_block, minimum_squared_distance):
+            retained_start = retained_block * block
+            right = jax.lax.dynamic_slice(
+                retained_padded,
+                (retained_start, 0),
+                (block, coordinate_size),
+            )
+            delta = left[:, None, :] - right[None, :, :]
+            squared_distance = jnp.sum(delta * delta, axis=2)
+            right_valid = retained_start + offsets < retained_count
+            block_minimum = jnp.min(
+                jnp.where(right_valid[None, :], squared_distance, jnp.inf),
+                axis=1,
+            )
+            return jnp.minimum(minimum_squared_distance, block_minimum)
+
+        minimum_squared_distance = jax.lax.fori_loop(
+            0,
+            retained_blocks,
+            retained_body,
+            jnp.full((block,), jnp.inf, dtype=source.dtype),
+        )
+        left_valid = source_start + offsets < source_count
+        block_maximum = jnp.max(
+            jnp.where(left_valid, minimum_squared_distance, 0.0)
+        )
+        return jnp.maximum(maximum_squared_distance, block_maximum)
+
+    maximum_squared_distance = jax.lax.fori_loop(
+        0,
+        source_blocks,
+        source_body,
+        jnp.asarray(0.0, dtype=source.dtype),
+    )
+    return jnp.sqrt(jnp.maximum(maximum_squared_distance, 0.0))
+
+
+def _point_feature_matrix(batch: PointBatch, axis: str, count: int, /) -> Array:
+    matrices = []
+    leaves = jtu.tree_leaves(
+        batch.points,
+        is_leaf=lambda value: isinstance(value, cx.Field),
+    )
+    for leaf in leaves:
+        if not isinstance(leaf, cx.Field) or axis not in leaf.named_dims:
+            continue
+        position = leaf.dims.index(axis)
+        values = jnp.moveaxis(jnp.asarray(leaf.data, dtype=float), position, 0)
+        if values.shape[0] != count:
+            raise ValueError("Candidate point fields disagree on sample count.")
+        matrices.append(values.reshape((count, -1)))
+    if not matrices:
+        raise ValueError("Could not derive coreset coordinates from candidate points.")
+    features = jnp.concatenate(tuple(matrices), axis=1)
+    if bool(jnp.any(~jnp.isfinite(features))):
+        raise ValueError("Coreset candidate coordinates must be finite.")
+    return features
+
+
+def CoresetCollocation(**kwargs) -> CoresetCollocationPolicy:
+    """Construct residual-weighted, diversity-preserving paired collocation."""
+    return CoresetCollocationPolicy(**kwargs)
+
+
+__all__ = ["CoresetCollocation", "CoresetCollocationPolicy"]

--- a/phydrax/coresets/__init__.py
+++ b/phydrax/coresets/__init__.py
@@ -1,0 +1,37 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+"""Measure-compression algorithms returning source indices and positive weights."""
+
+from ._herding import kernel_herd, KernelHerding, weighted_mmd
+from ._kernels import kernel_matrix, KernelName, RadialKernel
+from ._pivoted_cholesky import (
+    randomized_pivoted_cholesky,
+    RandomizedPivotedCholesky,
+)
+from ._recombination import moment_recombine, MomentRecombination
+from ._types import (
+    CoresetSelection,
+    KernelHerdingDiagnostics,
+    MomentRecombinationDiagnostics,
+    PivotedCholeskyDiagnostics,
+)
+
+
+__all__ = [
+    "CoresetSelection",
+    "KernelHerding",
+    "KernelHerdingDiagnostics",
+    "KernelName",
+    "RandomizedPivotedCholesky",
+    "MomentRecombination",
+    "MomentRecombinationDiagnostics",
+    "PivotedCholeskyDiagnostics",
+    "randomized_pivoted_cholesky",
+    "RadialKernel",
+    "kernel_herd",
+    "kernel_matrix",
+    "moment_recombine",
+    "weighted_mmd",
+]

--- a/phydrax/coresets/_herding.py
+++ b/phydrax/coresets/_herding.py
@@ -1,0 +1,239 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array
+
+from .._strict import StrictModule
+from ._kernels import _weighted_kernel_mean, _weighted_kernel_sum, RadialKernel
+from ._types import CoresetSelection, KernelHerdingDiagnostics
+from ._weights import log_weights_from_normalized, normalized_weights
+
+
+class KernelHerding(StrictModule):
+    """Fixed-size greedy minimization of weighted empirical MMD."""
+
+    kernel: RadialKernel
+    num_points: int = eqx.field(static=True)
+    block_size: int = eqx.field(static=True)
+    unique: bool = eqx.field(static=True)
+
+    def __init__(
+        self,
+        num_points: int,
+        /,
+        *,
+        kernel: RadialKernel | None = None,
+        block_size: int = 256,
+        unique: bool = True,
+    ):
+        count = int(num_points)
+        block = int(block_size)
+        if count <= 0:
+            raise ValueError("KernelHerding num_points must be positive.")
+        if block <= 0:
+            raise ValueError("KernelHerding block_size must be positive.")
+        if kernel is not None and not isinstance(kernel, RadialKernel):
+            raise TypeError("kernel must be a RadialKernel or None.")
+        self.num_points = count
+        self.kernel = RadialKernel() if kernel is None else kernel
+        self.block_size = block
+        self.unique = bool(unique)
+
+
+def _mmd_from_weights(
+    source_points: Array,
+    source_weights: Array,
+    comparison_points: Array,
+    comparison_weights: Array,
+    /,
+    *,
+    kernel: RadialKernel,
+    block_size: int,
+) -> Array:
+    source_self = _weighted_kernel_sum(
+        kernel,
+        source_points,
+        source_weights,
+        source_points,
+        source_weights,
+        block_size=block_size,
+    )
+    comparison_self = _weighted_kernel_sum(
+        kernel,
+        comparison_points,
+        comparison_weights,
+        comparison_points,
+        comparison_weights,
+        block_size=block_size,
+    )
+    cross = _weighted_kernel_sum(
+        kernel,
+        source_points,
+        source_weights,
+        comparison_points,
+        comparison_weights,
+        block_size=block_size,
+    )
+    squared = jnp.maximum(source_self + comparison_self - 2.0 * cross, 0.0)
+    return jnp.sqrt(squared)
+
+
+def weighted_mmd(
+    source_points: Array,
+    comparison_points: Array,
+    /,
+    *,
+    source_log_weights: Array | None = None,
+    comparison_log_weights: Array | None = None,
+    source_mask: Array | None = None,
+    comparison_mask: Array | None = None,
+    kernel: RadialKernel | None = None,
+    block_size: int = 256,
+) -> Array:
+    """Compute blockwise MMD between two finite nonnegative measures."""
+    source = jnp.asarray(source_points, dtype=float)
+    comparison = jnp.asarray(comparison_points, dtype=float)
+    if source.ndim != 2 or comparison.ndim != 2:
+        raise ValueError("MMD point arrays must be two-dimensional.")
+    if source.shape[1] != comparison.shape[1]:
+        raise ValueError("MMD point arrays must have equal coordinate size.")
+    block = int(block_size)
+    if block <= 0:
+        raise ValueError("block_size must be positive.")
+    source_rows = jnp.all(jnp.isfinite(source), axis=1)
+    comparison_rows = jnp.all(jnp.isfinite(comparison), axis=1)
+    source_weights, _, source_valid, _ = normalized_weights(
+        int(source.shape[0]),
+        log_weights=source_log_weights,
+        mask=source_mask,
+        rows_valid=source_rows,
+    )
+    comparison_weights, _, comparison_valid, _ = normalized_weights(
+        int(comparison.shape[0]),
+        log_weights=comparison_log_weights,
+        mask=comparison_mask,
+        rows_valid=comparison_rows,
+    )
+    kernel_ = RadialKernel() if kernel is None else kernel
+    if not isinstance(kernel_, RadialKernel):
+        raise TypeError("kernel must be a RadialKernel or None.")
+    value = _mmd_from_weights(
+        jnp.nan_to_num(source),
+        source_weights,
+        jnp.nan_to_num(comparison),
+        comparison_weights,
+        kernel=kernel_,
+        block_size=block,
+    )
+    return jnp.where(source_valid & comparison_valid, value, jnp.nan)
+
+
+def kernel_herd(
+    points: Array,
+    method: KernelHerding,
+    /,
+    *,
+    log_weights: Array | None = None,
+    mask: Array | None = None,
+) -> CoresetSelection:
+    """Select a fixed-capacity weighted empirical kernel herding coreset."""
+    if not isinstance(method, KernelHerding):
+        raise TypeError("method must be a KernelHerding.")
+    values = jnp.asarray(points, dtype=float)
+    if values.ndim != 2:
+        raise ValueError("points must have shape (source_points, coordinate_size).")
+    source_points, coordinate_size = values.shape
+    if source_points < 1:
+        raise ValueError("Kernel herding requires at least one source point.")
+    if method.unique and method.num_points > source_points:
+        raise ValueError("Unique kernel herding cannot select more points than supplied.")
+    rows_valid = jnp.all(jnp.isfinite(values), axis=1)
+    weights, active_source, input_valid, log_source_mass = normalized_weights(
+        source_points,
+        log_weights=log_weights,
+        mask=mask,
+        rows_valid=rows_valid,
+    )
+    safe_points = jnp.nan_to_num(values)
+    target_mean = _weighted_kernel_mean(
+        method.kernel,
+        safe_points,
+        weights,
+        block_size=method.block_size,
+    )
+    capacity = method.num_points
+    initial = (
+        jnp.zeros((capacity,), dtype=jnp.int32),
+        jnp.zeros((capacity,), dtype=bool),
+        jnp.zeros((source_points,), dtype=safe_points.dtype),
+        jnp.zeros((source_points,), dtype=bool),
+    )
+
+    def body(iteration, state):
+        indices, output_mask, penalty, selected = state
+        denominator = jnp.asarray(iteration + 1, dtype=safe_points.dtype)
+        objective = target_mean - penalty / denominator
+        eligible = active_source & (~selected if method.unique else True)
+        candidate = jnp.asarray(
+            jnp.argmax(jnp.where(eligible, objective, -jnp.inf)),
+            dtype=jnp.int32,
+        )
+        valid_choice = input_valid & jnp.any(eligible)
+        indices = indices.at[iteration].set(candidate)
+        output_mask = output_mask.at[iteration].set(valid_choice)
+        update = method.kernel(safe_points, safe_points[candidate])
+        penalty = penalty + jnp.where(valid_choice, update, 0.0)
+        selected = selected.at[candidate].set(selected[candidate] | valid_choice)
+        return indices, output_mask, penalty, selected
+
+    indices, output_mask, _, _ = jax.lax.fori_loop(0, capacity, body, initial)
+    active_points = jnp.sum(output_mask, dtype=jnp.int32)
+    equal_weight = jnp.where(
+        active_points > 0,
+        1.0 / active_points.astype(safe_points.dtype),
+        0.0,
+    )
+    selected_weights = jnp.where(output_mask, equal_weight, 0.0)
+    selected_points = safe_points[indices]
+    discrepancy = _mmd_from_weights(
+        safe_points,
+        weights,
+        selected_points,
+        selected_weights,
+        kernel=method.kernel,
+        block_size=method.block_size,
+    )
+    output_valid = input_valid & (active_points > 0) & jnp.isfinite(discrepancy)
+    output_mask = output_mask & output_valid
+    selected_weights = jnp.where(output_mask, selected_weights, 0.0)
+    minimum_weight = jnp.min(
+        jnp.where(output_mask, selected_weights, jnp.inf),
+        initial=jnp.inf,
+    )
+    diagnostics = KernelHerdingDiagnostics(
+        valid=output_valid,
+        active_points=active_points,
+        mmd=discrepancy,
+        minimum_weight=minimum_weight,
+        log_source_mass=log_source_mass,
+        source_points=source_points,
+        capacity=capacity,
+        coordinate_size=coordinate_size,
+        kernel=method.kernel.name,
+    )
+    return CoresetSelection(
+        indices,
+        log_weights_from_normalized(selected_weights, output_mask),
+        output_mask,
+        diagnostics,
+        method="kernel-herding",
+    )
+
+
+__all__ = ["KernelHerding", "kernel_herd", "weighted_mmd"]

--- a/phydrax/coresets/_kernels.py
+++ b/phydrax/coresets/_kernels.py
@@ -1,0 +1,197 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from typing import Literal
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array, ArrayLike
+
+from .._strict import StrictModule
+
+
+KernelName = Literal[
+    "squared_exponential",
+    "matern32",
+    "matern52",
+    "inverse_multiquadric",
+]
+
+
+class RadialKernel(StrictModule):
+    """Small scalar radial-kernel contract for coreset selection."""
+
+    length_scale: Array
+    name: KernelName = eqx.field(static=True)
+
+    def __init__(
+        self,
+        name: KernelName = "squared_exponential",
+        /,
+        *,
+        length_scale: ArrayLike = 1.0,
+    ):
+        if name not in (
+            "squared_exponential",
+            "matern32",
+            "matern52",
+            "inverse_multiquadric",
+        ):
+            raise ValueError(f"Unknown coreset kernel {name!r}.")
+        scale = jnp.asarray(length_scale, dtype=float)
+        if scale.ndim > 1:
+            raise ValueError("length_scale must be scalar or one-dimensional.")
+        if bool(jnp.any(~jnp.isfinite(scale) | (scale <= 0.0))):
+            raise ValueError("length_scale must be finite and strictly positive.")
+        self.name = name
+        self.length_scale = scale
+
+    def __call__(self, left: Array, right: Array, /) -> Array:
+        left_ = jnp.asarray(left, dtype=float)
+        right_ = jnp.asarray(right, dtype=float)
+        delta = (left_ - right_) / self.length_scale
+        squared_distance = jnp.sum(delta * delta, axis=-1)
+        if self.name == "squared_exponential":
+            return jnp.exp(-0.5 * squared_distance)
+        distance = jnp.sqrt(jnp.maximum(squared_distance, 0.0))
+        if self.name == "matern32":
+            scaled = jnp.sqrt(3.0) * distance
+            return (1.0 + scaled) * jnp.exp(-scaled)
+        if self.name == "matern52":
+            scaled = jnp.sqrt(5.0) * distance
+            return (1.0 + scaled + scaled * scaled / 3.0) * jnp.exp(-scaled)
+        return jax.lax.rsqrt(1.0 + squared_distance)
+
+
+def kernel_matrix(kernel: RadialKernel, left: Array, right: Array, /) -> Array:
+    """Evaluate a scalar kernel over two leading point axes."""
+    left_ = jnp.asarray(left, dtype=float)
+    right_ = jnp.asarray(right, dtype=float)
+    if left_.ndim != 2 or right_.ndim != 2:
+        raise ValueError("Kernel point arrays must be two-dimensional.")
+    if left_.shape[1] != right_.shape[1]:
+        raise ValueError("Kernel point arrays must have equal coordinate size.")
+    return kernel(left_[:, None, :], right_[None, :, :])
+
+
+def _weighted_kernel_sum(
+    kernel: RadialKernel,
+    left: Array,
+    left_weights: Array,
+    right: Array,
+    right_weights: Array,
+    /,
+    *,
+    block_size: int,
+) -> Array:
+    left_count, coordinate_size = left.shape
+    right_count = int(right.shape[0])
+    block = int(block_size)
+    left_blocks = (left_count + block - 1) // block
+    right_blocks = (right_count + block - 1) // block
+    left_padding = left_blocks * block - left_count
+    right_padding = right_blocks * block - right_count
+    padded_left = jnp.pad(left, ((0, left_padding), (0, 0)))
+    padded_right = jnp.pad(right, ((0, right_padding), (0, 0)))
+    padded_left_weights = jnp.pad(left_weights, (0, left_padding))
+    padded_right_weights = jnp.pad(right_weights, (0, right_padding))
+
+    def left_body(left_index, total):
+        left_start = left_index * block
+        left_points = jax.lax.dynamic_slice(
+            padded_left,
+            (left_start, 0),
+            (block, coordinate_size),
+        )
+        left_mass = jax.lax.dynamic_slice(
+            padded_left_weights,
+            (left_start,),
+            (block,),
+        )
+
+        def right_body(right_index, subtotal):
+            right_start = right_index * block
+            right_points = jax.lax.dynamic_slice(
+                padded_right,
+                (right_start, 0),
+                (block, coordinate_size),
+            )
+            right_mass = jax.lax.dynamic_slice(
+                padded_right_weights,
+                (right_start,),
+                (block,),
+            )
+            values = kernel_matrix(kernel, left_points, right_points)
+            return subtotal + jnp.sum(
+                left_mass[:, None] * values * right_mass[None, :]
+            )
+
+        return jax.lax.fori_loop(
+            0,
+            right_blocks,
+            right_body,
+            total,
+        )
+
+    return jax.lax.fori_loop(
+        0,
+        left_blocks,
+        left_body,
+        jnp.asarray(0.0, dtype=left.dtype),
+    )
+
+
+def _weighted_kernel_mean(
+    kernel: RadialKernel,
+    points: Array,
+    weights: Array,
+    /,
+    *,
+    block_size: int,
+) -> Array:
+    count, coordinate_size = points.shape
+    block = int(block_size)
+    blocks = (count + block - 1) // block
+    padding = blocks * block - count
+    padded_points = jnp.pad(points, ((0, padding), (0, 0)))
+    padded_weights = jnp.pad(weights, (0, padding))
+    output = jnp.zeros((blocks * block,), dtype=points.dtype)
+
+    def outer_body(outer_index, means):
+        outer_start = outer_index * block
+        outer_points = jax.lax.dynamic_slice(
+            padded_points,
+            (outer_start, 0),
+            (block, coordinate_size),
+        )
+
+        def inner_body(inner_index, subtotal):
+            inner_start = inner_index * block
+            inner_points = jax.lax.dynamic_slice(
+                padded_points,
+                (inner_start, 0),
+                (block, coordinate_size),
+            )
+            inner_weights = jax.lax.dynamic_slice(
+                padded_weights,
+                (inner_start,),
+                (block,),
+            )
+            return subtotal + kernel_matrix(kernel, outer_points, inner_points) @ inner_weights
+
+        block_mean = jax.lax.fori_loop(
+            0,
+            blocks,
+            inner_body,
+            jnp.zeros((block,), dtype=points.dtype),
+        )
+        return jax.lax.dynamic_update_slice(means, block_mean, (outer_start,))
+
+    return jax.lax.fori_loop(0, blocks, outer_body, output)[:count]
+
+
+__all__ = ["KernelName", "RadialKernel", "kernel_matrix"]

--- a/phydrax/coresets/_pivoted_cholesky.py
+++ b/phydrax/coresets/_pivoted_cholesky.py
@@ -1,0 +1,147 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+from jaxtyping import Array, Key
+
+from .._doc import DOC_KEY0
+from .._strict import StrictModule
+from ._kernels import RadialKernel
+from ._types import CoresetSelection, PivotedCholeskyDiagnostics
+from ._weights import log_weights_from_normalized
+
+
+class RandomizedPivotedCholesky(StrictModule):
+    """Residual-diagonal randomized pivoting for kernel column selection."""
+
+    kernel: RadialKernel
+    num_points: int = eqx.field(static=True)
+
+    def __init__(
+        self,
+        num_points: int,
+        /,
+        *,
+        kernel: RadialKernel | None = None,
+    ):
+        count = int(num_points)
+        if count <= 0:
+            raise ValueError("num_points must be positive.")
+        if kernel is not None and not isinstance(kernel, RadialKernel):
+            raise TypeError("kernel must be a RadialKernel or None.")
+        self.num_points = count
+        self.kernel = RadialKernel() if kernel is None else kernel
+
+
+def randomized_pivoted_cholesky(
+    points: Array,
+    method: RandomizedPivotedCholesky,
+    /,
+    *,
+    key: Key[Array, ""] = DOC_KEY0,
+) -> CoresetSelection:
+    """Select source rows using randomized residual Cholesky pivots."""
+    if not isinstance(method, RandomizedPivotedCholesky):
+        raise TypeError("method must be a RandomizedPivotedCholesky.")
+    values = jnp.asarray(points, dtype=float)
+    if values.ndim != 2:
+        raise ValueError("points must have shape (source_points, coordinate_size).")
+    source_points = int(values.shape[0])
+    if source_points < 1:
+        raise ValueError("Pivoted Cholesky requires at least one source point.")
+    if method.num_points > source_points:
+        raise ValueError("Cannot select more inducing points than source points.")
+    rows_valid = jnp.all(jnp.isfinite(values), axis=1)
+    input_valid = jnp.all(rows_valid)
+    safe_points = jnp.nan_to_num(values)
+    diagonal = method.kernel(safe_points, safe_points)
+    diagonal = jnp.where(rows_valid, jnp.maximum(diagonal, 0.0), 0.0)
+    initial_trace = jnp.sum(diagonal)
+    capacity = method.num_points
+    columns = jnp.zeros((source_points, capacity), dtype=safe_points.dtype)
+    indices = jnp.zeros((capacity,), dtype=jnp.int32)
+    output_mask = jnp.zeros((capacity,), dtype=bool)
+    selected = jnp.zeros((source_points,), dtype=bool)
+    tolerance = jnp.asarray(
+        jnp.finfo(safe_points.dtype).eps * jnp.maximum(initial_trace, 1.0) * 32.0
+    )
+
+    def body(iteration, state):
+        residual, factors, chosen, active, used = state
+        eligible_residual = jnp.where(~used, jnp.maximum(residual, 0.0), 0.0)
+        total = jnp.sum(eligible_residual)
+        valid_choice = input_valid & (total > tolerance)
+        fallback = jnp.full(
+            (source_points,),
+            1.0 / float(source_points),
+            dtype=safe_points.dtype,
+        )
+        probabilities = jnp.where(
+            total > 0.0,
+            eligible_residual / total,
+            fallback,
+        )
+        pivot = jnp.asarray(
+            jr.choice(jr.fold_in(key, iteration), source_points, p=probabilities),
+            dtype=jnp.int32,
+        )
+        kernel_column = method.kernel(safe_points, safe_points[pivot])
+        previous = factors @ factors[pivot]
+        pivot_residual = jnp.maximum(residual[pivot], tolerance)
+        column = (kernel_column - previous) / jnp.sqrt(pivot_residual)
+        column = jnp.where(valid_choice, column, 0.0)
+        factors = factors.at[:, iteration].set(column)
+        residual = jnp.maximum(residual - column * column, 0.0)
+        residual = residual.at[pivot].set(jnp.where(valid_choice, 0.0, residual[pivot]))
+        chosen = chosen.at[iteration].set(pivot)
+        active = active.at[iteration].set(valid_choice)
+        used = used.at[pivot].set(used[pivot] | valid_choice)
+        return residual, factors, chosen, active, used
+
+    residual, _, indices, output_mask, _ = jax.lax.fori_loop(
+        0,
+        capacity,
+        body,
+        (diagonal, columns, indices, output_mask, selected),
+    )
+    active_points = jnp.sum(output_mask, dtype=jnp.int32)
+    residual_trace = jnp.sum(residual)
+    explained = jnp.where(
+        initial_trace > 0.0,
+        jnp.clip(1.0 - residual_trace / initial_trace, 0.0, 1.0),
+        0.0,
+    )
+    output_valid = input_valid & (active_points == capacity)
+    output_mask = output_mask & output_valid
+    equal_weight = jnp.where(
+        active_points > 0,
+        1.0 / active_points.astype(safe_points.dtype),
+        0.0,
+    )
+    weights = jnp.where(output_mask, equal_weight, 0.0)
+    diagnostics = PivotedCholeskyDiagnostics(
+        valid=output_valid,
+        active_points=active_points,
+        initial_trace=initial_trace,
+        residual_trace=residual_trace,
+        explained_trace_fraction=explained,
+        source_points=source_points,
+        capacity=capacity,
+        kernel=method.kernel.name,
+    )
+    return CoresetSelection(
+        indices,
+        log_weights_from_normalized(weights, output_mask),
+        output_mask,
+        diagnostics,
+        method="randomized-pivoted-cholesky",
+    )
+
+
+__all__ = ["RandomizedPivotedCholesky", "randomized_pivoted_cholesky"]

--- a/phydrax/coresets/_recombination.py
+++ b/phydrax/coresets/_recombination.py
@@ -1,0 +1,290 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import math
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array
+
+from .._strict import StrictModule
+from ._types import CoresetSelection, MomentRecombinationDiagnostics
+from ._weights import log_weights_from_normalized, normalized_weights
+
+
+class MomentRecombination(StrictModule):
+    """Hierarchical positive reduction preserving supplied feature moments."""
+
+    rcond: float | None = eqx.field(static=True)
+    tree_reduction_factor: int = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        rcond: float | None = None,
+        tree_reduction_factor: int = 2,
+    ):
+        if rcond is not None:
+            condition = float(rcond)
+            if not math.isfinite(condition) or condition <= 0.0:
+                raise ValueError("rcond must be finite and strictly positive.")
+        factor = int(tree_reduction_factor)
+        if factor < 2:
+            raise ValueError("tree_reduction_factor must be at least two.")
+        self.rcond = None if rcond is None else float(rcond)
+        self.tree_reduction_factor = factor
+
+
+def _rank_and_tolerance(
+    augmented: Array,
+    weights: Array,
+    rcond: float | None,
+    /,
+) -> tuple[Array, Array]:
+    weighted = jnp.sqrt(jnp.maximum(weights, 0.0))[:, None] * augmented
+    singular_values = jnp.linalg.svd(weighted, full_matrices=False, compute_uv=False)
+    dtype = augmented.dtype
+    relative = (
+        jnp.asarray(rcond, dtype=dtype)
+        if rcond is not None
+        else jnp.asarray(
+            jnp.finfo(dtype).eps * max(augmented.shape),
+            dtype=dtype,
+        )
+    )
+    largest = jnp.max(singular_values, initial=jnp.asarray(0.0, dtype=dtype))
+    threshold = relative * largest
+    rank = jnp.sum(singular_values > threshold, dtype=jnp.int32)
+    weight_tolerance = jnp.asarray(jnp.finfo(dtype).eps * augmented.shape[0] * 16.0)
+    return rank, weight_tolerance
+
+
+def _eliminate_to_rank(
+    augmented: Array,
+    weights: Array,
+    /,
+    *,
+    rcond: float | None,
+) -> tuple[Array, Array]:
+    count, feature_count = augmented.shape
+    rank, weight_tolerance = _rank_and_tolerance(augmented, weights, rcond)
+    slots = feature_count + 1
+    slot_ids = jnp.arange(slots)
+
+    def eliminate_once(current: Array) -> Array:
+        active = current > weight_tolerance
+        active_count = jnp.sum(active, dtype=jnp.int32)
+        selected = jnp.nonzero(active, size=slots, fill_value=0)[0]
+        valid_slots = slot_ids < jnp.minimum(active_count, slots)
+        selected_features = augmented[selected].T
+        fixed_zero = jnp.diag((~valid_slots).astype(augmented.dtype))
+        system = jnp.concatenate((selected_features, fixed_zero), axis=0)
+        _, _, vectors = jnp.linalg.svd(system, full_matrices=False)
+        null_vector = jnp.where(valid_slots, vectors[-1], 0.0)
+        null_scale = jnp.max(jnp.abs(null_vector), initial=0.0)
+        null_vector = jnp.where(
+            null_scale > 0.0,
+            null_vector / null_scale,
+            null_vector,
+        )
+        selected_weights = current[selected]
+        direction_tolerance = jnp.asarray(jnp.finfo(augmented.dtype).eps * 32.0)
+        positive = null_vector > direction_tolerance
+        negative = null_vector < -direction_tolerance
+        positive_step = jnp.min(
+            jnp.where(positive & valid_slots, selected_weights / null_vector, jnp.inf),
+            initial=jnp.inf,
+        )
+        negative_step = jnp.min(
+            jnp.where(
+                negative & valid_slots,
+                selected_weights / -null_vector,
+                jnp.inf,
+            ),
+            initial=jnp.inf,
+        )
+        use_positive = positive_step <= negative_step
+        step = jnp.where(use_positive, positive_step, negative_step)
+        direction = jnp.where(use_positive, null_vector, -null_vector)
+        proposed = selected_weights - step * direction
+        proposed = jnp.where(
+            valid_slots,
+            jnp.where(proposed <= weight_tolerance, 0.0, jnp.maximum(proposed, 0.0)),
+            selected_weights,
+        )
+        delta = jnp.where(valid_slots, proposed - selected_weights, 0.0)
+        updated = current.at[selected].add(delta)
+        can_reduce = (
+            (active_count > rank)
+            & jnp.isfinite(step)
+            & (null_scale > direction_tolerance)
+        )
+        return jnp.where(can_reduce, updated, current)
+
+    def body(_, current):
+        return eliminate_once(current)
+
+    reduced = jax.lax.fori_loop(0, count, body, weights)
+    reduced = jnp.where(reduced > weight_tolerance, reduced, 0.0)
+    return reduced, rank
+
+
+def _standardized_augmented(features: Array, weights: Array, /) -> Array:
+    feature_count = int(features.shape[1])
+    if feature_count == 0:
+        return jnp.ones((features.shape[0], 1), dtype=features.dtype)
+    mean = weights @ features
+    centered = features - mean
+    variance = weights @ (centered * centered)
+    scale = jnp.sqrt(jnp.maximum(variance, 0.0))
+    floor = jnp.asarray(jnp.finfo(features.dtype).eps * 64.0)
+    safe_scale = jnp.where(scale > floor, scale, 1.0)
+    standardized = centered / safe_scale
+    return jnp.concatenate(
+        (jnp.ones((features.shape[0], 1), dtype=features.dtype), standardized),
+        axis=1,
+    )
+
+
+def moment_recombine(
+    features: Array,
+    method: MomentRecombination | None = None,
+    /,
+    *,
+    log_weights: Array | None = None,
+    mask: Array | None = None,
+) -> CoresetSelection:
+    """Reduce one positive empirical measure while preserving feature moments."""
+    config = MomentRecombination() if method is None else method
+    if not isinstance(config, MomentRecombination):
+        raise TypeError("method must be a MomentRecombination.")
+    feature_values = jnp.asarray(features, dtype=float)
+    if feature_values.ndim != 2:
+        raise ValueError("features must have shape (source_points, feature_count).")
+    source_points, supplied_feature_count = feature_values.shape
+    if source_points < 1:
+        raise ValueError("Moment recombination requires at least one source point.")
+    rows_valid = jnp.all(jnp.isfinite(feature_values), axis=1)
+    weights, _, input_valid, log_source_mass = normalized_weights(
+        source_points,
+        log_weights=log_weights,
+        mask=mask,
+        rows_valid=rows_valid,
+    )
+    safe_features = jnp.nan_to_num(feature_values)
+    augmented = _standardized_augmented(safe_features, weights)
+    capacity = supplied_feature_count + 1
+    factor = config.tree_reduction_factor
+    depth = (
+        0
+        if source_points <= capacity
+        else math.ceil(math.log(source_points / capacity, factor))
+    )
+    padded_count = capacity * factor**depth
+    padding = padded_count - source_points
+    current_features = jnp.pad(augmented, ((0, padding), (0, 0)))
+    current_weights = jnp.pad(weights, (0, padding))
+    current_indices = jnp.pad(jnp.arange(source_points, dtype=jnp.int32), (0, padding))
+    current_count = padded_count
+
+    for _ in range(depth):
+        cluster_count = factor * capacity
+        cluster_size = current_count // cluster_count
+        order = jnp.argsort(current_weights)
+        groups = order.reshape((cluster_size, cluster_count)).T
+        grouped_weights = current_weights[groups]
+        cluster_mass = jnp.sum(grouped_weights, axis=1)
+        weighted_features = jnp.sum(
+            grouped_weights[..., None] * current_features[groups],
+            axis=1,
+        )
+        safe_mass = jnp.where(cluster_mass > 0.0, cluster_mass, 1.0)
+        centroids = weighted_features / safe_mass[:, None]
+        reduced_mass, _ = _eliminate_to_rank(
+            centroids,
+            cluster_mass,
+            rcond=config.rcond,
+        )
+        selected_clusters = jnp.nonzero(
+            reduced_mass > 0.0,
+            size=capacity,
+            fill_value=0,
+        )[0]
+        selected_mass = reduced_mass[selected_clusters]
+        original_mass = cluster_mass[selected_clusters]
+        multiplier = jnp.where(original_mass > 0.0, selected_mass / original_mass, 0.0)
+        selected_groups = groups[selected_clusters]
+        current_features = current_features[selected_groups].reshape(
+            (capacity * cluster_size, capacity)
+        )
+        current_indices = current_indices[selected_groups].reshape(
+            (capacity * cluster_size,)
+        )
+        current_weights = (
+            grouped_weights[selected_clusters] * multiplier[:, None]
+        ).reshape((capacity * cluster_size,))
+        current_count = capacity * cluster_size
+
+    final_weights, numerical_rank = _eliminate_to_rank(
+        current_features,
+        current_weights,
+        rcond=config.rcond,
+    )
+    order = jnp.argsort(final_weights)[::-1]
+    selected_indices = current_indices[order]
+    selected_weights = final_weights[order]
+    dtype = selected_weights.dtype
+    active_tolerance = jnp.asarray(jnp.finfo(dtype).eps * capacity * 16.0)
+    selected_mask = selected_weights > active_tolerance
+    selected_weights = jnp.where(selected_mask, selected_weights, 0.0)
+    selected_total = jnp.sum(selected_weights)
+    selected_weights = jnp.where(
+        selected_total > 0.0,
+        selected_weights / selected_total,
+        selected_weights,
+    )
+    source_moments = weights @ safe_features
+    selected_moments = selected_weights @ safe_features[selected_indices]
+    mass_error = jnp.abs(jnp.sum(selected_weights) - jnp.sum(weights))
+    max_moment_error = (
+        jnp.max(jnp.abs(selected_moments - source_moments))
+        if supplied_feature_count
+        else jnp.asarray(0.0, dtype=dtype)
+    )
+    active_points = jnp.sum(selected_mask, dtype=jnp.int32)
+    minimum_weight = jnp.min(
+        jnp.where(selected_mask, selected_weights, jnp.inf),
+        initial=jnp.inf,
+    )
+    output_valid = input_valid & (active_points > 0) & jnp.all(
+        jnp.isfinite(selected_weights)
+    )
+    selected_mask = selected_mask & output_valid
+    selected_weights = jnp.where(selected_mask, selected_weights, 0.0)
+    diagnostics = MomentRecombinationDiagnostics(
+        valid=output_valid,
+        active_points=active_points,
+        numerical_rank=numerical_rank,
+        mass_error=mass_error,
+        max_moment_error=max_moment_error,
+        minimum_weight=minimum_weight,
+        log_source_mass=log_source_mass,
+        source_points=source_points,
+        capacity=capacity,
+        feature_count=supplied_feature_count,
+        tree_depth=depth,
+    )
+    return CoresetSelection(
+        selected_indices,
+        log_weights_from_normalized(selected_weights, selected_mask),
+        selected_mask,
+        diagnostics,
+        method="moment-recombination",
+    )
+
+
+__all__ = ["MomentRecombination", "moment_recombine"]

--- a/phydrax/coresets/_types.py
+++ b/phydrax/coresets/_types.py
@@ -1,0 +1,112 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from typing import Any
+
+import equinox as eqx
+import jax.numpy as jnp
+from jaxtyping import Array
+
+from .._strict import StrictModule
+
+
+class CoresetSelection(StrictModule):
+    """Fixed-capacity source indices and normalized weights for a coreset."""
+
+    indices: Array
+    log_weights: Array
+    mask: Array
+    diagnostics: Any
+    method: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        indices: Array,
+        log_weights: Array,
+        mask: Array,
+        diagnostics: Any,
+        /,
+        *,
+        method: str,
+    ):
+        indices_ = jnp.asarray(indices, dtype=jnp.int32)
+        log_weights_ = jnp.asarray(log_weights, dtype=float)
+        mask_ = jnp.asarray(mask, dtype=bool)
+        if indices_.ndim != 1:
+            raise ValueError("Coreset indices must be one-dimensional.")
+        if log_weights_.shape != indices_.shape or mask_.shape != indices_.shape:
+            raise ValueError("Coreset indices, log_weights, and mask must have equal shape.")
+        method_ = str(method)
+        if not method_:
+            raise ValueError("Coreset selection method must be non-empty.")
+        self.indices = indices_
+        self.log_weights = log_weights_
+        self.mask = mask_
+        self.diagnostics = diagnostics
+        self.method = method_
+
+    @property
+    def capacity(self) -> int:
+        return int(self.indices.shape[0])
+
+    @property
+    def active_points(self) -> Array:
+        return jnp.sum(self.mask, dtype=jnp.int32)
+
+    @property
+    def weights(self) -> Array:
+        return jnp.where(self.mask, jnp.exp(self.log_weights), 0.0)
+
+
+class MomentRecombinationDiagnostics(StrictModule):
+    """Mass, rank, and moment evidence for hierarchical recombination."""
+
+    valid: Array
+    active_points: Array
+    numerical_rank: Array
+    mass_error: Array
+    max_moment_error: Array
+    minimum_weight: Array
+    log_source_mass: Array
+    source_points: int = eqx.field(static=True)
+    capacity: int = eqx.field(static=True)
+    feature_count: int = eqx.field(static=True)
+    tree_depth: int = eqx.field(static=True)
+
+
+class KernelHerdingDiagnostics(StrictModule):
+    """Weighted empirical-measure discrepancy after kernel herding."""
+
+    valid: Array
+    active_points: Array
+    mmd: Array
+    minimum_weight: Array
+    log_source_mass: Array
+    source_points: int = eqx.field(static=True)
+    capacity: int = eqx.field(static=True)
+    coordinate_size: int = eqx.field(static=True)
+    kernel: str = eqx.field(static=True)
+
+
+class PivotedCholeskyDiagnostics(StrictModule):
+    """Residual-kernel evidence for an inducing-point selection."""
+
+    valid: Array
+    active_points: Array
+    initial_trace: Array
+    residual_trace: Array
+    explained_trace_fraction: Array
+    source_points: int = eqx.field(static=True)
+    capacity: int = eqx.field(static=True)
+    kernel: str = eqx.field(static=True)
+
+
+__all__ = [
+    "CoresetSelection",
+    "KernelHerdingDiagnostics",
+    "MomentRecombinationDiagnostics",
+    "PivotedCholeskyDiagnostics",
+]

--- a/phydrax/coresets/_weights.py
+++ b/phydrax/coresets/_weights.py
@@ -1,0 +1,57 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.scipy as jsp
+from jaxtyping import Array
+
+
+def normalized_weights(
+    count: int,
+    /,
+    *,
+    log_weights: Array | None,
+    mask: Array | None,
+    rows_valid: Array | None = None,
+) -> tuple[Array, Array, Array, Array]:
+    """Normalize a masked finite log-weight vector without changing its shape."""
+    if log_weights is None:
+        values = jnp.zeros((count,), dtype=float)
+    else:
+        values = jnp.asarray(log_weights, dtype=float)
+        if values.shape != (count,):
+            raise ValueError(f"log_weights must have shape ({count},).")
+    if mask is None:
+        included = jnp.ones((count,), dtype=bool)
+    else:
+        included = jnp.asarray(mask, dtype=bool)
+        if included.shape != (count,):
+            raise ValueError(f"mask must have shape ({count},).")
+    if rows_valid is None:
+        finite_rows = jnp.ones((count,), dtype=bool)
+    else:
+        finite_rows = jnp.asarray(rows_valid, dtype=bool)
+        if finite_rows.shape != (count,):
+            raise ValueError(f"rows_valid must have shape ({count},).")
+    admissible = jnp.isfinite(values) | jnp.isneginf(values)
+    valid_inputs = jnp.all(~included | (admissible & finite_rows))
+    active = included & finite_rows & jnp.isfinite(values)
+    safe_values = jnp.where(active, values, -jnp.inf)
+    log_mass = jsp.special.logsumexp(safe_values)
+    valid = valid_inputs & jnp.isfinite(log_mass)
+    weights = jnp.where(valid & active, jnp.exp(safe_values - log_mass), 0.0)
+    return weights, active, valid, log_mass
+
+
+def log_weights_from_normalized(weights: Array, mask: Array, /) -> Array:
+    """Represent normalized nonnegative weights with inactive negative infinities."""
+    values = jnp.asarray(weights, dtype=float)
+    included = jnp.asarray(mask, dtype=bool)
+    safe = jnp.where(included, values, 1.0)
+    return jnp.where(included, jnp.log(safe), -jnp.inf)
+
+
+__all__ = ["log_weights_from_normalized", "normalized_weights"]

--- a/phydrax/integration/__init__.py
+++ b/phydrax/integration/__init__.py
@@ -12,6 +12,11 @@ from ._batches import (
     SeparableIntegrationBatch,
     WeightedSampleBatch,
 )
+from ._compression import (
+    compress,
+    CompressedIntegrationDiagnostics,
+    MeasureCompressionDiagnostics,
+)
 from ._estimates import (
     AdaptivePartition,
     AdaptiveQuadratureDiagnostics,
@@ -139,6 +144,7 @@ __all__ = [
     "AntitheticDiagnostics",
     "CellQuadraturePlan",
     "ClenshawCurtisRule",
+    "CompressedIntegrationDiagnostics",
     "ComponentTarget",
     "ControlVariateEstimator",
     "DensityTarget",
@@ -155,6 +161,7 @@ __all__ = [
     "IntegrationBatch",
     "IntegrationEstimate",
     "IntegrationPlan",
+    "MeasureCompressionDiagnostics",
     "IntegrationProvenance",
     "IntegrationStatus",
     "IntegrationRealization",
@@ -205,6 +212,7 @@ __all__ = [
     "TanhSinhRule",
     "WeightedSampleBatch",
     "WeightedSampleTarget",
+    "compress",
     "discrete",
     "density",
     "from_samples",

--- a/phydrax/integration/_api.py
+++ b/phydrax/integration/_api.py
@@ -70,12 +70,41 @@ _KEY_UNSET = object()
 
 
 class IntegrationRealization(StrictModule):
-    """A target, plan, and reusable materialized execution realization."""
+    """A target, plan, reusable batch, execution key, and optional compression."""
 
     target: Any
     plan: Any
     batch: Any
     key: Any
+    compression: Any | None = None
+
+def _attach_compression(
+    estimate: IntegrationEstimate,
+    realization: IntegrationRealization,
+    /,
+) -> IntegrationEstimate:
+    if realization.compression is None:
+        return estimate
+    from ._compression import CompressedIntegrationDiagnostics
+    from ._estimates import IntegrationProvenance
+
+    return IntegrationEstimate(
+        estimate.value,
+        status=estimate.status,
+        num_evaluations=estimate.num_evaluations,
+        error_estimate=None,
+        error_kind=None,
+        diagnostics=CompressedIntegrationDiagnostics(
+            realization.compression,
+            estimate.diagnostics,
+        ),
+        provenance=IntegrationProvenance(
+            "compressed",
+            estimate.provenance.target,
+            estimate.provenance.realization,
+        ),
+    )
+
 
 
 def _base_target(target: Any, /) -> Any:
@@ -281,9 +310,10 @@ def reduce(
     plan = realization.plan
     key = DOC_KEY0 if realization.key is None else realization.key
     if isinstance(target, WeightedSampleTarget):
-        return integrate_weighted_samples(
+        estimate = integrate_weighted_samples(
             integrand, target, realization.batch, key=key, kwargs=kwargs
         )
+        return _attach_compression(estimate, realization)
     if isinstance(target, DiscreteMeasureTarget):
         return integrate_discrete_measure(
             integrand, target, realization.batch, key=key, kwargs=kwargs

--- a/phydrax/integration/_compression.py
+++ b/phydrax/integration/_compression.py
@@ -1,0 +1,405 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, cast
+
+import coordax as cx
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.tree_util as jtu
+from jaxtyping import Array
+
+from phydrax.coresets import (
+    CoresetSelection,
+    kernel_herd,
+    KernelHerding,
+    moment_recombine,
+    MomentRecombination,
+)
+from phydrax.domain import PointBatch
+
+from .._strict import StrictModule
+from ._batches import PointIntegrationBatch, WeightedSampleBatch
+from ._targets import (
+    DiscreteMeasureTarget,
+    ProbabilityTarget,
+    WeightedSampleTarget,
+)
+
+
+CompressionMethod = MomentRecombination | KernelHerding
+FeatureMap = Callable[[Any], Any]
+
+
+class MeasureCompressionDiagnostics(StrictModule):
+    """Selection evidence and source identity for one compressed realization."""
+
+    selection: Any
+    source_mass: Array
+    source_points: int = eqx.field(static=True)
+    feature_count: int = eqx.field(static=True)
+    source_provenance: str = eqx.field(static=True)
+
+
+class CompressedIntegrationDiagnostics(StrictModule):
+    """Compression evidence paired with the downstream measure reduction."""
+
+    compression: MeasureCompressionDiagnostics
+    reduction: Any
+
+
+def _single_named_axis(batch: PointIntegrationBatch, /) -> tuple[str, int]:
+    if len(batch.axes) != 1:
+        raise ValueError("Compression currently requires exactly one integration axis.")
+    axis = batch.axes[0]
+    if batch.weights.dims != (axis,):
+        raise ValueError(
+            "Compression currently requires a one-dimensional point-weight field."
+        )
+    if batch.stratum_indices is not None:
+        raise ValueError(
+            "Stratified realizations must be compressed within strata, which is not "
+            "yet supported."
+        )
+    if "antithetic" in batch.provenance:
+        raise ValueError(
+            "Antithetic realizations cannot be compressed without preserving pairs."
+        )
+    return axis, int(batch.weights.shape[0])
+
+
+def _single_weighted_axis(
+    batch: WeightedSampleBatch,
+    /,
+) -> tuple[str | int, int]:
+    if len(batch.sample_axes) != 1:
+        raise ValueError("Compression currently requires exactly one sample axis.")
+    if batch.stratum_ids is not None:
+        raise ValueError(
+            "Weighted strata must be compressed independently, which is not yet supported."
+        )
+    if batch.pair_ids is not None:
+        raise ValueError(
+            "Paired samples cannot be compressed without preserving their pair blocks."
+        )
+    if batch.replicate_ids is not None:
+        raise ValueError(
+            "Replicated samples must be compressed independently by replicate."
+        )
+    axis = batch.sample_axes[0]
+    if isinstance(batch.log_weights, cx.Field):
+        if not isinstance(axis, str) or batch.log_weights.dims != (axis,):
+            raise ValueError(
+                "Named compression currently requires a one-dimensional log-weight field."
+            )
+        return axis, int(batch.log_weights.shape[0])
+    if not isinstance(axis, int) or batch.log_weights.ndim != 1 or axis != 0:
+        raise ValueError(
+            "Raw compression currently requires a leading one-dimensional sample axis."
+        )
+    return axis, int(batch.log_weights.shape[0])
+
+
+def _matrix_leaf(value: Any, axis: str | int, count: int, /) -> Array | None:
+    if isinstance(value, cx.Field):
+        if isinstance(axis, str):
+            if axis not in value.named_dims:
+                return None
+            position = value.dims.index(axis)
+        else:
+            if axis >= value.data.ndim:
+                return None
+            position = axis
+        data = jnp.moveaxis(jnp.asarray(value.data, dtype=float), position, 0)
+    elif isinstance(value, (jax.Array, jax.core.Tracer)):
+        data = jnp.asarray(value, dtype=float)
+        position = axis if isinstance(axis, int) else 0
+        if data.ndim == 0 or position >= data.ndim or data.shape[position] != count:
+            return None
+        data = jnp.moveaxis(data, position, 0)
+    else:
+        return None
+    if data.shape[0] != count:
+        raise ValueError("Sample fields disagree on the compression-axis size.")
+    return data.reshape((count, -1))
+
+
+def _feature_matrix(value: Any, axis: str | int, count: int, /) -> Array:
+    if isinstance(value, cx.Field):
+        leaves = (value,)
+    elif isinstance(value, (jax.Array, jax.core.Tracer)):
+        leaves = (value,)
+    else:
+        leaves = tuple(
+            jtu.tree_leaves(value, is_leaf=lambda leaf: isinstance(leaf, cx.Field))
+        )
+    matrices = tuple(
+        matrix
+        for leaf in leaves
+        if (matrix := _matrix_leaf(leaf, axis, count)) is not None
+    )
+    if not matrices:
+        raise ValueError("Could not derive finite-dimensional compression features.")
+    return jnp.concatenate(matrices, axis=1)
+
+
+def _take_samples(value: Any, axis: str | int, indices: Array, /) -> Any:
+    def take(leaf: Any) -> Any:
+        if isinstance(leaf, cx.Field):
+            if isinstance(axis, str):
+                if axis not in leaf.named_dims:
+                    return leaf
+                position = leaf.dims.index(axis)
+            else:
+                if axis >= leaf.data.ndim:
+                    return leaf
+                position = axis
+            return cx.Field(jnp.take(leaf.data, indices, axis=position), dims=leaf.dims)
+        if isinstance(leaf, (jax.Array, jax.core.Tracer)):
+            position = axis if isinstance(axis, int) else 0
+            if leaf.ndim == 0 or position >= leaf.ndim:
+                return leaf
+            return jnp.take(leaf, indices, axis=position)
+        return leaf
+
+    if isinstance(value, PointBatch):
+        points = jtu.tree_map(
+            take,
+            value.points,
+            is_leaf=lambda leaf: isinstance(leaf, cx.Field),
+        )
+        metadata = jtu.tree_map(
+            take,
+            value.metadata,
+            is_leaf=lambda leaf: isinstance(leaf, cx.Field),
+        )
+        return PointBatch(points, value.structure, metadata=metadata)
+    return jtu.tree_map(take, value, is_leaf=lambda leaf: isinstance(leaf, cx.Field))
+
+
+def _select(
+    feature_values: Array,
+    method: CompressionMethod,
+    /,
+    *,
+    log_weights: Array,
+    mask: Array | None,
+) -> CoresetSelection:
+    if isinstance(method, MomentRecombination):
+        return moment_recombine(
+            feature_values,
+            method,
+            log_weights=log_weights,
+            mask=mask,
+        )
+    if isinstance(method, KernelHerding):
+        return kernel_herd(
+            feature_values,
+            method,
+            log_weights=log_weights,
+            mask=mask,
+        )
+    raise TypeError("method must be MomentRecombination or KernelHerding.")
+
+
+def _point_source(
+    realization: Any,
+    batch: PointIntegrationBatch,
+    /,
+) -> tuple[Any, str, int, Array, Array | None, bool, Array]:
+    target = realization.target
+    if not isinstance(target, (DiscreteMeasureTarget, ProbabilityTarget)):
+        raise TypeError(
+            "Point-realization compression currently supports probability and "
+            "external discrete targets only."
+        )
+    axis, count = _single_named_axis(batch)
+    weights = jnp.asarray(batch.weights.data, dtype=float)
+    mask = None if batch.mask is None else jnp.asarray(batch.mask.data, dtype=bool)
+    included = jnp.ones((count,), dtype=bool) if mask is None else mask
+    if bool(jnp.any(included & (~jnp.isfinite(weights) | (weights < 0.0)))):
+        raise ValueError("Compression requires finite nonnegative source weights.")
+    active_weights = jnp.where(included & (weights > 0.0), weights, 0.0)
+    source_mass = jnp.sum(active_weights)
+    if not bool(jnp.isfinite(source_mass) & (source_mass > 0.0)):
+        raise ValueError("Compression requires positive source mass.")
+    log_weights = jnp.where(active_weights > 0.0, jnp.log(active_weights), -jnp.inf)
+    normalized = target.normalized
+    return batch.points, axis, count, log_weights, mask, normalized, source_mass
+
+
+def _weighted_source(
+    realization: Any,
+    batch: WeightedSampleBatch,
+    /,
+) -> tuple[Any, str | int, int, Array, Array | None, bool, Array]:
+    target = realization.target
+    if not isinstance(target, WeightedSampleTarget):
+        raise TypeError(
+            "Weighted compression currently supports externally materialized "
+            "WeightedSampleTarget realizations only."
+        )
+    axis, count = _single_weighted_axis(batch)
+    if isinstance(batch.log_weights, cx.Field):
+        log_weights = jnp.asarray(batch.log_weights.data, dtype=float)
+        mask = None if batch.mask is None else jnp.asarray(cast(cx.Field, batch.mask).data)
+    else:
+        log_weights = jnp.asarray(batch.log_weights, dtype=float)
+        mask = None if batch.mask is None else jnp.asarray(batch.mask, dtype=bool)
+    included = jnp.ones((count,), dtype=bool) if mask is None else mask
+    admissible = jnp.isfinite(log_weights) | jnp.isneginf(log_weights)
+    if bool(jnp.any(included & ~admissible)):
+        raise ValueError("Compression requires finite or negative-infinite log weights.")
+    finite = included & jnp.isfinite(log_weights)
+    if not bool(jnp.any(finite)):
+        raise ValueError("Compression requires positive source mass.")
+    log_mass = jax.scipy.special.logsumexp(jnp.where(finite, log_weights, -jnp.inf))
+    if target.normalized:
+        source_mass = jnp.asarray(1.0)
+    elif target.target_mass is not None:
+        source_mass = jnp.asarray(target.target_mass, dtype=float)
+    else:
+        source_mass = jnp.exp(log_mass)
+    return (
+        batch.samples,
+        axis,
+        count,
+        log_weights,
+        mask,
+        target.normalized,
+        source_mass,
+    )
+
+
+def compress(
+    realization: Any,
+    method: CompressionMethod,
+    /,
+    *,
+    features: FeatureMap | Any | None = None,
+):
+    """Compress a finite positive realization before evaluating its integrand."""
+    from ._api import IntegrationRealization
+
+    if not isinstance(realization, IntegrationRealization):
+        raise TypeError("compress expects an IntegrationRealization from materialize().")
+    if isinstance(realization.batch, tuple):
+        raise ValueError(
+            "Replicated or component-union realizations must be compressed per member."
+        )
+    if isinstance(realization.batch, PointIntegrationBatch):
+        source = _point_source(realization, realization.batch)
+        source_provenance = realization.batch.provenance
+    elif isinstance(realization.batch, WeightedSampleBatch):
+        source = _weighted_source(realization, realization.batch)
+        source_provenance = realization.batch.provenance
+    else:
+        raise TypeError(
+            "Compression requires a one-axis PointIntegrationBatch or "
+            "WeightedSampleBatch."
+        )
+    samples, axis, count, source_log_weights, source_mask, normalized, source_mass = source
+    support_valid = (
+        realization.batch.support_valid
+        if isinstance(realization.batch, WeightedSampleBatch)
+        else None
+    )
+    raw_features = (
+        samples
+        if features is None
+        else features(samples)
+        if callable(features)
+        else features
+    )
+    feature_values = _feature_matrix(raw_features, axis, count)
+    selection = _select(
+        feature_values,
+        method,
+        log_weights=source_log_weights,
+        mask=source_mask,
+    )
+    if not bool(selection.diagnostics.valid):
+        raise ValueError("Coreset selection failed for the supplied measure.")
+    selected_samples = _take_samples(samples, axis, selection.indices)
+    selected_source_ancestry = (
+        None
+        if not isinstance(realization.batch, WeightedSampleBatch)
+        or realization.batch.ancestry_ids is None
+        else _take_samples(
+            realization.batch.ancestry_ids,
+            axis,
+            selection.indices,
+        )
+    )
+    if isinstance(axis, str):
+        selected_log_weights: Array | cx.Field = cx.Field(
+            selection.log_weights,
+            dims=(axis,),
+        )
+        selected_mask: Array | cx.Field = cx.Field(selection.mask, dims=(axis,))
+        ancestry: Array | cx.Field = (
+            cx.Field(selection.indices, dims=(axis,))
+            if selected_source_ancestry is None
+            else cast(cx.Field, selected_source_ancestry)
+        )
+        sample_axes: int | str = axis
+    else:
+        selected_log_weights = selection.log_weights
+        selected_mask = selection.mask
+        ancestry = (
+            selection.indices
+            if selected_source_ancestry is None
+            else jnp.asarray(selected_source_ancestry, dtype=jnp.int32)
+        )
+        sample_axes = 0
+    target_mass = None if normalized else source_mass
+    compressed_target = WeightedSampleTarget(
+        selected_samples,
+        selected_log_weights,
+        normalized=normalized,
+        target_mass=target_mass,
+        independent=False,
+        ancestry=ancestry,
+        support_valid=support_valid,
+        mask=selected_mask,
+        sample_axes=sample_axes,
+        provenance=f"compressed:{selection.method}:{source_provenance}",
+    )
+    compressed_batch = WeightedSampleBatch(
+        compressed_target.samples,
+        compressed_target.log_weights,
+        mask=compressed_target.mask,
+        target_mass=compressed_target.target_mass,
+        ancestry_ids=compressed_target.ancestry,
+        support_valid=compressed_target.support_valid,
+        sample_axes=compressed_target.sample_axes,
+        independent=False,
+        provenance=compressed_target.provenance,
+    )
+    diagnostics = MeasureCompressionDiagnostics(
+        selection=selection.diagnostics,
+        source_mass=source_mass,
+        source_points=count,
+        feature_count=int(feature_values.shape[1]),
+        source_provenance=source_provenance,
+    )
+    return IntegrationRealization(
+        compressed_target,
+        None,
+        compressed_batch,
+        realization.key,
+        diagnostics,
+    )
+
+
+__all__ = [
+    "CompressedIntegrationDiagnostics",
+    "CompressionMethod",
+    "MeasureCompressionDiagnostics",
+    "compress",
+]

--- a/phydrax/operators/integral/_batch_ops.py
+++ b/phydrax/operators/integral/_batch_ops.py
@@ -58,6 +58,7 @@ def mean(
             target_or_realization.plan,
             target_or_realization.batch,
             target_or_realization.key,
+            target_or_realization.compression,
         )
         estimate = reduce_integration(integrand, realization, **kwargs)
     else:

--- a/phydrax/uq/__init__.py
+++ b/phydrax/uq/__init__.py
@@ -117,6 +117,7 @@ from ._guided_particle import (
     LinearGaussianGuidedParticleProposal,
     ParticleProposalSample,
 )
+from ._inducing import InducingPointSelection, select_inducing_points
 from ._integration import particle_posterior_measure
 from ._kalman import (
     initialize_kalman_filter,
@@ -265,6 +266,7 @@ from ._posterior import (
     PosteriorProblem,
     SigmoidIntervalBijector,
 )
+from ._posterior_coreset import PosteriorCoreset, SteinThinning, thin_posterior
 from ._posterior_diagnostics import (
     diagnose_posterior,
     PosteriorCapabilities,
@@ -688,4 +690,9 @@ __all__ = [
     "export_result",
     "read_result_archive",
     "to_arviz",
+    "InducingPointSelection",
+    "PosteriorCoreset",
+    "SteinThinning",
+    "select_inducing_points",
+    "thin_posterior",
 ]

--- a/phydrax/uq/_inducing.py
+++ b/phydrax/uq/_inducing.py
@@ -1,0 +1,79 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from typing import Any
+
+import coordax as cx
+import jax.numpy as jnp
+from jaxtyping import Array, ArrayLike, Key
+
+from phydrax.coresets import (
+    RadialKernel,
+    randomized_pivoted_cholesky,
+    RandomizedPivotedCholesky,
+)
+
+from .._doc import DOC_KEY0
+from .._strict import StrictModule
+
+
+class InducingPointSelection(StrictModule):
+    """Selected source points and residual-kernel approximation evidence."""
+
+    points: Array
+    indices: Array
+    diagnostics: Any
+
+    def __init__(self, points: Array, indices: Array, diagnostics: Any, /):
+        points_ = jnp.asarray(points, dtype=float)
+        indices_ = jnp.asarray(indices, dtype=jnp.int32)
+        if points_.ndim != 2:
+            raise ValueError("Selected inducing points must be two-dimensional.")
+        if indices_.shape != (points_.shape[0],):
+            raise ValueError("Inducing indices must match the selected point count.")
+        self.points = points_
+        self.indices = indices_
+        self.diagnostics = diagnostics
+
+
+def select_inducing_points(
+    observation_points: ArrayLike | cx.Field,
+    num_points: int,
+    /,
+    *,
+    key: Key[Array, ""] = DOC_KEY0,
+    kernel: RadialKernel | None = None,
+) -> InducingPointSelection:
+    """Select sparse-GP inducing inputs with randomized pivoted Cholesky."""
+    raw = (
+        observation_points.data
+        if isinstance(observation_points, cx.Field)
+        else observation_points
+    )
+    points = jnp.asarray(raw, dtype=float)
+    if points.ndim == 1:
+        points = points[:, None]
+    if points.ndim != 2:
+        raise ValueError("observation_points must have shape (num_points, coordinates).")
+    if bool(jnp.any(~jnp.isfinite(points))):
+        raise ValueError("observation_points must be finite.")
+    selection = randomized_pivoted_cholesky(
+        points,
+        RandomizedPivotedCholesky(num_points, kernel=kernel),
+        key=key,
+    )
+    if not bool(selection.diagnostics.valid):
+        raise ValueError(
+            "The requested inducing-point count exceeds the numerical kernel rank."
+        )
+    return InducingPointSelection(
+        points[selection.indices],
+        selection.indices,
+        selection.diagnostics,
+    )
+
+
+__all__ = ["InducingPointSelection", "select_inducing_points"]

--- a/phydrax/uq/_posterior_coreset.py
+++ b/phydrax/uq/_posterior_coreset.py
@@ -1,0 +1,332 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+from jax.flatten_util import ravel_pytree
+from jaxtyping import Array, ArrayLike, Key
+
+from .._doc import DOC_KEY0
+from .._frozendict import frozendict
+from .._strict import StrictModule
+from ._diagnostics import MCMCDiagnostics
+from ._mcmc import MCMCResult
+from ._posterior import PosteriorProblem
+from ._posterior_predictive import (
+    predict_from_position_samples,
+    sample_observations_from_position_samples,
+)
+from ._predictive import PredictiveField
+
+
+class SteinThinning(StrictModule):
+    """Chain-preserving greedy thinning under an inverse-multiquadric Stein kernel."""
+
+    num_points: int = eqx.field(static=True)
+    beta: Array
+    offset: Array
+    length_scale: Array | None
+
+    def __init__(
+        self,
+        num_points: int,
+        /,
+        *,
+        beta: float = -0.5,
+        offset: float = 1.0,
+        length_scale: ArrayLike | None = None,
+    ):
+        count = int(num_points)
+        if count <= 0:
+            raise ValueError("num_points must be positive.")
+        if not -1.0 < float(beta) < 0.0:
+            raise ValueError("beta must lie strictly between -1 and 0.")
+        if not float(offset) > 0.0:
+            raise ValueError("offset must be strictly positive.")
+        scale = None if length_scale is None else jnp.asarray(length_scale, dtype=float)
+        if scale is not None and bool(jnp.any((~jnp.isfinite(scale)) | (scale <= 0.0))):
+            raise ValueError("length_scale must be finite and strictly positive.")
+        self.num_points = count
+        self.beta = jnp.asarray(beta, dtype=float)
+        self.offset = jnp.asarray(offset, dtype=float)
+        self.length_scale = scale
+
+
+class PosteriorCoreset(StrictModule):
+    """Chain-preserving constrained posterior draws selected from an MCMC result."""
+
+    problem: PosteriorProblem
+    samples: Any
+    unconstrained_samples: Any
+    log_density: Array
+    chain_indices: Array
+    draw_indices: Array
+    kernel_stein_discrepancy: Array
+    source_diagnostics: MCMCDiagnostics
+    source_algorithm: str = eqx.field(static=True)
+    source_chain_method: str = eqx.field(static=True)
+    source_num_draws: int = eqx.field(static=True)
+
+    def predict(
+        self,
+        *args: Any,
+        batch_size: int | None = None,
+        valid_policy: Literal["record", "raise"] = "record",
+        chain_dim: str = "__phydra_uq_chain",
+        draw_dim: str = "__phydra_uq_draw",
+        **kwargs: Any,
+    ) -> PredictiveField | frozendict[str, PredictiveField]:
+        """Evaluate selected draws without merging chain and draw dimensions."""
+        return predict_from_position_samples(
+            self.problem,
+            self.unconstrained_samples,
+            *args,
+            sample_dims=(chain_dim, draw_dim),
+            sample_sources=("epistemic", "epistemic"),
+            batch_size=batch_size,
+            valid_policy=valid_policy,
+            **kwargs,
+        )
+
+    def predict_observations(
+        self,
+        key: Array,
+        /,
+        *args: Any,
+        num_observation_samples: int,
+        batch_size: int | None = None,
+        valid_policy: Literal["record", "raise"] = "record",
+        chain_dim: str = "__phydra_uq_chain",
+        draw_dim: str = "__phydra_uq_draw",
+        observation_dim: str = "__phydra_uq_observation",
+        **kwargs: Any,
+    ) -> PredictiveField | frozendict[str, PredictiveField]:
+        """Draw observations without merging retained posterior chains."""
+        return sample_observations_from_position_samples(
+            self.problem,
+            key,
+            self.unconstrained_samples,
+            *args,
+            num_observation_samples=num_observation_samples,
+            sample_dims=(chain_dim, draw_dim),
+            sample_sources=("epistemic", "epistemic"),
+            observation_dim=observation_dim,
+            batch_size=batch_size,
+            valid_policy=valid_policy,
+            **kwargs,
+        )
+
+
+def thin_posterior(
+    result: MCMCResult,
+    method: SteinThinning,
+    /,
+    *,
+    key: Key[Array, ""] = DOC_KEY0,
+) -> PosteriorCoreset:
+    """Compress each MCMC chain without changing the source result's semantics."""
+    if not isinstance(result, MCMCResult):
+        raise TypeError("result must be an MCMCResult.")
+    if not isinstance(method, SteinThinning):
+        raise TypeError("method must be a SteinThinning.")
+    log_density = jnp.asarray(result.log_density, dtype=float)
+    if log_density.ndim != 2:
+        raise ValueError("MCMC log density must have shape (chains, draws).")
+    if bool(jnp.any(~jnp.isfinite(log_density))):
+        raise ValueError("MCMC log density must be finite before posterior thinning.")
+    num_chains, num_draws = map(int, log_density.shape)
+    if method.num_points > num_draws:
+        raise ValueError("Cannot retain more posterior draws than each chain contains.")
+    flat_samples, unravel = _flatten_position_samples(
+        result.unconstrained_samples,
+        num_chains,
+        num_draws,
+    )
+    scores = jax.vmap(jax.vmap(jax.grad(lambda value: result.problem.log_density(unravel(value)))))(
+        flat_samples
+    )
+    if bool(jnp.any(~jnp.isfinite(scores))):
+        raise ValueError("Posterior score evaluation produced non-finite values.")
+    scale = _resolve_length_scale(flat_samples, method.length_scale)
+    precision = 1.0 / jnp.square(scale)
+    keys = jr.split(key, num_chains)
+    draw_indices, discrepancy = jax.vmap(
+        lambda points, point_scores, chain_key: _thin_chain(
+            points,
+            point_scores,
+            method,
+            precision,
+            chain_key,
+        )
+    )(flat_samples, scores, keys)
+    chain_indices = jnp.broadcast_to(
+        jnp.arange(num_chains, dtype=jnp.int32)[:, None],
+        draw_indices.shape,
+    )
+    samples = jax.tree_util.tree_map(
+        lambda leaf: _gather_draws(leaf, draw_indices),
+        result.samples,
+    )
+    unconstrained = jax.tree_util.tree_map(
+        lambda leaf: _gather_draws(leaf, draw_indices),
+        result.unconstrained_samples,
+    )
+    selected_log_density = jnp.take_along_axis(log_density, draw_indices, axis=1)
+    return PosteriorCoreset(
+        problem=result.problem,
+        samples=samples,
+        unconstrained_samples=unconstrained,
+        log_density=selected_log_density,
+        chain_indices=chain_indices,
+        draw_indices=draw_indices,
+        kernel_stein_discrepancy=discrepancy,
+        source_diagnostics=result.diagnostics,
+        source_algorithm=result.algorithm,
+        source_chain_method=result.chain_method,
+        source_num_draws=num_draws,
+    )
+
+
+def _flatten_position_samples(
+    samples: Any,
+    num_chains: int,
+    num_draws: int,
+    /,
+) -> tuple[Array, Any]:
+    example = jax.tree_util.tree_map(lambda leaf: leaf[0, 0], samples)
+    _, unravel = ravel_pytree(example)
+    matrices = []
+    for leaf in jax.tree_util.tree_leaves(samples):
+        values = jnp.asarray(leaf, dtype=float)
+        if values.shape[:2] != (num_chains, num_draws):
+            raise ValueError("MCMC sample leaves must share leading chain and draw axes.")
+        matrices.append(values.reshape((num_chains, num_draws, -1)))
+    if not matrices:
+        raise ValueError("MCMC samples must contain at least one parameter leaf.")
+    return jnp.concatenate(tuple(matrices), axis=-1), unravel
+
+
+def _resolve_length_scale(samples: Array, supplied: Array | None, /) -> Array:
+    dimension = int(samples.shape[-1])
+    if supplied is not None:
+        scale = jnp.broadcast_to(jnp.asarray(supplied, dtype=float), (dimension,))
+        if bool(jnp.any((~jnp.isfinite(scale)) | (scale <= 0.0))):
+            raise ValueError("length_scale must broadcast to finite positive coordinates.")
+        return scale
+    scale = jnp.std(samples.reshape((-1, dimension)), axis=0)
+    floor = jnp.sqrt(jnp.finfo(samples.dtype).eps)
+    return jnp.where(scale > floor, scale, 1.0)
+
+
+def _stein_kernel(
+    left: Array,
+    left_score: Array,
+    right: Array,
+    right_score: Array,
+    precision: Array,
+    beta: Array,
+    offset: Array,
+    /,
+) -> Array:
+    difference = left - right
+    scaled_difference = difference * precision
+    radius = offset * offset + jnp.sum(difference * scaled_difference, axis=-1)
+    base = jnp.power(radius, beta)
+    first = 2.0 * beta * jnp.power(radius, beta - 1.0)
+    score_term = base * jnp.sum(left_score * right_score, axis=-1)
+    gradient_term = first * jnp.sum(
+        (right_score - left_score) * scaled_difference,
+        axis=-1,
+    )
+    mixed_trace = (
+        -4.0
+        * beta
+        * (beta - 1.0)
+        * jnp.power(radius, beta - 2.0)
+        * jnp.sum(scaled_difference * scaled_difference, axis=-1)
+        - 2.0 * beta * jnp.power(radius, beta - 1.0) * jnp.sum(precision)
+    )
+    return score_term + gradient_term + mixed_trace
+
+
+def _thin_chain(
+    points: Array,
+    scores: Array,
+    method: SteinThinning,
+    precision: Array,
+    key: Key[Array, ""],
+    /,
+) -> tuple[Array, Array]:
+    num_draws = int(points.shape[0])
+    diagonal = _stein_kernel(
+        points,
+        scores,
+        points,
+        scores,
+        precision,
+        method.beta,
+        method.offset,
+    )
+    selected = jnp.zeros((num_draws,), dtype=bool)
+    indices = jnp.zeros((method.num_points,), dtype=jnp.int32)
+    penalty = jnp.zeros((num_draws,), dtype=points.dtype)
+
+    def body(iteration, state):
+        chosen, used, accumulated = state
+        objective = diagonal + 2.0 * accumulated
+        minimum = jnp.min(jnp.where(~used, objective, jnp.inf))
+        tied = (~used) & jnp.isclose(objective, minimum, rtol=1e-12, atol=1e-14)
+        random_values = jr.uniform(jr.fold_in(key, iteration), (num_draws,))
+        pivot = jnp.asarray(
+            jnp.argmax(jnp.where(tied, random_values, -1.0)),
+            dtype=jnp.int32,
+        )
+        chosen = chosen.at[iteration].set(pivot)
+        used = used.at[pivot].set(True)
+        kernel_column = _stein_kernel(
+            points,
+            scores,
+            points[pivot],
+            scores[pivot],
+            precision,
+            method.beta,
+            method.offset,
+        )
+        return chosen, used, accumulated + kernel_column
+
+    indices, _, _ = jax.lax.fori_loop(
+        0,
+        method.num_points,
+        body,
+        (indices, selected, penalty),
+    )
+    selected_points = points[indices]
+    selected_scores = scores[indices]
+    gram = _stein_kernel(
+        selected_points[:, None, :],
+        selected_scores[:, None, :],
+        selected_points[None, :, :],
+        selected_scores[None, :, :],
+        precision,
+        method.beta,
+        method.offset,
+    )
+    discrepancy = jnp.sqrt(jnp.maximum(jnp.mean(gram), 0.0))
+    return indices, discrepancy
+
+
+def _gather_draws(leaf: Array, indices: Array, /) -> Array:
+    values = jnp.asarray(leaf)
+    expanded = indices.reshape(indices.shape + (1,) * (values.ndim - 2))
+    gather_indices = jnp.broadcast_to(expanded, indices.shape + values.shape[2:])
+    return jnp.take_along_axis(values, gather_indices, axis=1)
+
+
+__all__ = ["PosteriorCoreset", "SteinThinning", "thin_posterior"]

--- a/tests/unit/constraints/test_adaptive_collocation.py
+++ b/tests/unit/constraints/test_adaptive_collocation.py
@@ -8,6 +8,7 @@ import jax.random as jr
 
 import phydrax as phx
 from phydrax.constraints import (
+    CoresetCollocation,
     FunctionalConstraint,
     PeriodicCollocation,
     R3,
@@ -17,13 +18,20 @@ from phydrax.domain import Interval1d, PointBatch, SampleLayout
 from phydrax.sampling import HaltonDesign
 
 
-def _interval_constraint(policy, *, num_points=32):
-    domain = Interval1d(0.0, 1.0)
+def _interval_constraint(
+    policy,
+    *,
+    num_points=32,
+    upper=1.0,
+    residual_scale=1.0,
+    residual_power=1,
+):
+    domain = Interval1d(0.0, upper)
     structure = SampleLayout((("x",),))
 
     @domain.Function("x")
     def coordinate(x):
-        return x[0]
+        return residual_scale * (x[0] / upper) ** residual_power
 
     constraint = FunctionalConstraint.from_operator(
         component=domain.component(),
@@ -99,3 +107,186 @@ def test_fixed_capacity_rar_d_activates_new_slots():
     assert refreshed.active is not None
     assert int(jnp.sum(jnp.asarray(refreshed.active.data))) == before + 10
     assert _coordinates(refreshed).shape == (40,)
+
+
+def test_coreset_collocation_preserves_capacity_and_reports_candidate_cost():
+    policy = CoresetCollocation(
+        refresh_every=1,
+        sampler="halton_scrambled",
+        candidate_multiplier=4,
+        block_size=8,
+    )
+    _domain, constraint, functions = _interval_constraint(policy, num_points=16)
+    initial = policy.initialize(constraint, key=jr.key(20))
+
+    refreshed = policy.refresh(
+        constraint,
+        functions,
+        initial,
+        key=jr.key(21),
+        iter_=1,
+    )
+    metrics = policy.data_metrics(refreshed)
+
+    assert _coordinates(refreshed).shape == (16,)
+    assert jnp.unique(_coordinates(refreshed)).shape == (16,)
+    assert int(metrics["coreset_candidate_count"]) == 64
+    assert int(metrics["coreset_selection_kernel_evaluations"]) == 10_496
+    assert int(metrics["coreset_selection_valid"]) == 1
+    assert 0.0 < metrics["coreset_importance_effective_sample_size"] <= 64.0
+    assert jnp.isfinite(metrics["coreset_selection_mmd"])
+    assert int(policy.refresh_residual_evaluations(initial)) == 64
+    assert int(refreshed.refresh_count) == 1
+    assert int(refreshed.last_refresh) == 1
+
+
+def test_coreset_defaults_delay_refresh_and_controlled_policy_preserves_activation():
+    policy = CoresetCollocation(refresh_every=5)
+    _domain, constraint, _functions = _interval_constraint(policy)
+    population = policy.initialize(constraint, key=jr.key(30))
+    controlled = phx.constraints.controlled_collocation(policy)
+
+    assert policy.start_at == 10
+    assert not bool(policy.should_refresh(population, 9))
+    assert bool(policy.should_refresh(population, 10))
+    assert controlled.schedule.start_at == 10
+
+
+def test_coreset_importance_is_invariant_to_residual_units():
+    policy = CoresetCollocation(
+        refresh_every=1,
+        start_at=1,
+        candidate_multiplier=4,
+        uniform_fraction=0.25,
+        minimum_ess_fraction=0.25,
+        kernel=phx.coresets.RadialKernel(length_scale=0.2),
+        max_fill_distance_ratio=10.0,
+        block_size=8,
+    )
+    _domain, base_constraint, base_functions = _interval_constraint(
+        policy,
+        num_points=16,
+    )
+    _domain, scaled_constraint, scaled_functions = _interval_constraint(
+        policy,
+        num_points=16,
+        residual_scale=1_000.0,
+    )
+    base = policy.initialize(base_constraint, key=jr.key(31))
+    scaled = policy.initialize(scaled_constraint, key=jr.key(31))
+
+    base_refreshed = policy.refresh(
+        base_constraint,
+        base_functions,
+        base,
+        key=jr.key(32),
+        iter_=1,
+    )
+    scaled_refreshed = policy.refresh(
+        scaled_constraint,
+        scaled_functions,
+        scaled,
+        key=jr.key(32),
+        iter_=1,
+    )
+
+    assert jnp.array_equal(_coordinates(base_refreshed), _coordinates(scaled_refreshed))
+
+
+def test_coreset_auto_scale_is_affine_invariant_and_ess_guard_is_enforced():
+    policy = CoresetCollocation(
+        refresh_every=1,
+        start_at=1,
+        candidate_multiplier=4,
+        uniform_fraction=0.0,
+        minimum_ess_fraction=0.75,
+        max_fill_distance_ratio=10.0,
+        block_size=8,
+    )
+    _domain, unit_constraint, unit_functions = _interval_constraint(
+        policy,
+        num_points=16,
+        residual_power=32,
+    )
+    _domain, scaled_constraint, scaled_functions = _interval_constraint(
+        policy,
+        num_points=16,
+        upper=100.0,
+        residual_power=32,
+    )
+    unit = policy.initialize(unit_constraint, key=jr.key(33))
+    scaled = policy.initialize(scaled_constraint, key=jr.key(33))
+    unit_refreshed = policy.refresh(
+        unit_constraint,
+        unit_functions,
+        unit,
+        key=jr.key(34),
+        iter_=1,
+    )
+    scaled_refreshed = policy.refresh(
+        scaled_constraint,
+        scaled_functions,
+        scaled,
+        key=jr.key(34),
+        iter_=1,
+    )
+    unit_metrics = policy.data_metrics(unit_refreshed)
+    scaled_metrics = policy.data_metrics(scaled_refreshed)
+
+    assert jnp.allclose(
+        _coordinates(unit_refreshed),
+        _coordinates(scaled_refreshed) / 100.0,
+    )
+    assert jnp.allclose(
+        unit_metrics["coreset_kernel_length_scale_min"],
+        scaled_metrics["coreset_kernel_length_scale_min"],
+    )
+    assert int(unit_metrics["coreset_kernel_automatic"]) == 1
+    assert int(unit_metrics["coreset_ess_guard_triggered"]) == 1
+    assert unit_metrics["coreset_effective_uniform_fraction"] > 0.0
+    assert unit_metrics["coreset_importance_effective_sample_fraction"] >= 0.75
+
+
+def test_coreset_fill_distance_guard_retains_the_current_population():
+    policy = CoresetCollocation(
+        refresh_every=1,
+        start_at=1,
+        candidate_multiplier=8,
+        exponent=1.0,
+        uniform_fraction=0.0,
+        minimum_ess_fraction=0.01,
+        max_fill_distance_ratio=1.0,
+        kernel=phx.coresets.RadialKernel(length_scale=0.01),
+        block_size=16,
+    )
+    _domain, constraint, functions = _interval_constraint(
+        policy,
+        num_points=16,
+        residual_power=32,
+    )
+    initial = policy.initialize(constraint, key=jr.key(40))
+    refreshed = policy.refresh(
+        constraint,
+        functions,
+        initial,
+        key=jr.key(41),
+        iter_=1,
+    )
+    metrics = policy.data_metrics(refreshed)
+
+    assert jnp.array_equal(_coordinates(refreshed), _coordinates(initial))
+    assert int(metrics["coreset_selection_valid"]) == 1
+    assert int(metrics["coreset_selection_accepted"]) == 0
+    assert int(metrics["coreset_coverage_guard_triggered"]) == 1
+    assert (
+        metrics["coreset_coverage_fill_distance"]
+        > metrics["coreset_coverage_baseline_fill_distance"]
+    )
+    assert jnp.isfinite(metrics["coreset_selection_mmd"])
+
+
+def test_coreset_collocation_is_declared_conditional():
+    support = phx.constraints.collocation_policy_support(CoresetCollocation())
+
+    assert support.name == "coreset"
+    assert support.tier == "conditional"

--- a/tests/unit/constraints/test_adaptive_control.py
+++ b/tests/unit/constraints/test_adaptive_control.py
@@ -11,6 +11,7 @@ from phydrax.constraints import (
     collocation_policy_support,
     controlled_collocation,
     ControlledCollocationPopulation,
+    CoresetCollocation,
     CoverageAnchors,
     FunctionalConstraint,
     PeriodicCollocation,
@@ -223,3 +224,41 @@ def test_monitor_budget_reserves_validation_for_every_proposal():
     assert not bool(settled.proposal_pending)
     assert int(settled.monitor_evaluations) == 32
     assert not bool(policy.should_refresh(settled, 3))
+
+
+
+def test_controlled_coreset_policy_preserves_selection_metrics_through_anchors():
+    domain = Interval1d(0.0, 1.0)
+    structure = SampleLayout((("x",),))
+    policy = controlled_collocation(
+        CoresetCollocation(
+            refresh_every=1,
+            sampler="halton_scrambled",
+            candidate_multiplier=3,
+            block_size=8,
+        ),
+        schedule=RefreshSchedule(1),
+        anchors=CoverageAnchors(0.25),
+    )
+    constraint = FunctionalConstraint.from_operator(
+        component=domain.component(),
+        operator=lambda field: field,
+        constraint_vars="u",
+        sampling=phx.domain.PointSampling(16, layout=structure, design="uniform"),
+        collocation_policy=policy,
+    )
+    initial = policy.initialize(constraint, key=jr.key(30))
+    anchors = _x(initial)[:4]
+
+    refreshed = policy.refresh(
+        constraint,
+        {"u": domain.Function("x")(lambda x: x[0])},
+        initial,
+        key=jr.key(31),
+        iter_=1,
+    )
+    metrics = policy.data_metrics(refreshed)
+
+    assert jnp.array_equal(_x(refreshed)[:4], anchors)
+    assert int(metrics["coreset_candidate_count"]) == 48
+    assert jnp.isfinite(metrics["coreset_selection_mmd"])

--- a/tests/unit/integration/test_compression.py
+++ b/tests/unit/integration/test_compression.py
@@ -1,0 +1,160 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import coordax as cx
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+import phydrax as phx
+
+
+def test_moment_compression_is_reusable_and_preserves_named_ancestry():
+    axis = "sample"
+    coordinates = jnp.linspace(-1.0, 1.0, 33)
+    samples = cx.Field(coordinates, dims=(axis,))
+    log_weights = cx.Field(jnp.log(jnp.arange(1.0, 34.0)), dims=(axis,))
+    ancestry = cx.Field(jnp.arange(100, 133, dtype=jnp.int32), dims=(axis,))
+    features = cx.Field(
+        jnp.stack((coordinates, coordinates**2), axis=1),
+        dims=(axis, "feature"),
+    )
+    target = phx.integration.weighted(
+        samples,
+        log_weights,
+        ancestry=ancestry,
+        sample_axes=axis,
+    )
+    source = phx.integration.materialize(target)
+
+    compressed = phx.integration.compress(
+        source,
+        phx.coresets.MomentRecombination(),
+        features=features,
+    )
+    source_estimate = phx.integration.reduce(lambda value: value**2, source)
+    compressed_estimate = phx.integration.reduce(lambda value: value**2, compressed)
+
+    assert compressed.batch.num_samples <= 3
+    assert jnp.allclose(
+        compressed_estimate.value.data,
+        source_estimate.value.data,
+        atol=1e-11,
+        rtol=1e-11,
+    )
+    selected_coordinates = compressed.batch.samples.data
+    source_indices = jnp.searchsorted(coordinates, selected_coordinates)
+    assert jnp.array_equal(
+        compressed.batch.ancestry_ids.data,
+        ancestry.data[source_indices],
+    )
+    assert compressed_estimate.provenance.method == "compressed"
+    assert isinstance(
+        compressed_estimate.diagnostics,
+        phx.integration.CompressedIntegrationDiagnostics,
+    )
+
+
+def test_compression_preserves_nonnormalized_target_mass():
+    samples = jnp.linspace(0.0, 2.0, 25)
+    target = phx.integration.weighted(
+        samples,
+        jnp.zeros((25,)),
+        normalized=False,
+        target_mass=jnp.asarray(7.0),
+    )
+    source = phx.integration.materialize(target)
+    compressed = phx.integration.compress(
+        source,
+        phx.coresets.MomentRecombination(),
+        features=jnp.stack((samples, samples**2), axis=1),
+    )
+
+    source_estimate = phx.integration.reduce(lambda value: value**2, source)
+    compressed_estimate = phx.integration.reduce(lambda value: value**2, compressed)
+
+    assert jnp.isclose(compressed.target.target_mass, 7.0)
+    assert jnp.allclose(
+        compressed_estimate.value.data,
+        source_estimate.value.data,
+        atol=1e-11,
+    )
+
+
+def test_compression_lowers_a_named_discrete_point_measure():
+    domain = phx.domain.Interval1d(0.0, 1.0)
+    layout = phx.domain.SampleLayout((("x",),))
+    points = domain.component().sample(
+        phx.domain.PointSampling(16, layout=layout, design="halton"),
+        key=jr.key(11),
+    )
+    axis = points.points["x"].dims[0]
+    coordinates = points.points["x"].data[:, 0]
+    weights = cx.Field(jnp.linspace(1.0, 2.0, 16), dims=(axis,))
+    target = phx.integration.discrete(
+        points,
+        weights,
+        axes=axis,
+        normalized=True,
+    )
+    source = phx.integration.materialize(target)
+    features = cx.Field(
+        jnp.stack((coordinates, coordinates**2), axis=1),
+        dims=(axis, "feature"),
+    )
+    compressed = phx.integration.compress(
+        source,
+        phx.coresets.MomentRecombination(),
+        features=features,
+    )
+
+    @domain.Function("x")
+    def square(x):
+        return x[0] ** 2
+
+    source_estimate = phx.integration.reduce(square, source)
+    compressed_estimate = phx.integration.reduce(square, compressed)
+
+    assert compressed.batch.num_samples <= 3
+    assert jnp.allclose(
+        compressed_estimate.value.data,
+        source_estimate.value.data,
+        atol=1e-11,
+    )
+
+
+def test_compression_preserves_proposal_support_failure():
+    samples = jnp.linspace(0.0, 1.0, 9)
+    target = phx.integration.weighted(
+        samples,
+        jnp.zeros((9,)),
+        support_valid=jnp.asarray(False),
+    )
+    compressed = phx.integration.compress(
+        phx.integration.materialize(target),
+        phx.coresets.MomentRecombination(),
+    )
+    estimate = phx.integration.reduce(lambda value: value, compressed)
+
+    assert not bool(compressed.batch.support_valid)
+    assert int(estimate.status) == int(
+        phx.integration.IntegrationStatus.PROPOSAL_SUPPORT_FAILURE
+    )
+
+
+@pytest.mark.parametrize("identifier", ["stratum_ids", "pair_ids", "replicate_ids"])
+def test_compression_rejects_unpreserved_sample_grouping(identifier):
+    samples = jnp.linspace(0.0, 1.0, 12)
+    identifiers = jnp.arange(12, dtype=jnp.int32) // 2
+    target = phx.integration.weighted(
+        samples,
+        jnp.zeros((12,)),
+        **{identifier: identifiers},
+    )
+
+    with pytest.raises(ValueError, match="compressed"):
+        phx.integration.compress(
+            phx.integration.materialize(target),
+            phx.coresets.MomentRecombination(),
+        )

--- a/tests/unit/test_coresets.py
+++ b/tests/unit/test_coresets.py
@@ -1,0 +1,144 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+import phydrax as phx
+
+
+def _selection_weights(selection):
+    return jnp.where(selection.mask, jnp.exp(selection.log_weights), 0.0)
+
+
+def test_moment_recombination_preserves_weighted_feature_moments():
+    points = jnp.linspace(-2.0, 2.0, 65)
+    features = jnp.stack((points, points**2, jnp.sin(points)), axis=1)
+    source_weights = jnp.linspace(1.0, 3.0, points.size)
+    source_weights = source_weights / jnp.sum(source_weights)
+
+    selection = phx.coresets.moment_recombine(
+        features,
+        log_weights=jnp.log(source_weights),
+    )
+    weights = _selection_weights(selection)
+
+    assert bool(selection.diagnostics.valid)
+    assert int(selection.diagnostics.active_points) <= features.shape[1] + 1
+    assert jnp.all(weights >= 0.0)
+    assert jnp.isclose(jnp.sum(weights), 1.0, atol=1e-12)
+    assert jnp.allclose(
+        weights @ features[selection.indices],
+        source_weights @ features,
+        atol=1e-10,
+        rtol=1e-10,
+    )
+
+
+def test_moment_recombination_respects_mask_and_rank_deficiency():
+    features = jnp.stack(
+        (
+            jnp.arange(12.0),
+            jnp.ones((12,)),
+            jnp.ones((12,)),
+        ),
+        axis=1,
+    )
+    mask = jnp.arange(12) % 2 == 0
+
+    selection = phx.coresets.moment_recombine(features, mask=mask)
+
+    assert bool(selection.diagnostics.valid)
+    assert int(selection.diagnostics.active_points) <= 2
+    assert jnp.all(mask[selection.indices[selection.mask]])
+    assert float(selection.diagnostics.minimum_weight) >= 0.0
+
+
+def test_weighted_mmd_matches_dense_kernel_evaluation():
+    source = jnp.linspace(-1.0, 1.0, 17)[:, None]
+    comparison = jnp.asarray([[-0.75], [0.0], [0.9]])
+    source_weights = jnp.arange(1.0, 18.0)
+    source_weights = source_weights / jnp.sum(source_weights)
+    comparison_weights = jnp.asarray([0.2, 0.3, 0.5])
+    kernel = phx.coresets.RadialKernel("matern32", length_scale=0.4)
+
+    actual = phx.coresets.weighted_mmd(
+        source,
+        comparison,
+        source_log_weights=jnp.log(source_weights),
+        comparison_log_weights=jnp.log(comparison_weights),
+        kernel=kernel,
+        block_size=4,
+    )
+    source_gram = phx.coresets.kernel_matrix(kernel, source, source)
+    comparison_gram = phx.coresets.kernel_matrix(kernel, comparison, comparison)
+    cross_gram = phx.coresets.kernel_matrix(kernel, source, comparison)
+    expected_squared = (
+        source_weights @ source_gram @ source_weights
+        + comparison_weights @ comparison_gram @ comparison_weights
+        - 2.0 * source_weights @ cross_gram @ comparison_weights
+    )
+
+    assert jnp.isclose(actual, jnp.sqrt(jnp.maximum(expected_squared, 0.0)))
+
+
+def test_weighted_mmd_rejects_nonpositive_block_size():
+    with pytest.raises(ValueError, match="block_size"):
+        phx.coresets.weighted_mmd(
+            jnp.zeros((2, 1)),
+            jnp.zeros((2, 1)),
+            block_size=0,
+        )
+
+
+def test_kernel_herding_returns_unique_active_source_points():
+    points = jnp.linspace(-3.0, 3.0, 41)[:, None]
+    mask = jnp.arange(points.shape[0]) % 3 != 0
+    selection = phx.coresets.kernel_herd(
+        points,
+        phx.coresets.KernelHerding(9, block_size=7),
+        mask=mask,
+    )
+    active_indices = selection.indices[selection.mask]
+    weights = _selection_weights(selection)
+
+    assert bool(selection.diagnostics.valid)
+    assert active_indices.shape == (9,)
+    assert jnp.unique(active_indices).shape == active_indices.shape
+    assert jnp.all(mask[active_indices])
+    assert jnp.allclose(weights[selection.mask], jnp.full((9,), 1.0 / 9.0))
+    assert jnp.isfinite(selection.diagnostics.mmd)
+
+
+def test_randomized_pivoted_cholesky_is_keyed_and_reduces_trace():
+    points = jnp.linspace(0.0, 1.0, 48)[:, None]
+    method = phx.coresets.RandomizedPivotedCholesky(
+        10,
+        kernel=phx.coresets.RadialKernel(length_scale=0.15),
+    )
+    first = phx.coresets.randomized_pivoted_cholesky(
+        points,
+        method,
+        key=jr.key(7),
+    )
+    repeated = phx.coresets.randomized_pivoted_cholesky(
+        points,
+        method,
+        key=jr.key(7),
+    )
+
+    assert bool(first.diagnostics.valid)
+    assert jnp.array_equal(first.indices, repeated.indices)
+    assert jnp.unique(first.indices).shape == first.indices.shape
+    assert first.diagnostics.residual_trace < first.diagnostics.initial_trace
+    assert 0.0 < first.diagnostics.explained_trace_fraction <= 1.0
+
+
+def test_randomized_pivoted_cholesky_rejects_oversized_selection():
+    with pytest.raises(ValueError, match="more inducing points"):
+        phx.coresets.randomized_pivoted_cholesky(
+            jnp.ones((3, 1)),
+            phx.coresets.RandomizedPivotedCholesky(4),
+        )

--- a/tests/unit/uq/test_coreset_uq.py
+++ b/tests/unit/uq/test_coreset_uq.py
@@ -1,0 +1,127 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import coordax as cx
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+import phydrax as phx
+
+
+def _gaussian_mcmc_result():
+    chains = 2
+    draws = 48
+    parameter_space = phx.uq.ParameterSpace(
+        {"location": jnp.asarray([0.0])},
+        log_prior=lambda _parameters: 0.0,
+    )
+    problem = phx.uq.PosteriorProblem(
+        parameter_space,
+        lambda parameters: -0.5 * jnp.sum(parameters["location"] ** 2),
+        predict=lambda parameters, query: cx.Field(
+            parameters["location"][0] + query.data,
+            dims=query.dims,
+        ),
+    )
+    unconstrained = {
+        "location": jr.normal(jr.key(10), (chains, draws, 1)),
+    }
+    log_density = -0.5 * jnp.squeeze(unconstrained["location"] ** 2, axis=-1)
+    diagnostics = phx.uq.MCMCDiagnostics(
+        rhat={"location": jnp.ones((1,))},
+        bulk_ess={"location": jnp.full((1,), 70.0)},
+        tail_ess={"location": jnp.full((1,), 60.0)},
+        acceptance_rate=jnp.full((chains,), 0.9),
+        divergent=jnp.zeros((chains,), dtype=jnp.int32),
+    )
+    result = phx.uq.MCMCResult(
+        problem=problem,
+        samples=unconstrained,
+        unconstrained_samples=unconstrained,
+        log_density=log_density,
+        acceptance_rate=jnp.full((chains, draws), 0.9),
+        divergent=jnp.zeros((chains, draws), dtype=bool),
+        energy=jnp.zeros((chains, draws)),
+        num_integration_steps=jnp.ones((chains, draws), dtype=jnp.int32),
+        num_trajectory_expansions=jnp.zeros((chains, draws), dtype=jnp.int32),
+        final_states=(),
+        warmup=(),
+        diagnostics=diagnostics,
+        root_key=jr.key(0),
+        chain_keys=jr.split(jr.key(1), chains),
+        algorithm="nuts",
+        duration_seconds=1.0,
+        max_num_doublings=10,
+        chain_method="vectorized",
+        adaptation_duration_seconds=0.4,
+        sampling_duration_seconds=0.6,
+    )
+    return result
+
+
+def test_pivoted_cholesky_selection_builds_a_sparse_gp_factor():
+    coordinates = jnp.linspace(-1.0, 1.0, 64)
+    points = jnp.stack((coordinates, coordinates**2), axis=1)
+    selection = phx.uq.select_inducing_points(points, 12, key=jr.key(3))
+    factor = phx.uq.SparseGaussianProcessFactor(
+        points,
+        selection.points,
+        amplitude=0.2,
+        length_scale=0.4,
+        noise_scale=0.01,
+    )
+
+    assert selection.points.shape == (12, 2)
+    assert jnp.unique(selection.indices).shape == selection.indices.shape
+    assert selection.diagnostics.residual_trace < selection.diagnostics.initial_trace
+    assert jnp.isfinite(factor.log_probability(jnp.sin(points[:, 0])))
+
+
+def test_inducing_selection_reports_numerical_rank_exhaustion():
+    with pytest.raises(ValueError, match="kernel rank"):
+        phx.uq.select_inducing_points(jnp.zeros((8, 2)), 2, key=jr.key(4))
+
+
+def test_stein_thinning_preserves_chains_source_indices_and_diagnostics():
+    result = _gaussian_mcmc_result()
+    method = phx.uq.SteinThinning(10)
+
+    coreset = phx.uq.thin_posterior(result, method, key=jr.key(5))
+    repeated = phx.uq.thin_posterior(result, method, key=jr.key(5))
+
+    assert result.samples["location"].shape == (2, 48, 1)
+    assert coreset.samples["location"].shape == (2, 10, 1)
+    assert coreset.draw_indices.shape == (2, 10)
+    assert jnp.array_equal(coreset.draw_indices, repeated.draw_indices)
+    assert jnp.all(jax_unique_counts(coreset.draw_indices) == 10)
+    assert jnp.array_equal(
+        coreset.samples["location"],
+        jnp.take_along_axis(
+            result.samples["location"],
+            coreset.draw_indices[..., None],
+            axis=1,
+        ),
+    )
+    assert coreset.source_diagnostics is result.diagnostics
+    assert coreset.source_algorithm == result.algorithm
+    assert coreset.source_num_draws == 48
+    assert jnp.all(jnp.isfinite(coreset.kernel_stein_discrepancy))
+    prediction = coreset.predict(
+        cx.Field(jnp.linspace(0.0, 1.0, 3), dims=("x",)),
+        batch_size=4,
+    )
+    assert prediction.samples.dims == ("__phydra_uq_chain", "__phydra_uq_draw", "x")
+    assert prediction.samples.shape == (2, 10, 3)
+
+
+def test_stein_thinning_rejects_more_points_than_each_chain_contains():
+    result = _gaussian_mcmc_result()
+
+    with pytest.raises(ValueError, match="more posterior draws"):
+        phx.uq.thin_posterior(result, phx.uq.SteinThinning(49))
+
+
+def jax_unique_counts(indices):
+    return jnp.asarray([jnp.unique(row).size for row in indices])


### PR DESCRIPTION
## Summary

This PR introduces a Phydrax-native coreset engine and connects it to three scientific workflows where finite-measure compression has concrete value:

- reusable integration realizations,
- adaptive PINN collocation,
- posterior and sparse-GP workflows.

The implementation keeps the mathematical selectors independent from domain-specific lifecycle and metadata concerns. Algorithms return source indices, nonnegative weights, masks, and typed diagnostics; integration, constraints, and UQ adapters own reconstruction of their respective scientific objects.

## Motivation

Several Phydrax workloads repeatedly evaluate a much larger finite measure than the downstream computation can afford:

- multiple expensive integrands over the same materialized measure,
- PINN residual candidates competing for a fixed training capacity,
- repeated posterior predictions from long MCMC chains,
- sparse-GP inducing designs selected from a larger observation geometry.

Treating these as one generic “compress anything” API would erase important semantics such as target mass, sample ancestry, chain identity, fixed-shape collocation state, and proposal validity. This PR instead shares one small mathematical selection layer while retaining explicit adapters for each workload.

## Core coreset engine

A new `phydrax.coresets` namespace provides:

- `MomentRecombination` / `moment_recombine`
  - positive finite-measure recombination,
  - preservation of the supplied feature moments and total mass,
  - at most numerical-rank-plus-one active points,
  - mass error, moment error, numerical rank, minimum weight, and validity diagnostics.
- `KernelHerding` / `kernel_herd`
  - fixed-capacity, unique, equal-weight selection,
  - blockwise kernel means and MMD evaluation,
  - explicit masks and normalized log-weight handling.
- `RandomizedPivotedCholesky` / `randomized_pivoted_cholesky`
  - reproducible low-rank kernel landmark selection,
  - residual-trace and explained-trace diagnostics,
  - explicit rank-exhaustion behavior.
- `RadialKernel`, `kernel_matrix`, and `weighted_mmd`
  - squared-exponential, Matérn-3/2, Matérn-5/2, and inverse-multiquadric kernels,
  - scalar or anisotropic length scales,
  - blockwise finite-measure discrepancy computation.
- `CoresetSelection` and algorithm-specific diagnostic records
  - source indices remain the canonical representation,
  - inactive capacity is represented explicitly rather than hidden by dynamic shapes,
  - source mass and numerical validity remain observable.

Weight normalization is centralized around log weights, row validity, and masks. This prevents each downstream adapter from inventing subtly different behavior for nonfinite rows, degenerate mass, or inactive capacity.

## Reusable integration compression

`phx.integration.compress(...)` inserts an explicit compression step into the existing lifecycle:

```python
source = phx.integration.materialize(target, plan)
compressed = phx.integration.compress(source, method, features=features)
estimate = phx.integration.reduce(integrand, compressed)
```

The integration adapter:

- compresses finite one-axis point realizations without changing the target contract,
- preserves normalized versus nonnormalized target mass,
- carries masks, support validity, ancestry, stratum/pair/replicate identifiers, and provenance,
- reconstructs a typed compressed realization reusable by multiple integrands,
- attaches compression diagnostics to every reduced estimate,
- rejects unsupported multi-axis or independently stratified compression rather than silently flattening scientific structure.

Moment recombination is appropriate when downstream integrands are well represented by a known finite feature span. Kernel herding is available when smooth distributional coverage is the more relevant contract.

## Robust coreset collocation

`phx.constraints.CoresetCollocation(...)` adds residual-aware, diversity-preserving selection to the existing adaptive-collocation lifecycle.

Each refresh:

1. retains the current population and draws an oversampled candidate pool,
2. evaluates pointwise residual losses with explicit accounting,
3. converts the usual squared residual score to residual-magnitude importance by default,
4. normalizes the residual distribution before mixing it with a dimensionless uniform component,
5. raises the effective uniform fraction analytically when needed to enforce a minimum importance ESS,
6. range-normalizes candidate geometry and resolves an automatic median-distance kernel scale unless an explicit kernel is supplied,
7. kernel-herds a unique fixed-size proposal,
8. rejects proposals whose normalized fill distance regresses too far relative to the current population.

The policy adds:

- delayed activation through `start_at` (defaulting to two refresh intervals),
- `uniform_fraction`, `minimum_ess_fraction`, and `max_fill_distance_ratio` controls,
- automatic or explicit kernel scaling in normalized-coordinate units,
- compiled fixed-shape selection and coverage boundaries,
- diagnostics for requested/effective mixture fractions, ESS, kernel scale, MMD, fill distances, guard activation, selection validity, acceptance, candidate count, and kernel work.

`ControlledCollocationPolicy` inherits the coreset activation step when no explicit schedule is supplied. Existing monitor, rollback, budget, and persistent coverage-anchor contracts remain authoritative. Coreset collocation remains a conditional policy rather than replacing fixed low-discrepancy collocation for smooth, adequately resolved problems.

## UQ integrations

### Sparse-GP inducing points

`phx.uq.select_inducing_points(...)` uses randomized pivoted Cholesky to select a reproducible, low-rank subset of an observation design. `InducingPointSelection` retains selected points, source indices, and trace diagnostics and can be passed directly to the existing sparse-GP factorization path.

### Chain-preserving posterior thinning

`phx.uq.thin_posterior(...)` and `SteinThinning` compress completed MCMC output without changing its sampling semantics.

The adapter:

- computes transformed-posterior scores from the retained MCMC problem,
- performs inverse-multiquadric kernel Stein thinning independently within each chain,
- preserves separate chain and retained-draw axes,
- retains original chain/draw source indices and source convergence diagnostics,
- retains constrained and unconstrained samples,
- exposes the ordinary `predict(...)` and `predict_observations(...)` interfaces on the compressed posterior.

It deliberately does not recompute R-hat or effective sample size on selected draws and does not present thinning as evidence that an unconverged chain has converged.

## Public API additions

- `phydrax.coresets`
  - selectors, kernels, discrepancy functions, result types, and diagnostics.
- `phydrax.integration.compress`
  - `CompressedIntegrationDiagnostics`
  - `MeasureCompressionDiagnostics`
- `phydrax.constraints.CoresetCollocation`
  - `CoresetCollocationPolicy`
- `phydrax.uq.select_inducing_points`
  - `InducingPointSelection`
  - `SteinThinning`
  - `PosteriorCoreset`
  - `thin_posterior`

The top-level `phydrax` namespace now exposes `coresets` alongside the existing scientific subsystems.

## Deliberate boundaries

- No Coreax runtime dependency or copied solver hierarchy.
- No second kernel, dataset, solver-state, or generic weighting framework.
- No flattening of chain, stratum, pair, replicate, or multi-axis structure merely to make selection convenient.
- No claim that one coreset objective preserves arbitrary downstream quantities.
- No promotion of residual-adaptive collocation to the universal default.
- No dynamic-capacity output that would destabilize JAX compilation shapes.

These boundaries keep the reusable layer mathematical and small while allowing future domain adapters—case selection, operator-query selection, stochastic trajectory blocks, or empirical cubature—to reuse the same primitives without weakening their scientific contracts.

## Documentation

The integration, solver, constraints, and uncertainty guides now describe:

- when moment preservation versus kernel coverage is the appropriate objective,
- the materialize-compress-reduce lifecycle,
- robust delayed coreset collocation and its diagnostics,
- inducing-point selection for sparse Gaussian processes,
- chain-preserving posterior thinning,
- current scope limitations and failure modes.