### PR TITLE
Add native path signatures and signature kernels

### DIFF
--- a/docs/all-of-phydrax.md
+++ b/docs/all-of-phydrax.md
@@ -651,10 +651,11 @@ Below are the common SciML regimes expressed in Phydrax’s primitives.
 - `phydrax.operators` for PDE operators.
 - `phydrax.nn` for models, wrappers, and the generic diagonal state-space mixer.
 - `phydrax.stochastic` for process paths, trajectories, typed state-space
-  problems and inputs, transition kernels, and structural model compilation.
+  problems and inputs, transition kernels, exact signature and log-signature
+  features, and structural model compilation.
 - `phydrax.kernels` for covariance-safe stationary, algebraic, transformed,
-  finite-feature, graph/Hodge spectral, compact, combinatorial, and fixed-noise
-  noncompact kernels shared by GP and coreset methods.
+  finite-feature, structured-input, signature-PDE, graph/Hodge spectral, compact,
+  combinatorial, and fixed-noise noncompact kernels shared by GP and coreset methods.
 - `phydrax.uq` for Gaussian factors and transforms, filtering/smoothing,
   state-space estimation, sensitivities, and stochastic spectra.
 - `phydrax.optim` for canonical QPs and the native implicit QPax backend.

--- a/docs/api/integration.md
+++ b/docs/api/integration.md
@@ -8,6 +8,7 @@ Integration separates the mathematical measure from its numerical realization:
   method-valid error evidence.
 
 ```python
+import jax.numpy as jnp
 import phydrax as phx
 
 x = phx.domain.ScalarInterval(-1.0, 2.0, label="x")
@@ -55,6 +56,38 @@ measures, and composed space/time/stochastic reductions.
 ::: phydrax.integration.compress
 
 ## Measure compression
+
+`weighted_mmd`, `kernel_herd`, randomized pivoted Cholesky, and
+`select_inducing_points` preserve every trailing axis declared by
+`kernel.input_ndim`. Point designs therefore remain `(point, coordinate)`,
+while a signature-kernel empirical measure is `(path, knot, channel)`.
+Blockwise reductions slice only the leading measure axis. They never flatten a
+path or infer ragged lengths; canonicalize padded suffixes first with
+`phydrax.stochastic.repeat_last_path_padding`.
+
+```python
+observed_time = jnp.linspace(0.0, 1.0, 5)
+observed_path = jnp.stack((observed_time, observed_time**2), axis=-1)
+observed_paths = jnp.stack((observed_path, -observed_path, 0.5 * observed_path))
+simulated_time = jnp.linspace(0.0, 1.0, 6)
+simulated_path = jnp.stack((simulated_time, simulated_time**2), axis=-1)
+simulated_paths = jnp.stack(
+    (simulated_path, -simulated_path, 0.5 * simulated_path, 1.5 * simulated_path)
+)
+path_kernel = phx.kernels.SignaturePDEKernel(
+    phx.kernels.LinearKernel(),
+    polynomial_order=5,
+)
+distance = phx.coresets.weighted_mmd(
+    observed_paths,
+    simulated_paths,
+    kernel=path_kernel,
+)
+selection = phx.coresets.kernel_herd(
+    simulated_paths,
+    phx.coresets.KernelHerding(3, kernel=path_kernel),
+)
+```
 
 ::: phydrax.coresets.MomentRecombination
 

--- a/docs/api/kernels.md
+++ b/docs/api/kernels.md
@@ -9,12 +9,16 @@ feature maps, and transform parameters remain visible to JAX transformations.
 
 Every kernel implements three explicit operations:
 
-- `pairwise(left, right)` evaluates two coordinate vectors;
-- `matrix(left, right)` evaluates a Gram or cross-Gram matrix;
+- `pairwise(left, right)` evaluates two individual kernel inputs;
+- `matrix(left, right)` evaluates a Gram or cross-Gram matrix over a leading
+  design axis;
 - `diagonal(points)` evaluates only the Gram diagonal.
 
-A one-dimensional design may be passed as a vector. General designs have shape
-`(point, coordinate)`. Kernels also expose `max_derivative_order`,
+`input_ndim` declares the number of trailing axes that form one kernel input.
+Point kernels use `input_ndim == 1`; path kernels use `input_ndim == 2`.
+Accordingly, a path-kernel design has shape `(path, knot, channel)`. A
+one-dimensional design-vector convenience remains available only for point
+kernels in scalar GP APIs. Kernels also expose `max_derivative_order`,
 `is_unit_diagonal`, and a diagnostic `kernel_id`. The ID records a stable method
 identity; it is not a serialization or reconstruction format.
 
@@ -55,11 +59,14 @@ observations use this certificate to reject unsupported differential covariance
 blocks before inference.
 
 `InputTransformedKernel` pulls a positive-definite kernel back through one
-pointwise deterministic transform. Its transform may itself be an Equinox module,
-which gives a deep kernel whose feature parameters are differentiable PyTree leaves.
-Declare the transform's actual derivative support; `None` means no finite limit and
-`0` means value observations only. `AffineInputTransform.from_points` provides
-explicit coordinate standardization without changing the kernel's public contract.
+deterministic transform per kernel input. `input_ndim` declares the input rank
+before transformation, so a complete path can be mapped to one feature vector
+without flattening its design axis. The transform may itself be an Equinox
+module, which gives a deep kernel whose feature parameters are differentiable
+PyTree leaves. Declare the transform's actual derivative support; `None` means
+no finite limit and `0` means value observations only.
+`AffineInputTransform.from_points` remains a pointwise coordinate
+standardization utility.
 
 `AbstractFiniteFeatureKernel` is the capability contract for covariances with
 whitened real features. `FiniteFeatureKernel` is its callable-map implementation:
@@ -78,6 +85,7 @@ count; otherwise it retains the dense observation-space path.
             - pairwise
             - matrix
             - diagonal
+            - input_ndim
             - max_derivative_order
             - is_unit_diagonal
             - kernel_id
@@ -106,6 +114,28 @@ count; otherwise it retains the dense observation-space path.
 
 ::: phydrax.kernels.InverseMultiquadricKernel
 
+## Linear and path kernels
+
+`LinearKernel` evaluates ordinary inner products with specialized matrix and
+diagonal operations. `NormalizedKernel` divides any strictly
+positive-diagonal child kernel by the geometric mean of its self-covariances;
+invalid child diagonals are errors rather than clipped values.
+
+`SignaturePDEKernel` is a structured-input kernel with `input_ndim == 2`.
+At `polynomial_order=m`, its monomial Goursat recurrence exactly evaluates the
+inner product of signatures truncated through tensor level `m`. It avoids
+materializing exponentially growing tensor features and remains
+positive-definite at every finite order. See
+[Signatures and path kernels](stochastic/signatures.md) for path conventions,
+ragged padding, exact-feature alternatives, and numerical guidance.
+
+::: phydrax.kernels.LinearKernel
+
+---
+
+::: phydrax.kernels.SignaturePDEKernel
+
+
 ## Algebra
 
 ::: phydrax.kernels.SumKernel
@@ -128,6 +158,10 @@ count; otherwise it retains the dense observation-space path.
             - pairwise
             - matrix
             - diagonal
+
+---
+
+::: phydrax.kernels.NormalizedKernel
 
 ## Input and feature transforms
 

--- a/docs/api/nn/layers.md
+++ b/docs/api/nn/layers.md
@@ -165,3 +165,26 @@ parameter vector; it never materializes a dense parameter-by-parameter matrix.
 ---
 
 ::: phydrax.nn.layers.inference_mode
+
+## Recurrent execution
+
+`RecurrentBatch` is the canonical packed-sequence contract. Every input leaf
+begins with `case_shape + (sequence_length,)`; `valid`, `reset`, and optional
+physical `time` arrays use exactly that shape. Invalid padding preserves state
+and emits zero output. A valid reset restarts from the cell's canonical state
+before evaluating that step. `run_recurrent` returns the post-step state and
+output trajectories together with streaming-ready final values.
+
+::: phydrax.nn.layers.AbstractRecurrentCell
+
+---
+
+::: phydrax.nn.layers.RecurrentBatch
+
+---
+
+::: phydrax.nn.layers.RecurrentResult
+
+---
+
+::: phydrax.nn.layers.run_recurrent

--- a/docs/api/stochastic/index.md
+++ b/docs/api/stochastic/index.md
@@ -19,6 +19,7 @@ The central invariants are explicit:
 ## API sections
 
 - [State-space models and solver transition adapters](state_space.md)
+- [Signatures and path kernels](signatures.md)
 - [Martingale problems and stopping](martingales.md)
 - [Backward stochastic differential equations](bsde.md)
 - [Filtering and smoothing](../uq/filtering.md)

--- a/docs/api/stochastic/signatures.md
+++ b/docs/api/stochastic/signatures.md
@@ -1,0 +1,202 @@
+# Signatures and path kernels
+
+`phydrax.stochastic` provides one tensor-algebra implementation for rough controls,
+path features, and online recurrent updates. `phydrax.kernels` builds exact finite
+feature kernels and a pure-JAX signature-PDE kernel on that same convention.
+
+## Conventions
+
+A path-value array has shape
+`batch_shape + (num_knots, dimension)`. `path_signature(values, depth)` computes the
+piecewise-linear signature of the increments between adjacent knots. It returns tensor
+levels one through `depth`; the scalar level is deliberately external. A one-knot path
+therefore has zero nonscalar levels.
+
+With `stream=True`, each level has an additional knot axis and contains one value per
+input knot. The first value is the identity signature and each later value is the
+signature of the corresponding path prefix. Terminal mode returns only the final
+levels and does not retain prefix history.
+
+`flatten_signature(..., include_scalar=True)` prepends the scalar level. The flattened
+size is
+
+`1 + dimension + dimension**2 + ... + dimension**depth`.
+
+`SignatureFeatures` packages these rules as an Equinox feature map.
+`LogSignatureFeatures` applies the tensor logarithm and converts it to the
+standard-bracket Lyndon basis represented by `PrimitiveBasis`. Its coordinate order is
+exactly `primitive_basis.words`.
+
+```python
+import jax.numpy as jnp
+import phydrax as phx
+
+path = jnp.asarray(
+    [[0.0, 0.0], [0.3, -0.1], [0.5, 0.4], [0.8, 0.2]]
+)
+paths = jnp.stack((path, -path, 0.5 * path))
+features = phx.stochastic.SignatureFeatures(
+    2,
+    4,
+    include_scalar=True,
+)
+terminal = features(path)
+prefixes = phx.stochastic.SignatureFeatures(
+    2,
+    4,
+    include_scalar=True,
+    stream=True,
+)(path)
+```
+
+## Ragged paths and physical time
+
+Path kernels do not infer masks, normalize coordinates, interpolate missing values, or
+repair invalid samples.
+
+Use `repeat_last_path_padding(values, lengths)` to replace only the suffix after each
+valid prefix by its final valid knot. Zero terminal increments then make the signature
+independent of the padded capacity. Every declared valid prefix must already be finite.
+
+Use `time_augment_path(times, values, lengths=...)` to prepend physical time as a
+channel. Shared time vectors and per-case time arrays are supported. Valid times must
+be finite and strictly increasing; repeat-last padding is applied jointly to time and
+state when `lengths` is supplied.
+
+```python
+padded_paths = jnp.asarray(
+    [
+        [[0.0, 0.0], [0.4, 0.2], [0.7, 0.5], [jnp.nan, jnp.nan]],
+        [[0.0, 0.0], [0.3, -0.2], [jnp.nan, jnp.nan], [jnp.nan, jnp.nan]],
+    ]
+)
+lengths = jnp.asarray([3, 2])
+times = jnp.asarray(
+    [[0.0, 0.5, 1.0, jnp.nan], [0.0, 0.75, jnp.nan, jnp.nan]]
+)
+clean = phx.stochastic.repeat_last_path_padding(padded_paths, lengths)
+space_time = phx.stochastic.time_augment_path(times, clean, lengths=lengths)
+```
+
+## Online recurrent signatures
+
+`SignatureRecurrentCell` implements the same Chen updates through the canonical
+`phydrax.nn.layers.run_recurrent` contract. The first valid point establishes a
+basepoint and emits the identity signature. Later valid points update from the previous
+point. Invalid padding preserves state and produces the recurrent runner's masked zero
+output; a valid reset starts a new path segment. Passing `result.final_state` as the
+next call's `initial_state` gives chunked streaming without changing the result.
+
+```python
+valid = jnp.ones(path.shape[:-1], dtype=bool)
+batch = phx.nn.layers.RecurrentBatch(path, valid)
+cell = phx.stochastic.SignatureRecurrentCell(2, 4, include_scalar=True)
+result = phx.nn.layers.run_recurrent(cell, batch)
+assert jnp.allclose(result.final_output, features(path))
+```
+
+## Exact feature kernels
+
+For small feature spaces, pull `LinearKernel` back through `SignatureFeatures`. This
+constructs the exact truncated signature Gram matrix and exposes the feature map for
+reuse in linear models:
+
+```python
+features = phx.stochastic.SignatureFeatures(2, 4, include_scalar=True)
+exact_kernel = phx.kernels.InputTransformedKernel(
+    phx.kernels.LinearKernel(),
+    features,
+    transform_id=features.feature_id,
+    input_ndim=2,
+)
+gram = exact_kernel.matrix(paths, paths)
+```
+
+The tensor feature size grows exponentially with dimension and depth. Prefer this route
+when the resulting vectors are small or will be reused many times.
+
+## Signature-PDE kernel
+
+`SignaturePDEKernel(static_kernel, polynomial_order=m)` evaluates the Goursat-PDE
+recurrence over every pair of path intervals without constructing tensor features. The
+monomial boundary recurrence carries an additional global Picard-level axis. Truncating
+that axis after `m` makes the result exactly the inner product of signatures through
+tensor level `m`, rather than a local numerical approximation. Positive definiteness is
+therefore inherited from a real feature inner product.
+
+For a nonlinear `static_kernel`, each interval pairing is the four-point RKHS increment
+of the knot Gram matrix. For `LinearKernel`, it reduces to the ordinary dot product of
+path increments. One-knot paths return the scalar kernel value one, duplicate knots
+contribute zero increments, and left and right knot counts may differ.
+
+```python
+kernel = phx.kernels.SignaturePDEKernel(
+    phx.kernels.LinearKernel(),
+    polynomial_order=5,
+    pair_block_size=32,
+)
+gram = kernel.matrix(paths, paths)
+```
+
+The PDE route costs polynomial work in `polynomial_order` and quadratic work in the two
+path lengths, but its recurrence does not grow exponentially with channel dimension.
+Increase the order until the quantity of interest is stable. `pair_block_size` controls
+matrix-evaluation memory only; it does not change kernel values. No normalization,
+time augmentation, or ragged masking is implicit.
+
+The recurrence follows the Goursat formulation of the signature kernel and the
+monomial boundary propagation developed in
+[The Signature Kernel is the solution of a Goursat PDE](https://arxiv.org/abs/2006.14794)
+and
+[Numerical Schemes for Signature Kernels](https://arxiv.org/abs/2502.08470).
+Phydrax uses global level truncation to retain an exact positive-definite kernel at each
+finite order.
+
+The repository benchmark separates compilation, steady-state forward execution,
+and reverse-mode execution:
+
+```console
+python tools/signature_benchmarks.py --quick
+```
+
+It always compares tensor features with the PDE recurrence and automatically
+adds Signax and iisignature rows when those optional packages are installed.
+Sigkax is not retained as a reference backend: its archived custom-call bridge
+targets obsolete JAX/XLA extension APIs, while the native recurrence is portable
+pure JAX on CPU and GPU.
+
+## API
+
+::: phydrax.stochastic.path_signature
+
+---
+
+::: phydrax.stochastic.path_logsignature
+
+---
+
+::: phydrax.stochastic.flatten_signature
+
+---
+
+::: phydrax.stochastic.repeat_last_path_padding
+
+---
+
+::: phydrax.stochastic.time_augment_path
+
+---
+
+::: phydrax.stochastic.SignatureFeatures
+
+---
+
+::: phydrax.stochastic.LogSignatureFeatures
+
+---
+
+::: phydrax.stochastic.SignatureRecurrentState
+
+---
+
+::: phydrax.stochastic.SignatureRecurrentCell

--- a/docs/api/uq/inference.md
+++ b/docs/api/uq/inference.md
@@ -791,6 +791,46 @@ factorization. Equal or larger feature rank also uses the dense path. Both paths
 implement the same declared covariance and expose comparable log-probability,
 conditioning, and storage diagnostics.
 
+Scalar value-observation GPs accept any design rank declared by
+`state.kernel.input_ndim`. A signature-kernel observation design is
+`(observation, knot, channel)`; inducing and query paths may use different knot
+counts when the kernel supports rectangular cross-evaluation. Exact and FITC
+factorizations preserve these axes and return one scalar latent value per
+leading design row.
+
+```python
+import jax.numpy as jnp
+import phydrax as phx
+
+time = jnp.linspace(0.0, 1.0, 6)
+path = jnp.stack((time, time**2), axis=-1)
+paths = jnp.stack((path, -path, 0.5 * path, 1.5 * path))
+observations = paths[:, -1, 0]
+physical_mean = jnp.zeros_like(observations)
+query_time = jnp.linspace(0.0, 1.0, 4)
+query_path = jnp.stack((query_time, query_time**2), axis=-1)
+query_paths = jnp.stack((query_path, -query_path))
+path_kernel = phx.kernels.SignaturePDEKernel(
+    phx.kernels.LinearKernel(),
+    polynomial_order=5,
+)
+model = phx.uq.ExactGaussianProcessDiscrepancy(paths, observations)
+state = phx.uq.GaussianProcessLikelihoodState(
+    kernel=path_kernel,
+    noise_scale=0.05,
+)
+conditioned = model.condition(
+    physical_mean,
+    query_paths,
+    state=state,
+    output_dim="trajectory",
+)
+```
+
+Path kernels are not coordinate-functional kernels. `FunctionalDesign`,
+coordinate partial derivatives, and differential-functional GP states require
+`input_ndim == 1` and reject path kernels explicitly.
+
 ::: phydrax.uq.GaussianProcessLikelihoodState
 
 ---

--- a/docs/guides_differential.md
+++ b/docs/guides_differential.md
@@ -333,6 +333,14 @@ records the source knots, `times` records the integration knots, and
 The public `tensor_exponential`, `chen_multiply`, `tensor_logarithm`, and
 `PrimitiveBasis` operations expose the same algebra for diagnostics.
 
+These control objects retain interval provenance and solver semantics. For
+statistical path features, streaming updates, ragged padding, or path kernels,
+use the lighter-weight `path_signature`, `SignatureFeatures`,
+`SignatureRecurrentCell`, and `SignaturePDEKernel` APIs instead. They share the
+same tensor exponential, Chen product, tensor logarithm, and standard-bracket
+Lyndon basis, but they do not manufacture rough-control provenance. See
+[Signatures and path kernels](api/stochastic/signatures.md).
+
 Define dynamics with the state-shaped convention
 `(time, state, args) -> state.shape + (driver_dimension,)`:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -218,6 +218,7 @@ nav:
             - Activations: "api/nn/activations.md"
         - Stochastic processes:
             - Overview: "api/stochastic/index.md"
+            - Signatures and path kernels: "api/stochastic/signatures.md"
             - State-space models: "api/stochastic/state_space.md"
             - Martingales and stopping: "api/stochastic/martingales.md"
             - Backward stochastic equations: "api/stochastic/bsde.md"

--- a/phydrax/coresets/_herding.py
+++ b/phydrax/coresets/_herding.py
@@ -104,15 +104,22 @@ def weighted_mmd(
     """Compute blockwise MMD between two finite nonnegative measures."""
     source = jnp.asarray(source_points, dtype=float)
     comparison = jnp.asarray(comparison_points, dtype=float)
-    if source.ndim != 2 or comparison.ndim != 2:
-        raise ValueError("MMD point arrays must be two-dimensional.")
-    if source.shape[1] != comparison.shape[1]:
-        raise ValueError("MMD point arrays must have equal coordinate size.")
+    kernel_ = SquaredExponentialKernel() if kernel is None else kernel
+    if not isinstance(kernel_, AbstractPositiveDefiniteKernel):
+        raise TypeError("kernel must be an AbstractPositiveDefiniteKernel or None.")
+    expected_rank = kernel_.input_ndim + 1
+    if source.ndim != expected_rank or comparison.ndim != expected_rank:
+        raise ValueError(
+            "MMD inputs must have one design axis followed by "
+            f"{kernel_.input_ndim} kernel input axes."
+        )
+    source_rows = jnp.all(jnp.isfinite(source), axis=tuple(range(1, source.ndim)))
+    comparison_rows = jnp.all(
+        jnp.isfinite(comparison), axis=tuple(range(1, comparison.ndim))
+    )
     block = int(block_size)
     if block <= 0:
         raise ValueError("block_size must be positive.")
-    source_rows = jnp.all(jnp.isfinite(source), axis=1)
-    comparison_rows = jnp.all(jnp.isfinite(comparison), axis=1)
     source_weights, _, source_valid, _ = normalized_weights(
         int(source.shape[0]),
         log_weights=source_log_weights,
@@ -125,9 +132,6 @@ def weighted_mmd(
         mask=comparison_mask,
         rows_valid=comparison_rows,
     )
-    kernel_ = SquaredExponentialKernel() if kernel is None else kernel
-    if not isinstance(kernel_, AbstractPositiveDefiniteKernel):
-        raise TypeError("kernel must be an AbstractPositiveDefiniteKernel or None.")
     value = _mmd_from_weights(
         jnp.nan_to_num(source),
         source_weights,
@@ -151,14 +155,19 @@ def kernel_herd(
     if not isinstance(method, KernelHerding):
         raise TypeError("method must be a KernelHerding.")
     values = jnp.asarray(points, dtype=float)
-    if values.ndim != 2:
-        raise ValueError("points must have shape (source_points, coordinate_size).")
-    source_points, coordinate_size = values.shape
+    expected_rank = method.kernel.input_ndim + 1
+    if values.ndim != expected_rank:
+        raise ValueError(
+            "points must have one source axis followed by "
+            f"{method.kernel.input_ndim} kernel input axes."
+        )
+    source_points = int(values.shape[0])
+    input_shape = tuple(int(size) for size in values.shape[1:])
     if source_points < 1:
         raise ValueError("Kernel herding requires at least one source point.")
     if method.unique and method.num_points > source_points:
         raise ValueError("Unique kernel herding cannot select more points than supplied.")
-    rows_valid = jnp.all(jnp.isfinite(values), axis=1)
+    rows_valid = jnp.all(jnp.isfinite(values), axis=tuple(range(1, values.ndim)))
     weights, active_source, input_valid, log_source_mass = normalized_weights(
         source_points,
         log_weights=log_weights,
@@ -192,7 +201,9 @@ def kernel_herd(
         valid_choice = input_valid & jnp.any(eligible)
         indices = indices.at[iteration].set(candidate)
         output_mask = output_mask.at[iteration].set(valid_choice)
-        update = method.kernel.matrix(safe_points, safe_points[candidate][None, :])[:, 0]
+        update = method.kernel.matrix(safe_points, safe_points[candidate][None, ...])[
+            :, 0
+        ]
         penalty = penalty + jnp.where(valid_choice, update, 0.0)
         selected = selected.at[candidate].set(selected[candidate] | valid_choice)
         return indices, output_mask, penalty, selected
@@ -229,7 +240,7 @@ def kernel_herd(
         log_source_mass=log_source_mass,
         source_points=source_points,
         capacity=capacity,
-        coordinate_size=coordinate_size,
+        input_shape=input_shape,
         kernel_id=method.kernel.kernel_id,
     )
     return CoresetSelection(

--- a/phydrax/coresets/_kernel_reductions.py
+++ b/phydrax/coresets/_kernel_reductions.py
@@ -21,15 +21,19 @@ def _weighted_kernel_sum(
     *,
     block_size: int,
 ) -> Array:
-    left_count, coordinate_size = left.shape
+    left_count = int(left.shape[0])
     right_count = int(right.shape[0])
+    left_input_shape = tuple(int(size) for size in left.shape[1:])
+    right_input_shape = tuple(int(size) for size in right.shape[1:])
     block = int(block_size)
     left_blocks = (left_count + block - 1) // block
     right_blocks = (right_count + block - 1) // block
     left_padding = left_blocks * block - left_count
     right_padding = right_blocks * block - right_count
-    padded_left = jnp.pad(left, ((0, left_padding), (0, 0)))
-    padded_right = jnp.pad(right, ((0, right_padding), (0, 0)))
+    left_pad_width = ((0, left_padding),) + ((0, 0),) * kernel.input_ndim
+    right_pad_width = ((0, right_padding),) + ((0, 0),) * kernel.input_ndim
+    padded_left = jnp.pad(left, left_pad_width)
+    padded_right = jnp.pad(right, right_pad_width)
     padded_left_weights = jnp.pad(left_weights, (0, left_padding))
     padded_right_weights = jnp.pad(right_weights, (0, right_padding))
 
@@ -37,8 +41,8 @@ def _weighted_kernel_sum(
         left_start = left_index * block
         left_points = jax.lax.dynamic_slice(
             padded_left,
-            (left_start, 0),
-            (block, coordinate_size),
+            (left_start,) + (0,) * kernel.input_ndim,
+            (block,) + left_input_shape,
         )
         left_mass = jax.lax.dynamic_slice(
             padded_left_weights,
@@ -50,8 +54,8 @@ def _weighted_kernel_sum(
             right_start = right_index * block
             right_points = jax.lax.dynamic_slice(
                 padded_right,
-                (right_start, 0),
-                (block, coordinate_size),
+                (right_start,) + (0,) * kernel.input_ndim,
+                (block,) + right_input_shape,
             )
             right_mass = jax.lax.dynamic_slice(
                 padded_right_weights,
@@ -84,11 +88,13 @@ def _weighted_kernel_mean(
     *,
     block_size: int,
 ) -> Array:
-    count, coordinate_size = points.shape
+    count = int(points.shape[0])
+    input_shape = tuple(int(size) for size in points.shape[1:])
     block = int(block_size)
     blocks = (count + block - 1) // block
     padding = blocks * block - count
-    padded_points = jnp.pad(points, ((0, padding), (0, 0)))
+    pad_width = ((0, padding),) + ((0, 0),) * kernel.input_ndim
+    padded_points = jnp.pad(points, pad_width)
     padded_weights = jnp.pad(weights, (0, padding))
     output = jnp.zeros((blocks * block,), dtype=points.dtype)
 
@@ -96,16 +102,16 @@ def _weighted_kernel_mean(
         outer_start = outer_index * block
         outer_points = jax.lax.dynamic_slice(
             padded_points,
-            (outer_start, 0),
-            (block, coordinate_size),
+            (outer_start,) + (0,) * kernel.input_ndim,
+            (block,) + input_shape,
         )
 
         def inner_body(inner_index, subtotal):
             inner_start = inner_index * block
             inner_points = jax.lax.dynamic_slice(
                 padded_points,
-                (inner_start, 0),
-                (block, coordinate_size),
+                (inner_start,) + (0,) * kernel.input_ndim,
+                (block,) + input_shape,
             )
             inner_weights = jax.lax.dynamic_slice(
                 padded_weights,

--- a/phydrax/coresets/_pivoted_cholesky.py
+++ b/phydrax/coresets/_pivoted_cholesky.py
@@ -54,14 +54,18 @@ def randomized_pivoted_cholesky(
     if not isinstance(method, RandomizedPivotedCholesky):
         raise TypeError("method must be a RandomizedPivotedCholesky.")
     values = jnp.asarray(points, dtype=float)
-    if values.ndim != 2:
-        raise ValueError("points must have shape (source_points, coordinate_size).")
+    expected_rank = method.kernel.input_ndim + 1
+    if values.ndim != expected_rank:
+        raise ValueError(
+            "points must have one source axis followed by "
+            f"{method.kernel.input_ndim} kernel input axes."
+        )
     source_points = int(values.shape[0])
     if source_points < 1:
         raise ValueError("Pivoted Cholesky requires at least one source point.")
     if method.num_points > source_points:
         raise ValueError("Cannot select more inducing points than source points.")
-    rows_valid = jnp.all(jnp.isfinite(values), axis=1)
+    rows_valid = jnp.all(jnp.isfinite(values), axis=tuple(range(1, values.ndim)))
     input_valid = jnp.all(rows_valid)
     safe_points = jnp.nan_to_num(values)
     diagonal = method.kernel.diagonal(safe_points)
@@ -95,7 +99,7 @@ def randomized_pivoted_cholesky(
             jr.choice(jr.fold_in(key, iteration), source_points, p=probabilities),
             dtype=jnp.int32,
         )
-        kernel_column = method.kernel.matrix(safe_points, safe_points[pivot][None, :])[
+        kernel_column = method.kernel.matrix(safe_points, safe_points[pivot][None, ...])[
             :, 0
         ]
         previous = factors @ factors[pivot]

--- a/phydrax/coresets/_types.py
+++ b/phydrax/coresets/_types.py
@@ -89,7 +89,7 @@ class KernelHerdingDiagnostics(StrictModule):
     log_source_mass: Array
     source_points: int = eqx.field(static=True)
     capacity: int = eqx.field(static=True)
-    coordinate_size: int = eqx.field(static=True)
+    input_shape: tuple[int, ...] = eqx.field(static=True)
     kernel_id: str = eqx.field(static=True)
 
 

--- a/phydrax/kernels/__init__.py
+++ b/phydrax/kernels/__init__.py
@@ -4,7 +4,13 @@
 
 """Composable positive-definite kernels shared across Phydrax subsystems."""
 
-from ._algebra import AmplitudeKernel, ProductKernel, ScaleKernel, SumKernel
+from ._algebra import (
+    AmplitudeKernel,
+    NormalizedKernel,
+    ProductKernel,
+    ScaleKernel,
+    SumKernel,
+)
 from ._base import AbstractPositiveDefiniteKernel, AbstractUnitDiagonalKernel
 from ._combinatorial import HammingSpectralKernel, HypercubeSpectralKernel
 from ._compact import (
@@ -21,6 +27,7 @@ from ._finite_feature import (
     kernel_features,
 )
 from ._hodge import CochainHodgeSpectralKernel
+from ._linear import LinearKernel
 from ._noncompact import (
     hyperbolic_feature_proposal,
     HyperbolicRandomFeatureKernel,
@@ -37,6 +44,7 @@ from ._operator_valued import (
     sphere_tangent_kernel,
     sphere_tangent_projector,
 )
+from ._signature import SignaturePDEKernel
 from ._spectral import (
     AbstractSpectralMultiplier,
     HeatSpectralMultiplier,
@@ -74,8 +82,11 @@ __all__ = [
     "ImportanceFeatureDiagnostics",
     "InputTransformedKernel",
     "HypercubeSpectralKernel",
+    "LinearKernel",
+    "NormalizedKernel",
     "InverseMultiquadricKernel",
     "Matern32Kernel",
+    "SignaturePDEKernel",
     "Matern52Kernel",
     "ProductKernel",
     "MaternSpectralMultiplier",

--- a/phydrax/kernels/_algebra.py
+++ b/phydrax/kernels/_algebra.py
@@ -27,6 +27,9 @@ class SumKernel(AbstractPositiveDefiniteKernel):
                 flattened.append(kernel)
         if not flattened:
             raise ValueError("SumKernel requires at least one child kernel.")
+        input_ndim = flattened[0].input_ndim
+        if any(kernel.input_ndim != input_ndim for kernel in flattened[1:]):
+            raise ValueError("SumKernel children must have equal input_ndim.")
         self.kernels = tuple(flattened)
 
     def pairwise(self, left: ArrayLike, right: ArrayLike, /) -> Array:
@@ -46,6 +49,10 @@ class SumKernel(AbstractPositiveDefiniteKernel):
         for kernel in self.kernels[1:]:
             value = value + kernel.diagonal(points)
         return value
+
+    @property
+    def input_ndim(self) -> int:
+        return self.kernels[0].input_ndim
 
     @property
     def max_derivative_order(self) -> int | None:
@@ -79,6 +86,9 @@ class ProductKernel(AbstractPositiveDefiniteKernel):
                 flattened.append(kernel)
         if not flattened:
             raise ValueError("ProductKernel requires at least one child kernel.")
+        input_ndim = flattened[0].input_ndim
+        if any(kernel.input_ndim != input_ndim for kernel in flattened[1:]):
+            raise ValueError("ProductKernel children must have equal input_ndim.")
         self.kernels = tuple(flattened)
 
     def pairwise(self, left: ArrayLike, right: ArrayLike, /) -> Array:
@@ -98,6 +108,10 @@ class ProductKernel(AbstractPositiveDefiniteKernel):
         for kernel in self.kernels[1:]:
             value = value * kernel.diagonal(points)
         return value
+
+    @property
+    def input_ndim(self) -> int:
+        return self.kernels[0].input_ndim
 
     @property
     def max_derivative_order(self) -> int | None:
@@ -145,6 +159,10 @@ class ScaleKernel(AbstractPositiveDefiniteKernel):
 
     def diagonal(self, points: ArrayLike, /) -> Array:
         return self.scale * self.kernel.diagonal(points)
+
+    @property
+    def input_ndim(self) -> int:
+        return self.kernel.input_ndim
 
     @property
     def max_derivative_order(self) -> int | None:
@@ -197,6 +215,10 @@ class AmplitudeKernel(AbstractPositiveDefiniteKernel):
         return self.variance_scale * self.kernel.diagonal(points)
 
     @property
+    def input_ndim(self) -> int:
+        return self.kernel.input_ndim
+
+    @property
     def max_derivative_order(self) -> int | None:
         return self.kernel.max_derivative_order
 
@@ -207,6 +229,59 @@ class AmplitudeKernel(AbstractPositiveDefiniteKernel):
     @property
     def kernel_id(self) -> str:
         return f"AmplitudeKernel[{self.kernel.kernel_id}]"
+
+
+class NormalizedKernel(AbstractPositiveDefiniteKernel):
+    """Unit-diagonal normalization of a strictly positive-diagonal kernel."""
+
+    kernel: AbstractPositiveDefiniteKernel
+
+    def __init__(self, kernel: AbstractPositiveDefiniteKernel, /):
+        if not isinstance(kernel, AbstractPositiveDefiniteKernel):
+            raise TypeError("kernel must be a positive-definite kernel.")
+        self.kernel = kernel
+
+    @staticmethod
+    def _checked_diagonal(diagonal: Array, /) -> Array:
+        return eqx.error_if(
+            diagonal,
+            jnp.any(~jnp.isfinite(diagonal)) | jnp.any(diagonal <= 0.0),
+            "NormalizedKernel requires a finite strictly positive child diagonal.",
+        )
+
+    def pairwise(self, left: ArrayLike, right: ArrayLike, /) -> Array:
+        left_diagonal = self._checked_diagonal(self.kernel.pairwise(left, left))
+        right_diagonal = self._checked_diagonal(self.kernel.pairwise(right, right))
+        return self.kernel.pairwise(left, right) / jnp.sqrt(
+            left_diagonal * right_diagonal
+        )
+
+    def matrix(self, left: ArrayLike, right: ArrayLike, /) -> Array:
+        left_diagonal = self._checked_diagonal(self.kernel.diagonal(left))
+        right_diagonal = self._checked_diagonal(self.kernel.diagonal(right))
+        return self.kernel.matrix(left, right) / jnp.sqrt(
+            left_diagonal[:, None] * right_diagonal[None, :]
+        )
+
+    def diagonal(self, points: ArrayLike, /) -> Array:
+        diagonal = self._checked_diagonal(self.kernel.diagonal(points))
+        return diagonal / diagonal
+
+    @property
+    def input_ndim(self) -> int:
+        return self.kernel.input_ndim
+
+    @property
+    def max_derivative_order(self) -> int | None:
+        return self.kernel.max_derivative_order
+
+    @property
+    def is_unit_diagonal(self) -> bool:
+        return True
+
+    @property
+    def kernel_id(self) -> str:
+        return f"NormalizedKernel[{self.kernel.kernel_id}]"
 
 
 def _minimum_regularity(
@@ -220,6 +295,7 @@ def _minimum_regularity(
 
 __all__ = [
     "AmplitudeKernel",
+    "NormalizedKernel",
     "ProductKernel",
     "ScaleKernel",
     "SumKernel",

--- a/phydrax/kernels/_base.py
+++ b/phydrax/kernels/_base.py
@@ -16,7 +16,7 @@ from .._strict import StrictModule
 
 
 class AbstractPositiveDefiniteKernel(StrictModule):
-    """Real scalar positive-definite kernel over coordinate vectors."""
+    """Real scalar positive-definite kernel over declared array inputs."""
 
     @abstractmethod
     def pairwise(self, left: ArrayLike, right: ArrayLike, /) -> Array:
@@ -32,6 +32,11 @@ class AbstractPositiveDefiniteKernel(StrictModule):
     def diagonal(self, points: ArrayLike, /) -> Array:
         """Evaluate the Gram diagonal without materializing the Gram matrix."""
         raise NotImplementedError
+
+    @property
+    def input_ndim(self) -> int:
+        """Number of trailing axes forming one kernel input."""
+        return 1
 
     @property
     @abstractmethod
@@ -75,7 +80,11 @@ class AbstractUnitDiagonalKernel(AbstractPositiveDefiniteKernel):
     """Positive-definite correlation kernel with an exact unit diagonal."""
 
     def diagonal(self, points: ArrayLike, /) -> Array:
-        point_design = _as_points(points, name="points")
+        point_design = _as_inputs(
+            points,
+            input_ndim=self.input_ndim,
+            name="points",
+        )
         return jnp.ones((point_design.shape[0],), dtype=point_design.dtype)
 
     @property
@@ -98,32 +107,61 @@ def _pairwise_matrix(
     )(left_points)
 
 
-def _as_point(value: ArrayLike, /, *, name: str) -> Array:
-    point = jnp.asarray(value, dtype=float)
-    if point.ndim == 0:
-        point = point.reshape((1,))
-    if point.ndim != 1 or point.shape[0] == 0:
-        raise ValueError(f"{name} must be a nonempty coordinate vector.")
+def _as_input(
+    value: ArrayLike,
+    /,
+    *,
+    input_ndim: int,
+    name: str,
+) -> Array:
+    rank = int(input_ndim)
+    if rank <= 0:
+        raise ValueError("input_ndim must be positive.")
+    sample = jnp.asarray(value, dtype=float)
+    if rank == 1 and sample.ndim == 0:
+        sample = sample.reshape((1,))
+    if sample.ndim != rank or any(int(size) <= 0 for size in sample.shape):
+        raise ValueError(
+            f"{name} must have {rank} nonempty input axes; got shape {sample.shape}."
+        )
     return eqx.error_if(
-        point,
-        jnp.any(~jnp.isfinite(point)),
-        f"{name} must contain only finite coordinates.",
+        sample,
+        jnp.any(~jnp.isfinite(sample)),
+        f"{name} must contain only finite values.",
     )
+
+
+def _as_inputs(
+    value: ArrayLike,
+    /,
+    *,
+    input_ndim: int,
+    name: str,
+) -> Array:
+    rank = int(input_ndim)
+    if rank <= 0:
+        raise ValueError("input_ndim must be positive.")
+    samples = jnp.asarray(value, dtype=float)
+    if rank == 1 and samples.ndim == 1:
+        samples = samples[:, None]
+    if samples.ndim != rank + 1 or any(int(size) <= 0 for size in samples.shape):
+        raise ValueError(
+            f"{name} must have one design axis followed by {rank} nonempty "
+            f"input axes; got shape {samples.shape}."
+        )
+    return eqx.error_if(
+        samples,
+        jnp.any(~jnp.isfinite(samples)),
+        f"{name} must contain only finite values.",
+    )
+
+
+def _as_point(value: ArrayLike, /, *, name: str) -> Array:
+    return _as_input(value, input_ndim=1, name=name)
 
 
 def _as_points(value: ArrayLike, /, *, name: str) -> Array:
-    points = jnp.asarray(value, dtype=float)
-    if points.ndim == 1:
-        points = points[:, None]
-    if points.ndim != 2 or points.shape[0] == 0 or points.shape[1] == 0:
-        raise ValueError(
-            f"{name} must have shape (point, coordinate) with nonempty axes."
-        )
-    return eqx.error_if(
-        points,
-        jnp.any(~jnp.isfinite(points)),
-        f"{name} must contain only finite coordinates.",
-    )
+    return _as_inputs(value, input_ndim=1, name=name)
 
 
 __all__ = ["AbstractPositiveDefiniteKernel", "AbstractUnitDiagonalKernel"]

--- a/phydrax/kernels/_linear.py
+++ b/phydrax/kernels/_linear.py
@@ -1,0 +1,47 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+from jaxtyping import Array, ArrayLike
+
+from ._base import _as_point, _as_points, AbstractPositiveDefiniteKernel
+
+
+class LinearKernel(AbstractPositiveDefiniteKernel):
+    """Euclidean linear kernel with no implicit scale or offset."""
+
+    def pairwise(self, left: ArrayLike, right: ArrayLike, /) -> Array:
+        left_point = _as_point(left, name="left")
+        right_point = _as_point(right, name="right")
+        if left_point.shape != right_point.shape:
+            raise ValueError("LinearKernel points must have equal coordinate size.")
+        return jnp.vdot(left_point, right_point).real
+
+    def matrix(self, left: ArrayLike, right: ArrayLike, /) -> Array:
+        left_points = _as_points(left, name="left")
+        right_points = _as_points(right, name="right")
+        if left_points.shape[1] != right_points.shape[1]:
+            raise ValueError("LinearKernel designs must have equal coordinate size.")
+        return left_points @ right_points.T
+
+    def diagonal(self, points: ArrayLike, /) -> Array:
+        point_design = _as_points(points, name="points")
+        return jnp.sum(point_design * point_design, axis=1)
+
+    @property
+    def max_derivative_order(self) -> int | None:
+        return None
+
+    @property
+    def is_unit_diagonal(self) -> bool:
+        return False
+
+    @property
+    def kernel_id(self) -> str:
+        return "LinearKernel"
+
+
+__all__ = ["LinearKernel"]

--- a/phydrax/kernels/_signature.py
+++ b/phydrax/kernels/_signature.py
@@ -1,0 +1,229 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from math import factorial
+from numbers import Integral
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array, ArrayLike
+
+from ._base import _as_input, _as_inputs, AbstractPositiveDefiniteKernel
+
+
+class SignaturePDEKernel(AbstractPositiveDefiniteKernel):
+    """Truncated signature kernel evaluated through its Goursat PDE recurrence.
+
+    The recurrence propagates monomial boundary coefficients over every pair of
+    path intervals. An additional level axis truncates the global Picard series,
+    so order ``m`` is exactly the positive-definite inner product of signatures
+    truncated after tensor level ``m`` rather than a locally truncated PDE
+    approximation.
+    """
+
+    static_kernel: AbstractPositiveDefiniteKernel
+    polynomial_order: int = eqx.field(static=True)
+    pair_block_size: int = eqx.field(static=True)
+
+    def __init__(
+        self,
+        static_kernel: AbstractPositiveDefiniteKernel,
+        /,
+        *,
+        polynomial_order: int = 5,
+        pair_block_size: int = 64,
+    ):
+        if not isinstance(static_kernel, AbstractPositiveDefiniteKernel):
+            raise TypeError("static_kernel must be a positive-definite kernel.")
+        if static_kernel.input_ndim != 1:
+            raise ValueError("static_kernel.input_ndim must be 1.")
+        if not isinstance(polynomial_order, Integral) or isinstance(
+            polynomial_order, bool
+        ):
+            raise TypeError("polynomial_order must be an integer.")
+        if not isinstance(pair_block_size, Integral) or isinstance(pair_block_size, bool):
+            raise TypeError("pair_block_size must be an integer.")
+        resolved_order = int(polynomial_order)
+        resolved_block_size = int(pair_block_size)
+        if resolved_order <= 0:
+            raise ValueError("polynomial_order must be positive.")
+        if resolved_block_size <= 0:
+            raise ValueError("pair_block_size must be positive.")
+        self.static_kernel = static_kernel
+        self.polynomial_order = resolved_order
+        self.pair_block_size = resolved_block_size
+
+    def pairwise(self, left: ArrayLike, right: ArrayLike, /) -> Array:
+        left_path = _as_input(left, input_ndim=2, name="left")
+        right_path = _as_input(right, input_ndim=2, name="right")
+        _validate_path_channels(left_path, right_path)
+        return self._pairwise_paths(left_path, right_path)
+
+    def matrix(self, left: ArrayLike, right: ArrayLike, /) -> Array:
+        left_paths = _as_inputs(left, input_ndim=2, name="left")
+        right_paths = _as_inputs(right, input_ndim=2, name="right")
+        _validate_path_channels(left_paths, right_paths)
+        left_count = int(left_paths.shape[0])
+        right_count = int(right_paths.shape[0])
+        if left_count == 0 or right_count == 0:
+            return jnp.empty(
+                (left_count, right_count),
+                dtype=jnp.result_type(left_paths, right_paths),
+            )
+
+        pair_count = left_count * right_count
+        block_size = self.pair_block_size
+        block_count = (pair_count + block_size - 1) // block_size
+        block_offsets = jnp.arange(block_count, dtype=jnp.int32) * block_size
+        within_block = jnp.arange(block_size, dtype=jnp.int32)
+
+        def evaluate_block(offset: Array, /) -> Array:
+            indices = offset + within_block
+            valid = indices < pair_count
+            safe_indices = jnp.minimum(indices, pair_count - 1)
+            left_indices = safe_indices // right_count
+            right_indices = safe_indices % right_count
+            values = jax.vmap(self._pairwise_paths)(
+                left_paths[left_indices], right_paths[right_indices]
+            )
+            return jnp.where(valid, values, 0.0)
+
+        blocks = jax.lax.map(evaluate_block, block_offsets)
+        return blocks.reshape((-1,))[:pair_count].reshape((left_count, right_count))
+
+    def diagonal(self, points: ArrayLike, /) -> Array:
+        paths = _as_inputs(points, input_ndim=2, name="points")
+        return jax.vmap(self._pairwise_paths)(paths, paths)
+
+    def _pairwise_paths(self, left_path: Array, right_path: Array, /) -> Array:
+        left_segment_count = int(left_path.shape[0]) - 1
+        right_segment_count = int(right_path.shape[0]) - 1
+        if left_segment_count == 0 or right_segment_count == 0:
+            return jnp.asarray(1.0, dtype=jnp.result_type(left_path, right_path))
+
+        point_gram = self.static_kernel.matrix(left_path, right_path)
+        increment_gram = jnp.diff(jnp.diff(point_gram, axis=0), axis=1)
+        order = self.polynomial_order
+        identity = (
+            jnp.zeros((order + 1, order + 1), dtype=increment_gram.dtype)
+            .at[0, 0]
+            .set(1.0)
+        )
+        horizontal_boundaries = jnp.broadcast_to(
+            identity, (left_segment_count,) + identity.shape
+        )
+
+        def propagate_row(
+            bottom_boundaries: Array, increment_column: Array, /
+        ) -> tuple[Array, Array]:
+            def propagate_cell(
+                left_boundary: Array, cell: tuple[Array, Array], /
+            ) -> tuple[Array, Array]:
+                bottom_boundary, increment = cell
+                top_boundary, right_boundary = self._propagate_rectangle(
+                    bottom_boundary, left_boundary, increment
+                )
+                return right_boundary, top_boundary
+
+            right_boundary, top_boundaries = jax.lax.scan(
+                propagate_cell,
+                identity,
+                (bottom_boundaries, increment_column),
+            )
+            return top_boundaries, right_boundary
+
+        top_boundaries, right_boundaries = jax.lax.scan(
+            propagate_row,
+            horizontal_boundaries,
+            jnp.swapaxes(increment_gram, 0, 1),
+        )
+        top_value = jnp.sum(top_boundaries[-1])
+        right_value = jnp.sum(right_boundaries[-1])
+        return 0.5 * (top_value + right_value)
+
+    def _propagate_rectangle(
+        self,
+        bottom: Array,
+        left: Array,
+        increment: Array,
+        /,
+    ) -> tuple[Array, Array]:
+        order = self.polynomial_order
+        dtype = jnp.result_type(bottom, left, increment)
+        same_coefficients, cross_coefficients = _propagation_coefficients(
+            order, dtype=dtype
+        )
+        powers = [jnp.ones((), dtype=dtype)]
+        for _ in range(order):
+            powers.append(powers[-1] * increment)
+        powers_array = jnp.stack(powers)
+        top = jnp.zeros_like(bottom)
+        right = jnp.zeros_like(left)
+        cross_from_left = cross_coefficients @ left
+        cross_from_bottom = cross_coefficients @ bottom
+
+        for shift in range(order + 1):
+            size = order + 1 - shift
+            same_weights = jnp.diagonal(same_coefficients[shift:, :size])[:, None]
+            top = top.at[shift:, shift:].add(
+                powers_array[shift] * same_weights * bottom[:size, :size]
+            )
+            right = right.at[shift:, shift:].add(
+                powers_array[shift] * same_weights * left[:size, :size]
+            )
+            top = top.at[shift, shift:].add(
+                powers_array[shift] * cross_from_left[shift, :size]
+            )
+            right = right.at[shift, shift:].add(
+                powers_array[shift] * cross_from_bottom[shift, :size]
+            )
+        return top, right
+
+    @property
+    def input_ndim(self) -> int:
+        return 2
+
+    @property
+    def max_derivative_order(self) -> int:
+        return 0
+
+    @property
+    def is_unit_diagonal(self) -> bool:
+        return False
+
+    @property
+    def kernel_id(self) -> str:
+        return (
+            f"SignaturePDEKernel[order={self.polynomial_order},"
+            f"static={self.static_kernel.kernel_id}]"
+        )
+
+
+def _propagation_coefficients(order: int, /, *, dtype: jnp.dtype) -> tuple[Array, Array]:
+    same = tuple(
+        tuple(
+            (factorial(k) / (factorial(n - k) * factorial(n)) if k <= n else 0.0)
+            for k in range(order + 1)
+        )
+        for n in range(order + 1)
+    )
+    cross = tuple(
+        tuple(
+            (factorial(k) / (factorial(n + k) * factorial(n)) if k >= 1 else 0.0)
+            for k in range(order + 1)
+        )
+        for n in range(order + 1)
+    )
+    return jnp.asarray(same, dtype=dtype), jnp.asarray(cross, dtype=dtype)
+
+
+def _validate_path_channels(left: Array, right: Array, /) -> None:
+    if left.shape[-1] != right.shape[-1]:
+        raise ValueError("Path channel dimensions must be equal.")
+
+
+__all__ = ["SignaturePDEKernel"]

--- a/phydrax/kernels/_transforms.py
+++ b/phydrax/kernels/_transforms.py
@@ -12,16 +12,23 @@ import jax.numpy as jnp
 from jaxtyping import Array, ArrayLike
 
 from .._strict import StrictModule
-from ._base import _as_point, _as_points, AbstractPositiveDefiniteKernel
+from ._base import (
+    _as_input,
+    _as_inputs,
+    _as_point,
+    _as_points,
+    AbstractPositiveDefiniteKernel,
+)
 
 
 class InputTransformedKernel(AbstractPositiveDefiniteKernel):
-    """Positive-definite pullback through a deterministic pointwise feature map."""
+    """Positive-definite pullback through a deterministic input transform."""
 
     kernel: AbstractPositiveDefiniteKernel
     transform_function: Callable[[Array], Array]
     transform_id: str = eqx.field(static=True)
     transform_derivative_order: int | None = eqx.field(static=True)
+    _input_ndim: int = eqx.field(static=True)
 
     def __init__(
         self,
@@ -31,6 +38,7 @@ class InputTransformedKernel(AbstractPositiveDefiniteKernel):
         *,
         transform_id: str,
         max_derivative_order: int | None = 0,
+        input_ndim: int = 1,
     ):
         if not isinstance(kernel, AbstractPositiveDefiniteKernel):
             raise TypeError("kernel must be a positive-definite kernel.")
@@ -40,35 +48,47 @@ class InputTransformedKernel(AbstractPositiveDefiniteKernel):
             raise ValueError("transform_id must be a nonempty string.")
         if max_derivative_order is not None and int(max_derivative_order) < 0:
             raise ValueError("max_derivative_order must be nonnegative or None.")
+        resolved_input_ndim = int(input_ndim)
+        if resolved_input_ndim <= 0:
+            raise ValueError("input_ndim must be positive.")
         self.kernel = kernel
         self.transform_function = transform_function
         self.transform_id = transform_id
         self.transform_derivative_order = (
             None if max_derivative_order is None else int(max_derivative_order)
         )
+        self._input_ndim = resolved_input_ndim
 
     def pairwise(self, left: ArrayLike, right: ArrayLike, /) -> Array:
-        left_point = _as_point(left, name="left")
-        right_point = _as_point(right, name="right")
+        left_input = _as_input(left, input_ndim=self.input_ndim, name="left")
+        right_input = _as_input(right, input_ndim=self.input_ndim, name="right")
         return self.kernel.pairwise(
-            self._transform_point(left_point),
-            self._transform_point(right_point),
+            self._transform_input(left_input),
+            self._transform_input(right_input),
         )
 
     def matrix(self, left: ArrayLike, right: ArrayLike, /) -> Array:
-        left_points = _as_points(left, name="left")
-        right_points = _as_points(right, name="right")
-        left_features = jax.vmap(self._transform_point)(left_points)
-        right_features = jax.vmap(self._transform_point)(right_points)
+        left_inputs = _as_inputs(left, input_ndim=self.input_ndim, name="left")
+        right_inputs = _as_inputs(right, input_ndim=self.input_ndim, name="right")
+        left_features = jax.vmap(self._transform_input)(left_inputs)
+        right_features = jax.vmap(self._transform_input)(right_inputs)
         return self.kernel.matrix(left_features, right_features)
 
     def diagonal(self, points: ArrayLike, /) -> Array:
-        point_design = _as_points(points, name="points")
-        features = jax.vmap(self._transform_point)(point_design)
+        inputs = _as_inputs(points, input_ndim=self.input_ndim, name="points")
+        features = jax.vmap(self._transform_input)(inputs)
         return self.kernel.diagonal(features)
 
-    def _transform_point(self, point: Array, /) -> Array:
-        return _as_point(self.transform_function(point), name="transformed point")
+    def _transform_input(self, value: Array, /) -> Array:
+        return _as_input(
+            self.transform_function(value),
+            input_ndim=self.kernel.input_ndim,
+            name="transformed input",
+        )
+
+    @property
+    def input_ndim(self) -> int:
+        return self._input_ndim
 
     @property
     def max_derivative_order(self) -> int | None:

--- a/phydrax/nn/layers/_recurrent.py
+++ b/phydrax/nn/layers/_recurrent.py
@@ -477,6 +477,7 @@ def run_affine_recurrence(
 
 __all__ = [
     "AbstractRecurrentCell",
+    "AbstractRecurrentOutputCell",
     "AffineRecurrence",
     "RecurrentBatch",
     "RecurrentResult",

--- a/phydrax/stochastic/__init__.py
+++ b/phydrax/stochastic/__init__.py
@@ -184,6 +184,16 @@ from ._signature import (
     tensor_exponential,
     tensor_logarithm,
 )
+from ._signature_features import (
+    flatten_signature,
+    LogSignatureFeatures,
+    path_logsignature,
+    path_signature,
+    repeat_last_path_padding,
+    SignatureFeatures,
+    time_augment_path,
+)
+from ._signature_recurrent import SignatureRecurrentCell, SignatureRecurrentState
 from ._solution import (
     SPDEFormulation,
     SPDENoiseRegularization,
@@ -388,6 +398,15 @@ __all__ = [
     "GaussianFieldDiagnostics",
     "GeometricRoughPath",
     "LogSignatureControl",
+    "LogSignatureFeatures",
+    "SignatureFeatures",
+    "SignatureRecurrentCell",
+    "SignatureRecurrentState",
+    "flatten_signature",
+    "path_logsignature",
+    "path_signature",
+    "repeat_last_path_padding",
+    "time_augment_path",
     "piecewise_linear_signature",
     "PrimitiveBasis",
     "tensor_exponential",

--- a/phydrax/stochastic/_signature.py
+++ b/phydrax/stochastic/_signature.py
@@ -53,13 +53,49 @@ def _signature_shape(signature: Sequence[ArrayLike], /) -> tuple[tuple[Array, ..
     return levels, dimension
 
 
-def _tensor_product(left: Array, right: Array, left_degree: int, right_degree: int) -> Array:
+def _tensor_product(
+    left: Array, right: Array, left_degree: int, right_degree: int
+) -> Array:
     batch_shape = left.shape[:-left_degree]
     if right.shape[:-right_degree] != batch_shape:
         raise ValueError("Tensor factors must have matching batch shapes.")
     return left.reshape(
         batch_shape + left.shape[-left_degree:] + (1,) * right_degree
     ) * right.reshape(batch_shape + (1,) * left_degree + right.shape[-right_degree:])
+
+
+def _signature_identity(
+    batch_shape: tuple[int, ...],
+    dimension: int,
+    depth: int,
+    dtype,
+    /,
+) -> tuple[Array, ...]:
+    return tuple(
+        jnp.zeros(batch_shape + (dimension,) * degree, dtype=dtype)
+        for degree in range(1, depth + 1)
+    )
+
+
+def _chen_multiply_increment(
+    signature: tuple[Array, ...],
+    increment: Array,
+    /,
+) -> tuple[Array, ...]:
+    """Multiply a validated signature by one straight-segment signature."""
+    straight = tensor_exponential(increment, len(signature))
+    result: list[Array] = []
+    for degree in range(1, len(signature) + 1):
+        level = signature[degree - 1] + straight[degree - 1]
+        for split in range(1, degree):
+            level = level + _tensor_product(
+                signature[split - 1],
+                straight[degree - split - 1],
+                split,
+                degree - split,
+            )
+        result.append(level)
+    return tuple(result)
 
 
 def tensor_exponential(increment: ArrayLike, depth: int, /) -> tuple[Array, ...]:
@@ -70,9 +106,7 @@ def tensor_exponential(increment: ArrayLike, depth: int, /) -> tuple[Array, ...]
         raise ValueError("increment must end in a non-empty driver axis.")
     levels: list[Array] = [value]
     for degree in range(2, resolved_depth + 1):
-        levels.append(
-            _tensor_product(levels[-1], value, degree - 1, 1) / float(degree)
-        )
+        levels.append(_tensor_product(levels[-1], value, degree - 1, 1) / float(degree))
     return tuple(levels)
 
 
@@ -123,32 +157,55 @@ def tensor_logarithm(signature: Sequence[ArrayLike], /) -> tuple[Array, ...]:
     for exponent in range(1, len(levels) + 1):
         coefficient = (1.0 if exponent % 2 else -1.0) / float(exponent)
         result = tuple(
-            accumulated + coefficient * term
-            for accumulated, term in zip(result, power)
+            accumulated + coefficient * term for accumulated, term in zip(result, power)
         )
         power = _nonunital_product(power, levels)
     return result
 
 
-def piecewise_linear_signature(increments: ArrayLike, depth: int, /) -> tuple[Array, ...]:
-    """Aggregate straight-segment tensor exponentials along the penultimate axis."""
+def piecewise_linear_signature(
+    increments: ArrayLike,
+    depth: int,
+    /,
+    *,
+    stream: bool = False,
+) -> tuple[Array, ...]:
+    """Aggregate straight-segment signatures along the penultimate axis.
+
+    Streaming output retains the signature after each supplied increment. The
+    empty signature is not included because increments do not declare an
+    initial knot.
+    """
     values = _inexact_array(increments)
     resolved_depth = _validate_depth(depth)
-    if values.ndim < 2 or int(values.shape[-2]) <= 0 or int(values.shape[-1]) <= 0:
+    if values.ndim < 2 or int(values.shape[-1]) <= 0:
         raise ValueError(
             "increments must have shape batch_shape + (num_segments, dimension)."
         )
     dimension = int(values.shape[-1])
-    batch_shape = values.shape[:-2]
-    initial = tuple(
-        jnp.zeros(batch_shape + (dimension,) * degree, dtype=values.dtype)
-        for degree in range(1, resolved_depth + 1)
+    batch_shape = tuple(int(size) for size in values.shape[:-2])
+    initial = _signature_identity(
+        batch_shape,
+        dimension,
+        resolved_depth,
+        values.dtype,
     )
+    scan_values = jnp.moveaxis(values, -2, 0)
 
-    def combine(carry, increment):
-        return chen_multiply(carry, tensor_exponential(increment, resolved_depth)), None
+    if stream:
 
-    return jax.lax.scan(combine, initial, jnp.moveaxis(values, -2, 0))[0]
+        def combine_stream(carry, increment):
+            updated = _chen_multiply_increment(carry, increment)
+            return updated, updated
+
+        _, history = jax.lax.scan(combine_stream, initial, scan_values)
+        sequence_axis = len(batch_shape)
+        return tuple(jnp.moveaxis(level, 0, sequence_axis) for level in history)
+
+    def combine_terminal(carry, increment):
+        return _chen_multiply_increment(carry, increment), None
+
+    return jax.lax.scan(combine_terminal, initial, scan_values)[0]
 
 
 def _is_lyndon(word: Word, /) -> bool:
@@ -190,9 +247,7 @@ class PrimitiveBasis(StrictModule):
     conversion_inverses: tuple[tuple[tuple[float, ...], ...], ...] = eqx.field(
         static=True
     )
-    expansion_matrices: tuple[tuple[tuple[float, ...], ...], ...] = eqx.field(
-        static=True
-    )
+    expansion_matrices: tuple[tuple[tuple[float, ...], ...], ...] = eqx.field(static=True)
 
     def __init__(self, dimension: int, depth: int, /):
         resolved_dimension = int(dimension)
@@ -215,9 +270,7 @@ class PrimitiveBasis(StrictModule):
                 expansions.append({word: 1})
                 continue
             split = next(
-                index
-                for index in range(1, len(word))
-                if word[index:] in lyndon_set
+                index for index in range(1, len(word)) if word[index:] in lyndon_set
             )
             left_word = word[:split]
             right_word = word[split:]
@@ -242,10 +295,7 @@ class PrimitiveBasis(StrictModule):
             if indices:
                 restricted = np.asarray(
                     [
-                        [
-                            expansions[column].get(words[row], 0)
-                            for column in indices
-                        ]
+                        [expansions[column].get(words[row], 0) for column in indices]
                         for row in indices
                     ],
                     dtype=float,
@@ -280,13 +330,17 @@ class PrimitiveBasis(StrictModule):
         """Convert tensor-log word coefficients to standard Lyndon coefficients."""
         levels, dimension = _signature_shape(tensor_log)
         if dimension != self.dimension or len(levels) != self.depth:
-            raise ValueError("Tensor log must match the primitive basis depth and dimension.")
+            raise ValueError(
+                "Tensor log must match the primitive basis depth and dimension."
+            )
         coefficients: list[Array] = []
         for degree, indices in enumerate(self.degree_indices, start=1):
             if not indices:
                 continue
             selected = jnp.stack(
-                tuple(levels[degree - 1][(...,) + self.words[index]] for index in indices),
+                tuple(
+                    levels[degree - 1][(...,) + self.words[index]] for index in indices
+                ),
                 axis=-1,
             )
             inverse = jnp.asarray(
@@ -303,14 +357,10 @@ class PrimitiveBasis(StrictModule):
         levels: list[Array] = []
         for degree, indices in enumerate(self.degree_indices, start=1):
             selected = values[..., jnp.asarray(indices)]
-            matrix = jnp.asarray(
-                self.expansion_matrices[degree - 1], dtype=values.dtype
-            )
+            matrix = jnp.asarray(self.expansion_matrices[degree - 1], dtype=values.dtype)
             flattened = jnp.einsum("wi,...i->...w", matrix, selected)
             levels.append(
-                flattened.reshape(
-                    values.shape[:-1] + (self.dimension,) * degree
-                )
+                flattened.reshape(values.shape[:-1] + (self.dimension,) * degree)
             )
         return tuple(levels)
 
@@ -430,10 +480,9 @@ class LogSignatureControl(AbstractRoughControl):
             raise ValueError(
                 "values must have shape sample_shape + (num_times, dimension)."
             )
-        if (
-            path_values.shape[: len(samples)] != samples
-            or path_values.shape[len(samples)] != int(nodes.size)
-        ):
+        if path_values.shape[: len(samples)] != samples or path_values.shape[
+            len(samples)
+        ] != int(nodes.size):
             raise ValueError("values must align with sample_shape and fine times.")
         source_dimension = int(path_values.shape[-1])
         if source_dimension <= 0 or bool(jnp.any(~jnp.isfinite(path_values))):
@@ -497,9 +546,7 @@ class LogSignatureControl(AbstractRoughControl):
             lifted_values = path_values
         increments = jnp.diff(lifted_values, axis=len(samples))
         interval_signatures = tuple(
-            piecewise_linear_signature(
-                increments[..., left:right, :], resolved_depth
-            )
+            piecewise_linear_signature(increments[..., left:right, :], resolved_depth)
             for left, right in pairwise(indices)
         )
         step_axis = len(samples)

--- a/phydrax/stochastic/_signature_features.py
+++ b/phydrax/stochastic/_signature_features.py
@@ -1,0 +1,275 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import equinox as eqx
+import jax.numpy as jnp
+from jaxtyping import Array, ArrayLike
+
+from .._strict import StrictModule
+from ._signature import (
+    _inexact_array,
+    _signature_shape,
+    piecewise_linear_signature,
+    PrimitiveBasis,
+    tensor_logarithm,
+)
+
+
+def path_signature(
+    values: ArrayLike,
+    depth: int,
+    /,
+    *,
+    stream: bool = False,
+) -> tuple[Array, ...]:
+    """Return the truncated signature of one or batched path-value arrays.
+
+    ``values`` has shape ``batch_shape + (num_knots, dimension)``. Streaming
+    output aligns with those knots and includes the empty signature at the
+    initial knot.
+    """
+    path = _inexact_array(values)
+    if path.ndim < 2 or int(path.shape[-2]) <= 0 or int(path.shape[-1]) <= 0:
+        raise ValueError(
+            "values must have shape batch_shape + (num_knots, dimension) "
+            "with nonempty path axes."
+        )
+    path = eqx.error_if(
+        path,
+        jnp.any(~jnp.isfinite(path)),
+        "Path values must be finite.",
+    )
+    signature = piecewise_linear_signature(
+        jnp.diff(path, axis=-2),
+        depth,
+        stream=stream,
+    )
+    if not stream:
+        return signature
+
+    batch_shape = path.shape[:-2]
+    sequence_axis = len(batch_shape)
+    return tuple(
+        jnp.concatenate(
+            (
+                jnp.zeros(
+                    batch_shape + (1,) + level.shape[sequence_axis + 1 :],
+                    dtype=level.dtype,
+                ),
+                level,
+            ),
+            axis=sequence_axis,
+        )
+        for level in signature
+    )
+
+
+def flatten_signature(
+    signature: tuple[ArrayLike, ...],
+    /,
+    *,
+    include_scalar: bool = False,
+) -> Array:
+    """Pack tensor levels into degree-major real feature vectors."""
+    levels, dimension = _signature_shape(signature)
+    batch_shape = levels[0].shape[:-1]
+    flattened = tuple(
+        level.reshape(batch_shape + (dimension**degree,))
+        for degree, level in enumerate(levels, start=1)
+    )
+    if include_scalar:
+        flattened = (jnp.ones(batch_shape + (1,), dtype=levels[0].dtype),) + flattened
+    return jnp.concatenate(flattened, axis=-1)
+
+
+def path_logsignature(
+    values: ArrayLike,
+    primitive_basis: PrimitiveBasis,
+    /,
+    *,
+    stream: bool = False,
+) -> Array:
+    """Return standard-bracket Lyndon coordinates of a path log signature."""
+    if not isinstance(primitive_basis, PrimitiveBasis):
+        raise TypeError("primitive_basis must be a PrimitiveBasis.")
+    signature = path_signature(values, primitive_basis.depth, stream=stream)
+    return primitive_basis.tensor_to_primitive(tensor_logarithm(signature))
+
+
+def repeat_last_path_padding(values: ArrayLike, lengths: ArrayLike, /) -> Array:
+    """Replace every padded suffix by its final valid path value."""
+    path = _inexact_array(values)
+    if path.ndim < 2 or int(path.shape[-2]) <= 0 or int(path.shape[-1]) <= 0:
+        raise ValueError(
+            "values must have shape batch_shape + (max_knots, dimension) "
+            "with nonempty path axes."
+        )
+    length_values = jnp.asarray(lengths)
+    batch_shape = path.shape[:-2]
+    if length_values.shape != batch_shape:
+        raise ValueError(
+            f"lengths must have shape {batch_shape}; got {length_values.shape}."
+        )
+    if not jnp.issubdtype(length_values.dtype, jnp.integer):
+        raise TypeError("lengths must have an integer dtype.")
+    max_knots = int(path.shape[-2])
+    length_values = eqx.error_if(
+        length_values,
+        jnp.any((length_values < 1) | (length_values > max_knots)),
+        "Each path length must lie between one and max_knots.",
+    )
+    positions = jnp.arange(max_knots, dtype=length_values.dtype)
+    gather_indices = jnp.minimum(positions, length_values[..., None] - 1)
+    canonical = jnp.take_along_axis(path, gather_indices[..., None], axis=-2)
+    return eqx.error_if(
+        canonical,
+        jnp.any(~jnp.isfinite(canonical)),
+        "Valid path prefixes must be finite.",
+    )
+
+
+def time_augment_path(
+    times: ArrayLike,
+    values: ArrayLike,
+    /,
+    *,
+    lengths: ArrayLike | None = None,
+) -> Array:
+    """Prepend physical time, optionally canonicalizing ragged suffix padding."""
+    path = _inexact_array(values)
+    if path.ndim < 2 or int(path.shape[-2]) <= 0 or int(path.shape[-1]) <= 0:
+        raise ValueError(
+            "values must have shape batch_shape + (num_knots, dimension) "
+            "with nonempty path axes."
+        )
+    batch_shape = path.shape[:-2]
+    num_knots = int(path.shape[-2])
+    time_values = _inexact_array(times)
+    expected_shape = batch_shape + (num_knots,)
+    if time_values.shape == (num_knots,):
+        time_values = jnp.broadcast_to(time_values, expected_shape)
+    elif time_values.shape != expected_shape:
+        raise ValueError(
+            "times must be shared or have shape "
+            f"batch_shape + (num_knots,) = {expected_shape}; got {time_values.shape}."
+        )
+    joint = jnp.concatenate((time_values[..., None], path), axis=-1)
+    if lengths is None:
+        joint = eqx.error_if(
+            joint,
+            jnp.any(~jnp.isfinite(joint)),
+            "Times and path values must be finite.",
+        )
+        return eqx.error_if(
+            joint,
+            jnp.any(jnp.diff(time_values, axis=-1) <= 0.0),
+            "Times must be strictly increasing.",
+        )
+
+    length_values = jnp.asarray(lengths)
+    joint = repeat_last_path_padding(joint, length_values)
+    continuation = jnp.arange(max(num_knots - 1, 0)) < length_values[..., None] - 1
+    return eqx.error_if(
+        joint,
+        jnp.any(continuation & (jnp.diff(joint[..., 0], axis=-1) <= 0.0)),
+        "Valid path times must be strictly increasing.",
+    )
+
+
+class SignatureFeatures(StrictModule):
+    """Flattened truncated tensor-signature features of complete paths."""
+
+    dimension: int = eqx.field(static=True)
+    depth: int = eqx.field(static=True)
+    include_scalar: bool = eqx.field(static=True)
+    stream: bool = eqx.field(static=True)
+    feature_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        dimension: int,
+        depth: int,
+        /,
+        *,
+        include_scalar: bool = False,
+        stream: bool = False,
+    ):
+        resolved_dimension = int(dimension)
+        resolved_depth = int(depth)
+        if resolved_dimension <= 0:
+            raise ValueError("dimension must be positive.")
+        if resolved_depth <= 0:
+            raise ValueError("depth must be positive.")
+        self.dimension = resolved_dimension
+        self.depth = resolved_depth
+        self.include_scalar = bool(include_scalar)
+        self.stream = bool(stream)
+        self.feature_id = (
+            "SignatureFeatures["
+            f"dimension={resolved_dimension},depth={resolved_depth},"
+            f"scalar={self.include_scalar},stream={self.stream}]"
+        )
+
+    @property
+    def output_size(self) -> int:
+        return int(self.include_scalar) + sum(
+            self.dimension**degree for degree in range(1, self.depth + 1)
+        )
+
+    def __call__(self, values: ArrayLike, /) -> Array:
+        path = jnp.asarray(values)
+        if path.ndim < 2 or int(path.shape[-1]) != self.dimension:
+            raise ValueError(
+                f"values must end in path shape (num_knots, {self.dimension})."
+            )
+        return flatten_signature(
+            path_signature(path, self.depth, stream=self.stream),
+            include_scalar=self.include_scalar,
+        )
+
+
+class LogSignatureFeatures(StrictModule):
+    """Standard-bracket Lyndon log-signature features of complete paths."""
+
+    primitive_basis: PrimitiveBasis
+    dimension: int = eqx.field(static=True)
+    depth: int = eqx.field(static=True)
+    stream: bool = eqx.field(static=True)
+    feature_id: str = eqx.field(static=True)
+
+    def __init__(self, dimension: int, depth: int, /, *, stream: bool = False):
+        basis = PrimitiveBasis(dimension, depth)
+        self.primitive_basis = basis
+        self.dimension = basis.dimension
+        self.depth = basis.depth
+        self.stream = bool(stream)
+        self.feature_id = (
+            "LogSignatureFeatures["
+            f"dimension={basis.dimension},depth={basis.depth},stream={self.stream}]"
+        )
+
+    @property
+    def output_size(self) -> int:
+        return self.primitive_basis.size
+
+    def __call__(self, values: ArrayLike, /) -> Array:
+        path = jnp.asarray(values)
+        if path.ndim < 2 or int(path.shape[-1]) != self.dimension:
+            raise ValueError(
+                f"values must end in path shape (num_knots, {self.dimension})."
+            )
+        return path_logsignature(path, self.primitive_basis, stream=self.stream)
+
+
+__all__ = [
+    "LogSignatureFeatures",
+    "SignatureFeatures",
+    "flatten_signature",
+    "path_logsignature",
+    "path_signature",
+    "repeat_last_path_padding",
+    "time_augment_path",
+]

--- a/phydrax/stochastic/_signature_recurrent.py
+++ b/phydrax/stochastic/_signature_recurrent.py
@@ -1,0 +1,142 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from typing import Any
+
+import equinox as eqx
+import jax.numpy as jnp
+from jaxtyping import Array, ArrayLike
+
+from .._strict import StrictModule
+from ..nn._keys import EvalKey
+from ..nn.layers._recurrent import AbstractRecurrentOutputCell
+from ._signature import (
+    _chen_multiply_increment,
+    _inexact_array,
+    _signature_identity,
+    _signature_shape,
+)
+from ._signature_features import flatten_signature
+
+
+class SignatureRecurrentState(StrictModule):
+    """Truncated signature carry for one packed recurrent stream."""
+
+    signature: tuple[Array, ...]
+    previous_point: Array
+    has_previous: Array
+
+
+class SignatureRecurrentCell(AbstractRecurrentOutputCell):
+    """Exact online path-signature updates under canonical recurrent semantics.
+
+    The first valid point establishes a basepoint and emits the identity
+    signature. Each later valid point applies one Chen update. Reset handling,
+    invalid padding, and streaming carries are delegated to ``run_recurrent``.
+    """
+
+    dimension: int = eqx.field(static=True)
+    depth: int = eqx.field(static=True)
+    include_scalar: bool = eqx.field(static=True)
+    feature_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        dimension: int,
+        depth: int,
+        /,
+        *,
+        include_scalar: bool = False,
+    ):
+        resolved_dimension = int(dimension)
+        resolved_depth = int(depth)
+        if resolved_dimension <= 0:
+            raise ValueError("dimension must be positive.")
+        if resolved_depth <= 0:
+            raise ValueError("depth must be positive.")
+        self.dimension = resolved_dimension
+        self.depth = resolved_depth
+        self.include_scalar = bool(include_scalar)
+        self.feature_id = (
+            "SignatureRecurrentCell["
+            f"dimension={resolved_dimension},depth={resolved_depth},"
+            f"scalar={self.include_scalar}]"
+        )
+
+    @property
+    def output_size(self) -> int:
+        return int(self.include_scalar) + sum(
+            self.dimension**degree for degree in range(1, self.depth + 1)
+        )
+
+    def initial_state(
+        self, case_shape: tuple[int, ...], /, *, dtype: Any
+    ) -> SignatureRecurrentState:
+        state_dtype = jnp.result_type(dtype, jnp.asarray(0.0))
+        return SignatureRecurrentState(
+            signature=_signature_identity(
+                case_shape,
+                self.dimension,
+                self.depth,
+                state_dtype,
+            ),
+            previous_point=jnp.zeros(case_shape + (self.dimension,), dtype=state_dtype),
+            has_previous=jnp.zeros(case_shape, dtype=bool),
+        )
+
+    def step(
+        self,
+        state: SignatureRecurrentState,
+        inputs: ArrayLike,
+        /,
+        *,
+        key: EvalKey = None,
+    ) -> tuple[SignatureRecurrentState, Array]:
+        del key
+        if not isinstance(state, SignatureRecurrentState):
+            raise TypeError("state must be a SignatureRecurrentState.")
+        point = _inexact_array(inputs)
+        levels, dimension = _signature_shape(state.signature)
+        case_shape = levels[0].shape[:-1]
+        expected_point_shape = case_shape + (self.dimension,)
+        if dimension != self.dimension or len(levels) != self.depth:
+            raise ValueError("state signature does not match this cell.")
+        if state.previous_point.shape != expected_point_shape:
+            raise ValueError(
+                f"state.previous_point must have shape {expected_point_shape}."
+            )
+        if state.has_previous.shape != case_shape:
+            raise ValueError(f"state.has_previous must have shape {case_shape}.")
+        if point.shape != expected_point_shape:
+            raise ValueError(f"inputs must have shape {expected_point_shape}.")
+        point = eqx.error_if(
+            point,
+            jnp.any(~jnp.isfinite(point)),
+            "Signature recurrent points must be finite.",
+        )
+
+        increment = jnp.where(
+            state.has_previous[..., None],
+            point - state.previous_point,
+            jnp.zeros_like(point),
+        )
+        next_state = SignatureRecurrentState(
+            signature=_chen_multiply_increment(levels, increment),
+            previous_point=point,
+            has_previous=jnp.ones_like(state.has_previous),
+        )
+        return next_state, self.output_from_state(next_state)
+
+    def output_from_state(self, state: SignatureRecurrentState, /) -> Array:
+        if not isinstance(state, SignatureRecurrentState):
+            raise TypeError("state must be a SignatureRecurrentState.")
+        return flatten_signature(
+            state.signature,
+            include_scalar=self.include_scalar,
+        )
+
+
+__all__ = ["SignatureRecurrentCell", "SignatureRecurrentState"]

--- a/phydrax/transport/_measure.py
+++ b/phydrax/transport/_measure.py
@@ -15,7 +15,7 @@ from jaxtyping import Array
 
 from .._numerics import log_normalize
 from .._strict import StrictModule
-from ..integration import DiscreteMeasureTarget, WeightedSampleTarget
+from ..integration._targets import DiscreteMeasureTarget, WeightedSampleTarget
 
 
 EventEncoder = Callable[[Any], Array | cx.Field]

--- a/phydrax/transport/_problem.py
+++ b/phydrax/transport/_problem.py
@@ -12,7 +12,7 @@ import jax.numpy as jnp
 from jaxtyping import Array
 
 from .._strict import StrictModule
-from ..integration import DiscreteMeasureTarget, WeightedSampleTarget
+from ..integration._targets import DiscreteMeasureTarget, WeightedSampleTarget
 from ._costs import AbstractGroundCost, GroundCost, PrecomputedCost
 from ._measure import _FiniteTransportMeasure, EventEncoder, lower_transport_measure
 

--- a/phydrax/transport/_references.py
+++ b/phydrax/transport/_references.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from .._strict import StrictModule
-from ..integration import DiscreteMeasureTarget, WeightedSampleTarget
+from ..integration._targets import DiscreteMeasureTarget, WeightedSampleTarget
 from ._costs import AbstractGroundCost
 from ._divergence import SinkhornDivergenceResult
 from ._measure import _FiniteTransportMeasure, EventEncoder, lower_transport_measure

--- a/phydrax/uq/_gp_backend.py
+++ b/phydrax/uq/_gp_backend.py
@@ -20,7 +20,9 @@ def exact_gp_cholesky(
     jitter: ArrayLike,
 ) -> Array:
     """Factor an exact scalar GP observation covariance."""
-    points = _as_points(observation_points)
+    points = _as_kernel_inputs(
+        observation_points, kernel=kernel, name="observation_points"
+    )
     diagonal = _observation_diagonal(
         noise_scale,
         jitter,
@@ -51,8 +53,10 @@ def exact_gp_conditioner(
     kernel: AbstractPositiveDefiniteKernel,
 ) -> tuple[Array, Array, Array]:
     """Precompute exact residual projection and latent query covariance."""
-    points = _as_points(observation_points)
-    query = _as_points(query_points)
+    points = _as_kernel_inputs(
+        observation_points, kernel=kernel, name="observation_points"
+    )
+    query = _as_kernel_inputs(query_points, kernel=kernel, name="query_points")
     return exact_gp_conditioner_from_covariances(
         cholesky,
         kernel.matrix(query, points),
@@ -88,8 +92,10 @@ def fitc_factors(
     jitter: ArrayLike,
 ) -> tuple[Array, Array, Array, Array]:
     """Build generic FITC factors from a positive-definite kernel."""
-    points = _as_points(observation_points)
-    inducing = _as_points(inducing_points)
+    points = _as_kernel_inputs(
+        observation_points, kernel=kernel, name="observation_points"
+    )
+    inducing = _as_kernel_inputs(inducing_points, kernel=kernel, name="inducing_points")
     return fitc_factors_from_covariances(
         kernel.matrix(points, inducing),
         kernel.diagonal(points),
@@ -183,9 +189,9 @@ def sparse_gp_conditioner(
     kernel: AbstractPositiveDefiniteKernel,
 ) -> tuple[Array, Array, Array]:
     """Precompute FITC residual projection and latent query covariance."""
-    _as_points(observation_points)
-    inducing = _as_points(inducing_points)
-    query = _as_points(query_points)
+    _as_kernel_inputs(observation_points, kernel=kernel, name="observation_points")
+    inducing = _as_kernel_inputs(inducing_points, kernel=kernel, name="inducing_points")
+    query = _as_kernel_inputs(query_points, kernel=kernel, name="query_points")
     return sparse_gp_conditioner_from_covariances(
         kernel.matrix(query, inducing),
         kernel.diagonal(query),
@@ -275,12 +281,24 @@ def _observation_diagonal(
     return noise * noise + jnp.asarray(jitter)
 
 
-def _as_points(value: ArrayLike) -> Array:
+def _as_kernel_inputs(
+    value: ArrayLike,
+    /,
+    *,
+    kernel: AbstractPositiveDefiniteKernel,
+    name: str,
+) -> Array:
     array = jnp.asarray(value, dtype=float)
-    if array.ndim == 1:
-        return array[:, None]
-    if array.ndim != 2:
-        raise ValueError("GP points must have shape (point, coordinate).")
+    if kernel.input_ndim == 1 and array.ndim == 1:
+        array = array[:, None]
+    expected_rank = kernel.input_ndim + 1
+    if array.ndim != expected_rank:
+        raise ValueError(
+            f"{name} must have one design axis followed by "
+            f"{kernel.input_ndim} kernel input axes."
+        )
+    if any(int(size) <= 0 for size in array.shape[1:]):
+        raise ValueError(f"{name} must have nonempty kernel input axes.")
     return array
 
 

--- a/phydrax/uq/_gp_condition.py
+++ b/phydrax/uq/_gp_condition.py
@@ -32,7 +32,7 @@ class GaussianProcessCondition(StrictModule):
         variance: ArrayLike,
         output_dims: tuple[str | None, ...],
     ):
-        points = _as_points(query_points)
+        points = _as_design(query_points)
         mean_array = _as_vector(mean, name="conditioned GP mean")
         covariance_array = jnp.asarray(covariance, dtype=float)
         variance_array = _as_vector(variance, name="conditioned GP variance")
@@ -112,7 +112,7 @@ class GaussianProcessConditioner(StrictModule):
         variance: ArrayLike,
         output_dims: tuple[str | None, ...],
     ):
-        points = _as_points(query_points)
+        points = _as_design(query_points)
         projection = jnp.asarray(residual_projection, dtype=float)
         covariance_array = jnp.asarray(covariance, dtype=float)
         variance_array = _as_vector(variance, name="conditioned GP variance")
@@ -158,12 +158,16 @@ def _sample_gaussian_psd(
     return mean + noise @ factor.T
 
 
-def _as_points(value: ArrayLike) -> Array:
+def _as_design(value: ArrayLike) -> Array:
     array = jnp.asarray(value, dtype=float)
     if array.ndim == 1:
-        return array[:, None]
-    if array.ndim != 2:
-        raise ValueError("GP points must have shape (point, coordinate).")
+        array = array[:, None]
+    if array.ndim < 2:
+        raise ValueError(
+            "GP inputs must have one design axis and at least one input axis."
+        )
+    if any(int(size) <= 0 for size in array.shape[1:]):
+        raise ValueError("GP kernel input axes must be nonempty.")
     return array
 
 

--- a/phydrax/uq/_gp_functional.py
+++ b/phydrax/uq/_gp_functional.py
@@ -374,6 +374,8 @@ class FunctionalGaussianProcessLikelihoodState(StrictModule):
     ):
         if not isinstance(kernel, AbstractPositiveDefiniteKernel):
             raise TypeError("kernel must be a positive-definite kernel.")
+        if kernel.input_ndim != 1:
+            raise ValueError("Functional GP kernels must have input_ndim == 1.")
         noise = jnp.asarray(noise_scale, dtype=float)
         if noise.ndim > 1 or (noise.ndim == 1 and noise.shape[0] <= 0):
             raise ValueError("noise_scale must be scalar or a nonempty vector.")
@@ -606,6 +608,8 @@ def functional_kernel_matrix(
     """Assemble covariance between two ordered functional designs."""
     if not isinstance(kernel, AbstractPositiveDefiniteKernel):
         raise TypeError("kernel must be a positive-definite kernel.")
+    if kernel.input_ndim != 1:
+        raise ValueError("Functional GP kernels must have input_ndim == 1.")
     _validate_design_pair(left, right)
     rows = tuple(
         jnp.concatenate(
@@ -628,6 +632,8 @@ def functional_kernel_diagonal(
     """Assemble functional prior variances without a dense covariance matrix."""
     if not isinstance(kernel, AbstractPositiveDefiniteKernel):
         raise TypeError("kernel must be a positive-definite kernel.")
+    if kernel.input_ndim != 1:
+        raise ValueError("Functional GP kernels must have input_ndim == 1.")
     if not isinstance(design, FunctionalDesign):
         raise TypeError("design must be a FunctionalDesign.")
     values = []

--- a/phydrax/uq/_gp_scalar.py
+++ b/phydrax/uq/_gp_scalar.py
@@ -401,7 +401,7 @@ class SparseGaussianProcessDiscrepancy(StrictModule):
         num_inducing: int,
     ) -> SparseGaussianProcessDiscrepancy:
         """Choose a deterministic index-spaced inducing subset."""
-        points = _as_points(_field_data(observation_points))
+        points = _as_design(_field_data(observation_points))
         count = int(num_inducing)
         if not 0 < count < int(points.shape[0]):
             raise ValueError(
@@ -506,12 +506,16 @@ def _field_data(value: Any) -> Array:
     return jnp.asarray(value.data if isinstance(value, cx.Field) else value, dtype=float)
 
 
-def _as_points(value: ArrayLike) -> Array:
+def _as_design(value: ArrayLike) -> Array:
     array = jnp.asarray(value, dtype=float)
     if array.ndim == 1:
-        return array[:, None]
-    if array.ndim != 2:
-        raise ValueError("GP points must have shape (point, coordinate).")
+        array = array[:, None]
+    if array.ndim < 2:
+        raise ValueError(
+            "GP inputs must have one design axis and at least one input axis."
+        )
+    if any(int(size) <= 0 for size in array.shape[1:]):
+        raise ValueError("GP kernel input axes must be nonempty.")
     return array
 
 
@@ -533,13 +537,13 @@ def _query_output_dims(
     if isinstance(query_points, cx.Field):
         if query_points.data.ndim == 1:
             return tuple(query_points.dims)
-        if query_points.data.ndim == 2:
+        if query_points.data.ndim >= 2:
             return (query_points.dims[0],)
     return (output_dim,)
 
 
 def _validated_factor_points(value: ArrayLike | cx.Field, /) -> Array:
-    points = _as_points(_field_data(value))
+    points = _as_design(_field_data(value))
     return eqx.error_if(
         points,
         jnp.any(~jnp.isfinite(points)),
@@ -554,7 +558,7 @@ def _validated_observations(
     *,
     name: str,
 ) -> tuple[Array, Array]:
-    points = _as_points(_field_data(observation_points))
+    points = _as_design(_field_data(observation_points))
     values = _as_vector(_field_data(observations), name=name)
     if int(points.shape[0]) != int(values.shape[0]):
         raise ValueError("GP observations must align with observation points.")
@@ -573,10 +577,6 @@ def _observation_noise(noise_scale: ArrayLike, /, *, count: int) -> Array:
 
 
 def _validate_inducing_design(points: Array, inducing: Array, /) -> None:
-    if inducing.shape[1] != points.shape[1]:
-        raise ValueError(
-            "inducing_points and observation_points need equal coordinate size."
-        )
     if not 0 < int(inducing.shape[0]) < int(points.shape[0]):
         raise ValueError("Sparse GP requires fewer inducing points than observations.")
 

--- a/phydrax/uq/_inducing.py
+++ b/phydrax/uq/_inducing.py
@@ -30,8 +30,10 @@ class InducingPointSelection(StrictModule):
     def __init__(self, points: Array, indices: Array, diagnostics: Any, /):
         points_ = jnp.asarray(points, dtype=float)
         indices_ = jnp.asarray(indices, dtype=jnp.int32)
-        if points_.ndim != 2:
-            raise ValueError("Selected inducing points must be two-dimensional.")
+        if points_.ndim < 2:
+            raise ValueError(
+                "Selected inducing inputs need one design axis and input axes."
+            )
         if indices_.shape != (points_.shape[0],):
             raise ValueError("Inducing indices must match the selected point count.")
         self.points = points_
@@ -54,15 +56,20 @@ def select_inducing_points(
         else observation_points
     )
     points = jnp.asarray(raw, dtype=float)
-    if points.ndim == 1:
+    method = RandomizedPivotedCholesky(num_points, kernel=kernel)
+    if method.kernel.input_ndim == 1 and points.ndim == 1:
         points = points[:, None]
-    if points.ndim != 2:
-        raise ValueError("observation_points must have shape (num_points, coordinates).")
+    expected_rank = method.kernel.input_ndim + 1
+    if points.ndim != expected_rank:
+        raise ValueError(
+            "observation_points must have one design axis followed by "
+            f"{method.kernel.input_ndim} kernel input axes."
+        )
     if bool(jnp.any(~jnp.isfinite(points))):
         raise ValueError("observation_points must be finite.")
     selection = randomized_pivoted_cholesky(
         points,
-        RandomizedPivotedCholesky(num_points, kernel=kernel),
+        method,
         key=key,
     )
     if not bool(selection.diagnostics.valid):

--- a/tests/unit/kernels/test_linear.py
+++ b/tests/unit/kernels/test_linear.py
@@ -1,0 +1,103 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import pytest
+
+import phydrax as phx
+
+
+def test_linear_kernel_specialized_operations_agree():
+    left = jnp.asarray([[1.0, 2.0], [-1.0, 3.0]])
+    right = jnp.asarray([[0.5, -2.0], [4.0, 1.0], [2.0, 2.0]])
+    kernel = phx.kernels.LinearKernel()
+    matrix = kernel.matrix(left, right)
+
+    assert kernel.input_ndim == 1
+    assert kernel.max_derivative_order is None
+    assert kernel.kernel_id == "LinearKernel"
+    assert jnp.allclose(matrix, left @ right.T)
+    assert jnp.allclose(
+        matrix,
+        jax.vmap(lambda x: jax.vmap(lambda y: kernel.pairwise(x, y))(right))(left),
+    )
+    assert jnp.allclose(kernel.diagonal(left), jnp.sum(left * left, axis=1))
+
+
+def test_path_input_transform_builds_exact_truncated_signature_gram():
+    paths = jnp.asarray(
+        [
+            [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0]],
+            [[0.0, 0.0], [0.5, 0.0], [1.0, 0.0]],
+            [[1.0, -1.0], [1.0, 0.0], [1.0, 1.0]],
+        ]
+    )
+    features = phx.stochastic.SignatureFeatures(2, 3, include_scalar=True)
+    kernel = phx.kernels.InputTransformedKernel(
+        phx.kernels.LinearKernel(),
+        features,
+        transform_id=features.feature_id,
+        input_ndim=2,
+        max_derivative_order=0,
+    )
+    feature_matrix = jax.vmap(features)(paths)
+
+    assert kernel.input_ndim == 2
+    assert jnp.allclose(kernel.matrix(paths, paths), feature_matrix @ feature_matrix.T)
+    assert jnp.allclose(
+        kernel.diagonal(paths),
+        jnp.sum(feature_matrix * feature_matrix, axis=1),
+    )
+    assert jnp.allclose(
+        kernel.pairwise(paths[0], paths[1]), feature_matrix[0] @ feature_matrix[1]
+    )
+
+
+def test_normalized_kernel_has_checked_exact_unit_diagonal():
+    points = jnp.asarray([[1.0, 0.0], [1.0, 1.0], [-1.0, 2.0]])
+    kernel = phx.kernels.NormalizedKernel(phx.kernels.LinearKernel())
+    matrix = kernel.matrix(points, points)
+
+    assert kernel.input_ndim == 1
+    assert kernel.is_unit_diagonal
+    assert jnp.allclose(jnp.diag(matrix), 1.0)
+    assert jnp.allclose(kernel.diagonal(points), jnp.ones((3,)))
+    assert kernel.kernel_id == "NormalizedKernel[LinearKernel]"
+
+    with pytest.raises(eqx.EquinoxRuntimeError, match="strictly positive"):
+        invalid = eqx.filter_jit(kernel.diagonal)(jnp.zeros((2, 2)))
+        jax.block_until_ready(invalid)
+
+
+def test_kernel_algebra_rejects_mixed_input_ranks_and_propagates_path_rank():
+    features = phx.stochastic.SignatureFeatures(2, 2)
+    path_kernel = phx.kernels.InputTransformedKernel(
+        phx.kernels.LinearKernel(),
+        features,
+        transform_id=features.feature_id,
+        input_ndim=2,
+    )
+
+    assert (2.0 * path_kernel).input_ndim == 2
+    assert (path_kernel * path_kernel).input_ndim == 2
+    assert phx.kernels.NormalizedKernel(path_kernel).input_ndim == 2
+    with pytest.raises(ValueError, match="equal input_ndim"):
+        path_kernel + phx.kernels.LinearKernel()
+    with pytest.raises(ValueError, match="equal input_ndim"):
+        path_kernel * phx.kernels.LinearKernel()
+
+
+def test_input_transform_validates_declared_input_rank():
+    transform = phx.kernels.InputTransformedKernel(
+        phx.kernels.LinearKernel(),
+        lambda path: jnp.sum(path, axis=0),
+        transform_id="path-sum",
+        input_ndim=2,
+    )
+    with pytest.raises(ValueError, match="2 nonempty input axes"):
+        transform.pairwise(jnp.ones((2,)), jnp.ones((2,)))
+    with pytest.raises(ValueError, match="design axis followed by 2"):
+        transform.matrix(jnp.ones((3, 2)), jnp.ones((3, 2)))

--- a/tests/unit/kernels/test_signature.py
+++ b/tests/unit/kernels/test_signature.py
@@ -1,0 +1,229 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from math import factorial
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import pytest
+
+import phydrax as phx
+
+
+def _feature_gram(paths, depth):
+    features = phx.stochastic.SignatureFeatures(
+        int(paths.shape[-1]), depth, include_scalar=True
+    )
+    values = jax.vmap(features)(paths)
+    return values @ values.T
+
+
+def test_one_segment_signature_kernel_has_analytic_picard_series():
+    left = jnp.asarray([[0.0, 0.0], [2.0, -1.0]])
+    right = jnp.asarray([[1.0, 3.0], [0.5, 5.0]])
+    increment_inner_product = jnp.dot(left[1] - left[0], right[1] - right[0])
+
+    for order in (1, 3, 6):
+        kernel = phx.kernels.SignaturePDEKernel(
+            phx.kernels.LinearKernel(), polynomial_order=order
+        )
+        expected = sum(
+            increment_inner_product**level / factorial(level) ** 2
+            for level in range(order + 1)
+        )
+        assert jnp.allclose(kernel.pairwise(left, right), expected)
+
+
+@pytest.mark.parametrize(
+    ("dtype", "tolerance"),
+    ((jnp.float32, 3e-5), (jnp.float64, 2e-11)),
+)
+def test_signature_pde_matches_explicit_truncated_signature_features(dtype, tolerance):
+    key = jax.random.key(18)
+    paths = jnp.cumsum(jax.random.normal(key, (5, 5, 2), dtype=dtype), axis=1)
+
+    for order in (1, 2, 4, 6):
+        kernel = phx.kernels.SignaturePDEKernel(
+            phx.kernels.LinearKernel(),
+            polynomial_order=order,
+            pair_block_size=3,
+        )
+        actual = kernel.matrix(paths, paths)
+        expected = _feature_gram(paths, order)
+
+        assert jnp.allclose(actual, expected, rtol=tolerance, atol=tolerance)
+        assert jnp.allclose(
+            kernel.diagonal(paths),
+            jnp.diag(expected),
+            rtol=tolerance,
+            atol=tolerance,
+        )
+        assert jnp.allclose(actual, actual.T, rtol=tolerance, atol=tolerance)
+
+
+def test_signature_pde_supports_rectangular_paths_and_block_sizes():
+    left = jnp.asarray([[0.0, 0.0], [1.0, -0.5], [0.5, 1.0], [1.5, 0.5]])
+    right = jnp.asarray([[1.0, 0.0], [0.5, 0.0], [0.5, 1.0], [1.0, 1.5], [2.0, 1.0]])
+    left_paths = jnp.stack((left, -left, 0.5 * left))
+    right_paths = jnp.stack((right, -0.25 * right))
+
+    expected = jax.vmap(
+        lambda x: jax.vmap(
+            lambda y: (
+                phx.stochastic.SignatureFeatures(2, 5, include_scalar=True)(x)
+                @ phx.stochastic.SignatureFeatures(2, 5, include_scalar=True)(y)
+            )
+        )(right_paths)
+    )(left_paths)
+    for block_size in (1, 2, 4, 17):
+        kernel = phx.kernels.SignaturePDEKernel(
+            phx.kernels.LinearKernel(),
+            polynomial_order=5,
+            pair_block_size=block_size,
+        )
+        assert jnp.allclose(kernel.matrix(left_paths, right_paths), expected)
+        assert jnp.allclose(kernel.pairwise(left, right), expected[0, 0])
+
+
+def test_signature_pde_is_positive_semidefinite_for_linear_and_rbf_lifts():
+    paths = jnp.cumsum(
+        jax.random.normal(jax.random.key(93), (9, 6, 3), dtype=jnp.float64),
+        axis=1,
+    )
+    kernels = (
+        phx.kernels.SignaturePDEKernel(
+            phx.kernels.LinearKernel(), polynomial_order=5, pair_block_size=7
+        ),
+        phx.kernels.SignaturePDEKernel(
+            phx.kernels.SquaredExponentialKernel(length_scale=1.3),
+            polynomial_order=5,
+            pair_block_size=7,
+        ),
+    )
+
+    for kernel in kernels:
+        gram = kernel.matrix(paths, paths)
+        eigenvalues = jnp.linalg.eigvalsh(0.5 * (gram + gram.T))
+        tolerance = 5e-11 * jnp.max(jnp.diag(gram))
+        assert eigenvalues.min() >= -tolerance
+
+
+def test_signature_pde_is_positive_semidefinite_on_fractional_gaussian_paths():
+    process = phx.stochastic.FractionalGaussianProcess(
+        0.35,
+        jnp.asarray([0.4, 0.7]),
+        process_id="signature-kernel-fractional-fixture",
+    )
+    realization = phx.stochastic.FractionalGaussianRealization(
+        process,
+        jax.random.key(94),
+        jnp.linspace(0.0, 1.0, 7),
+        sample_shape=(8,),
+    )
+    kernel = phx.kernels.SignaturePDEKernel(
+        phx.kernels.LinearKernel(),
+        polynomial_order=5,
+        pair_block_size=5,
+    )
+    gram = kernel.matrix(realization.values, realization.values)
+    eigenvalues = jnp.linalg.eigvalsh(0.5 * (gram + gram.T))
+    tolerance = 5e-11 * jnp.max(jnp.diag(gram))
+
+    assert eigenvalues.min() >= -tolerance
+
+
+def test_signature_pde_handles_degenerate_segments_and_one_knot_paths():
+    path = jnp.asarray([[0.0, 0.0], [1.0, -1.0], [2.0, 0.5]])
+    repeated = jnp.concatenate((path, jnp.broadcast_to(path[-1], (3, 2))), axis=0)
+    constant = jnp.broadcast_to(jnp.asarray([2.0, -3.0]), (4, 2))
+    kernel = phx.kernels.SignaturePDEKernel(
+        phx.kernels.LinearKernel(), polynomial_order=5
+    )
+
+    assert jnp.allclose(kernel.pairwise(path, repeated), kernel.pairwise(path, path))
+    assert jnp.allclose(kernel.pairwise(constant, path), 1.0)
+    assert jnp.allclose(kernel.pairwise(path[:1], repeated), 1.0)
+    assert jnp.allclose(kernel.pairwise(path[:1], path[:1]), 1.0)
+
+
+def test_signature_pde_jit_and_gradients_are_finite_and_correct():
+    left = jnp.asarray([[0.0, 0.0], [1.0, 0.0], [1.0, 1.0]])
+    right = jnp.asarray([[0.0, 0.0], [-0.5, 1.0], [0.25, 1.5]])
+    kernel = phx.kernels.SignaturePDEKernel(
+        phx.kernels.LinearKernel(), polynomial_order=4, pair_block_size=2
+    )
+    compiled = eqx.filter_jit(kernel.pairwise)
+    value = compiled(left, right)
+    path_gradient = jax.grad(lambda path: kernel.pairwise(path, right))(left)
+    epsilon = 1e-5
+    direction = jnp.asarray([[0.2, -0.1], [0.3, 0.4], [-0.2, 0.5]])
+    finite_difference = (
+        kernel.pairwise(left + epsilon * direction, right)
+        - kernel.pairwise(left - epsilon * direction, right)
+    ) / (2.0 * epsilon)
+
+    def scaled_value(scale):
+        scaled_kernel = phx.kernels.SignaturePDEKernel(
+            phx.kernels.ScaleKernel(phx.kernels.LinearKernel(), scale),
+            polynomial_order=4,
+        )
+        return scaled_kernel.pairwise(left, right)
+
+    assert jnp.isfinite(value)
+    assert jnp.all(jnp.isfinite(path_gradient))
+    assert jnp.allclose(jnp.sum(path_gradient * direction), finite_difference, rtol=2e-7)
+    assert jnp.isfinite(jax.grad(scaled_value)(jnp.asarray(0.8)))
+
+
+def test_signature_pde_converges_by_exact_nonnegative_self_levels():
+    path = jnp.cumsum(
+        jax.random.normal(jax.random.key(7), (5, 2), dtype=jnp.float64) * 0.4,
+        axis=0,
+    )
+    reference = phx.kernels.SignaturePDEKernel(
+        phx.kernels.LinearKernel(), polynomial_order=10
+    ).pairwise(path, path)
+    approximations = jnp.asarray(
+        [
+            phx.kernels.SignaturePDEKernel(
+                phx.kernels.LinearKernel(), polynomial_order=order
+            ).pairwise(path, path)
+            for order in (1, 3, 5, 7)
+        ]
+    )
+    errors = reference - approximations
+
+    assert jnp.all(errors >= 0.0)
+    assert jnp.all(errors[1:] < errors[:-1])
+
+
+def test_signature_pde_rejects_invalid_contracts():
+    with pytest.raises(ValueError, match="input_ndim must be 1"):
+        phx.kernels.SignaturePDEKernel(
+            phx.kernels.InputTransformedKernel(
+                phx.kernels.LinearKernel(),
+                lambda x: jnp.sum(x, axis=0),
+                transform_id="path-sum",
+                input_ndim=2,
+            )
+        )
+    with pytest.raises(ValueError, match="polynomial_order must be positive"):
+        phx.kernels.SignaturePDEKernel(phx.kernels.LinearKernel(), polynomial_order=0)
+    with pytest.raises(ValueError, match="pair_block_size must be positive"):
+        phx.kernels.SignaturePDEKernel(phx.kernels.LinearKernel(), pair_block_size=0)
+
+    kernel = phx.kernels.SignaturePDEKernel(phx.kernels.LinearKernel())
+    with pytest.raises(ValueError, match="2 nonempty input axes"):
+        kernel.pairwise(jnp.ones((2,)), jnp.ones((2,)))
+    with pytest.raises(ValueError, match="channel dimensions"):
+        kernel.pairwise(jnp.ones((2, 2)), jnp.ones((2, 3)))
+    with pytest.raises(ValueError, match="nonempty input axes"):
+        kernel.pairwise(jnp.empty((0, 2)), jnp.ones((2, 2)))
+    with pytest.raises(eqx.EquinoxRuntimeError, match="finite values"):
+        invalid = eqx.filter_jit(kernel.pairwise)(
+            jnp.asarray([[0.0, 0.0], [jnp.nan, 1.0]]),
+            jnp.ones((2, 2)),
+        )
+        jax.block_until_ready(invalid)

--- a/tests/unit/stochastic/test_signature_features.py
+++ b/tests/unit/stochastic/test_signature_features.py
@@ -1,0 +1,234 @@
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import pytest
+
+import phydrax as phx
+
+
+def _path():
+    return jnp.asarray([[0.0, 0.0], [1.0, 0.0], [1.0, 1.0]])
+
+
+def test_path_signature_stream_aligns_identity_and_prefixes():
+    path = _path()
+    terminal = phx.stochastic.path_signature(path, 3)
+    stream = phx.stochastic.path_signature(path, 3, stream=True)
+
+    assert tuple(level.shape for level in stream) == ((3, 2), (3, 2, 2), (3, 2, 2, 2))
+    assert all(jnp.allclose(level[0], 0.0) for level in stream)
+    assert all(jnp.allclose(level[-1], final) for level, final in zip(stream, terminal))
+    for stop in range(1, path.shape[0] + 1):
+        prefix = phx.stochastic.path_signature(path[:stop], 3)
+        assert all(
+            jnp.allclose(level[stop - 1], expected)
+            for level, expected in zip(stream, prefix)
+        )
+
+
+def test_piecewise_signature_supports_empty_and_streaming_segments():
+    increments = jnp.asarray([[1.0, 0.0], [0.0, 1.0]])
+    streamed = phx.stochastic.piecewise_linear_signature(
+        increments,
+        2,
+        stream=True,
+    )
+    empty = phx.stochastic.piecewise_linear_signature(jnp.empty((0, 2)), 2)
+
+    assert streamed[0].shape == (2, 2)
+    assert jnp.allclose(streamed[0][0], increments[0])
+    assert jnp.allclose(streamed[0][-1], jnp.sum(increments, axis=0))
+    assert jnp.allclose(empty[0], jnp.zeros((2,)))
+    assert jnp.allclose(empty[1], jnp.zeros((2, 2)))
+
+
+def test_signature_features_flatten_degree_order_and_scalar():
+    path = _path()
+    signature = phx.stochastic.path_signature(path, 2)
+    features = phx.stochastic.SignatureFeatures(2, 2, include_scalar=True)
+    actual = features(path)
+    expected = jnp.concatenate(
+        (jnp.ones((1,)), signature[0], signature[1].reshape((-1,)))
+    )
+
+    assert features.output_size == 7
+    assert actual.shape == (7,)
+    assert jnp.allclose(actual, expected)
+    assert features.feature_id.startswith("SignatureFeatures[")
+
+
+def test_signature_feature_modules_support_batches_streaming_jit_and_gradients():
+    paths = jnp.stack((_path(), 2.0 * _path()))
+    terminal = phx.stochastic.SignatureFeatures(2, 3)
+    streaming = phx.stochastic.SignatureFeatures(2, 3, stream=True)
+    compiled = eqx.filter_jit(terminal)(paths)
+    streamed = eqx.filter_jit(streaming)(paths)
+    gradient = jax.grad(lambda path: jnp.sum(terminal(path) ** 2))(_path())
+
+    assert terminal.output_size == 14
+    assert compiled.shape == (2, 14)
+    assert streamed.shape == (2, 3, 14)
+    assert gradient.shape == _path().shape
+    assert jnp.all(jnp.isfinite(gradient))
+
+
+def test_log_signature_features_use_standard_bracket_coordinates():
+    path = _path()
+    basis = phx.stochastic.PrimitiveBasis(2, 3)
+    expected = basis.tensor_to_primitive(
+        phx.stochastic.tensor_logarithm(phx.stochastic.path_signature(path, 3))
+    )
+    features = phx.stochastic.LogSignatureFeatures(2, 3)
+    streaming = phx.stochastic.LogSignatureFeatures(2, 3, stream=True)(path)
+
+    assert features.output_size == basis.size == 5
+    assert jnp.allclose(features(path), expected)
+    assert streaming.shape == (3, basis.size)
+    assert jnp.allclose(streaming[0], 0.0)
+    assert jnp.allclose(streaming[-1], expected)
+
+
+def test_time_augmentation_broadcasts_and_canonicalizes_ragged_suffixes():
+    times = jnp.asarray([[0.0, 0.5, jnp.nan], [0.0, 0.4, 1.0]])
+    values = jnp.asarray(
+        [
+            [[0.0], [1.0], [jnp.nan]],
+            [[2.0], [3.0], [5.0]],
+        ]
+    )
+    joint = phx.stochastic.time_augment_path(
+        times,
+        values,
+        lengths=jnp.asarray([2, 3]),
+    )
+
+    assert joint.shape == (2, 3, 2)
+    assert jnp.allclose(joint[0, -1], joint[0, 1])
+    assert jnp.allclose(joint[1, :, 0], times[1])
+    assert jnp.all(jnp.isfinite(joint))
+
+
+def test_repeat_last_padding_preserves_valid_prefix_and_rejects_internal_nan():
+    padded = jnp.asarray([[[0.0], [1.0], [jnp.nan], [jnp.nan]]])
+    actual = phx.stochastic.repeat_last_path_padding(padded, jnp.asarray([2]))
+
+    assert jnp.allclose(actual, jnp.asarray([[[0.0], [1.0], [1.0], [1.0]]]))
+    with pytest.raises(eqx.EquinoxRuntimeError, match="Valid path prefixes"):
+        invalid = eqx.filter_jit(phx.stochastic.repeat_last_path_padding)(
+            padded.at[0, 1, 0].set(jnp.nan),
+            jnp.asarray([2]),
+        )
+        jax.block_until_ready(invalid)
+
+
+def test_time_augmentation_rejects_invalid_valid_schedule():
+    with pytest.raises(eqx.EquinoxRuntimeError, match="strictly increasing"):
+        actual = phx.stochastic.time_augment_path(
+            jnp.asarray([0.0, 0.5, 0.4]),
+            jnp.ones((3, 1)),
+        )
+        jax.block_until_ready(actual)
+
+
+def test_signature_features_validate_declared_dimension():
+    with pytest.raises(ValueError, match="num_knots, 3"):
+        phx.stochastic.SignatureFeatures(3, 2)(_path())
+    with pytest.raises(ValueError, match="nonempty path axes"):
+        phx.stochastic.path_signature(jnp.empty((0, 2)), 2)
+
+
+def test_signature_recurrent_cell_matches_dense_prefixes_and_padding():
+    paths = jnp.asarray(
+        [
+            [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [2.0, 1.0]],
+            [[1.0, -1.0], [0.5, 0.0], [9.0, 9.0], [-3.0, 4.0]],
+        ]
+    )
+    valid = jnp.asarray([[True, True, True, True], [True, True, False, False]])
+    cell = phx.stochastic.SignatureRecurrentCell(2, 3, include_scalar=True)
+    result = phx.nn.layers.run_recurrent(
+        cell,
+        phx.nn.layers.RecurrentBatch(paths, valid),
+    )
+    dense = phx.stochastic.SignatureFeatures(2, 3, include_scalar=True)
+
+    for case_index, length in enumerate((4, 2)):
+        for stop in range(1, length + 1):
+            assert jnp.allclose(
+                result.outputs[case_index, stop - 1],
+                dense(paths[case_index, :stop]),
+            )
+        assert jnp.allclose(
+            result.final_output[case_index],
+            dense(paths[case_index, :length]),
+        )
+    assert jnp.allclose(result.outputs[1, 2:], 0.0)
+
+
+def test_signature_recurrent_cell_resets_to_a_new_path_basepoint():
+    points = jnp.asarray([[0.0, 0.0], [1.0, 0.0], [10.0, -2.0], [10.0, 1.0]])
+    reset = jnp.asarray([False, False, True, False])
+    cell = phx.stochastic.SignatureRecurrentCell(2, 2, include_scalar=True)
+    result = phx.nn.layers.run_recurrent(
+        cell,
+        phx.nn.layers.RecurrentBatch(
+            points,
+            jnp.ones((4,), dtype=bool),
+            reset=reset,
+        ),
+    )
+    dense = phx.stochastic.SignatureFeatures(2, 2, include_scalar=True)
+
+    assert jnp.allclose(result.outputs[0], dense(points[:1]))
+    assert jnp.allclose(result.outputs[1], dense(points[:2]))
+    assert jnp.allclose(result.outputs[2], dense(points[2:3]))
+    assert jnp.allclose(result.outputs[3], dense(points[2:4]))
+
+
+def test_signature_recurrent_cell_streaming_carry_matches_one_pass():
+    paths = jnp.asarray(
+        [
+            [[0.0, 0.0], [0.5, 0.0], [1.0, 1.0], [1.5, 0.5], [2.0, 1.0]],
+            [[1.0, 1.0], [0.0, 1.0], [0.0, 0.0], [-1.0, 0.5], [-1.0, 1.0]],
+        ]
+    )
+    cell = phx.stochastic.SignatureRecurrentCell(2, 4)
+    full = phx.nn.layers.run_recurrent(
+        cell,
+        phx.nn.layers.RecurrentBatch(paths, jnp.ones(paths.shape[:-1], dtype=bool)),
+    )
+    first = phx.nn.layers.run_recurrent(
+        cell,
+        phx.nn.layers.RecurrentBatch(paths[:, :3], jnp.ones((2, 3), dtype=bool)),
+    )
+    second = phx.nn.layers.run_recurrent(
+        cell,
+        phx.nn.layers.RecurrentBatch(paths[:, 3:], jnp.ones((2, 2), dtype=bool)),
+        initial_state=first.final_state,
+    )
+
+    assert jnp.allclose(
+        jnp.concatenate((first.outputs, second.outputs), axis=1),
+        full.outputs,
+    )
+    assert jnp.allclose(second.final_output, full.final_output)
+
+
+def test_signature_recurrent_cell_jit_gradients_and_case_axes():
+    points = jnp.arange(48.0).reshape((2, 3, 4, 2)) / 10.0
+    valid = jnp.ones((2, 3, 4), dtype=bool)
+    cell = phx.stochastic.SignatureRecurrentCell(2, 2, include_scalar=True)
+
+    def terminal(values):
+        result = phx.nn.layers.run_recurrent(
+            cell,
+            phx.nn.layers.RecurrentBatch(values, valid),
+        )
+        return result.final_output
+
+    output = eqx.filter_jit(terminal)(points)
+    gradient = jax.grad(lambda values: jnp.sum(terminal(values)))(points)
+
+    assert output.shape == (2, 3, cell.output_size)
+    assert jnp.all(jnp.isfinite(output))
+    assert jnp.all(jnp.isfinite(gradient))

--- a/tests/unit/test_coresets.py
+++ b/tests/unit/test_coresets.py
@@ -142,3 +142,94 @@ def test_randomized_pivoted_cholesky_rejects_oversized_selection():
             jnp.ones((3, 1)),
             phx.coresets.RandomizedPivotedCholesky(4),
         )
+
+
+def test_structured_path_mmd_matches_dense_kernel_evaluation():
+    source = jnp.cumsum(jr.normal(jr.key(12), (7, 4, 2)), axis=1)
+    comparison = jnp.cumsum(jr.normal(jr.key(13), (3, 6, 2)), axis=1)
+    source_weights = jnp.arange(1.0, 8.0)
+    source_weights = source_weights / jnp.sum(source_weights)
+    comparison_weights = jnp.asarray([0.2, 0.3, 0.5])
+    kernel = phx.kernels.SignaturePDEKernel(
+        phx.kernels.LinearKernel(),
+        polynomial_order=4,
+        pair_block_size=3,
+    )
+
+    actual = phx.coresets.weighted_mmd(
+        source,
+        comparison,
+        source_log_weights=jnp.log(source_weights),
+        comparison_log_weights=jnp.log(comparison_weights),
+        kernel=kernel,
+        block_size=3,
+    )
+    expected_squared = (
+        source_weights @ kernel.matrix(source, source) @ source_weights
+        + comparison_weights @ kernel.matrix(comparison, comparison) @ comparison_weights
+        - 2.0 * source_weights @ kernel.matrix(source, comparison) @ comparison_weights
+    )
+
+    assert jnp.allclose(
+        actual,
+        jnp.sqrt(jnp.maximum(expected_squared, 0.0)),
+        rtol=2e-11,
+        atol=2e-11,
+    )
+
+
+def test_kernel_herding_selects_structured_paths_without_flattening():
+    paths = jnp.cumsum(jr.normal(jr.key(21), (9, 5, 2)) * 0.2, axis=1)
+    kernel = phx.kernels.SignaturePDEKernel(
+        phx.kernels.LinearKernel(),
+        polynomial_order=4,
+        pair_block_size=4,
+    )
+    selection = phx.coresets.kernel_herd(
+        paths,
+        phx.coresets.KernelHerding(
+            4,
+            kernel=kernel,
+            block_size=3,
+        ),
+    )
+
+    assert bool(selection.diagnostics.valid)
+    assert selection.diagnostics.input_shape == (5, 2)
+    assert jnp.unique(selection.indices).shape == (4,)
+    assert paths[selection.indices].shape == (4, 5, 2)
+    assert jnp.isfinite(selection.diagnostics.mmd)
+
+
+def test_pivoted_cholesky_selects_structured_path_inputs():
+    paths = jnp.cumsum(jr.normal(jr.key(27), (8, 5, 2)) * 0.3, axis=1)
+    kernel = phx.kernels.SignaturePDEKernel(
+        phx.kernels.LinearKernel(),
+        polynomial_order=5,
+        pair_block_size=4,
+    )
+    selection = phx.coresets.randomized_pivoted_cholesky(
+        paths,
+        phx.coresets.RandomizedPivotedCholesky(4, kernel=kernel),
+        key=jr.key(4),
+    )
+
+    assert bool(selection.diagnostics.valid)
+    assert jnp.unique(selection.indices).shape == (4,)
+    assert paths[selection.indices].shape == (4, 5, 2)
+    assert selection.diagnostics.residual_trace < selection.diagnostics.initial_trace
+
+
+def test_structured_coresets_validate_kernel_input_rank():
+    path_kernel = phx.kernels.SignaturePDEKernel(phx.kernels.LinearKernel())
+    with pytest.raises(ValueError, match="2 kernel input axes"):
+        phx.coresets.weighted_mmd(
+            jnp.ones((3, 2)),
+            jnp.ones((3, 2)),
+            kernel=path_kernel,
+        )
+    with pytest.raises(ValueError, match="2 kernel input axes"):
+        phx.coresets.kernel_herd(
+            jnp.ones((3, 2)),
+            phx.coresets.KernelHerding(2, kernel=path_kernel),
+        )

--- a/tests/unit/uq/test_coreset_uq.py
+++ b/tests/unit/uq/test_coreset_uq.py
@@ -88,6 +88,25 @@ def test_inducing_selection_reports_numerical_rank_exhaustion():
         phx.uq.select_inducing_points(jnp.zeros((8, 2)), 2, key=jr.key(4))
 
 
+def test_inducing_selection_preserves_structured_path_inputs():
+    paths = jnp.cumsum(jr.normal(jr.key(44), (7, 5, 2)) * 0.2, axis=1)
+    kernel = phx.kernels.SignaturePDEKernel(
+        phx.kernels.LinearKernel(),
+        polynomial_order=4,
+        pair_block_size=3,
+    )
+    selection = phx.uq.select_inducing_points(
+        paths,
+        3,
+        kernel=kernel,
+        key=jr.key(45),
+    )
+
+    assert selection.points.shape == (3, 5, 2)
+    assert jnp.allclose(selection.points, paths[selection.indices])
+    assert jnp.unique(selection.indices).shape == (3,)
+
+
 def test_stein_thinning_preserves_chains_source_indices_and_diagnostics():
     result = _gaussian_mcmc_result()
     method = phx.uq.SteinThinning(10)

--- a/tests/unit/uq/test_discrepancy.py
+++ b/tests/unit/uq/test_discrepancy.py
@@ -3,6 +3,7 @@
 #
 
 import coordax as cx
+import jax
 import jax.numpy as jnp
 import jax.random as jr
 import pytest
@@ -103,4 +104,126 @@ def test_gp_discrepancy_rejects_misaligned_scalar_observations():
         phx.uq.ExactGaussianProcessDiscrepancy(
             jnp.linspace(0.0, 1.0, 4),
             jnp.ones((4, 2)),
+        )
+
+
+def test_exact_scalar_gp_supports_path_valued_kernel_inputs():
+    observation_paths = jnp.cumsum(
+        jr.normal(jr.key(30), (7, 5, 2)) * 0.25,
+        axis=1,
+    )
+    query_paths = jnp.cumsum(
+        jr.normal(jr.key(31), (4, 7, 2)) * 0.25,
+        axis=1,
+    )
+    observations = 0.3 * observation_paths[:, -1, 0] - 0.2 * observation_paths[:, -1, 1]
+    kernel = phx.kernels.SignaturePDEKernel(
+        phx.kernels.LinearKernel(),
+        polynomial_order=4,
+        pair_block_size=3,
+    )
+    state = phx.uq.GaussianProcessLikelihoodState(
+        kernel=kernel,
+        noise_scale=0.05,
+        jitter=1e-9,
+    )
+    model = phx.uq.ExactGaussianProcessDiscrepancy(
+        observation_paths,
+        observations,
+    )
+    residual = model.residual(jnp.zeros_like(observations))
+    factor = model.factor(state=state)
+    conditioned = factor.condition(residual, query_paths, output_dim="path")
+
+    observation_covariance = kernel.matrix(observation_paths, observation_paths)
+    observation_covariance = observation_covariance + (
+        state.noise_scale**2 + state.jitter
+    ) * jnp.eye(observation_paths.shape[0])
+    cross_covariance = kernel.matrix(query_paths, observation_paths)
+    expected_projection = jnp.linalg.solve(observation_covariance, cross_covariance.T).T
+    expected_covariance = (
+        kernel.matrix(query_paths, query_paths) - expected_projection @ cross_covariance.T
+    )
+
+    assert jnp.isfinite(factor.log_probability(residual))
+    assert conditioned.query_points.shape == query_paths.shape
+    assert conditioned.output_dims == ("path",)
+    assert jnp.allclose(conditioned.mean, expected_projection @ residual)
+    assert jnp.allclose(conditioned.covariance, expected_covariance)
+    assert jnp.all(conditioned.variance >= 0.0)
+
+
+def test_sparse_scalar_gp_supports_different_path_design_lengths():
+    observation_paths = jnp.cumsum(
+        jr.normal(jr.key(40), (8, 6, 2)) * 0.2,
+        axis=1,
+    )
+    inducing_paths = jnp.cumsum(
+        jr.normal(jr.key(41), (3, 4, 2)) * 0.2,
+        axis=1,
+    )
+    query_paths = jnp.cumsum(
+        jr.normal(jr.key(42), (5, 7, 2)) * 0.2,
+        axis=1,
+    )
+    observations = observation_paths[:, -1, 0]
+    kernel = phx.kernels.SignaturePDEKernel(
+        phx.kernels.SquaredExponentialKernel(length_scale=0.8),
+        polynomial_order=4,
+        pair_block_size=3,
+    )
+    state = phx.uq.GaussianProcessLikelihoodState(
+        kernel=kernel,
+        noise_scale=0.08,
+    )
+    model = phx.uq.SparseGaussianProcessDiscrepancy(
+        observation_paths,
+        observations,
+        inducing_paths,
+    )
+    factor = model.factor(state=state)
+    conditioned = factor.condition(
+        model.residual(jnp.zeros_like(observations)),
+        query_paths,
+        output_dim="path",
+    )
+
+    assert jnp.isfinite(
+        model.log_marginal_likelihood(
+            jnp.zeros_like(observations),
+            state=state,
+        )
+    )
+    assert factor.observation_points.shape == observation_paths.shape
+    assert factor.inducing_points.shape == inducing_paths.shape
+    assert conditioned.mean.shape == (5,)
+    assert conditioned.covariance.shape == (5, 5)
+    assert jnp.all(conditioned.variance >= 0.0)
+
+
+def test_path_valued_gp_likelihood_is_differentiable_and_functional_gp_rejects_it():
+    paths = jnp.cumsum(jr.normal(jr.key(50), (5, 4, 2)) * 0.15, axis=1)
+    observations = paths[:, -1, 0]
+    model = phx.uq.ExactGaussianProcessDiscrepancy(paths, observations)
+
+    def objective(scale):
+        state = phx.uq.GaussianProcessLikelihoodState(
+            kernel=phx.kernels.SignaturePDEKernel(
+                phx.kernels.ScaleKernel(phx.kernels.LinearKernel(), scale),
+                polynomial_order=3,
+            ),
+            noise_scale=0.05,
+        )
+        return model.log_marginal_likelihood(
+            jnp.zeros_like(observations),
+            state=state,
+        )
+
+    gradient = jax.grad(objective)(jnp.asarray(0.7))
+    assert jnp.isfinite(gradient)
+
+    with pytest.raises(ValueError, match="input_ndim == 1"):
+        phx.uq.FunctionalGaussianProcessLikelihoodState(
+            kernel=phx.kernels.SignaturePDEKernel(phx.kernels.LinearKernel()),
+            noise_scale=0.1,
         )

--- a/tools/signature_benchmarks.py
+++ b/tools/signature_benchmarks.py
@@ -1,0 +1,375 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import importlib.util
+import json
+import time
+from collections.abc import Callable, Sequence
+from dataclasses import asdict, dataclass
+from types import ModuleType
+from typing import Any, TypeVar
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+import phydrax as phx
+
+
+_Result = TypeVar("_Result")
+
+
+@dataclass(frozen=True)
+class BenchmarkResult:
+    method: str
+    length: int
+    dimension: int
+    order: int
+    batch_size: int
+    feature_size: int | None
+    compile_forward_seconds: float | None
+    forward_seconds: float
+    compile_reverse_seconds: float | None
+    reverse_seconds: float | None
+    max_abs_error: float | None
+
+
+def _integers(value: str, /) -> tuple[int, ...]:
+    values = tuple(int(item) for item in value.split(","))
+    if not values or any(item <= 0 for item in values):
+        raise argparse.ArgumentTypeError("Expected comma-separated positive integers.")
+    return values
+
+
+def _block_until_ready(value: Any, /) -> None:
+    for leaf in jax.tree.leaves(value):
+        leaf.block_until_ready()
+
+
+def _measure(
+    function: Callable[..., _Result],
+    arguments: tuple[Any, ...],
+    /,
+    *,
+    repeats: int,
+) -> tuple[float, float, _Result]:
+    compiled = jax.jit(function)
+    start = time.perf_counter()
+    value = compiled(*arguments)
+    _block_until_ready(value)
+    compile_seconds = time.perf_counter() - start
+    samples = []
+    for _ in range(repeats):
+        start = time.perf_counter()
+        value = compiled(*arguments)
+        _block_until_ready(value)
+        samples.append(time.perf_counter() - start)
+    return compile_seconds, float(jnp.median(jnp.asarray(samples))), value
+
+
+def _measure_eager(
+    function: Callable[..., _Result],
+    arguments: tuple[Any, ...],
+    /,
+    *,
+    repeats: int,
+) -> tuple[float, _Result]:
+    value = function(*arguments)
+    samples = []
+    for _ in range(repeats):
+        start = time.perf_counter()
+        value = function(*arguments)
+        samples.append(time.perf_counter() - start)
+    return float(np.median(np.asarray(samples))), value
+
+
+def _paths(
+    key: jax.Array,
+    batch_size: int,
+    length: int,
+    dimension: int,
+    /,
+) -> jax.Array:
+    increments = jax.random.normal(key, (batch_size, length - 1, dimension))
+    increments = increments / jnp.sqrt(jnp.asarray(max(length - 1, 1), dtype=float))
+    origins = jnp.zeros((batch_size, 1, dimension), dtype=increments.dtype)
+    return jnp.concatenate((origins, jnp.cumsum(increments, axis=1)), axis=1)
+
+
+def _feature_size(dimension: int, depth: int, /) -> int:
+    return 1 + sum(dimension**degree for degree in range(1, depth + 1))
+
+
+def _feature_benchmark(
+    paths: jax.Array,
+    depth: int,
+    /,
+    *,
+    repeats: int,
+) -> BenchmarkResult:
+    dimension = int(paths.shape[-1])
+    features = phx.stochastic.SignatureFeatures(
+        dimension,
+        depth,
+        include_scalar=True,
+    )
+    forward = jax.vmap(features)
+    reverse = jax.grad(lambda values: jnp.sum(forward(values)))
+    compile_forward, forward_seconds, _ = _measure(forward, (paths,), repeats=repeats)
+    compile_reverse, reverse_seconds, _ = _measure(reverse, (paths,), repeats=repeats)
+    return BenchmarkResult(
+        method="tensor-features",
+        length=int(paths.shape[1]),
+        dimension=dimension,
+        order=depth,
+        batch_size=int(paths.shape[0]),
+        feature_size=features.output_size,
+        compile_forward_seconds=compile_forward,
+        forward_seconds=forward_seconds,
+        compile_reverse_seconds=compile_reverse,
+        reverse_seconds=reverse_seconds,
+        max_abs_error=None,
+    )
+
+
+def _signax_benchmark(
+    paths: jax.Array,
+    depth: int,
+    signax: ModuleType,
+    /,
+    *,
+    repeats: int,
+) -> BenchmarkResult:
+    def forward(values):
+        return signax.signature(values, depth=depth, flatten=True)
+
+    reverse = jax.grad(lambda values: jnp.sum(forward(values)))
+    compile_forward, forward_seconds, values = _measure(
+        forward, (paths,), repeats=repeats
+    )
+    compile_reverse, reverse_seconds, _ = _measure(reverse, (paths,), repeats=repeats)
+    exact = jax.vmap(
+        phx.stochastic.SignatureFeatures(
+            int(paths.shape[-1]),
+            depth,
+            include_scalar=False,
+        )
+    )(paths)
+    return BenchmarkResult(
+        method="signax",
+        length=int(paths.shape[1]),
+        dimension=int(paths.shape[-1]),
+        order=depth,
+        batch_size=int(paths.shape[0]),
+        feature_size=int(exact.shape[-1]),
+        compile_forward_seconds=compile_forward,
+        forward_seconds=forward_seconds,
+        compile_reverse_seconds=compile_reverse,
+        reverse_seconds=reverse_seconds,
+        max_abs_error=float(jnp.max(jnp.abs(values - exact))),
+    )
+
+
+def _iisignature_benchmark(
+    paths: jax.Array,
+    depth: int,
+    iisignature: ModuleType,
+    /,
+    *,
+    repeats: int,
+) -> BenchmarkResult:
+    host_paths = np.asarray(paths)
+    forward_seconds, values = _measure_eager(
+        lambda array: iisignature.sig(array, depth),
+        (host_paths,),
+        repeats=repeats,
+    )
+    exact = np.asarray(
+        jax.vmap(
+            phx.stochastic.SignatureFeatures(
+                int(paths.shape[-1]),
+                depth,
+                include_scalar=False,
+            )
+        )(paths)
+    )
+    return BenchmarkResult(
+        method="iisignature",
+        length=int(paths.shape[1]),
+        dimension=int(paths.shape[-1]),
+        order=depth,
+        batch_size=int(paths.shape[0]),
+        feature_size=int(exact.shape[-1]),
+        compile_forward_seconds=None,
+        forward_seconds=forward_seconds,
+        compile_reverse_seconds=None,
+        reverse_seconds=None,
+        max_abs_error=float(np.max(np.abs(values - exact))),
+    )
+
+
+def _pde_benchmark(
+    left: jax.Array,
+    right: jax.Array,
+    order: int,
+    /,
+    *,
+    repeats: int,
+    max_feature_size: int,
+) -> BenchmarkResult:
+    dimension = int(left.shape[-1])
+    kernel = phx.kernels.SignaturePDEKernel(
+        phx.kernels.LinearKernel(),
+        polynomial_order=order,
+        pair_block_size=1,
+    )
+    forward = jax.vmap(kernel.pairwise)
+    reverse = jax.grad(lambda values: jnp.sum(forward(values, right)))
+    compile_forward, forward_seconds, values = _measure(
+        forward, (left, right), repeats=repeats
+    )
+    compile_reverse, reverse_seconds, _ = _measure(reverse, (left,), repeats=repeats)
+    feature_size = _feature_size(dimension, order)
+    max_abs_error = None
+    if feature_size <= max_feature_size:
+        features = phx.stochastic.SignatureFeatures(
+            dimension,
+            order,
+            include_scalar=True,
+        )
+        left_features = jax.vmap(features)(left)
+        right_features = jax.vmap(features)(right)
+        exact = jnp.sum(left_features * right_features, axis=1)
+        max_abs_error = float(jnp.max(jnp.abs(values - exact)))
+    return BenchmarkResult(
+        method="signature-pde",
+        length=int(left.shape[1]),
+        dimension=dimension,
+        order=order,
+        batch_size=int(left.shape[0]),
+        feature_size=feature_size,
+        compile_forward_seconds=compile_forward,
+        forward_seconds=forward_seconds,
+        compile_reverse_seconds=compile_reverse,
+        reverse_seconds=reverse_seconds,
+        max_abs_error=max_abs_error,
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Benchmark exact tensor features and the signature PDE kernel."
+    )
+    parser.add_argument("--lengths", type=_integers, default=(16, 64, 256))
+    parser.add_argument("--dimensions", type=_integers, default=(2, 4, 8))
+    parser.add_argument("--depths", type=_integers, default=(2, 4, 6))
+    parser.add_argument("--orders", type=_integers, default=(3, 5, 7))
+    parser.add_argument("--batch-sizes", type=_integers, default=(1, 32))
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("--max-feature-size", type=int, default=100_000)
+    parser.add_argument("--platform", choices=("cpu", "gpu"), default=None)
+    parser.add_argument("--quick", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    arguments = _parser().parse_args(argv)
+    if arguments.repeats <= 0:
+        raise ValueError("repeats must be positive.")
+    if arguments.max_feature_size <= 0:
+        raise ValueError("max_feature_size must be positive.")
+    if arguments.platform is not None:
+        jax.config.update("jax_platform_name", arguments.platform)
+
+    signax = (
+        importlib.import_module("signax")
+        if importlib.util.find_spec("signax") is not None
+        else None
+    )
+    iisignature = (
+        importlib.import_module("iisignature")
+        if importlib.util.find_spec("iisignature") is not None
+        else None
+    )
+    lengths = (16, 64) if arguments.quick else arguments.lengths
+    dimensions = (2, 4) if arguments.quick else arguments.dimensions
+    depths = (2, 4) if arguments.quick else arguments.depths
+    orders = (3, 5) if arguments.quick else arguments.orders
+    batch_sizes = (1, 4) if arguments.quick else arguments.batch_sizes
+    print(
+        json.dumps(
+            {
+                "backend": jax.default_backend(),
+                "devices": [str(device) for device in jax.devices()],
+                "max_feature_size": arguments.max_feature_size,
+                "references": {
+                    "iisignature": iisignature is not None,
+                    "signax": signax is not None,
+                    "sigkax": False,
+                },
+            },
+            sort_keys=True,
+        )
+    )
+
+    key = jax.random.key(2026)
+    for length in lengths:
+        for dimension in dimensions:
+            for batch_size in batch_sizes:
+                key, left_key, right_key = jax.random.split(key, 3)
+                left = _paths(left_key, batch_size, length, dimension)
+                right = _paths(right_key, batch_size, length, dimension)
+                for depth in depths:
+                    if _feature_size(dimension, depth) <= arguments.max_feature_size:
+                        result = _feature_benchmark(
+                            left,
+                            depth,
+                            repeats=arguments.repeats,
+                        )
+                        print(json.dumps(asdict(result), sort_keys=True))
+                        if signax is not None:
+                            print(
+                                json.dumps(
+                                    asdict(
+                                        _signax_benchmark(
+                                            left,
+                                            depth,
+                                            signax,
+                                            repeats=arguments.repeats,
+                                        )
+                                    ),
+                                    sort_keys=True,
+                                )
+                            )
+                        if iisignature is not None:
+                            print(
+                                json.dumps(
+                                    asdict(
+                                        _iisignature_benchmark(
+                                            left,
+                                            depth,
+                                            iisignature,
+                                            repeats=arguments.repeats,
+                                        )
+                                    ),
+                                    sort_keys=True,
+                                )
+                            )
+                for order in orders:
+                    result = _pde_benchmark(
+                        left,
+                        right,
+                        order,
+                        repeats=arguments.repeats,
+                        max_feature_size=arguments.max_feature_size,
+                    )
+                    print(json.dumps(asdict(result), sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a first-class, pure-JAX path-signature stack spanning stochastic path features, recurrent execution, positive-definite kernels, coreset compression, and scalar Gaussian-process inference.

The implementation absorbs the useful architectural ideas behind Signax and Sigkax without introducing either package as a runtime dependency. Tensor signatures and standard-bracket log-signatures reuse Phydrax's existing rough-path algebra; the signature kernel replaces Sigkax's archived custom XLA primitive with a portable JAX recurrence that composes with ordinary transformations on CPU and GPU.

The central design decision is to represent structured kernel inputs explicitly. Point kernels declare one trailing input axis, while path kernels declare two. Kernel algebra and downstream consumers preserve those axes rather than flattening paths into accidental point designs.

## Public API

### Path signatures and features

`phydrax.stochastic` now exposes:

- `path_signature`
- `path_logsignature`
- `flatten_signature`
- `repeat_last_path_padding`
- `time_augment_path`
- `SignatureFeatures`
- `LogSignatureFeatures`
- `SignatureRecurrentState`
- `SignatureRecurrentCell`

A path-value array follows the convention `batch_shape + (num_knots, dimension)`. Terminal signature calls return tensor levels one through the requested depth. Streaming calls add a knot-aligned sequence axis, beginning with the empty-path identity and ending at the terminal signature.

`SignatureFeatures` provides flattened degree-major tensor coordinates with an explicit `include_scalar` option. `LogSignatureFeatures` applies the tensor logarithm and converts the result into the canonical standard-bracket Lyndon basis already represented by `PrimitiveBasis`; coordinate order is therefore stable and inspectable through the basis words.

### Kernels

`phydrax.kernels` now exposes:

- `LinearKernel`
- `NormalizedKernel`
- `SignaturePDEKernel`

Every positive-definite kernel also exposes `input_ndim`, declaring the number of trailing axes forming one kernel input. Existing point kernels retain `input_ndim == 1`; `SignaturePDEKernel` uses `input_ndim == 2`.

`NormalizedKernel` applies checked unit-diagonal normalization to any compatible positive-definite kernel. `LinearKernel` supplies the canonical finite-feature inner product and the static linear lift for path-signature kernels.

## Signature algebra and feature semantics

The existing Chen-product implementation is extended with one canonical scan contract rather than introducing a second tensor algebra:

- terminal and dense-prefix signatures share the same update;
- the empty signature is represented explicitly for streaming output;
- one-knot paths return zero nonscalar levels;
- integer-valued paths promote to an inexact computation dtype;
- batch axes remain arbitrary and are preserved throughout;
- shape, dimension, depth, and finite-value failures are explicit.

This keeps rough-control construction, diagnostic tensor operations, statistical feature maps, and recurrent updates on the same multiplication and logarithm conventions.

## Ragged paths and physical time

Path kernels deliberately do not infer masks or interpolate missing values.

`repeat_last_path_padding(values, lengths)` canonicalizes only the padded suffix after each valid path prefix. Repeated terminal knots contribute zero increments, so signatures become independent of padded capacity without changing valid observations.

`time_augment_path(times, values, lengths=...)` prepends physical time as a path channel. It supports shared or per-case time arrays, requires finite strictly increasing valid times, and applies repeat-last padding jointly when lengths are supplied.

These utilities keep masking and time semantics visible at the data boundary instead of hiding them inside individual feature maps or kernels.

## Online recurrent execution

`SignatureRecurrentCell` composes directly with the canonical `RecurrentBatch` and `run_recurrent` substrate now present on `dev`.

Its state contains:

- the truncated tensor signature;
- the previous valid path point;
- a per-case flag recording whether a basepoint has been observed.

The first valid point establishes the basepoint and emits the identity signature. Each subsequent valid point applies one exact Chen increment. Invalid padding preserves state and receives the recurrent runner's masked output semantics. Valid resets restart a packed path segment, and `final_state` can be passed into a later chunk without changing the dense-path result.

The recurrent module also exports `AbstractRecurrentOutputCell`, making the existing state-to-observable protocol explicit for cells, such as signatures, whose carry contains more information than their emitted feature vector.

## Structured kernel substrate

The shared kernel abstraction now distinguishes an individual kernel input from a design of inputs:

- point input: `(coordinate,)`
- point design: `(point, coordinate)`
- path input: `(knot, channel)`
- path design: `(path, knot, channel)`

Base conversion helpers validate these contracts without flattening trailing axes. One-dimensional design-vector convenience remains limited to point kernels.

Kernel combinators enforce compatible input ranks:

- sums and products require children with equal `input_ndim`;
- scaling and amplitude wrappers preserve their child's rank;
- normalization preserves structured inputs;
- `InputTransformedKernel` declares the rank before transformation and validates the transformed value against the wrapped kernel.

This makes complete-path feature transforms and direct path kernels ordinary members of the same covariance algebra.

## Signature-PDE kernel

`SignaturePDEKernel(static_kernel, polynomial_order=m)` evaluates the signature-kernel Goursat recurrence over every pair of path intervals.

The implementation propagates monomial boundary coefficients while retaining an explicit global Picard-level axis. Truncating that axis after order `m` computes

`K_m(x, y) = Σ_{k=0}^m ⟨S^k(x), S^k(y)⟩`

for the path lifted through the static kernel's feature space. This is a global truncation of the signature expansion, not an independently truncated approximation in every PDE cell.

Consequences of that construction:

- every finite order remains positive definite;
- the linear static kernel agrees exactly with explicit truncated tensor features;
- nonlinear static kernels use four-point RKHS interval increments derived from the knot cross-Gram matrix;
- left and right paths may have different knot counts;
- repeated knots contribute zero increments;
- one-knot paths return the scalar kernel value one;
- ordinary JAX autodiff differentiates path coordinates and trainable static-kernel parameters;
- no custom primitive, custom VJP, C++, CUDA, Pallas, or host callback is required.

`pair_block_size` bounds memory during Gram evaluation by blocking only the leading pair axis. It does not alter the recurrence or numerical value.

## Coreset integration

Kernel-based measure compression now preserves all trailing axes declared by `kernel.input_ndim`.

The generalized paths cover:

- weighted MMD;
- greedy kernel herding;
- randomized pivoted Cholesky;
- sparse-GP inducing-point selection.

Blockwise reductions pad and slice only the leading empirical-measure axis. Candidate selection, diagnostics, and selected points retain the complete structured input shape. Point-design behavior is unchanged.

## Gaussian-process integration

Value-observation scalar GPs now accept any design rank supported by their covariance kernel.

This enables:

- exact GP states over path observations;
- FITC states with path-valued inducing inputs;
- query paths whose knot count differs from observation and inducing paths;
- differentiable likelihoods with respect to signature-kernel parameters;
- coreset-selected path inducing designs.

The mathematical scalar-output GP backend remains unchanged: only the input-shape validation and design plumbing become structure-aware.

Coordinate-functional GPs retain an explicit point-domain contract. `FunctionalDesign`, coordinate partial derivatives, differential-functional likelihood states, and multioutput spatial-functional kernels require `input_ndim == 1` and reject path kernels with a direct error. This prevents a path axis from being misinterpreted as a coordinate axis.

## Documentation and tooling

- Adds a dedicated signatures and path-kernels API guide.
- Documents tensor, log-signature, streaming, padding, time, recurrent, exact-feature, and PDE conventions.
- Extends the kernel API with structured-input contracts and the new kernels.
- Adds path-valued examples to integration and GP inference documentation.
- Clarifies the boundary between solver rough controls and statistical path features.
- Documents canonical recurrent execution in the neural-layer API.
- Updates navigation and the global architecture overview.
- Adds `tools/signature_benchmarks.py` for compilation, forward, and reverse execution across path length, channel dimension, order, and batch size.
- Automatically adds Signax and iisignature reference rows when those optional packages are available.

Sigkax is intentionally not retained as a backend. Its custom-call bridge targets obsolete JAX/XLA extension interfaces, whereas the native recurrence is backend-portable and keeps every parameter visible to JAX transformations.

## Compatibility and review notes

- Existing point kernels preserve their public call shapes and default to `input_ndim == 1`.
- Kernel IDs remain diagnostic identities rather than serialization formats.
- No implicit path normalization, time augmentation, interpolation, or ragged masking is introduced.
- Exact tensor features remain preferable when their feature dimension is small or reused repeatedly.
- The PDE route avoids exponential growth in channel dimension at the cost of work quadratic in the two path lengths and polynomial in truncation order.
- No new runtime dependency is introduced.
- The branch is rebased onto the current `dev`, including the latest recurrent and neural-substrate changes.

Suggested review order:

1. `phydrax/stochastic/_signature.py` and `_signature_features.py`
2. `phydrax/kernels/_base.py`, `_algebra.py`, `_linear.py`, and `_transforms.py`
3. `phydrax/kernels/_signature.py`
4. structured coreset reductions and inducing-point selection
5. scalar GP backend, factor, and conditioning changes
6. public exports, documentation, and benchmark tooling
