### PR TITLE
Add native differentiable ordering and harden relaxation semantics

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -11,6 +11,14 @@ Licensed under the Apache License, Version 2.0.
 The Faddeeva and Dawson implementations are adapted from JAX special-function kernels.
 See LICENSES/JAX-APACHE-2.0.txt.
 
+Fast Soft Sort
+Copyright 2020 Google LLC
+Licensed under the Apache License, Version 2.0.
+The fast unweighted permutahedron ordering implementation follows the
+pool-adjacent-violators formulation of Fast Differentiable Sorting and Ranking
+(Blondel, Teboul, Berthet, and Djolonga, ICML 2020).
+The Apache License text is included at LICENSES/JAX-APACHE-2.0.txt.
+
 Numerax
 Copyright (c) 2025 Juehang Qin
 Licensed under the MIT License.

--- a/docs/api/geometry.md
+++ b/docs/api/geometry.md
@@ -80,6 +80,16 @@ Sharp CSG preserves exact set membership but generally yields a nonsmooth level-
 field at operation seams. Blend CSG provides a smooth approximate zero set and
 reports that weaker contract through its field certificate.
 
+Blend width is a geometry approximation parameter, not an optimizer guarantee.
+A fixed positive width solves a different geometric problem. If blend CSG is used
+for continuation, schedule it outside the geometry and solver abstractions, finish
+against the sharp geometry, and report terminal sharp-field metrics. Phydrax does
+not couple a continuation policy to either abstraction.
+
+`python -m tools.geometric_benchmarks --csg-continuation --smoke` compares
+sharp, fixed-width blend, and width-annealed training while evaluating all terminal
+scientific metrics on the sharp geometry.
+
 ## Simplicial geometry
 
 `TriangleMesh` and `SegmentMesh` own canonical validated arrays and topology.

--- a/docs/api/ml/core.md
+++ b/docs/api/ml/core.md
@@ -11,6 +11,26 @@ nonconvergence, infeasibility, rank deficiency, capacity exhaustion, and an
 unsupported requested derivative. The temperature and soft-discrete functions are
 explicit relaxations, not straight-through versions of exact discrete operations.
 
+## Rank and top-k semantics
+
+The similarly named APIs solve different mathematical problems. They are intentionally
+not routed through one shared helper.
+
+| API | Construction | Rank convention | Weights and axes | Conservation claim |
+| --- | --- | --- | --- | --- |
+| `phydrax.ml.soft_ranks` | pairwise logistic comparisons | one-based, ascending by default; optional descending | unweighted; integer axis | ranks sum to `n * (n + 1) / 2` |
+| `phydrax.ml.soft_topk_weights` | logistic gate over descending pairwise ranks | membership only | unweighted; integer axis | values lie in `[0, 1]`; no general sum-to-`k` claim |
+| `phydrax.ml.metrics.smooth_*` ranking metrics | metric-specific pairwise ranks and masks | metric-specific | metric-specific sample weights and masks | only the documented metric invariant |
+| `phydrax.transport.soft_rank` | entropic monotone coupling | zero-based ascending barycentric rank | weighted; integer array axis or named field dimension | coupling-preserving weighted rank mass |
+| `phydrax.transport.fast_soft_rank` | PAV permutahedron projection | zero-based ascending relaxed rank | unweighted; integer array axis or named field dimension | ranks sum to `n * (n - 1) / 2` |
+| `phydrax.transport.soft_topk_mask` | barycentric top-bin membership | not a rank output | weighted; integer array axis or named field dimension | uniform memberships sum to `k`; weighted mean is `k / n` |
+
+Use pairwise ML ranks for lightweight small-cardinality losses, fast PAV ranks for
+unweighted larger-cardinality arrays, and transport ordering when empirical-measure
+weights or a reusable monotone coupling are semantic. Named dimensions alone do not
+require Sinkhorn: the fast PAV API also accepts `coordax.Field`. None of these families
+hardens its forward value or installs a straight-through gradient.
+
 ::: phydrax.ml
     options:
         members:

--- a/docs/api/ml/trees_ensembles_selection.md
+++ b/docs/api/ml/trees_ensembles_selection.md
@@ -29,6 +29,15 @@ Variance, score, mutual-information, recursive, sequential, and model-based
 selectors return exact selected indices. Continuous sparse gates are a separately
 named relaxation.
 
+`ContinuousSparseGateRecipe` keeps `temperature` and `sparsity` as differentiable
+scalar array leaves. Its fit gradients with respect to features, targets, sample
+weights, and those hyperparameters are conditional, not globally smooth. The scorer
+must be differentiable at the supplied batch; masks and positive effective mass must
+remain fixed; normalized scores need a nonzero range with stable minimum and maximum
+identities. The default absolute-correlation scorer also requires nonzero covariance
+and variance. Equal-score and zero-variance inputs remain finite, but do not strengthen
+that derivative claim. A later hard threshold is a disconnected exact model.
+
 ::: phydrax.ml.feature_selection
     options:
         filters: ["!^_"]

--- a/docs/api/nn/parameters.md
+++ b/docs/api/nn/parameters.md
@@ -96,9 +96,10 @@ spd = phx.nn.parameters.PositiveDefiniteTransform()(raw)
 `ParameterSubspace` partitions selected inexact array leaves from a frozen complement and reconstructs the original model topology exactly. It also records deterministic leaf paths, shapes, exact dtypes, and total dimension. `pack()` and `unpack()` provide the canonical vector coordinate system; `reconstruct_vector()` rebuilds a complete model directly from that vector. Use exact leaf paths or named subtree paths for branched architectures. `last_layer(...)` means the globally final array leaves in deterministic PyTree order; it is not architecture-aware and does not select one output head per branch.
 
 ```python
+model = positive_layer
 subspace = phx.nn.parameters.ParameterSubspace.from_subtree_paths(
     model,
-    (".projection",),
+    (".weight",),
 )
 selected = subspace.initial
 vector = subspace.pack()

--- a/docs/api/terms.md
+++ b/docs/api/terms.md
@@ -90,10 +90,16 @@ reconstruction is a separate problem.
 ## Transport functionals
 
 Transport terms compare complete physical measures or empirical events instead of
-reducing pointwise discrepancies first. Sinkhorn terms retain native convergence
-diagnostics and reject a failed solve. Prepared references reuse only the fixed target
-self term. Sliced terms retain their projection design; soft quantile functionals are
-regularized order objectives, not exact sample quantiles.
+reducing pointwise discrepancies first. Sinkhorn divergence terms retain native
+convergence diagnostics and reject a failed solve. Prepared references reuse only the
+fixed target self term. Sliced terms retain their projection design.
+
+`SoftQuantileFunctional` is a regularized order objective, not an exact sample-quantile
+penalty. Its diagnostics expose the effective solver epsilon and mark exact `q=0` and
+`q=1` endpoints. Interior squared penalties inherit the finite Sinkhorn map's
+regularity. Exact endpoints are only almost-everywhere differentiable, and absolute
+discrepancy has a kink at zero residual. A supplied `Sinkhorn` overrides the convenience
+`epsilon`; convenience diagnostics do not retain complete solver evidence.
 
 ::: phydrax.terms.SpatialSinkhornDivergenceTerm
 

--- a/docs/api/transport/index.md
+++ b/docs/api/transport/index.md
@@ -63,8 +63,12 @@ needed.
   event encodings are rejected.
 - A structured event PyTree must lower to one array leaf or provide an explicit
   `encoder=`. The encoder is part of the scientific model, not serialization detail.
-- Ground-cost units determine the units of `epsilon`; coordinate scaling therefore
-  changes both geometry and the appropriate regularization scale.
+- For general transport, ground-cost units determine the units of `epsilon`; coordinate
+  scaling changes both geometry and the appropriate regularization scale.
+  Differentiable ordering explicitly canonicalizes values first, so its `epsilon` is
+  dimensionless in the order geometry described on the ordering page.
+  The separate fast unweighted PAV family uses a dimensionless `temperature` and
+  exposes no coupling or solver diagnostics.
 
 ::: phydrax.transport.DiscreteTransportProblem
 

--- a/docs/api/transport/soft.md
+++ b/docs/api/transport/soft.md
@@ -1,16 +1,44 @@
 # Differentiable ordering
 
 The soft-order family builds one entropic monotone coupling between observed values and
-ordered target mass bins. Every operation is derived from that coupling; none replaces
-the hard combinatorial operator in the forward pass.
+ordered target mass bins. Every operation is derived from that coupling. It is a
+separate relaxed model, not a hard operator with substituted gradients.
 
-For arrays, `axis` is an integer. For `coordax.Field`, it may be a named dimension and
-the returned field preserves caller dimension order. Weights must broadcast exactly
-under the selected axis contract.
+For arrays, `axis` is an integer. For `coordax.Field`, it is a named dimension and the
+returned field preserves caller dimension order. Weights must broadcast exactly under
+the selected axis contract. Zero-weight atoms remain shape-present but are inert.
 
 ## Core coupling
 
 ::: phydrax.transport.soft_order_transport
+
+### Canonical dimensionless geometry
+
+Soft ordering does not transport values in their raw physical units. For normalized
+source probabilities `p`, it computes the weighted center `μ`, the weighted scale
+`σ = sqrt(weighted_variance + machine_epsilon)`, and source locations
+`sigmoid((value - μ) / σ)`. Target locations are cumulative-probability bin midpoints.
+The source provenance is
+`soft-order-source:weighted-standardize-sigmoid`; the target provenance is
+`soft-order-target:probability-midpoints`.
+
+This canonicalization makes the order map translation-equivariant and, within floating
+point tolerance, positive-affine-equivariant. Negative scaling reverses order.
+`epsilon` is dimensionless in this canonical order geometry. Do not interpret it as the
+ground-cost regularization for raw physical coordinates. Changing one candidate changes
+the weighted center and scale, and can therefore change every relaxed location and
+gradient.
+
+There is deliberately no numerical “unsquash.” The returned result retains the
+canonical source and target supports, masses, provenance, and coupling; physical
+sorted values are recovered by applying that coupling to the original values as a
+payload through `result.barycentric_source_to_target(values)`. Without the original
+payload, the result makes no physical-value reconstruction claim and does not attempt
+an unstable inverse sigmoid.
+
+The convenience `epsilon=` value configures the default solver. When `solver=` is
+supplied, that solver owns the effective epsilon, iteration budget, tolerance,
+block size, and differentiation behavior.
 
 ## Sorting and ranking
 
@@ -24,6 +52,54 @@ under the selected axis contract.
 
 ::: phydrax.transport.soft_sort_by
 
+`soft_rank` returns zero-based ascending barycentric ranks. Its weighting and
+coupling-conservation semantics are not interchangeable with one-based pairwise
+logistic ranks used by `phydrax.ml.soft_ranks`.
+
+## Fast unweighted ordering
+
+::: phydrax.transport.fast_soft_sort
+
+---
+
+::: phydrax.transport.fast_soft_rank
+
+The `fast_soft_*` family is a separate unweighted algorithm, not a `method=` option on
+the Sinkhorn API. It follows the L2 permutahedron relaxation and pool-adjacent-violators
+construction of [Blondel et al. (2020)](https://arxiv.org/abs/2002.08871). Sorting
+dominates its asymptotic cost: it uses `O(n log n)` work and `O(n)` temporary state
+rather than constructing an `n`-by-`n` transport problem.
+
+Each row is centered and variance-standardized before relaxation. `temperature` is
+therefore dimensionless; larger values are smoother and smaller values approach hard
+ordering. Constant rows are handled without dividing by zero. The operators preserve
+permutation symmetry and positive-affine equivariance within floating-point tolerance.
+`fast_soft_sort` preserves the unweighted sum and returns monotone values.
+`fast_soft_rank` returns zero-based ascending ranks in `[0, n - 1]` whose unweighted
+sum is `n * (n - 1) / 2`.
+
+The relaxation is continuous and piecewise smooth, not globally smooth. Its PAV active
+partition can change at chamber boundaries, and sufficiently separated values can
+enter an exactly ordered region with zero rank derivative. Tune `temperature` against
+both hard-order error and gradient utility on the actual data.
+
+Use this family only when every atom has equal importance and only sorted values or
+ranks are needed. It has no weights, transport plan, barycentric payload map,
+convergence iterations, or marginal-residual diagnostics. Use the Sinkhorn family
+when any of those semantics matter. Both raw arrays with integer axes and
+`coordax.Field` values with named axes are supported.
+
+```python
+import jax.numpy as jnp
+
+import phydrax as phx
+
+values = jnp.asarray([3.0, 1.0, 4.0, 2.0])
+
+sorted_values = phx.transport.fast_soft_sort(values, temperature=0.5)
+zero_based_ranks = phx.transport.fast_soft_rank(values, temperature=2.0)
+```
+
 ## Top-k relaxations
 
 ::: phydrax.transport.soft_topk_mask
@@ -32,10 +108,13 @@ under the selected axis contract.
 
 ::: phydrax.transport.soft_topk_values
 
-`soft_topk_mask(values, k)` returns fractional membership with total mass `k`. The
-boundary cases are exact: `k=0` returns zeros and `k=axis_size` returns ones.
-`soft_topk_values` returns values in the largest `k` ordered bins, with the selected
-axis retained at size `k`.
+`soft_topk_mask(values, k)` maps the indicator of the largest `k`
+equal-probability target bins back to source atoms. With uniform source weights, its
+fractional memberships sum to `k`. With normalized nonuniform source weights `p`, the
+conserved statement is `sum(p * mask) = k / axis_size`, not an unweighted cardinality
+claim. The boundary cases are exact: `k=0` returns zeros and `k=axis_size` returns
+ones. `soft_topk_values` returns values in the largest `k` ordered bins, with the
+selected axis retained at size `k`.
 
 ## Quantiles and quantization
 
@@ -50,14 +129,28 @@ axis retained at size `k`.
 ::: phydrax.transport.soft_quantize
 
 Quantiles may be scalar or array-valued and must lie in the closed unit interval.
-Caller quantile order is preserved. Exact endpoints return the sample minimum and
-maximum. `soft_quantile_normalize` maps through a differentiable empirical CDF-like
-rank; `soft_quantize` maps those normalized levels onto supplied target levels.
+Caller quantile order is preserved. Interior quantiles interpolate relaxed sorted
+values. Exact endpoints return the active sample minimum and maximum, so their
+derivatives are only almost-everywhere defined and are nondifferentiable at relevant
+ties. `soft_quantile_normalize` maps through the same relaxed empirical order;
+`soft_quantize` maps normalized levels through learned ordered barycentric levels.
 
-## Regularization and gradients
+## Regularization, diagnostics, and method choice
 
 Smaller `epsilon` approaches harder order but makes Sinkhorn iterations more
-ill-conditioned; larger `epsilon` smooths gradients and increases approximation bias.
+ill-conditioned; larger `epsilon` broadens the coupling and usually distributes
+gradients across more atoms, at the cost of greater approximation bias.
+`soft_order_transport` returns the full `SinkhornResult`, including convergence,
+marginal residuals, potentials, and transport provenance. Convenience functions return
+only transformed values, but still fail explicitly when the solve does not converge.
+They do not retain full solver evidence for later inspection.
+
 Do not report a soft sort, rank, quantile, or top-k output as exact. Validate the
 chosen regularization with hard-order approximation error, monotonicity, range,
-finite-gradient, and convergence diagnostics on the workload's actual scale.
+finite-gradient, convergence, and final scientific metrics on the actual workload.
+
+Use pairwise logistic ranks in `phydrax.ml` for lightweight unweighted ML losses. Use
+this Sinkhorn family when nonuniform empirical weights, zero-mass support, named
+scientific axes, or a shared monotone coupling are part of the model. Use hard JAX
+ordering for exact reporting and guarantee-bearing statistics. Hardening is terminal:
+Phydrax installs no straight-through derivative.

--- a/docs/appendix/ml_differentiability.md
+++ b/docs/appendix/ml_differentiability.md
@@ -148,10 +148,26 @@ A relaxed model is a separate mathematical model:
 - sigmoid or sparse-continuous tree gates instead of threshold routing;
 - smooth sorting or quantile approximations instead of exact order statistics.
 
+`phydrax.transport.fast_soft_sort` and `fast_soft_rank` use an L2
+permutahedron projection. Their custom JVP differentiates block averages for the
+current pool-adjacent-violators partition. The map is continuous and piecewise
+smooth; derivatives are conditional on that active partition, and a sufficiently
+hard rank relaxation can have an exactly discrete local value with zero derivative.
+
 Temperature and regularization remain array-valued continuous hyperparameters when
-possible. A temperature approaching zero can make derivatives singular or
-ill-conditioned. Hardening produces a new exact model and terminates the gradient
-path; Phydrax does not install a straight-through gradient by default.
+possible. `ContinuousSparseGateRecipe.temperature` and `.sparsity` are differentiable
+array leaves, but their derivatives are conditional: score functions must be
+differentiable, masks and positive effective mass must remain fixed, score
+normalization needs a nonzero range with stable extrema, and the default absolute
+correlation must stay away from zero covariance and variance. A temperature
+approaching zero can make derivatives singular or ill-conditioned.
+
+Relaxed quantile interiors inherit their solver's regularity. Exact minimum/maximum
+endpoints remain only almost-everywhere differentiable, and an absolute-discrepancy
+objective has an additional kink at zero residual.
+
+Hardening produces a new exact model and terminates the gradient path; Phydrax does
+not install a straight-through gradient by default.
 
 ## Weights and masks
 
@@ -248,7 +264,7 @@ family-level rule, not a substitute for reading the returned conditions.
 | Soft voting/mixture of experts | probabilities, expert weights, gate | optional hard expert/vote | normalized finite weights and valid children |
 | Hard voting/stacking selection | meta-model values conditional on child outputs | hard vote and fold/candidate identity | fixed folds/children and valid meta-design |
 | Exact feature selection | transformed retained values | selected indices, bins, recursive/sequential path | fixed selected set |
-| Continuous sparse gates | gate values and relaxed fit | optional hard threshold | positive temperature/regularization and fixed iterations |
+| Continuous sparse gates | gate values and relaxed fit, conditionally including features, targets, weights, temperature, and sparsity | optional hard threshold | differentiable scorer, fixed masks, positive effective mass, nonzero score range, stable extrema, and no absolute-correlation kink |
 | Sensitivity and partial dependence | derivative of the actual callable and weighted reduction | hard model branches inherited from the model | model's own prediction contract and valid domain |
 | Permutation importance | score conditional on a fixed permutation | permutation draw and ranking | explicit fixed key and valid scorer |
 | Influence functions | implicit parameter/data influence | active set inherited from objective | nonsingular regularized Hessian/KKT system |

--- a/docs/guides_transport.md
+++ b/docs/guides_transport.md
@@ -60,6 +60,13 @@ A custom cost subclasses `AbstractGroundCost` and implements a JAX-transformable
 A precomputed matrix supports only dense execution because arbitrary blocks cannot be
 reconstructed from coordinates.
 
+Differentiable ordering is a declared exception to raw-coordinate scaling. Before
+constructing its squared ground cost, `soft_order_transport` weighted-centers and
+weighted-standardizes scalar candidates, then maps them through a sigmoid to a unit
+order interval. Its `epsilon` is therefore dimensionless in canonical order geometry.
+That convention is appropriate only because hard order is invariant under positive
+affine changes. Never infer the same normalization for physical transport problems.
+
 ## 4. Choose the transport quantity
 
 | Question | Native method | Important limitation |
@@ -69,11 +76,22 @@ reconstructed from coordinates.
 | Smooth multivariate discrepancy | `sinkhorn_divergence` | Entropically regularized and iterative |
 | Finite regularized coupling or barycentric action | `Sinkhorn(problem)` | Balanced mass only |
 | Differentiable sort/rank/quantile/top-k | soft-order functions | Relaxations, not hard order |
+| Fast unweighted relaxed sort/rank | `fast_soft_sort`, `fast_soft_rank` | No weights, coupling, or solver diagnostics |
 
 The regularized Sinkhorn objective contains self-interaction bias. Use
 `sinkhorn_divergence` for a discrepancy expected to vanish on identical measures. Use
 the raw `SinkhornResult` when the coupling, transport component, regularization
 component, or barycentric action is the actual object of interest.
+
+For unweighted sorted values or ranks at moderate and large cardinality,
+`phydrax.transport.fast_soft_sort` and `fast_soft_rank` use a PAV permutahedron
+relaxation with linear temporary state. Pairwise logistic `phydrax.ml.soft_ranks` is
+still the lighter rank-only primitive for small ML losses. Use Sinkhorn soft order
+when empirical weights, zero-mass atoms, reusable barycentric actions, or one shared
+monotone coupling matter. Use hard order for exact reporting, calibration guarantees,
+and other guarantee-bearing statistics. These methods are not hidden behind one
+`method=` switch because their weighting, regularization, convergence, output, and
+rank-base contracts differ.
 
 Sliced Wasserstein stores normalized projections. Supply explicit projections when
 replay, common random numbers, or deterministic gradient comparison matters.
@@ -182,11 +200,17 @@ never treated as physical cases.
 - `EmpiricalSinkhornDivergenceTerm` compares a model-generated empirical law with a
   prepared reference.
 - `SlicedWassersteinTerm` provides a projection-based whole-event discrepancy.
-- `SoftQuantileFunctional` penalizes regularized empirical quantiles.
+- `SoftQuantileFunctional` penalizes regularized empirical quantiles. Its diagnostics
+  contain transformed quantiles, targets, residuals, an exact-endpoint mask, and the
+  effective epsilon. A supplied solver owns that epsilon.
 
-Each is an evaluated scalar term and retains method diagnostics in `TermEvaluation`.
-The model-facing provider or measure builder determines which functions are objective
-variables; no implicit domain sampling is introduced.
+Each is an evaluated scalar term and retains method-appropriate diagnostics in
+`TermEvaluation`. Quantile convenience diagnostics are intentionally not a retained
+batch of complete `SinkhornResult` objects. Interior squared quantile penalties can be
+smooth where the finite solve is regular; exact endpoints are only almost-everywhere
+differentiable, and absolute discrepancy has a kink at zero residual. The model-facing
+provider or measure builder determines which functions are objective variables; no
+implicit domain sampling is introduced.
 
 ### Distributional semigroup consistency
 
@@ -217,16 +241,23 @@ package's class hierarchy.
 
 ## 11. Benchmark the relevant regime
 
-Three deterministic JSON harnesses separate core, soft-order, and scientific paths:
+Five deterministic JSON harnesses separate core, soft-order, fast unweighted order,
+scientific transport, and quantile-objective paths:
 
 ```bash
 python -m tools.transport_benchmarks --smoke
 python -m tools.soft_transport_benchmarks --smoke
+python -m tools.fast_order_benchmarks --smoke
 python -m tools.transport_scientific_benchmarks --smoke
+python -m tools.soft_quantile_objective_benchmarks --smoke
 ```
 
 The core harness reports compile-plus-first, steady solve, plan application, backward
-execution, convergence, and result bytes for dense and blockwise modes. The soft
-harness reports approximation, order, range, and gradient evidence. The scientific
-harness exercises nonuniform spatial density, whole-field operator ensembles, and the
-particle transform.
+execution, convergence, and result bytes for dense and blockwise modes. The general
+soft-order harness reports approximation, order, range, coupling, and gradient
+evidence. The fast-order harness compares Sinkhorn and PAV compile, execution, memory,
+approximation, equivariance, and derivative evidence without pretending their
+regularization parameters are interchangeable. The scientific harness exercises
+nonuniform spatial density, whole-field operator ensembles, and the particle
+transform. The quantile-objective harness compares terminal hard-tail and physical
+metrics across several deterministic training workloads.

--- a/docs/guides_uncertainty.md
+++ b/docs/guides_uncertainty.md
@@ -1652,6 +1652,14 @@ For a reciprocal weighted `GraphIR`, the complete graph-to-posterior path remain
 inside the same kernel and GP contracts:
 
 ```python
+graph = phx.graph.GraphIR(
+    nodes=jnp.arange(3, dtype=float)[:, None],
+    edges={"conductance": jnp.asarray([1.0, 1.0, 2.0, 2.0])},
+    senders=jnp.asarray([0, 1, 1, 2], dtype=jnp.int32),
+    receivers=jnp.asarray([1, 0, 2, 1], dtype=jnp.int32),
+    n_node=jnp.asarray([3], dtype=jnp.int32),
+    n_edge=jnp.asarray([4], dtype=jnp.int32),
+)
 complex_ir = phx.graph.graph_to_cochain_complex(
     graph,
     edge_weight_key="conductance",
@@ -1659,7 +1667,7 @@ complex_ir = phx.graph.graph_to_cochain_complex(
 spectrum = phx.graph.cochain_laplacian_eigenbasis(
     complex_ir,
     0,
-    num_modes=31,
+    num_modes=3,
 )
 kernel = phx.kernels.AmplitudeKernel(
     phx.kernels.SpectralFeatureKernel(
@@ -1669,6 +1677,9 @@ kernel = phx.kernels.AmplitudeKernel(
     0.2,
 )
 entities = complex_ir.cell_entities(0)
+observed_entities = entities[:2]
+observations = jnp.asarray([0.1, -0.1])
+model_values = jnp.zeros_like(observations)
 discrepancy = phx.uq.ExactGaussianProcessDiscrepancy(
     observed_entities,
     observations,

--- a/phydrax/kernels/_finite_feature.py
+++ b/phydrax/kernels/_finite_feature.py
@@ -13,7 +13,7 @@ import jax.numpy as jnp
 import jax.scipy as jsp
 from jaxtyping import Array, ArrayLike
 
-from ._base import _as_point, _as_points, AbstractPositiveDefiniteKernel
+from ._base import _as_inputs, _as_point, _as_points, AbstractPositiveDefiniteKernel
 
 
 class AbstractFiniteFeatureKernel(AbstractPositiveDefiniteKernel):
@@ -184,8 +184,12 @@ def kernel_features(
             axis=-1,
         )
     elif isinstance(kernel, InputTransformedKernel):
-        point_design = _as_points(points, name="points")
-        transformed = jax.vmap(kernel._transform_point)(point_design)
+        point_design = _as_inputs(
+            points,
+            input_ndim=kernel.input_ndim,
+            name="points",
+        )
+        transformed = jax.vmap(kernel._transform_input)(point_design)
         features = kernel_features(kernel.kernel, transformed)
     else:
         raise TypeError(f"{kernel.kernel_id} has no exact finite-feature representation.")

--- a/phydrax/ml/_soft_discrete.py
+++ b/phydrax/ml/_soft_discrete.py
@@ -33,7 +33,7 @@ def masked_softmax(
     mask: ArrayLike | None = None,
     axis: int = -1,
 ) -> Array:
-    """Stable softmax returning zeros, rather than NaNs, for empty masks."""
+    """Stable softmax that returns zeros for an entirely masked slice."""
     values = _real_values(logits, name="logits")
     if mask is not None:
         values = jnp.where(jnp.asarray(mask, dtype=bool), values, -jnp.inf)
@@ -77,7 +77,7 @@ def gumbel_softmax(
     temperature: ArrayLike,
     axis: int = -1,
 ) -> Array:
-    """Sample a differentiable categorical relaxation without hardening it."""
+    """Sample a relaxed categorical probability vector without hardening."""
     values = _real_values(logits, name="logits")
     uniform = jax.random.uniform(
         key,
@@ -102,6 +102,11 @@ def soft_ranks(
     axis: int = -1,
     descending: bool = False,
 ) -> Array:
+    """Return one-based pairwise-logistic ranks.
+
+    Ranks are ascending by default and descending when requested. Equal values
+    receive equal ranks; an all-equal axis receives its one-based midpoint rank.
+    """
     array = _real_values(values, name="values")
     moved = jnp.moveaxis(array, axis, -1)
     difference = moved[..., :, None] - moved[..., None, :]
@@ -121,7 +126,11 @@ def soft_topk_weights(
     gate_temperature: ArrayLike | None = None,
     axis: int = -1,
 ) -> Array:
-    """Continuous top-k memberships derived from smooth descending ranks."""
+    """Return logistic memberships derived from one-based descending soft ranks.
+
+    Values lie in ``[0, 1]`` but do not generally sum to ``k``. This is a
+    membership surrogate, not a cardinality-preserving transport mask.
+    """
     values = _real_values(scores, name="scores")
     count = int(k)
     if count <= 0 or count > values.shape[axis]:

--- a/phydrax/ml/feature_selection/_selection.py
+++ b/phydrax/ml/feature_selection/_selection.py
@@ -188,6 +188,15 @@ def _correlation_scores(batch: MLBatch) -> Array:
     return jnp.where(total > 0.0, jnp.abs(covariance) / scale, -jnp.inf)
 
 
+def _gate_hyperparameter(value: Any, name: str, /) -> Array:
+    scalar = jnp.asarray(value)
+    if scalar.ndim != 0:
+        raise ValueError(f"{name} must be a scalar.")
+    if jnp.issubdtype(scalar.dtype, jnp.complexfloating):
+        raise TypeError(f"{name} must be real-valued.")
+    return scalar.astype(jnp.result_type(scalar.dtype, float))
+
+
 def _selection(scores: Array, eligible: Array, capacity: int) -> ExactSelection:
     if capacity <= 0 or capacity > scores.shape[0]:
         raise ValueError("Selection capacity must be in [1, feature_count].")
@@ -641,22 +650,30 @@ class ModelBasedSelectionRecipe(AbstractRecipe):
 
 
 class ContinuousSparseGateRecipe(AbstractRecipe):
-    temperature: float = eqx.field(static=True)
-    sparsity: float = eqx.field(static=True)
+    temperature: Array
+    sparsity: Array
     scorer: Callable[[MLBatch], Array] = eqx.field(static=True)
 
     def __init__(
         self,
         /,
         *,
-        temperature: float = 0.1,
-        sparsity: float = 0.5,
+        temperature: Any = 0.1,
+        sparsity: Any = 0.5,
         scorer: Callable[[MLBatch], Array] | None = None,
     ):
-        if float(temperature) <= 0.0 or not 0.0 <= float(sparsity) <= 1.0:
-            raise ValueError("temperature must be positive and sparsity in [0, 1].")
-        self.temperature = float(temperature)
-        self.sparsity = float(sparsity)
+        temperature_ = _gate_hyperparameter(temperature, "temperature")
+        sparsity_ = _gate_hyperparameter(sparsity, "sparsity")
+        self.temperature = eqx.error_if(
+            temperature_,
+            ~jnp.isfinite(temperature_) | (temperature_ <= 0.0),
+            "temperature must be finite and positive.",
+        )
+        self.sparsity = eqx.error_if(
+            sparsity_,
+            ~jnp.isfinite(sparsity_) | (sparsity_ < 0.0) | (sparsity_ > 1.0),
+            "sparsity must be finite and lie in [0, 1].",
+        )
         self.scorer = _correlation_scores if scorer is None else scorer
 
     def fit_batch(self, batch: MLBatch, /, *, key: Any = None) -> FitResult:
@@ -688,12 +705,16 @@ class ContinuousSparseGateRecipe(AbstractRecipe):
             status=status,
             method="continuous-sparse-gates",
             gradient_contract=GradientContract(
-                fit_features="smooth",
-                fit_targets="smooth",
-                fit_hyperparameters="smooth",
+                fit_features="conditional",
+                fit_targets="conditional",
+                fit_weights="conditional",
+                fit_hyperparameters="conditional",
                 fit_mode="relaxed",
                 conditions=(
-                    "The configured score function must itself be differentiable.",
+                    "The configured scorer must be differentiable at the supplied batch.",
+                    "Feature and target masks must remain fixed with positive effective mass.",
+                    "Score normalization requires a nonzero finite range and stable extrema.",
+                    "Absolute correlation requires nonzero covariance and variance.",
                 ),
             ),
         )

--- a/phydrax/nn/operator/architectures/geometric/_lattice_equivariant_cno.py
+++ b/phydrax/nn/operator/architectures/geometric/_lattice_equivariant_cno.py
@@ -104,10 +104,15 @@ class _LatticeEquivariantBlock(StrictModule):
         /,
         *,
         activation: LatticeActivation,
+        use_bias: bool,
         key: Key[Array, ""],
     ):
         first_key, second_key = jr.split(key)
-        self.first = LatticeEquivariantConvND(basis, key=first_key)
+        self.first = LatticeEquivariantConvND(
+            basis,
+            use_bias=use_bias,
+            key=first_key,
+        )
         self.normalization = TensorRMSNorm(basis.output_layout)
         self.activation = TensorNormActivation(
             basis.output_layout,
@@ -213,6 +218,9 @@ class LatticeEquivariantCNO(AbstractOperatorModel):
             raise TypeError("hidden_layout must be a TensorFieldLayout or None.")
         if hidden_layout.dimension != group.dimension:
             raise ValueError("Hidden tensor layout and group dimensions must agree.")
+        use_hidden_bias = any(
+            block.tensor_type.is_scalar for block in hidden_layout.blocks
+        )
         if squeeze_scalar_output and output_layout.channel_count != 1:
             raise ValueError("squeeze_scalar_output requires exactly one output channel.")
 
@@ -238,11 +246,16 @@ class LatticeEquivariantCNO(AbstractOperatorModel):
             max_construction_bytes=max_basis_construction_bytes,
         )
         keys = jr.split(key, resolved_depth + 2)
-        self.lift = LatticeEquivariantConvND(lift_basis, key=keys[0])
+        self.lift = LatticeEquivariantConvND(
+            lift_basis,
+            use_bias=use_hidden_bias,
+            key=keys[0],
+        )
         self.blocks = tuple(
             _LatticeEquivariantBlock(
                 hidden_basis,
                 activation=activation,
+                use_bias=use_hidden_bias,
                 key=block_key,
             )
             for block_key in keys[1:-1]

--- a/phydrax/terms/_transport.py
+++ b/phydrax/terms/_transport.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import math
 from collections.abc import Callable, Mapping, Sequence
 from typing import Any, Literal
 
@@ -265,7 +266,12 @@ class SlicedWassersteinTerm(AbstractEvaluatedScalarTerm):
 
 
 class SoftQuantileFunctional(AbstractEvaluatedScalarTerm):
-    """Differentiable scalar penalty on one or more empirical quantiles."""
+    """Penalty on relaxed empirical quantiles with exact hard endpoints.
+
+    Interior quantiles inherit the regularity of the soft-order solve. Exact
+    endpoints are only almost-everywhere differentiable, and absolute discrepancy
+    additionally has a kink at zero residual.
+    """
 
     objective_vars: tuple[str, ...]
     values: Provider
@@ -308,7 +314,10 @@ class SoftQuantileFunctional(AbstractEvaluatedScalarTerm):
         self.solver = solver
         self.weight = _scalar_weight(weight)
         self.axis = axis
-        self.epsilon = float(epsilon)
+        epsilon_ = float(epsilon)
+        if not math.isfinite(epsilon_) or epsilon_ <= 0.0:
+            raise ValueError("epsilon must be finite and positive.")
+        self.epsilon = epsilon_
         self.discrepancy = mode
         self.label = None if label is None else str(label)
 
@@ -337,7 +346,15 @@ class SoftQuantileFunctional(AbstractEvaluatedScalarTerm):
                 "target_quantiles must describe a scalar empirical law."
             )
         penalty = residual**2 if self.discrepancy == "squared" else jnp.abs(residual)
+        effective_epsilon = (
+            self.solver.epsilon
+            if self.solver is not None
+            else jnp.asarray(self.epsilon, dtype=estimate_data.dtype)
+        )
+        endpoint_mask = (self.q == 0.0) | (self.q == 1.0)
         diagnostics = {
+            "effective_epsilon": jnp.asarray(effective_epsilon),
+            "endpoint_mask": endpoint_mask,
             "quantiles": jnp.asarray(estimate_data),
             "target_quantiles": self.target_quantiles,
             "residuals": residual,

--- a/phydrax/transport/__init__.py
+++ b/phydrax/transport/__init__.py
@@ -10,6 +10,7 @@ from ._costs import (
     WeightedSquaredEuclideanCost,
 )
 from ._divergence import sinkhorn_divergence, SinkhornDivergenceResult
+from ._fast_order import fast_soft_rank, fast_soft_sort
 from ._problem import (
     discrete_problem,
     DiscreteTransportProblem,
@@ -60,6 +61,8 @@ __all__ = [
     "TransportStatus",
     "WeightedSquaredEuclideanCost",
     "discrete_problem",
+    "fast_soft_rank",
+    "fast_soft_sort",
     "sliced_wasserstein_distance",
     "soft_order_transport",
     "soft_quantile",

--- a/phydrax/transport/_fast_order.py
+++ b/phydrax/transport/_fast_order.py
@@ -1,0 +1,275 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+"""Fast unweighted ordering via L2 permutahedron projection.
+
+The formulation follows Blondel, Teboul, Berthet, and Djolonga,
+``Fast Differentiable Sorting and Ranking`` (ICML 2020).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import coordax as cx
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array, ArrayLike
+
+
+Value = ArrayLike | cx.Field
+
+
+def _pav_decreasing_with_blocks(values: Array, /) -> tuple[Array, Array]:
+    """Project one vector onto the nonincreasing cone with a PAV stack."""
+    count = values.shape[0]
+    levels = jnp.zeros_like(values)
+    block_sizes = jnp.zeros((count,), dtype=jnp.int32)
+
+    def append(index, state):
+        levels_, block_sizes_, num_blocks = state
+        levels_ = levels_.at[num_blocks].set(values[index])
+        block_sizes_ = block_sizes_.at[num_blocks].set(1)
+        num_blocks = num_blocks + 1
+
+        def violates(inner_state):
+            levels__, _, num_blocks__ = inner_state
+            previous = jnp.maximum(num_blocks__ - 2, 0)
+            current = jnp.maximum(num_blocks__ - 1, 0)
+            return (num_blocks__ > 1) & (
+                levels__[previous] < levels__[current]
+            )
+
+        def merge(inner_state):
+            levels__, block_sizes__, num_blocks__ = inner_state
+            previous = num_blocks__ - 2
+            current = num_blocks__ - 1
+            merged_size = block_sizes__[previous] + block_sizes__[current]
+            merged_level = (
+                block_sizes__[previous] * levels__[previous]
+                + block_sizes__[current] * levels__[current]
+            ) / merged_size
+            levels__ = levels__.at[previous].set(merged_level)
+            block_sizes__ = block_sizes__.at[previous].set(merged_size)
+            block_sizes__ = block_sizes__.at[current].set(0)
+            return levels__, block_sizes__, num_blocks__ - 1
+
+        return jax.lax.while_loop(
+            violates,
+            merge,
+            (levels_, block_sizes_, num_blocks),
+        )
+
+    levels, block_sizes, num_blocks = jax.lax.fori_loop(
+        0,
+        count,
+        append,
+        (levels, block_sizes, jnp.asarray(0, dtype=jnp.int32)),
+    )
+    block_ends = jnp.cumsum(block_sizes)
+    block_index = jnp.arange(count, dtype=block_sizes.dtype)
+    block_ends = jnp.where(block_index < num_blocks, block_ends, count + 1)
+    assignments = jnp.searchsorted(
+        block_ends,
+        block_index,
+        side="right",
+    )
+    return levels[assignments], assignments
+
+
+@jax.custom_jvp
+def _pav_decreasing(values: Array, /) -> Array:
+    projected, _ = _pav_decreasing_with_blocks(values)
+    return projected
+
+
+@_pav_decreasing.defjvp
+def _pav_decreasing_jvp(primals, tangents):
+    (values,), (values_dot,) = primals, tangents
+    projected, assignments = _pav_decreasing_with_blocks(values)
+    count = values.shape[0]
+    tangent_sums = jax.ops.segment_sum(
+        values_dot,
+        assignments,
+        num_segments=count,
+    )
+    block_sizes = jax.ops.segment_sum(
+        jnp.ones_like(values),
+        assignments,
+        num_segments=count,
+    )
+    projected_dot = tangent_sums[assignments] / block_sizes[assignments]
+    return projected, projected_dot
+
+
+def _standardize(values: Array, /) -> tuple[Array, Array, Array]:
+    center = jnp.mean(values)
+    centered = values - center
+    variance = jnp.mean(centered**2)
+    scale = jnp.where(variance > 0.0, jnp.sqrt(variance), 1.0)
+    return centered / scale, center, scale
+
+
+def _soft_sort_row(values: Array, temperature: Array, /) -> Array:
+    count = values.shape[0]
+    standardized, center, scale = _standardize(values)
+    ordered = jnp.sort(standardized)
+    denominator = max(count - 1, 1)
+    anchors = jnp.arange(
+        count - 1,
+        -1,
+        -1,
+        dtype=values.dtype,
+    ) / (denominator * temperature)
+    relaxed = _pav_decreasing(anchors + ordered) - anchors
+    return center + scale * relaxed
+
+
+def _soft_rank_row(values: Array, temperature: Array, /) -> Array:
+    count = values.shape[0]
+    standardized, _, _ = _standardize(values)
+    denominator = max(count - 1, 1)
+    anchors = jnp.arange(
+        count - 1,
+        -1,
+        -1,
+        dtype=values.dtype,
+    ) / denominator
+    scaled = standardized / temperature
+    permutation = jnp.argsort(scaled, descending=True, stable=True)
+    ordered = scaled[permutation]
+    projected = ordered - _pav_decreasing(ordered - anchors)
+    inverse = jnp.zeros((count,), dtype=jnp.int32).at[permutation].set(
+        jnp.arange(count, dtype=jnp.int32)
+    )
+    return (denominator * projected)[inverse]
+
+
+def _data_axis(
+    value: Value,
+    /,
+    *,
+    axis: int | str,
+) -> tuple[Array, int, tuple[Any, ...] | None]:
+    if isinstance(value, cx.Field):
+        if not isinstance(axis, str):
+            raise TypeError("Named values fields require a named axis.")
+        if axis not in value.named_dims:
+            raise ValueError(f"values is missing named axis {axis!r}.")
+        data = jnp.asarray(value.data)
+        position = value.dims.index(axis)
+        dims: tuple[Any, ...] | None = value.dims
+    else:
+        if not isinstance(axis, int):
+            raise TypeError("Raw values arrays require an integer axis.")
+        data = jnp.asarray(value)
+        if data.ndim < 1:
+            raise ValueError("values must have at least one dimension.")
+        position = axis + data.ndim if axis < 0 else axis
+        if position < 0 or position >= data.ndim:
+            raise ValueError("values axis is out of range.")
+        dims = None
+    if jnp.issubdtype(data.dtype, jnp.complexfloating):
+        raise TypeError("values must be real-valued.")
+    if not jnp.issubdtype(data.dtype, jnp.floating):
+        data = data.astype(jnp.result_type(float))
+    if data.shape[position] < 1:
+        raise ValueError("values ordering axis must be nonempty.")
+    data = eqx.error_if(
+        data,
+        jnp.any(~jnp.isfinite(data)),
+        "values must contain only finite values.",
+    )
+    return data, position, dims
+
+
+def _temperature(value: ArrayLike, dtype: jnp.dtype, /) -> Array:
+    temperature = jnp.asarray(value, dtype=dtype)
+    if temperature.ndim != 0:
+        raise ValueError("temperature must be a scalar.")
+    return eqx.error_if(
+        temperature,
+        ~jnp.isfinite(temperature) | (temperature <= 0.0),
+        "temperature must be finite and positive.",
+    )
+
+
+def _map_rows(
+    data: Array,
+    position: int,
+    temperature: Array,
+    operation,
+    /,
+) -> Array:
+    moved = jnp.moveaxis(data, position, -1)
+    leading_shape = moved.shape[:-1]
+    count = moved.shape[-1]
+    if count == 1:
+        if operation is _soft_rank_row:
+            output = jnp.zeros_like(moved)
+        else:
+            output = moved
+    else:
+        rows = moved.reshape((-1, count))
+        output = jax.vmap(lambda row: operation(row, temperature))(rows)
+        output = output.reshape(leading_shape + (count,))
+    return jnp.moveaxis(output, -1, position)
+
+
+def _restore(data: Array, dims: tuple[Any, ...] | None, /) -> Array | cx.Field:
+    return data if dims is None else cx.Field(data, dims=dims)
+
+
+def fast_soft_sort(
+    values: Value,
+    /,
+    *,
+    temperature: ArrayLike = 0.5,
+    axis: int | str = -1,
+    descending: bool = False,
+) -> Array | cx.Field:
+    """Return fast relaxed sorted values for an unweighted ordering axis.
+
+    Rows are centered and variance-standardized before an L2 permutahedron
+    projection solved by pool-adjacent violators. ``temperature`` is therefore
+    dimensionless. Smaller values approach hard sorting; the map remains
+    piecewise smooth rather than globally smooth. This operator returns values,
+    not a transport plan, and does not support weights.
+    """
+    if not isinstance(descending, bool):
+        raise TypeError("descending must be a bool.")
+    data, position, dims = _data_axis(values, axis=axis)
+    configured = _temperature(temperature, data.dtype)
+    output = _map_rows(data, position, configured, _soft_sort_row)
+    if descending:
+        output = jnp.flip(output, axis=position)
+    return _restore(output, dims)
+
+
+def fast_soft_rank(
+    values: Value,
+    /,
+    *,
+    temperature: ArrayLike = 0.5,
+    axis: int | str = -1,
+    descending: bool = False,
+) -> Array | cx.Field:
+    """Return fast zero-based relaxed ranks for an unweighted ordering axis.
+
+    The result is a membership-free rank surrogate on ``[0, n - 1]`` whose
+    unweighted sum is ``n * (n - 1) / 2``. It is not interchangeable with the
+    weighted barycentric ranks returned by :func:`soft_rank`.
+    """
+    if not isinstance(descending, bool):
+        raise TypeError("descending must be a bool.")
+    data, position, dims = _data_axis(values, axis=axis)
+    configured = _temperature(temperature, data.dtype)
+    output = _map_rows(data, position, configured, _soft_rank_row)
+    if descending:
+        output = data.shape[position] - 1 - output
+    return _restore(output, dims)
+
+
+__all__ = ["fast_soft_rank", "fast_soft_sort"]

--- a/phydrax/transport/_results.py
+++ b/phydrax/transport/_results.py
@@ -127,14 +127,16 @@ class SinkhornResult(StrictModule):
         applied = self.apply_source_to_target(values)
         weights = self.problem.target_weights
         denominator = weights.reshape((weights.shape[0],) + (1,) * (applied.ndim - 1))
-        return jnp.where(denominator > 0.0, applied / denominator, 0.0)
+        safe_denominator = jnp.where(denominator > 0.0, denominator, 1.0)
+        return jnp.where(denominator > 0.0, applied / safe_denominator, 0.0)
 
     def barycentric_target_to_source(self, values: ArrayLike, /) -> Array:
         """Return source-conditioned barycenters of target payloads."""
         applied = self.apply_target_to_source(values)
         weights = self.problem.source_weights
         denominator = weights.reshape((weights.shape[0],) + (1,) * (applied.ndim - 1))
-        return jnp.where(denominator > 0.0, applied / denominator, 0.0)
+        safe_denominator = jnp.where(denominator > 0.0, denominator, 1.0)
+        return jnp.where(denominator > 0.0, applied / safe_denominator, 0.0)
 
     def dense_plan(self) -> Array:
         """Explicitly materialize the complete physical transport matrix."""

--- a/phydrax/transport/_soft.py
+++ b/phydrax/transport/_soft.py
@@ -34,7 +34,13 @@ def soft_order_transport(
     epsilon: float = 0.1,
     solver: Sinkhorn | None = None,
 ) -> SinkhornResult:
-    """Fit one soft monotone coupling from values to ordered mass bins."""
+    """Fit a soft monotone coupling in canonical dimensionless order coordinates.
+
+    Source values are weighted-centered, weighted-standardized, and mapped through
+    a sigmoid before transport. Consequently, ``epsilon`` is dimensionless and
+    specific to this order geometry; it is not expressed in the units of ``values``.
+    A supplied ``solver`` owns the effective epsilon and other solve settings.
+    """
     source_values = _vector(values, name="values")
     count = source_values.shape[0]
     targets = count if num_targets is None else int(num_targets)
@@ -52,7 +58,7 @@ def soft_order_transport(
         name="target_weights",
         dtype=source_values.dtype,
     )
-    source_locations = _squash(source_values, source_probabilities)
+    source_locations = _canonical_order_locations(source_values, source_probabilities)
     target_locations = (
         jnp.cumsum(target_probabilities) - 0.5 * target_probabilities
     )
@@ -63,7 +69,7 @@ def soft_order_transport(
         source_probabilities > 0.0,
         event_shape=(),
         normalized=True,
-        provenance="soft-order-source",
+        provenance="soft-order-source:weighted-standardize-sigmoid",
     )
     target_measure = _FiniteTransportMeasure(
         target_locations[:, None],
@@ -72,7 +78,7 @@ def soft_order_transport(
         target_probabilities > 0.0,
         event_shape=(),
         normalized=True,
-        provenance="soft-order-target",
+        provenance="soft-order-target:probability-midpoints",
     )
     problem = DiscreteTransportProblem(
         source_measure,
@@ -92,7 +98,7 @@ def soft_sort(
     epsilon: float = 0.1,
     solver: Sinkhorn | None = None,
 ) -> Array | cx.Field:
-    """Differentiably sort values along one array axis or named field dimension."""
+    """Return ascending values from the canonical soft-order coupling."""
     data, position, dims = _data_axis(values, axis=axis, name="values")
     weight_data = _weight_data(weights, data, position, dims=dims)
     configured = _soft_solver(epsilon, solver)
@@ -118,7 +124,7 @@ def soft_rank(
     epsilon: float = 0.1,
     solver: Sinkhorn | None = None,
 ) -> Array | cx.Field:
-    """Return zero-based differentiable ranks along one axis."""
+    """Return zero-based ascending barycentric ranks along one axis."""
     data, position, dims = _data_axis(values, axis=axis, name="values")
     weight_data = _weight_data(weights, data, position, dims=dims)
     configured = _soft_solver(epsilon, solver)
@@ -193,7 +199,12 @@ def soft_topk_mask(
     epsilon: float = 0.1,
     solver: Sinkhorn | None = None,
 ) -> Array | cx.Field:
-    """Return differentiable membership in the largest ``k`` ordered bins."""
+    """Return membership in the largest ``k`` equal-probability target bins.
+
+    With uniform source weights the memberships sum to ``k``. More generally,
+    coupling conservation fixes their source-probability-weighted mean to
+    ``k / axis_size``.
+    """
     data, position, dims = _data_axis(values, axis=axis, name="values")
     count = data.shape[position]
     selected = int(k)
@@ -264,7 +275,12 @@ def soft_quantile(
     solver: Sinkhorn | None = None,
     quantile_dim: str = "quantile",
 ) -> Array | cx.Field:
-    """Return differentiable weighted quantiles in caller-specified order."""
+    """Return relaxed weighted quantiles, with exact hard endpoints.
+
+    Interior quantiles interpolate the soft sorted values. ``q=0`` and ``q=1``
+    instead return the exact active sample minimum and maximum, so endpoint
+    derivatives are only almost-everywhere defined.
+    """
     data, position, dims = _data_axis(values, axis=axis, name="values")
     quantiles = jnp.asarray(q, dtype=data.dtype)
     quantiles = eqx.error_if(
@@ -408,7 +424,8 @@ def _soft_solver(epsilon: float, solver: Sinkhorn | None, /) -> Sinkhorn:
     )
 
 
-def _squash(values: Array, probabilities: Array, /) -> Array:
+def _canonical_order_locations(values: Array, probabilities: Array, /) -> Array:
+    """Embed scalar values in weighted, dimensionless order coordinates."""
     center = jnp.sum(probabilities * values)
     variance = jnp.sum(probabilities * (values - center) ** 2)
     scale = jnp.sqrt(variance + jnp.finfo(values.dtype).eps)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ order-by-type = false
 max-line-length = 120
 
 [tool.pytest.ini_options]
+addopts = "--import-mode=importlib"
 filterwarnings = [
     "ignore::DeprecationWarning:ezdxf.queryparser:",
     "ignore::DeprecationWarning:build123d.objects_curve:",

--- a/tests/unit/kernels/test_spectral.py
+++ b/tests/unit/kernels/test_spectral.py
@@ -112,7 +112,7 @@ def test_spectral_kernel_rejects_nonintegral_nonfinite_and_out_of_range_ids():
     ):
         with pytest.raises(Exception, match="in-range integers"):
             kernel.features(invalid)
-    with pytest.raises(Exception, match="finite coordinates"):
+    with pytest.raises(Exception, match="finite values"):
         kernel.features(jnp.asarray([jnp.inf]))
     with pytest.raises(ValueError, match="one spectral entity"):
         kernel.pairwise(jnp.asarray([0, 1]), 0)

--- a/tests/unit/ml/feature_selection/test_selection.py
+++ b/tests/unit/ml/feature_selection/test_selection.py
@@ -74,6 +74,15 @@ def _linear_importance(model):
     return model.coefficients
 
 
+def _smooth_feature_scores(batch):
+    features = batch.dense_features()
+    targets = batch.require_targets()
+    weights = batch.effective_weight("statistical")
+    return jnp.sum(weights[:, None] * features * targets[:, None], axis=0) / jnp.sum(
+        weights
+    )
+
+
 def _batch(case=False):
     base = jnp.array(
         [
@@ -180,6 +189,128 @@ def test_continuous_sparse_gate_is_distinct_smooth_jittable_and_vmap_safe():
     assert jax.vmap(model)(batch.dense_features()[0]).shape == (6, 3)
     assert result.gradient_contract.fit_mode == "relaxed"
 
+
+
+def test_continuous_sparse_gate_hyperparameters_are_validated_array_leaves():
+    recipe = ContinuousSparseGateRecipe(
+        temperature=jnp.asarray(0.2),
+        sparsity=jnp.asarray(0.4),
+    )
+    leaves = jax.tree.leaves(recipe)
+
+    assert recipe.temperature.shape == ()
+    assert recipe.sparsity.shape == ()
+    assert any(leaf is recipe.temperature for leaf in leaves)
+    assert any(leaf is recipe.sparsity for leaf in leaves)
+
+    eager_invalid = (
+        {"temperature": 0.0, "sparsity": 0.4},
+        {"temperature": jnp.inf, "sparsity": 0.4},
+        {"temperature": 0.2, "sparsity": -0.1},
+        {"temperature": 0.2, "sparsity": jnp.nan},
+        {"temperature": 0.2, "sparsity": 1.1},
+    )
+    for configuration in eager_invalid:
+        with pytest.raises(Exception, match="temperature|sparsity"):
+            invalid = ContinuousSparseGateRecipe(**configuration)
+            jax.block_until_ready((invalid.temperature, invalid.sparsity))
+
+    batch = _batch()
+    with pytest.raises(Exception, match="temperature must be finite and positive"):
+        invalid_gates = jax.jit(
+            lambda temperature: ContinuousSparseGateRecipe(
+                temperature=temperature,
+                sparsity=0.4,
+            )
+            .fit_batch(batch)
+            .as_trainable()
+            .gates
+        )(jnp.asarray(0.0))
+        jax.block_until_ready(invalid_gates)
+    with pytest.raises(Exception, match=r"sparsity must be finite and lie in \[0, 1\]"):
+        invalid_gates = jax.jit(
+            lambda sparsity: ContinuousSparseGateRecipe(
+                temperature=0.2,
+                sparsity=sparsity,
+            )
+            .fit_batch(batch)
+            .as_trainable()
+            .gates
+        )(jnp.asarray(1.1))
+        jax.block_until_ready(invalid_gates)
+
+
+def test_continuous_sparse_gate_gradients_match_its_conditional_contract():
+    batch = _batch()
+    features = batch.dense_features()
+    targets = batch.require_targets()
+    weights = jnp.asarray(batch.sample_weight)
+
+    def objective(features_, targets_, weights_, temperature, sparsity):
+        candidate = MLBatch(
+            features_,
+            targets_,
+            feature_mask=batch.feature_mask,
+            sample_mask=batch.sample_mask,
+            sample_weight=weights_,
+        )
+        gates = ContinuousSparseGateRecipe(
+            temperature=temperature,
+            sparsity=sparsity,
+            scorer=_smooth_feature_scores,
+        ).fit_batch(candidate).as_trainable().gates
+        return jnp.dot(gates, jnp.asarray([1.0, -0.5, 2.0]))
+
+    gradients = jax.grad(objective, argnums=(0, 1, 2, 3, 4))(
+        features,
+        targets,
+        weights,
+        jnp.asarray(0.3),
+        jnp.asarray(0.4),
+    )
+    for gradient in gradients:
+        assert jnp.all(jnp.isfinite(gradient))
+        assert jnp.linalg.norm(gradient) > 0.0
+
+    result = ContinuousSparseGateRecipe(
+        temperature=0.3,
+        sparsity=0.4,
+        scorer=_smooth_feature_scores,
+    ).fit_batch(batch)
+    contract = result.gradient_contract
+    assert contract.fit_features == "conditional"
+    assert contract.fit_targets == "conditional"
+    assert contract.fit_weights == "conditional"
+    assert contract.fit_hyperparameters == "conditional"
+    assert contract.fit_mode == "relaxed"
+    assert len(contract.conditions) == 4
+
+
+def test_continuous_sparse_gate_preserves_values_and_stays_finite_at_degeneracy():
+    scores = jnp.asarray([0.2, 0.5, 0.9])
+    result = ContinuousSparseGateRecipe(
+        temperature=0.25,
+        sparsity=0.4,
+        scorer=lambda _: scores,
+    ).fit_batch(_batch())
+    normalised = (scores - jnp.min(scores)) / (jnp.max(scores) - jnp.min(scores))
+    expected = jax.nn.sigmoid((normalised - 0.4) / 0.25)
+    assert jnp.allclose(result.as_trainable().gates, expected)
+
+    equal = ContinuousSparseGateRecipe(
+        temperature=0.25,
+        sparsity=0.4,
+        scorer=lambda _: jnp.ones((3,)),
+    ).fit_batch(_batch())
+    constant_batch = MLBatch(
+        jnp.ones((5, 3)),
+        jnp.ones((5,)),
+    )
+    zero_variance = ContinuousSparseGateRecipe().fit_batch(constant_batch)
+    assert jnp.all(jnp.isfinite(equal.as_trainable().gates))
+    assert jnp.all(jnp.isfinite(zero_variance.as_trainable().gates))
+    assert equal.gradient_contract.fit_features == "conditional"
+    assert zero_variance.gradient_contract.fit_targets == "conditional"
 
 def test_selector_capacity_scores_weights_and_importance_fail_closed():
     batch = _batch()

--- a/tests/unit/ml/test_soft_discrete.py
+++ b/tests/unit/ml/test_soft_discrete.py
@@ -1,0 +1,196 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+import phydrax as phx
+
+
+def test_masked_softmax_normalizes_active_entries_and_closes_empty_masks():
+    logits = jnp.asarray([[1.0, -2.0, 3.0], [4.0, 0.0, -1.0]])
+    mask = jnp.asarray([[True, False, True], [False, False, False]])
+    probabilities = phx.ml.masked_softmax(logits, mask=mask, axis=1)
+
+    assert jnp.allclose(jnp.sum(probabilities[0]), 1.0)
+    assert probabilities[0, 1] == 0.0
+    assert jnp.array_equal(probabilities[1], jnp.zeros((3,)))
+    assert jnp.allclose(
+        phx.ml.masked_softmax(logits + 17.0, mask=mask, axis=1),
+        probabilities,
+    )
+
+    empty = jnp.zeros((3,), dtype=bool)
+    gradient = jax.grad(
+        lambda values: jnp.sum(phx.ml.masked_softmax(values, mask=empty) ** 2)
+    )(logits[0])
+    jacobian = jax.jacfwd(lambda values: phx.ml.masked_softmax(values, mask=empty))(
+        logits[0]
+    )
+    assert jnp.array_equal(gradient, jnp.zeros_like(gradient))
+    assert jnp.array_equal(jacobian, jnp.zeros_like(jacobian))
+
+
+def test_soft_discrete_primitives_reject_nonfloating_values():
+    with pytest.raises(TypeError, match="logits must have a real floating dtype"):
+        phx.ml.masked_softmax(jnp.asarray([1, 2, 3]))
+    with pytest.raises(TypeError, match="values must have a real floating dtype"):
+        phx.ml.soft_ranks(jnp.asarray([1.0 + 1.0j, 2.0 + 0.0j]), temperature=0.1)
+
+
+def test_temperature_primitives_are_transformable_and_validate_dynamic_values():
+    logits = jnp.asarray([-1.0, 0.3, 2.0])
+    temperature = jnp.asarray(0.7)
+    probabilities = phx.ml.temperature_softmax(logits, temperature=temperature)
+    gates = phx.ml.temperature_sigmoid(logits, temperature=temperature)
+
+    assert jnp.allclose(jnp.sum(probabilities), 1.0)
+    assert jnp.all((gates > 0.0) & (gates < 1.0))
+    assert jnp.allclose(
+        jax.jit(lambda x, t: phx.ml.temperature_softmax(x, temperature=t))(
+            logits, temperature
+        ),
+        probabilities,
+    )
+    batched = jax.vmap(
+        lambda x: phx.ml.temperature_softmax(x, temperature=temperature)
+    )(jnp.stack((logits, -logits)))
+    assert batched.shape == (2, 3)
+
+    tangent = jax.jvp(
+        lambda t: phx.ml.temperature_softmax(logits, temperature=t),
+        (temperature,),
+        (jnp.asarray(0.2),),
+    )[1]
+    reverse = jax.grad(
+        lambda t: jnp.dot(
+            phx.ml.temperature_softmax(logits, temperature=t),
+            jnp.asarray([1.0, -2.0, 0.5]),
+        )
+    )(temperature)
+    assert jnp.all(jnp.isfinite(tangent))
+    assert jnp.isfinite(reverse) & (jnp.abs(reverse) > 0.0)
+
+    for invalid in (0.0, -1.0, jnp.nan, jnp.inf):
+        with pytest.raises(Exception, match="temperature must be finite and positive"):
+            result = jax.jit(
+                lambda t: phx.ml.temperature_sigmoid(logits, temperature=t)
+            )(jnp.asarray(invalid))
+            jax.block_until_ready(result)
+
+
+def test_gumbel_softmax_replays_keys_and_has_relaxed_gradients():
+    key = jax.random.key(4)
+    other_key = jax.random.key(5)
+    logits = jnp.asarray([0.2, -0.5, 1.3])
+    first = phx.ml.gumbel_softmax(key, logits, temperature=0.8)
+    replay = phx.ml.gumbel_softmax(key, logits, temperature=0.8)
+    other = phx.ml.gumbel_softmax(other_key, logits, temperature=0.8)
+
+    assert jnp.array_equal(first, replay)
+    assert not jnp.array_equal(first, other)
+    assert jnp.all(first > 0.0)
+    assert jnp.allclose(jnp.sum(first), 1.0)
+
+    weights = jnp.asarray([-1.0, 0.5, 2.0])
+    logits_gradient = jax.grad(
+        lambda values: jnp.dot(
+            phx.ml.gumbel_softmax(key, values, temperature=0.8), weights
+        )
+    )(logits)
+    temperature_gradient = jax.grad(
+        lambda value: jnp.dot(
+            phx.ml.gumbel_softmax(key, logits, temperature=value), weights
+        )
+    )(jnp.asarray(0.8))
+    samples = jax.jit(
+        jax.vmap(lambda sample_key: phx.ml.gumbel_softmax(sample_key, logits, temperature=0.8))
+    )(jax.random.split(key, 4))
+    assert samples.shape == (4, 3)
+    assert jnp.all(jnp.isfinite(logits_gradient))
+    assert jnp.isfinite(temperature_gradient) & (jnp.abs(temperature_gradient) > 0.0)
+
+
+def test_soft_ranks_define_one_based_orientation_ties_and_axis_semantics():
+    values = jnp.asarray([3.0, 1.0, 4.0, 2.0])
+    ascending = phx.ml.soft_ranks(values, temperature=0.01)
+    descending = phx.ml.soft_ranks(values, temperature=0.01, descending=True)
+    tied = phx.ml.soft_ranks(jnp.asarray([0.0, 0.0, 2.0]), temperature=0.05)
+    equal = phx.ml.soft_ranks(jnp.ones((4,)), temperature=0.3)
+
+    assert jnp.allclose(ascending, jnp.asarray([3.0, 1.0, 4.0, 2.0]), atol=1e-6)
+    assert jnp.allclose(descending, 5.0 - ascending, atol=1e-12)
+    assert tied[0] == tied[1]
+    assert jnp.allclose(equal, 2.5)
+    assert jnp.allclose(
+        phx.ml.soft_ranks(values + 100.0, temperature=0.01), ascending
+    )
+
+    matrix = jnp.stack((values, values[::-1]), axis=1)
+    along_rows = phx.ml.soft_ranks(matrix, temperature=0.2, axis=0)
+    assert along_rows.shape == matrix.shape
+    assert jnp.allclose(jnp.sum(along_rows, axis=0), 10.0)
+
+    tangent = jax.jvp(
+        lambda candidate: phx.ml.soft_ranks(candidate, temperature=0.2),
+        (values,),
+        (jnp.asarray([0.2, -0.1, 0.3, 0.4]),),
+    )[1]
+    gradient = jax.grad(
+        lambda candidate: jnp.sum(
+            phx.ml.soft_ranks(candidate, temperature=0.2) ** 2
+        )
+    )(values)
+    assert jnp.all(jnp.isfinite(tangent))
+    assert jnp.all(jnp.isfinite(gradient))
+
+
+def test_soft_topk_weights_are_bounded_memberships_with_separate_temperatures():
+    scores = jnp.asarray([1.0, 4.0, 2.0, 3.0])
+    memberships = phx.ml.soft_topk_weights(
+        scores,
+        k=2,
+        rank_temperature=0.05,
+        gate_temperature=0.1,
+    )
+    shared_temperature = phx.ml.soft_topk_weights(
+        scores,
+        k=2,
+        rank_temperature=0.05,
+    )
+    tied = phx.ml.soft_topk_weights(
+        jnp.asarray([3.0, 3.0, 1.0]),
+        k=1,
+        rank_temperature=0.2,
+        gate_temperature=0.2,
+    )
+
+    assert jnp.all((memberships >= 0.0) & (memberships <= 1.0))
+    assert jnp.array_equal(jnp.argsort(memberships)[-2:], jnp.asarray([3, 1]))
+    assert not jnp.allclose(memberships, shared_temperature)
+    assert tied[0] == tied[1]
+
+    rank_gradient, gate_gradient = jax.grad(
+        lambda rank_temperature, gate_temperature: jnp.dot(
+            phx.ml.soft_topk_weights(
+                scores,
+                k=2,
+                rank_temperature=rank_temperature,
+                gate_temperature=gate_temperature,
+            ),
+            jnp.arange(4.0),
+        ),
+        argnums=(0, 1),
+    )(jnp.asarray(0.3), jnp.asarray(0.4))
+    assert jnp.isfinite(rank_gradient) & (jnp.abs(rank_gradient) > 0.0)
+    assert jnp.isfinite(gate_gradient) & (jnp.abs(gate_gradient) > 0.0)
+
+    for invalid in (0, 5):
+        with pytest.raises(ValueError, match="selected score axis"):
+            phx.ml.soft_topk_weights(
+                scores,
+                k=invalid,
+                rank_temperature=0.1,
+            )

--- a/tests/unit/nn/test_operator_suite.py
+++ b/tests/unit/nn/test_operator_suite.py
@@ -143,6 +143,7 @@ def test_operator_architecture_tiers_and_recommendation_eligibility_are_exact():
             "IFNO",
             "AxialFactorizedFNO",
             "ConditionalFlowFunctionOperator",
+            "LinearRecurrentOperator",
         },
         "research": {
             "Flower",
@@ -172,6 +173,8 @@ def test_operator_architecture_tiers_and_recommendation_eligibility_are_exact():
             "GNOT",
             "KoopmanTemporalOperator",
             "GreenKernelOperator",
+            "LatticeEquivariantCNO",
+            "WeightSpaceOperator",
         },
     }
     assert set(phx.nn.operator.OPERATOR_ARCHITECTURE_STATUSES) == set().union(

--- a/tests/unit/nn/test_recurrent.py
+++ b/tests/unit/nn/test_recurrent.py
@@ -46,14 +46,14 @@ def _packed_affine_batch():
 
 
 def test_recurrent_batch_rejects_ambiguous_padding_and_resets():
-    with pytest.raises(eqx.EquinoxRuntimeError, match="after padding"):
+    with pytest.raises((ValueError, eqx.EquinoxRuntimeError), match="after padding"):
         batch = RecurrentBatch(
             jnp.ones((4, 2)),
             jnp.asarray([True, False, True, False]),
         )
         jax.block_until_ready(batch.valid)
 
-    with pytest.raises(eqx.EquinoxRuntimeError, match="requires a valid"):
+    with pytest.raises((ValueError, eqx.EquinoxRuntimeError), match="requires a valid"):
         batch = RecurrentBatch(
             jnp.ones((3, 2)),
             jnp.asarray([True, False, False]),

--- a/tests/unit/transport/test_distances_soft.py
+++ b/tests/unit/transport/test_distances_soft.py
@@ -218,3 +218,206 @@ def test_soft_order_transport_exposes_solver_diagnostics_and_rejects_bad_weights
             weights=jnp.asarray([0.2, -0.3, 0.5]),
         )
         jax.block_until_ready(invalid.source_potential)
+
+
+@pytest.mark.parametrize(
+    "operator",
+    (
+        lambda values: phx.transport.soft_sort(values, epsilon=0.15),
+        lambda values: phx.transport.soft_rank(values, epsilon=0.15),
+        lambda values: phx.transport.soft_quantile(values, 0.35, epsilon=0.15),
+        lambda values: phx.transport.soft_topk_mask(values, 2, epsilon=0.15),
+    ),
+    ids=("sort", "rank", "quantile", "topk"),
+)
+def test_soft_order_operators_compose_with_forward_reverse_and_batch_transforms(
+    operator,
+):
+    values = jnp.asarray([-1.3, 0.2, 2.1, 0.8])
+    direction = jnp.asarray([0.3, -0.5, 0.2, 0.7])
+    eager = operator(values)
+    compiled = jax.jit(operator)(values)
+    _, tangent = jax.jvp(operator, (values,), (direction,))
+    jacobian = jax.jacfwd(operator)(values)
+    expected_tangent = jnp.tensordot(jacobian, direction, axes=([-1], [0]))
+    gradient = jax.grad(lambda candidate: jnp.sum(operator(candidate) ** 2))(values)
+    batched = jax.vmap(operator)(jnp.stack((values, values + 1.0)))
+
+    assert jnp.allclose(compiled, eager, rtol=1e-8, atol=1e-9)
+    assert jnp.allclose(tangent, expected_tangent, rtol=1e-7, atol=1e-8)
+    assert jnp.all(jnp.isfinite(jacobian))
+    assert jnp.all(jnp.isfinite(gradient))
+    assert batched.shape == (2,) + jnp.shape(eager)
+
+
+def test_soft_order_has_finite_symmetric_second_derivatives_and_tie_sensitivities():
+    values = jnp.asarray([-1.1, 0.4, 1.7, 3.2])
+    hessian = jax.hessian(
+        lambda candidate: jnp.sum(
+            phx.transport.soft_sort(candidate, epsilon=0.15) ** 2
+        )
+    )(values)
+    constant = jnp.ones((4,))
+    constant_sorted = phx.transport.soft_sort(constant, epsilon=0.15)
+    constant_jacobian = jax.jacfwd(
+        lambda candidate: phx.transport.soft_sort(candidate, epsilon=0.15)
+    )(constant)
+    tied = jnp.asarray([1.0, 1.0, 2.0, 4.0])
+    tied_ranks = phx.transport.soft_rank(tied, epsilon=0.15)
+    tied_gradient = jax.grad(
+        lambda candidate: jnp.sum(
+            phx.transport.soft_rank(candidate, epsilon=0.15) ** 2
+        )
+    )(tied)
+
+    assert jnp.all(jnp.isfinite(hessian))
+    assert jnp.allclose(hessian, hessian.T, rtol=1e-7, atol=1e-8)
+    assert jnp.array_equal(constant_sorted, constant)
+    assert jnp.all(jnp.isfinite(constant_jacobian))
+    assert jnp.allclose(constant_jacobian, constant_jacobian[0])
+    assert tied_ranks[0] == tied_ranks[1]
+    assert jnp.allclose(tied_gradient[0], tied_gradient[1], atol=1e-10)
+
+
+def test_soft_order_preserves_order_invariances_and_coupling_mass():
+    values = jnp.asarray([3.0, -1.0, 2.0, 0.5])
+    permutation = jnp.asarray([2, 0, 3, 1])
+    ordered = phx.transport.soft_sort(values, epsilon=0.15)
+    ranks = phx.transport.soft_rank(values, epsilon=0.15)
+    mask = phx.transport.soft_topk_mask(values, 2, epsilon=0.15)
+
+    assert jnp.allclose(
+        phx.transport.soft_sort(values + 7.0, epsilon=0.15),
+        ordered + 7.0,
+        rtol=1e-9,
+        atol=1e-9,
+    )
+    assert jnp.allclose(
+        phx.transport.soft_sort(2.5 * values - 4.0, epsilon=0.15),
+        2.5 * ordered - 4.0,
+        rtol=1e-8,
+        atol=1e-8,
+    )
+    assert jnp.allclose(
+        phx.transport.soft_sort(-2.0 * values + 1.0, epsilon=0.15),
+        (-2.0 * ordered + 1.0)[::-1],
+        rtol=1e-8,
+        atol=1e-8,
+    )
+    assert jnp.allclose(
+        phx.transport.soft_sort(values[permutation], epsilon=0.15), ordered
+    )
+    assert jnp.allclose(
+        phx.transport.soft_rank(values[permutation], epsilon=0.15),
+        ranks[permutation],
+    )
+    assert jnp.allclose(
+        phx.transport.soft_topk_mask(values[permutation], 2, epsilon=0.15),
+        mask[permutation],
+    )
+    assert jnp.allclose(jnp.sum(ranks), 6.0, atol=1e-8)
+    assert jnp.allclose(jnp.sum(mask), 2.0, atol=1e-8)
+
+    weights = jnp.asarray([0.1, 0.2, 0.3, 0.4])
+    weighted_mask = phx.transport.soft_topk_mask(
+        values,
+        2,
+        weights=weights,
+        epsilon=0.15,
+    )
+    assert jnp.allclose(jnp.sum(weights * weighted_mask), 0.5, atol=1e-8)
+
+
+def test_soft_order_weighted_named_and_blockwise_paths_share_one_contract():
+    values = jnp.asarray([[3.0, 1.0, 4.0, 2.0], [0.5, -2.0, 1.5, 3.0]])
+    field = cx.Field(values, dims=("case", "sample"))
+    named = phx.transport.soft_sort(field, axis="sample", epsilon=0.2)
+    plain = phx.transport.soft_sort(values, axis=1, epsilon=0.2)
+
+    assert named.dims == field.dims
+    assert jnp.allclose(named.data, plain)
+
+    vector = values[0]
+    zero_weights = jnp.asarray([0.2, 0.0, 0.3, 0.5])
+    zero_weight_result = phx.transport.soft_sort(
+        vector,
+        weights=zero_weights,
+        epsilon=0.2,
+    )
+    changed_inert_atom = phx.transport.soft_sort(
+        vector.at[1].set(1e6),
+        weights=zero_weights,
+        epsilon=0.2,
+    )
+    assert jnp.allclose(zero_weight_result, changed_inert_atom)
+
+    zero_weight_gradient = jax.grad(
+        lambda candidate: jnp.dot(
+            phx.transport.soft_topk_mask(
+                candidate,
+                2,
+                weights=zero_weights,
+                epsilon=0.2,
+            ),
+            jnp.arange(4.0),
+        )
+    )(vector)
+    assert jnp.all(jnp.isfinite(zero_weight_gradient))
+    assert zero_weight_gradient[1] == 0.0
+
+    dense_solver = phx.transport.Sinkhorn(
+        0.2,
+        max_iterations=300,
+        tolerance=1e-7,
+        check_every=5,
+    )
+    block_solver = phx.transport.Sinkhorn(
+        0.2,
+        max_iterations=300,
+        tolerance=1e-7,
+        check_every=5,
+        block_size=2,
+    )
+    dense = phx.transport.soft_sort(vector, weights=zero_weights, solver=dense_solver)
+    block = phx.transport.soft_sort(vector, weights=zero_weights, solver=block_solver)
+    assert jnp.allclose(block, dense, rtol=1e-8, atol=1e-8)
+
+    positive_weights = jnp.asarray([0.2, 0.1, 0.3, 0.4])
+    weight_gradient = jax.grad(
+        lambda candidate_weights: jnp.sum(
+            phx.transport.soft_sort(
+                vector,
+                weights=candidate_weights,
+                solver=dense_solver,
+            )
+            ** 2
+        )
+    )(positive_weights)
+    assert jnp.all(jnp.isfinite(weight_gradient))
+
+
+def test_soft_order_provenance_and_explicit_solver_precedence_are_visible():
+    solver = phx.transport.Sinkhorn(
+        0.3,
+        max_iterations=300,
+        tolerance=1e-7,
+        check_every=5,
+    )
+    values = jnp.asarray([3.0, 1.0, 2.0])
+    result = phx.transport.soft_order_transport(
+        values,
+        epsilon=jnp.nan,
+        solver=solver,
+    )
+
+    assert result.problem.provenance.source == (
+        "soft-order-source:weighted-standardize-sigmoid"
+    )
+    assert result.problem.provenance.target == (
+        "soft-order-target:probability-midpoints"
+    )
+    assert jnp.array_equal(result.epsilon, solver.epsilon)
+    assert jnp.allclose(
+        result.barycentric_source_to_target(values),
+        phx.transport.soft_sort(values, solver=solver),
+    )

--- a/tests/unit/transport/test_fast_order.py
+++ b/tests/unit/transport/test_fast_order.py
@@ -1,0 +1,239 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import coordax as cx
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import pytest
+
+import phydrax as phx
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_fast_soft_sort_preserves_value_contract(dtype):
+    values = jnp.asarray([3.0, -1.0, 2.0, 0.5, 4.0], dtype=dtype)
+    result = phx.transport.fast_soft_sort(values, temperature=0.8)
+
+    tolerance = 2e-5 if dtype == jnp.float32 else 1e-11
+    assert result.dtype == dtype
+    assert result.shape == values.shape
+    assert jnp.all(jnp.isfinite(result))
+    assert jnp.all(jnp.diff(result) >= -tolerance)
+    assert jnp.min(result) >= jnp.min(values) - tolerance
+    assert jnp.max(result) <= jnp.max(values) + tolerance
+    assert jnp.allclose(jnp.sum(result), jnp.sum(values), atol=tolerance)
+    assert not jnp.array_equal(result, jnp.sort(values))
+
+
+def test_fast_soft_order_is_affine_and_permutation_equivariant():
+    values = jnp.asarray([2.0, -0.5, 4.0, 1.0, 0.2])
+    permutation = jnp.asarray([3, 0, 4, 1, 2])
+    sorted_values = phx.transport.fast_soft_sort(values, temperature=0.9)
+    ranks = phx.transport.fast_soft_rank(values, temperature=2.5)
+
+    assert jnp.allclose(
+        phx.transport.fast_soft_sort(3.0 * values + 7.0, temperature=0.9),
+        3.0 * sorted_values + 7.0,
+    )
+    assert jnp.allclose(
+        phx.transport.fast_soft_sort(values[permutation], temperature=0.9),
+        sorted_values,
+    )
+    assert jnp.allclose(
+        phx.transport.fast_soft_sort(-2.0 * values + 1.0, temperature=0.9),
+        -2.0
+        * phx.transport.fast_soft_sort(
+            values,
+            temperature=0.9,
+            descending=True,
+        )
+        + 1.0,
+    )
+    assert jnp.allclose(
+        phx.transport.fast_soft_rank(
+            3.0 * values + 7.0,
+            temperature=2.5,
+        ),
+        ranks,
+    )
+    assert jnp.allclose(
+        phx.transport.fast_soft_rank(
+            values[permutation],
+            temperature=2.5,
+        ),
+        ranks[permutation],
+    )
+
+
+def test_fast_soft_rank_is_zero_based_and_tie_symmetric():
+    values = jnp.asarray([3.0, 1.0, 1.0, 5.0, 2.0])
+    ranks = phx.transport.fast_soft_rank(values, temperature=3.0)
+    descending = phx.transport.fast_soft_rank(
+        values,
+        temperature=3.0,
+        descending=True,
+    )
+
+    assert ranks.shape == values.shape
+    assert jnp.all(ranks >= 0.0)
+    assert jnp.all(ranks <= values.size - 1)
+    assert jnp.allclose(jnp.sum(ranks), values.size * (values.size - 1) / 2)
+    assert jnp.allclose(ranks[1], ranks[2])
+    assert jnp.allclose(descending, values.size - 1 - ranks)
+    assert jnp.array_equal(jnp.argsort(ranks), jnp.argsort(values, stable=True))
+
+
+def test_fast_soft_order_handles_axes_fields_constants_and_singletons():
+    values = jnp.asarray([[3.0, 1.0, 2.0], [4.0, -1.0, 0.0]])
+    field = cx.Field(values, dims=("case", "sample"))
+    named = phx.transport.fast_soft_sort(
+        field,
+        axis="sample",
+        temperature=0.8,
+    )
+    plain = phx.transport.fast_soft_sort(values, axis=1, temperature=0.8)
+    constant_ranks = phx.transport.fast_soft_rank(
+        jnp.ones((2, 5)),
+        axis=1,
+        temperature=1.0,
+    )
+
+    assert named.dims == field.dims
+    assert jnp.allclose(named.data, plain)
+    assert jnp.allclose(constant_ranks, 2.0)
+    assert jnp.array_equal(
+        phx.transport.fast_soft_sort(jnp.asarray([4.0])),
+        jnp.asarray([4.0]),
+    )
+    assert jnp.array_equal(
+        phx.transport.fast_soft_rank(jnp.asarray([4.0])),
+        jnp.asarray([0.0]),
+    )
+
+
+def test_fast_soft_order_supports_jit_vmap_forward_and_reverse_ad():
+    values = jnp.asarray([-0.9, -0.2, 0.1, 0.8, 1.4])
+    direction = jnp.asarray([0.2, -0.1, 0.4, -0.3, 0.5])
+    coefficients = jnp.asarray([0.4, -0.7, 0.3, 0.8, -0.2])
+
+    def operation(candidate):
+        return phx.transport.fast_soft_sort(
+            candidate,
+            temperature=1.2,
+        )
+
+    eager = operation(values)
+    compiled = jax.jit(operation)(values)
+    _, tangent = jax.jvp(operation, (values,), (direction,))
+    finite_difference = (
+        operation(values + 1e-4 * direction)
+        - operation(values - 1e-4 * direction)
+    ) / 2e-4
+    forward_jacobian = jax.jacfwd(operation)(values)
+    reverse_jacobian = jax.jacrev(operation)(values)
+    gradient = jax.grad(lambda candidate: jnp.dot(operation(candidate), coefficients))(
+        values
+    )
+    batched = jax.vmap(operation)(jnp.stack((values, values + 0.3)))
+    temperature_gradient = jax.grad(
+        lambda temperature: jnp.sum(
+            phx.transport.fast_soft_sort(values, temperature=temperature) ** 2
+        )
+    )(jnp.asarray(1.2))
+    rank_temperature_gradient = jax.grad(
+        lambda temperature: jnp.dot(
+            phx.transport.fast_soft_rank(values, temperature=temperature),
+            coefficients,
+        )
+    )(jnp.asarray(2.0))
+
+    assert jnp.allclose(compiled, eager)
+    assert jnp.allclose(tangent, finite_difference, rtol=3e-3, atol=3e-3)
+    assert jnp.allclose(forward_jacobian, reverse_jacobian)
+    assert batched.shape == (2, values.size)
+    assert jnp.all(jnp.isfinite(gradient))
+    assert jnp.any(jnp.abs(gradient) > 1e-6)
+    assert jnp.isfinite(temperature_gradient)
+    assert jnp.isfinite(rank_temperature_gradient)
+    assert jnp.abs(rank_temperature_gradient) > 1e-6
+
+
+def test_fast_soft_rank_has_informative_gradients_for_nearby_values():
+    values = jnp.asarray([-0.2, -0.1, 0.0, 0.1, 0.2])
+    jacobian = jax.jacfwd(
+        lambda candidate: phx.transport.fast_soft_rank(
+            candidate,
+            temperature=4.0,
+        )
+    )(values)
+    reverse = jax.grad(
+        lambda candidate: jnp.dot(
+            phx.transport.fast_soft_rank(candidate, temperature=4.0),
+            jnp.asarray([0.1, 0.4, -0.3, 0.8, -0.2]),
+        )
+    )(values)
+
+    assert jnp.all(jnp.isfinite(jacobian))
+    assert jnp.all(jnp.isfinite(reverse))
+    assert jnp.any(jnp.abs(jacobian) > 1e-6)
+
+
+def test_fast_soft_order_temperature_controls_hard_approximation():
+    values = jnp.asarray([3.0, -1.0, 2.0, 0.5, 4.0])
+    order = jnp.argsort(values, stable=True)
+    hard_ranks = jnp.zeros_like(values).at[order].set(
+        jnp.arange(values.size, dtype=values.dtype)
+    )
+    low_sort = phx.transport.fast_soft_sort(values, temperature=0.03)
+    high_sort = phx.transport.fast_soft_sort(values, temperature=1.5)
+    low_ranks = phx.transport.fast_soft_rank(values, temperature=0.03)
+    high_ranks = phx.transport.fast_soft_rank(values, temperature=6.0)
+
+    assert jnp.linalg.norm(low_sort - jnp.sort(values)) < jnp.linalg.norm(
+        high_sort - jnp.sort(values)
+    )
+    assert jnp.linalg.norm(low_ranks - hard_ranks) < jnp.linalg.norm(
+        high_ranks - hard_ranks
+    )
+
+
+
+def test_fast_soft_order_rejects_invalid_inputs_eagerly_and_under_jit():
+    values = jnp.asarray([3.0, 1.0, 2.0])
+
+    with pytest.raises(ValueError, match="at least one dimension"):
+        phx.transport.fast_soft_sort(1.0)
+    with pytest.raises(ValueError, match="nonempty"):
+        phx.transport.fast_soft_sort(jnp.empty((0,)))
+    with pytest.raises(TypeError, match="real-valued"):
+        phx.transport.fast_soft_sort(jnp.asarray([1.0 + 2.0j]))
+    with pytest.raises(ValueError, match="scalar"):
+        phx.transport.fast_soft_sort(values, temperature=jnp.ones((2,)))
+    with pytest.raises(TypeError, match="integer axis"):
+        phx.transport.fast_soft_sort(values, axis="sample")
+    with pytest.raises(TypeError, match="named axis"):
+        phx.transport.fast_soft_sort(
+            cx.Field(values, dims=("sample",)),
+            axis=0,
+        )
+
+    invalid_temperature = eqx.filter_jit(
+        lambda temperature: phx.transport.fast_soft_sort(
+            values,
+            temperature=temperature,
+        )
+    )
+    invalid_values = eqx.filter_jit(phx.transport.fast_soft_rank)
+    for temperature in (0.0, -1.0, jnp.inf, jnp.nan):
+        with pytest.raises(
+            (ValueError, eqx.EquinoxRuntimeError),
+            match="temperature must be finite and positive",
+        ):
+            jax.block_until_ready(invalid_temperature(jnp.asarray(temperature)))
+    with pytest.raises(
+        (ValueError, eqx.EquinoxRuntimeError),
+        match="values must contain only finite values",
+    ):
+        jax.block_until_ready(invalid_values(jnp.asarray([0.0, jnp.nan, 1.0])))

--- a/tests/unit/uq/test_transport_integrations.py
+++ b/tests/unit/uq/test_transport_integrations.py
@@ -260,6 +260,18 @@ def test_transport_functional_terms_return_scalar_values_and_native_diagnostics(
     assert jnp.allclose(sliced_evaluation.value, 1.0)
     assert jnp.allclose(quantile_evaluation.value, 0.0, atol=1e-28)
     assert quantile_evaluation.diagnostics["quantiles"].shape == (3,)
+    assert jnp.array_equal(
+        quantile_evaluation.diagnostics["endpoint_mask"],
+        jnp.asarray([True, False, True]),
+    )
+    assert jnp.allclose(quantile_evaluation.diagnostics["effective_epsilon"], 0.2)
+    assert set(quantile_evaluation.diagnostics) == {
+        "effective_epsilon",
+        "endpoint_mask",
+        "quantiles",
+        "target_quantiles",
+        "residuals",
+    }
 
 
 def test_transport_terms_reject_nonconverged_training_solves():
@@ -278,6 +290,97 @@ def test_transport_terms_reject_nonconverged_training_solves():
     source = _measure([[4.0], [8.0]], [0.9, 0.1], provenance="source")
     term = phx.terms.SpatialSinkhornDivergenceTerm(lambda _: source, reference)
 
+    with pytest.raises((ValueError, eqx.EquinoxRuntimeError), match="did not converge"):
+        evaluation = term.term_evaluation({})
+        jax.block_until_ready(evaluation.value)
+
+
+def test_soft_quantile_functional_reports_regularity_and_solver_precedence():
+    values = jnp.asarray([-2.0, -0.3, 1.4, 3.0])
+    quantile_levels = jnp.asarray([0.0, 0.35, 1.0])
+    solver = phx.transport.Sinkhorn(
+        0.35,
+        max_iterations=300,
+        tolerance=1e-7,
+        check_every=5,
+    )
+    estimates = phx.transport.soft_quantile(
+        values,
+        quantile_levels,
+        solver=solver,
+    )
+    residuals = jnp.asarray([1.0, -2.0, 0.5])
+    targets = estimates - residuals
+    squared = phx.terms.SoftQuantileFunctional(
+        values,
+        quantile_levels,
+        targets,
+        epsilon=0.1,
+        solver=solver,
+        discrepancy="squared",
+    ).term_evaluation({})
+    absolute = phx.terms.SoftQuantileFunctional(
+        values,
+        quantile_levels,
+        targets,
+        epsilon=0.1,
+        solver=solver,
+        discrepancy="absolute",
+    ).term_evaluation({})
+
+    assert jnp.allclose(squared.value, jnp.mean(residuals**2))
+    assert jnp.allclose(absolute.value, jnp.mean(jnp.abs(residuals)))
+    assert jnp.array_equal(
+        squared.diagnostics["endpoint_mask"],
+        jnp.asarray([True, False, True]),
+    )
+    assert jnp.array_equal(
+        squared.diagnostics["effective_epsilon"],
+        solver.epsilon,
+    )
+    assert jnp.array_equal(
+        squared.diagnostics["quantiles"][jnp.asarray([0, 2])],
+        jnp.asarray([jnp.min(values), jnp.max(values)]),
+    )
+
+
+def test_soft_quantile_functional_has_finite_interior_gradient_and_validates_epsilon():
+    term = phx.terms.SoftQuantileFunctional(
+        lambda functions: functions["values"],
+        jnp.asarray([0.25, 0.75]),
+        jnp.asarray([-0.5, 1.0]),
+        epsilon=0.2,
+    )
+    values = jnp.asarray([-2.0, -0.2, 0.8, 2.5])
+    gradient = jax.grad(lambda candidate: term.loss({"values": candidate}))(values)
+    assert jnp.all(jnp.isfinite(gradient))
+    assert jnp.linalg.norm(gradient) > 0.0
+    assert not jnp.any(term.term_evaluation({"values": values}).diagnostics["endpoint_mask"])
+
+    for invalid in (0.0, -0.1, jnp.nan, jnp.inf):
+        with pytest.raises(ValueError, match="epsilon must be finite and positive"):
+            phx.terms.SoftQuantileFunctional(
+                values,
+                0.5,
+                0.0,
+                epsilon=invalid,
+            )
+
+
+def test_soft_quantile_functional_rejects_a_nonconverged_solver():
+    solver = phx.transport.Sinkhorn(
+        0.02,
+        max_iterations=1,
+        tolerance=1e-14,
+        check_every=1,
+    )
+    term = phx.terms.SoftQuantileFunctional(
+        jnp.asarray([-3.0, -0.1, 2.0, 9.0]),
+        0.8,
+        1.0,
+        weights=jnp.asarray([0.7, 0.1, 0.1, 0.1]),
+        solver=solver,
+    )
     with pytest.raises((ValueError, eqx.EquinoxRuntimeError), match="did not converge"):
         evaluation = term.term_evaluation({})
         jax.block_until_ready(evaluation.value)

--- a/tools/fast_order_benchmarks.py
+++ b/tools/fast_order_benchmarks.py
@@ -1,0 +1,457 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+
+import phydrax as phx
+
+
+_DTYPES = {"float32": jnp.float32, "float64": jnp.float64}
+
+
+@dataclass(frozen=True)
+class _Case:
+    backend: str
+    operation: str
+    size: int
+    dtype_name: str
+    workload: str
+
+
+@dataclass(frozen=True)
+class _Configuration:
+    native_epsilon: float
+    fast_temperature: float
+    warmups: int
+    repeats: int
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Compare native Sinkhorn and fast PAV soft ordering."
+    )
+    parser.add_argument(
+        "--backends",
+        nargs="+",
+        choices=("native-sinkhorn", "fast-pav"),
+        default=("native-sinkhorn", "fast-pav"),
+    )
+    parser.add_argument(
+        "--operations",
+        nargs="+",
+        choices=("sort", "rank"),
+        default=("sort", "rank"),
+    )
+    parser.add_argument("--sizes", nargs="+", type=int, default=(64, 256, 1024))
+    parser.add_argument(
+        "--dtypes",
+        nargs="+",
+        choices=tuple(_DTYPES),
+        default=("float32",),
+    )
+    parser.add_argument(
+        "--workloads",
+        nargs="+",
+        choices=("sinusoidal", "nearly-tied", "repeated", "heavy-tailed"),
+        default=("sinusoidal",),
+    )
+    parser.add_argument("--native-epsilon", type=float, default=0.1)
+    parser.add_argument("--fast-temperature", type=float, default=0.4)
+    parser.add_argument("--warmups", type=int, default=1)
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--max-native-pairs", type=int)
+    parser.add_argument("--smoke", action="store_true")
+    parser.add_argument("--output", type=Path)
+    return parser
+
+
+def _validate(arguments: argparse.Namespace) -> None:
+    if any(size < 2 for size in arguments.sizes):
+        raise ValueError("sizes must be at least two.")
+    if arguments.native_epsilon <= 0.0:
+        raise ValueError("native-epsilon must be positive.")
+    if arguments.fast_temperature <= 0.0:
+        raise ValueError("fast-temperature must be positive.")
+    if arguments.warmups < 0 or arguments.repeats < 1:
+        raise ValueError("warmups must be nonnegative and repeats positive.")
+    if arguments.max_native_pairs is not None and arguments.max_native_pairs < 1:
+        raise ValueError("max-native-pairs must be positive or omitted.")
+
+
+def _cases(arguments: argparse.Namespace) -> list[_Case]:
+    if arguments.smoke:
+        return [
+            _Case("native-sinkhorn", "sort", 8, "float32", "sinusoidal"),
+            _Case("fast-pav", "sort", 8, "float32", "sinusoidal"),
+            _Case("fast-pav", "rank", 8, "float64", "nearly-tied"),
+        ]
+    return [
+        _Case(backend, operation, size, dtype_name, workload)
+        for backend in arguments.backends
+        for operation in arguments.operations
+        for size in arguments.sizes
+        for dtype_name in arguments.dtypes
+        for workload in arguments.workloads
+    ]
+
+
+def _values(case: _Case, seed: int) -> jax.Array:
+    dtype = _DTYPES[case.dtype_name]
+    index = jnp.arange(case.size, dtype=dtype)
+    phase = jnp.asarray(1.61803398875, dtype=dtype) * index
+    base = jnp.sin(phase) + 0.1 * jnp.cos(0.37 * phase)
+    if case.workload == "sinusoidal":
+        return base
+    if case.workload == "nearly-tied":
+        scale = 1e-3 if dtype == jnp.float32 else 1e-7
+        return jnp.ones_like(base) + scale * (base + index / case.size)
+    if case.workload == "repeated":
+        return jnp.mod(jnp.arange(case.size), min(case.size, 8)).astype(dtype)
+    key = jax.random.fold_in(jax.random.key(seed), case.size)
+    uniform = jax.random.uniform(
+        key,
+        (case.size,),
+        dtype=dtype,
+        minval=1e-3,
+        maxval=1.0 - 1e-3,
+    )
+    return jnp.tan(jnp.pi * (uniform - 0.5))
+
+
+def _operation(case: _Case, configuration: _Configuration):
+    if case.backend == "native-sinkhorn":
+        solver = phx.transport.Sinkhorn(
+            configuration.native_epsilon,
+            max_iterations=300,
+            min_iterations=1,
+            tolerance=1e-7,
+            check_every=5,
+            early_stop=False,
+            store_history=False,
+        )
+        if case.operation == "sort":
+            return lambda values: phx.transport.soft_sort(values, solver=solver)
+        return lambda values: phx.transport.soft_rank(values, solver=solver)
+    if case.operation == "sort":
+        return lambda values: phx.transport.fast_soft_sort(
+            values,
+            temperature=configuration.fast_temperature,
+        )
+    return lambda values: phx.transport.fast_soft_rank(
+        values,
+        temperature=configuration.fast_temperature,
+    )
+
+
+def _hard_output(case: _Case, values: jax.Array) -> jax.Array:
+    if case.operation == "sort":
+        return jnp.sort(values)
+    order = jnp.argsort(values, stable=True)
+    return jnp.zeros((case.size,), dtype=values.dtype).at[order].set(
+        jnp.arange(case.size, dtype=values.dtype)
+    )
+
+
+def _block(value: Any) -> Any:
+    return jax.tree.map(jax.block_until_ready, value)
+
+
+def _compile(function, *arguments):
+    started = time.perf_counter_ns()
+    compiled = jax.jit(function).lower(*arguments).compile()
+    elapsed_ms = (time.perf_counter_ns() - started) / 1e6
+    return compiled, elapsed_ms
+
+
+def _execute(compiled, *arguments):
+    started = time.perf_counter_ns()
+    output = _block(compiled(*arguments))
+    elapsed_ms = (time.perf_counter_ns() - started) / 1e6
+    return output, elapsed_ms
+
+
+def _steady(compiled, arguments, *, warmups: int, repeats: int) -> float:
+    for _ in range(warmups):
+        _block(compiled(*arguments))
+    started = time.perf_counter_ns()
+    for _ in range(repeats):
+        _block(compiled(*arguments))
+    return (time.perf_counter_ns() - started) / (1e6 * repeats)
+
+
+def _memory(compiled) -> dict[str, int | str]:
+    analysis = compiled.memory_analysis()
+    if analysis is None:
+        return {"status": "unavailable"}
+    return {
+        "status": "available",
+        "argument_bytes": int(analysis.argument_size_in_bytes),
+        "output_bytes": int(analysis.output_size_in_bytes),
+        "temporary_bytes": int(analysis.temp_size_in_bytes),
+        "alias_bytes": int(analysis.alias_size_in_bytes),
+        "generated_code_bytes": int(analysis.generated_code_size_in_bytes),
+    }
+
+
+def _accuracy(case: _Case, values: jax.Array, output: jax.Array) -> dict[str, Any]:
+    hard = _hard_output(case, values).astype(output.dtype)
+    relative_error = jnp.linalg.norm(output - hard) / jnp.maximum(
+        jnp.linalg.norm(hard),
+        jnp.asarray(1e-12, dtype=output.dtype),
+    )
+    tolerance = 20.0 * jnp.finfo(output.dtype).eps
+    order = jnp.argsort(values, stable=True)
+    ordered_output = output if case.operation == "sort" else output[order]
+    maximum = jnp.max(values) if case.operation == "sort" else case.size - 1
+    minimum = jnp.min(values) if case.operation == "sort" else 0.0
+    expected_sum = (
+        jnp.sum(values)
+        if case.operation == "sort"
+        else case.size * (case.size - 1) / 2
+    )
+    return {
+        "relative_hard_error": float(relative_error),
+        "monotonicity_violations": int(
+            jnp.sum(jnp.diff(ordered_output) < -tolerance)
+        ),
+        "range_violations": int(
+            jnp.sum((output < minimum - tolerance) | (output > maximum + tolerance))
+        ),
+        "sum_error": float(jnp.abs(jnp.sum(output) - expected_sum)),
+    }
+
+
+def _equivariance(case: _Case, operation, values, output) -> dict[str, float]:
+    transformed = operation(3.0 * values - 2.0)
+    if case.operation == "sort":
+        residual = transformed - (3.0 * output - 2.0)
+    else:
+        residual = transformed - output
+    permutation = jnp.roll(jnp.arange(case.size), max(1, case.size // 3))
+    permuted = operation(values[permutation])
+    if case.operation == "sort":
+        permutation_residual = permuted - output
+    else:
+        permutation_residual = permuted - output[permutation]
+    return {
+        "positive_affine_linf": float(jnp.max(jnp.abs(residual))),
+        "permutation_linf": float(jnp.max(jnp.abs(permutation_residual))),
+    }
+
+
+def _convergence(
+    case: _Case,
+    values: jax.Array,
+    configuration: _Configuration,
+) -> dict[str, Any]:
+    if case.backend != "native-sinkhorn":
+        return {"status": "not-applicable"}
+    solver = phx.transport.Sinkhorn(
+        configuration.native_epsilon,
+        max_iterations=300,
+        min_iterations=1,
+        tolerance=1e-7,
+        check_every=5,
+        early_stop=False,
+        store_history=False,
+    )
+    solve = jax.jit(
+        lambda candidate: phx.transport.soft_order_transport(
+            candidate,
+            solver=solver,
+        )
+    )
+    result = _block(solve(values))
+    diagnostics = result.diagnostics
+    return {
+        "status": "available",
+        "converged": bool(result.converged),
+        "iterations": int(diagnostics.num_iterations),
+        "normalized_marginal_residual": float(
+            diagnostics.normalized_marginal_residual
+        ),
+        "physical_marginal_residual": float(diagnostics.physical_marginal_residual),
+    }
+
+
+def _record(
+    case: _Case,
+    configuration: _Configuration,
+    *,
+    seed: int,
+) -> dict[str, Any]:
+    values = _values(case, seed)
+    operation = _operation(case, configuration)
+    forward, forward_compile_ms = _compile(operation, values)
+    output, first_forward_ms = _execute(forward, values)
+    steady_forward_ms = _steady(
+        forward,
+        (values,),
+        warmups=configuration.warmups,
+        repeats=configuration.repeats,
+    )
+
+    coefficients = jnp.linspace(0.5, 1.5, case.size, dtype=values.dtype)
+
+    def objective(candidate):
+        return jnp.sum(coefficients * operation(candidate))
+
+    reverse, reverse_compile_ms = _compile(jax.grad(objective), values)
+    gradient, first_reverse_ms = _execute(reverse, values)
+    steady_reverse_ms = _steady(
+        reverse,
+        (values,),
+        warmups=configuration.warmups,
+        repeats=configuration.repeats,
+    )
+    direction = jnp.cos(jnp.arange(case.size, dtype=values.dtype))
+
+    def jvp(candidate, tangent):
+        return jax.jvp(operation, (candidate,), (tangent,))[1]
+
+    forward_mode, jvp_compile_ms = _compile(jvp, values, direction)
+    tangent, first_jvp_ms = _execute(forward_mode, values, direction)
+    steady_jvp_ms = _steady(
+        forward_mode,
+        (values, direction),
+        warmups=configuration.warmups,
+        repeats=configuration.repeats,
+    )
+    return {
+        "backend": case.backend,
+        "operation": case.operation,
+        "size": case.size,
+        "dtype": case.dtype_name,
+        "output_dtype": str(output.dtype),
+        "workload": case.workload,
+        "parameter": {
+            "name": (
+                "epsilon" if case.backend == "native-sinkhorn" else "temperature"
+            ),
+            "value": (
+                configuration.native_epsilon
+                if case.backend == "native-sinkhorn"
+                else configuration.fast_temperature
+            ),
+        },
+        "status": "ok",
+        "timing_ms": {
+            "forward_compile": forward_compile_ms,
+            "first_forward_execution": first_forward_ms,
+            "steady_forward": steady_forward_ms,
+            "reverse_compile": reverse_compile_ms,
+            "first_reverse_execution": first_reverse_ms,
+            "steady_reverse": steady_reverse_ms,
+            "jvp_compile": jvp_compile_ms,
+            "first_jvp_execution": first_jvp_ms,
+            "steady_jvp": steady_jvp_ms,
+        },
+        "compiled_memory": {
+            "forward": _memory(forward),
+            "reverse": _memory(reverse),
+            "jvp": _memory(forward_mode),
+        },
+        "accuracy": _accuracy(case, values, output),
+        "equivariance": _equivariance(case, operation, values, output),
+        "convergence": _convergence(case, values, configuration),
+        "gradient_norm": float(jnp.linalg.norm(gradient)),
+        "jvp_norm": float(jnp.linalg.norm(tangent)),
+        "nonfinite_gradient_count": int(jnp.sum(~jnp.isfinite(gradient))),
+        "nonfinite_jvp_count": int(jnp.sum(~jnp.isfinite(tangent))),
+    }
+
+
+def _metadata() -> dict[str, Any]:
+    return {
+        "python": platform.python_version(),
+        "jax": jax.__version__,
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+        "byteorder": sys.byteorder,
+        "default_backend": jax.default_backend(),
+        "devices": [
+            {
+                "id": device.id,
+                "platform": device.platform,
+                "device_kind": device.device_kind,
+                "process_index": device.process_index,
+            }
+            for device in jax.devices()
+        ],
+    }
+
+
+def main() -> None:
+    arguments = _parser().parse_args()
+    _validate(arguments)
+    configuration = _Configuration(
+        native_epsilon=arguments.native_epsilon,
+        fast_temperature=arguments.fast_temperature,
+        warmups=0 if arguments.smoke else arguments.warmups,
+        repeats=1 if arguments.smoke else arguments.repeats,
+    )
+    records = []
+    for case in _cases(arguments):
+        if (
+            case.backend == "native-sinkhorn"
+            and arguments.max_native_pairs is not None
+            and case.size * case.size > arguments.max_native_pairs
+        ):
+            records.append(
+                {
+                    "backend": case.backend,
+                    "operation": case.operation,
+                    "size": case.size,
+                    "dtype": case.dtype_name,
+                    "workload": case.workload,
+                    "status": "resource-limit",
+                    "reason": (
+                        f"size^2={case.size * case.size} exceeds explicit "
+                        f"max_native_pairs={arguments.max_native_pairs}"
+                    ),
+                }
+            )
+            continue
+        records.append(_record(case, configuration, seed=arguments.seed))
+    report = {
+        "schema": "phydrax.fast-order-benchmark.v1",
+        "configuration": {
+            "backends": list(arguments.backends),
+            "operations": list(arguments.operations),
+            "sizes": list(arguments.sizes),
+            "dtypes": list(arguments.dtypes),
+            "workloads": list(arguments.workloads),
+            "native_epsilon": configuration.native_epsilon,
+            "fast_temperature": configuration.fast_temperature,
+            "warmups": configuration.warmups,
+            "repeats": configuration.repeats,
+            "seed": arguments.seed,
+            "max_native_pairs": arguments.max_native_pairs,
+            "smoke": arguments.smoke,
+        },
+        "metadata": _metadata(),
+        "records": records,
+    }
+    rendered = json.dumps(report, indent=2, sort_keys=True)
+    if arguments.output is not None:
+        arguments.output.parent.mkdir(parents=True, exist_ok=True)
+        arguments.output.write_text(rendered + "\n", encoding="utf-8")
+    print(rendered)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/geometric_benchmarks.py
+++ b/tools/geometric_benchmarks.py
@@ -8,6 +8,7 @@ import argparse
 import json
 import time
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 
 import jax
@@ -160,6 +161,381 @@ def run_benchmarks(
     }
 
 
+
+
+def _csg_setup(grid_size: int):
+    Sphere = phx.geometry.analytic.Sphere
+    target_source = Sphere(
+        (-0.45, 0.0, 0.0),
+        0.75,
+        feature_id="left",
+    ) | Sphere((0.45, 0.0, 0.0), 0.75, feature_id="right")
+    sharp_source = Sphere(
+        (-0.85, 0.0, 0.0),
+        0.75,
+        feature_id="left",
+    ) | Sphere((0.8, 0.0, 0.0), 0.75, feature_id="right")
+    blend_source = phx.geometry.analytic.BlendUnion(
+        Sphere((-0.85, 0.0, 0.0), 0.75, feature_id="left"),
+        Sphere((0.8, 0.0, 0.0), 0.75, feature_id="right"),
+        width=0.3,
+    )
+    target = target_source.compile()
+    sharp = sharp_source.compile()
+    blend = blend_source.compile()
+    left_id = phx.geometry.ParameterId("left", "center")
+    right_id = phx.geometry.ParameterId("right", "center")
+    width_id = phx.geometry.ParameterId(blend_source.feature_id, "width")
+    sharp_indices = (
+        sharp.schema.index(left_id),
+        sharp.schema.index(right_id),
+    )
+    blend_indices = (
+        blend.schema.index(left_id),
+        blend.schema.index(right_id),
+        blend.schema.index(width_id),
+    )
+
+    axis = jnp.linspace(-1.4, 1.4, grid_size)
+    xx, yy = jnp.meshgrid(axis, axis, indexing="ij")
+    training_points = jnp.stack(
+        (xx.reshape((-1,)), yy.reshape((-1,)), jnp.zeros((grid_size**2,))),
+        axis=-1,
+    )
+    target_training_field = target.boundary_field(training_points)
+
+    boundary_count = max(64, 4 * grid_size)
+    index = jnp.arange(boundary_count, dtype=float)
+    z = 1.0 - 2.0 * (index + 0.5) / boundary_count
+    angle = jnp.pi * (3.0 - jnp.sqrt(5.0)) * index
+    radius = jnp.sqrt(jnp.maximum(1.0 - z**2, 0.0))
+    directions = jnp.stack(
+        (radius * jnp.cos(angle), radius * jnp.sin(angle), z),
+        axis=-1,
+    )
+    target_centers = jnp.asarray([[-0.45, 0.0, 0.0], [0.45, 0.0, 0.0]])
+    boundary_points = (
+        target_centers[:, None, :] + 0.75 * directions[None, :, :]
+    ).reshape((-1, 3))
+    other_center = jnp.repeat(target_centers[::-1], boundary_count, axis=0)
+    boundary_mask = (
+        jnp.linalg.norm(boundary_points - other_center, axis=-1) >= 0.75 - 1e-10
+    )
+
+    pde_points = jnp.asarray(
+        [
+            [-1.1, 0.15, 0.1],
+            [-0.8, -0.25, 0.2],
+            [-0.55, 0.3, -0.15],
+            [-0.3, -0.45, 0.1],
+            [0.3, 0.4, -0.1],
+            [0.55, -0.3, 0.15],
+            [0.8, 0.2, -0.2],
+            [1.1, -0.1, 0.1],
+        ]
+    )
+
+    def state_with_centers(compiled, indices, parameters, width=None):
+        left = jnp.stack((parameters[0], jnp.asarray(0.0), jnp.asarray(0.0)))
+        right = jnp.stack((parameters[1], jnp.asarray(0.0), jnp.asarray(0.0)))
+        state = compiled.state.replace_at(indices[0], left)
+        state = state.replace_at(indices[1], right)
+        if width is not None:
+            state = state.replace_at(indices[2], width)
+        return state
+
+    def sharp_field(parameters, points):
+        state = state_with_centers(sharp, sharp_indices, parameters)
+        return sharp.kernel.boundary_field(state, points)
+
+    def blend_field(parameters, width, points):
+        state = state_with_centers(blend, blend_indices, parameters, width)
+        return blend.kernel.boundary_field(state, points)
+
+    def target_field(point):
+        return target.kernel.boundary_field(target.state, point)
+
+    def target_trial(point):
+        value = target_field(point)
+        return value**2
+
+    target_forcing = jax.vmap(
+        lambda point: jnp.trace(jax.hessian(target_trial)(point))
+    )(pde_points)
+    return {
+        "target": target,
+        "sharp_field": sharp_field,
+        "blend_field": blend_field,
+        "training_points": training_points,
+        "target_training_field": target_training_field,
+        "boundary_points": boundary_points,
+        "boundary_mask": boundary_mask,
+        "pde_points": pde_points,
+        "target_forcing": target_forcing,
+        "target_parameters": jnp.asarray([-0.45, 0.45]),
+    }
+
+
+def _csg_loss(setup, strategy: str):
+    def loss(parameters, width):
+        if strategy == "sharp":
+            field = setup["sharp_field"](parameters, setup["training_points"])
+        else:
+            field = setup["blend_field"](
+                parameters,
+                width,
+                setup["training_points"],
+            )
+        residual = field - setup["target_training_field"]
+        return jnp.mean(residual**2) + 1e-5 * jnp.sum(parameters**2)
+
+    return loss
+
+
+def _fit_csg(setup, strategy: str, seed: int, steps: int):
+    key = jax.random.key(seed)
+    parameters = jnp.asarray([-0.85, 0.8]) + 0.08 * jax.random.normal(key, (2,))
+    state = (
+        parameters,
+        jnp.zeros_like(parameters),
+        jnp.zeros_like(parameters),
+        jnp.asarray(0, dtype=jnp.int32),
+    )
+    loss = _csg_loss(setup, strategy)
+
+    def step(state_, width):
+        parameters_, first_moment, second_moment, iteration = state_
+        value, gradient = jax.value_and_grad(loss)(parameters_, width)
+        iteration = iteration + 1
+        first_moment = 0.9 * first_moment + 0.1 * gradient
+        second_moment = 0.999 * second_moment + 0.001 * gradient**2
+        corrected_first = first_moment / (1.0 - 0.9**iteration)
+        corrected_second = second_moment / (1.0 - 0.999**iteration)
+        parameters_ = parameters_ - 0.04 * corrected_first / (
+            jnp.sqrt(corrected_second) + 1e-8
+        )
+        return (
+            parameters_,
+            first_moment,
+            second_moment,
+            iteration,
+        ), value, gradient
+
+    if strategy == "sharp":
+        widths = jnp.zeros((steps,))
+    elif strategy == "fixed":
+        widths = jnp.full((steps,), 0.3)
+    else:
+        widths = jnp.geomspace(0.4, 0.02, steps)
+    compiled = jax.jit(step)
+    started = time.perf_counter()
+    state, value, gradient = _block(compiled(state, widths[0]))
+    compile_and_first_seconds = time.perf_counter() - started
+    started = time.perf_counter()
+    for width in widths[1:]:
+        state, value, gradient = _block(compiled(state, width))
+    remaining_seconds = time.perf_counter() - started
+    return {
+        "parameters": state[0],
+        "final_training_loss": value,
+        "final_gradient_norm": jnp.linalg.norm(gradient),
+        "compile_and_first_seconds": compile_and_first_seconds,
+        "remaining_training_seconds": remaining_seconds,
+        "final_width": widths[-1],
+    }
+
+
+
+
+def _csg_metric_functions(setup, geometry: str, width: jax.Array):
+    if geometry == "sharp":
+        return lambda parameters, points: setup["sharp_field"](parameters, points)
+    return lambda parameters, points: setup["blend_field"](parameters, width, points)
+
+
+def _csg_record(setup, strategy: str, seed: int, fit, *, geometry: str):
+    width = fit["final_width"]
+    evaluated = _block(
+        _csg_record_metrics(
+            setup,
+            fit["parameters"],
+            geometry=geometry,
+            width=width,
+        )
+    )
+    if geometry == "sharp":
+        final_sharp = evaluated
+    else:
+        final_sharp = _block(
+            _csg_record_metrics(
+                setup,
+                fit["parameters"],
+                geometry="sharp",
+                width=width,
+            )
+        )
+    success = (
+        final_sharp["parameter_recovery_error"] < 0.08
+    ) & (final_sharp["containment_error"] < 0.02)
+    return {
+        "strategy": strategy,
+        "evaluation_geometry": geometry,
+        "seed": seed,
+        "parameters": [float(value) for value in fit["parameters"]],
+        "final_width": float(width),
+        "final_training_loss": float(fit["final_training_loss"]),
+        "final_gradient_norm": float(fit["final_gradient_norm"]),
+        "compile_and_first_seconds": fit["compile_and_first_seconds"],
+        "remaining_training_seconds": fit["remaining_training_seconds"],
+        "metrics": {name: float(value) for name, value in evaluated.items()},
+        "final_sharp_metrics": {
+            name: float(value) for name, value in final_sharp.items()
+        },
+        "success": bool(success),
+    }
+
+
+def _csg_record_metrics(setup, parameters, *, geometry: str, width: jax.Array):
+    field_for = _csg_metric_functions(setup, geometry, width)
+
+    def field(points):
+        return field_for(parameters, points)
+
+    mask = setup["boundary_mask"]
+    count = jnp.maximum(jnp.sum(mask), 1)
+    boundary_values = field(setup["boundary_points"])
+    zero_set = jnp.sum(jnp.where(mask, jnp.abs(boundary_values), 0.0)) / count
+    boundary_trial = boundary_values * (
+        1.0 + 0.2 * jnp.sum(setup["boundary_points"] ** 2, axis=-1)
+    )
+    boundary_error = jnp.sum(
+        jnp.where(mask, jnp.abs(boundary_trial), 0.0)
+    ) / count
+    containment = jnp.mean(
+        (field(setup["training_points"]) <= 0.0)
+        != (setup["target_training_field"] <= 0.0)
+    )
+
+    def trial(point):
+        return field(point) ** 2
+
+    forcing = jax.vmap(
+        lambda point: jnp.trace(jax.hessian(trial)(point))
+    )(setup["pde_points"])
+    pde_residual = forcing - setup["target_forcing"]
+    target = setup["target_parameters"]
+    parameter_error = jnp.minimum(
+        jnp.linalg.norm(parameters - target),
+        jnp.linalg.norm(parameters - target[::-1]),
+    )
+    delta = 1e-5
+    switch = 0.5 * (parameters[0] + parameters[1])
+    transverse = jnp.linspace(-0.5, 0.5, 9)
+    left_points = jnp.stack(
+        (
+            jnp.full_like(transverse, switch - delta),
+            transverse,
+            jnp.zeros_like(transverse),
+        ),
+        axis=-1,
+    )
+    right_points = left_points.at[:, 0].set(switch + delta)
+    left_jacobian = jax.jacfwd(
+        lambda candidate: field_for(candidate, left_points)
+    )(parameters)
+    right_jacobian = jax.jacfwd(
+        lambda candidate: field_for(candidate, right_points)
+    )(parameters)
+    switch_jacobian = jnp.concatenate((left_jacobian, right_jacobian), axis=0)
+    singular_values = jnp.linalg.svd(switch_jacobian, compute_uv=False)
+    condition = singular_values[0] / jnp.maximum(
+        singular_values[-1],
+        jnp.finfo(singular_values.dtype).eps,
+    )
+    jump = jnp.linalg.norm(right_jacobian - left_jacobian) / jnp.sqrt(
+        right_jacobian.size
+    )
+    return {
+        "sharp_zero_set_error": zero_set,
+        "containment_error": containment,
+        "boundary_condition_error": boundary_error,
+        "pde_residual_l2": jnp.sqrt(jnp.mean(pde_residual**2)),
+        "pde_residual_linf": jnp.max(jnp.abs(pde_residual)),
+        "parameter_recovery_error": parameter_error,
+        "switch_gradient_condition": condition,
+        "switch_gradient_jump": jump,
+    }
+
+
+def run_csg_continuation(
+    *,
+    steps: int = 100,
+    seeds: tuple[int, ...] = (0, 1, 2, 3, 4),
+    grid_size: int = 31,
+) -> dict[str, Any]:
+    """Compare sharp fitting with fixed and annealed smooth CSG continuation."""
+    if steps < 1 or grid_size < 5 or not seeds:
+        raise ValueError("steps, grid_size, and seeds must define nonempty work.")
+    setup = _csg_setup(grid_size)
+    records = []
+    for seed in seeds:
+        sharp = _fit_csg(setup, "sharp", seed, steps)
+        fixed = _fit_csg(setup, "fixed", seed, steps)
+        annealed = _fit_csg(setup, "annealed", seed, steps)
+        records.extend(
+            (
+                _csg_record(
+                    setup,
+                    "sharp-csg",
+                    seed,
+                    sharp,
+                    geometry="sharp",
+                ),
+                _csg_record(
+                    setup,
+                    "fixed-width-blend-csg",
+                    seed,
+                    fixed,
+                    geometry="blend",
+                ),
+                _csg_record(
+                    setup,
+                    "width-annealed-blend-csg",
+                    seed,
+                    annealed,
+                    geometry="blend",
+                ),
+                _csg_record(
+                    setup,
+                    "annealed-sharp-final",
+                    seed,
+                    annealed,
+                    geometry="sharp",
+                ),
+            )
+        )
+    success_by_strategy = {
+        strategy: sum(
+            record["success"] for record in records if record["strategy"] == strategy
+        )
+        for strategy in (
+            "sharp-csg",
+            "fixed-width-blend-csg",
+            "width-annealed-blend-csg",
+            "annealed-sharp-final",
+        )
+    }
+    return {
+        "schema": "phydrax.csg-continuation.v1",
+        "jax_version": jax.__version__,
+        "backend": jax.default_backend(),
+        "steps": steps,
+        "seeds": list(seeds),
+        "grid_size": grid_size,
+        "success_by_strategy": success_by_strategy,
+        "records": records,
+    }
+
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Benchmark Phydrax differentiable-geometric kernels."
@@ -167,18 +543,34 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--batch-size", type=int, default=256)
     parser.add_argument("--dimension", type=int, default=4)
     parser.add_argument("--repeats", type=int, default=10)
+    parser.add_argument("--csg-continuation", action="store_true")
+    parser.add_argument("--csg-steps", type=int, default=100)
+    parser.add_argument("--csg-seeds", type=int, nargs="+", default=(0, 1, 2, 3, 4))
+    parser.add_argument("--csg-grid-size", type=int, default=31)
+    parser.add_argument("--output", type=Path)
     parser.add_argument("--smoke", action="store_true")
     return parser
 
 
 def main() -> None:
     arguments = _parser().parse_args()
-    report = run_benchmarks(
-        batch_size=8 if arguments.smoke else arguments.batch_size,
-        dimension=4 if arguments.smoke else arguments.dimension,
-        repeats=1 if arguments.smoke else arguments.repeats,
-    )
-    print(json.dumps(report, indent=2, sort_keys=True))
+    if arguments.csg_continuation:
+        report = run_csg_continuation(
+            steps=3 if arguments.smoke else arguments.csg_steps,
+            seeds=(0,) if arguments.smoke else tuple(arguments.csg_seeds),
+            grid_size=7 if arguments.smoke else arguments.csg_grid_size,
+        )
+    else:
+        report = run_benchmarks(
+            batch_size=8 if arguments.smoke else arguments.batch_size,
+            dimension=4 if arguments.smoke else arguments.dimension,
+            repeats=1 if arguments.smoke else arguments.repeats,
+        )
+    rendered = json.dumps(report, indent=2, sort_keys=True)
+    if arguments.output is not None:
+        arguments.output.parent.mkdir(parents=True, exist_ok=True)
+        arguments.output.write_text(rendered + "\n", encoding="utf-8")
+    print(rendered)
 
 
 if __name__ == "__main__":

--- a/tools/soft_quantile_objective_benchmarks.py
+++ b/tools/soft_quantile_objective_benchmarks.py
@@ -1,0 +1,557 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+import jax.scipy as jsp
+
+import phydrax as phx
+
+
+_METHODS = ("hard-quantile", "soft-quantile", "logsumexp", "hard-cvar")
+_DTYPES = {"float32": jnp.float32, "float64": jnp.float64}
+
+
+@dataclass(frozen=True)
+class _Problem:
+    name: str
+    initial_parameters: jax.Array
+    residuals: Callable[[jax.Array], jax.Array]
+    physical_metrics: Callable[[jax.Array], dict[str, jax.Array]]
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Compare training objectives for high empirical residual quantiles."
+    )
+    parser.add_argument("--methods", nargs="+", choices=_METHODS, default=_METHODS)
+    parser.add_argument("--size", type=int, default=64)
+    parser.add_argument("--quantile", type=float, default=0.9)
+    parser.add_argument("--epsilon", type=float, default=0.1)
+    parser.add_argument("--sinkhorn-iterations", type=int, default=100)
+    parser.add_argument("--logsumexp-temperature", type=float, default=0.1)
+    parser.add_argument("--learning-rate", type=float, default=0.03)
+    parser.add_argument("--steps", type=int, default=30)
+    parser.add_argument("--seeds", type=int, nargs="+", default=(0, 1, 2))
+    parser.add_argument("--dtype", choices=tuple(_DTYPES), default="float64")
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--smoke", action="store_true")
+    return parser
+
+
+def _validate(arguments: argparse.Namespace) -> None:
+    if arguments.size < 8:
+        raise ValueError("size must be at least eight.")
+    if not 0.0 < arguments.quantile < 1.0:
+        raise ValueError("quantile must lie strictly inside (0, 1).")
+    if arguments.epsilon <= 0.0 or not jnp.isfinite(arguments.epsilon):
+        raise ValueError("epsilon must be finite and positive.")
+    if arguments.sinkhorn_iterations < 1:
+        raise ValueError("sinkhorn-iterations must be positive.")
+    if arguments.logsumexp_temperature <= 0.0:
+        raise ValueError("logsumexp-temperature must be positive.")
+    if arguments.learning_rate <= 0.0:
+        raise ValueError("learning-rate must be positive.")
+    if arguments.steps < 1:
+        raise ValueError("steps must be positive.")
+
+
+def _heavy_tailed_problem(size: int, dtype: jnp.dtype) -> _Problem:
+    coordinate = jnp.linspace(-1.0, 1.0, size, dtype=dtype)
+    design = jnp.stack(
+        (
+            jnp.ones_like(coordinate),
+            coordinate,
+            jnp.sin(jnp.pi * coordinate),
+            jnp.cos(2.0 * jnp.pi * coordinate),
+        ),
+        axis=-1,
+    )
+    baseline = (
+        0.15
+        + 0.08 * jnp.sin(5.0 * coordinate)
+        + 1.8 / (1.0 + (18.0 * (coordinate - 0.62)) ** 2)
+        - 1.2 / (1.0 + (24.0 * (coordinate + 0.48)) ** 2)
+    )
+
+    def signed(parameters):
+        return baseline + design @ parameters
+
+    def residuals(parameters):
+        return jnp.abs(signed(parameters))
+
+    def metrics(parameters):
+        errors = signed(parameters)
+        return {
+            "signed_bias": jnp.mean(errors),
+            "residual_rms": jnp.sqrt(jnp.mean(errors**2)),
+            "parameter_norm": jnp.linalg.norm(parameters),
+        }
+
+    return _Problem(
+        "deterministic-heavy-tail",
+        jnp.zeros((design.shape[-1],), dtype=dtype),
+        residuals,
+        metrics,
+    )
+
+
+def _pde_problem(size: int, dtype: jnp.dtype) -> _Problem:
+    coordinate = jnp.linspace(0.0, 1.0, size + 2, dtype=dtype)[1:-1]
+    mode = jnp.arange(1, 9, dtype=dtype)
+    basis = jnp.sin(jnp.pi * coordinate[:, None] * mode[None, :])
+    second_derivative = -(jnp.pi * mode) ** 2 * basis
+    forcing = (
+        jnp.pi**2 * jnp.sin(jnp.pi * coordinate)
+        + 16.0 * jnp.exp(-((coordinate - 0.72) / 0.055) ** 2)
+    )
+    boundary_basis = jnp.sin(
+        jnp.pi * jnp.asarray([[0.0], [1.0]], dtype=dtype) * mode[None, :]
+    )
+
+    def signed(parameters):
+        return second_derivative @ parameters + forcing
+
+    def residuals(parameters):
+        return jnp.abs(signed(parameters))
+
+    def metrics(parameters):
+        equation_residual = signed(parameters)
+        boundary_values = boundary_basis @ parameters
+        return {
+            "pde_residual_l2": jnp.sqrt(jnp.mean(equation_residual**2)),
+            "pde_residual_linf": jnp.max(jnp.abs(equation_residual)),
+            "boundary_linf": jnp.max(jnp.abs(boundary_values)),
+        }
+
+    return _Problem(
+        "localized-poisson-residual",
+        jnp.zeros((mode.shape[0],), dtype=dtype),
+        residuals,
+        metrics,
+    )
+
+
+def _ensemble_problem(size: int, dtype: jnp.dtype) -> _Problem:
+    case_count = max(4, size // 4)
+    member_count = 4
+    coordinate = jnp.linspace(-1.0, 1.0, case_count, dtype=dtype)
+    member = jnp.arange(member_count, dtype=dtype)
+    true_mean = 0.4 - 0.7 * coordinate + 0.5 * coordinate**2
+    scale = 0.08 + 0.5 * (coordinate + 1.0) ** 2
+    noise = jnp.sin(
+        1.7
+        + 2.3 * jnp.arange(case_count, dtype=dtype)[:, None]
+        + 3.1 * member[None, :]
+    )
+    observations = true_mean[:, None] + scale[:, None] * noise
+    design = jnp.stack(
+        (jnp.ones_like(coordinate), coordinate, coordinate**2),
+        axis=-1,
+    )
+
+    def signed(parameters):
+        prediction = design @ parameters
+        return observations - prediction[:, None]
+
+    def residuals(parameters):
+        return jnp.abs(signed(parameters)).reshape((-1,))
+
+    def metrics(parameters):
+        errors = signed(parameters)
+        split = case_count // 2
+        return {
+            "ensemble_rmse": jnp.sqrt(jnp.mean(errors**2)),
+            "low_variance_rmse": jnp.sqrt(jnp.mean(errors[:split] ** 2)),
+            "high_variance_rmse": jnp.sqrt(jnp.mean(errors[split:] ** 2)),
+        }
+
+    return _Problem(
+        "heteroskedastic-ensemble-output",
+        jnp.zeros((design.shape[-1],), dtype=dtype),
+        residuals,
+        metrics,
+    )
+
+
+def _problems(size: int, dtype: jnp.dtype) -> tuple[_Problem, ...]:
+    return (
+        _heavy_tailed_problem(size, dtype),
+        _pde_problem(size, dtype),
+        _ensemble_problem(size, dtype),
+    )
+
+
+def _hard_cvar(residuals: jax.Array, quantile: float) -> jax.Array:
+    threshold = jax.lax.stop_gradient(jnp.quantile(residuals, quantile))
+    selected = residuals >= threshold
+    count = jnp.maximum(jnp.sum(selected), 1)
+    return jnp.sum(jnp.where(selected, residuals, 0.0)) / count
+
+
+def _objective(
+    method: str,
+    problem: _Problem,
+    *,
+    quantile: float,
+    epsilon: float,
+    solver_iterations: int,
+    logsumexp_temperature: float,
+):
+    solver = phx.transport.Sinkhorn(
+        epsilon,
+        max_iterations=solver_iterations,
+        tolerance=1e-7,
+        check_every=5,
+        early_stop=False,
+    )
+
+    def objective(parameters):
+        residuals = problem.residuals(parameters)
+        if method == "hard-quantile":
+            tail = jnp.quantile(residuals, quantile)
+        elif method == "soft-quantile":
+            tail = phx.transport.soft_quantile(
+                residuals,
+                quantile,
+                solver=solver,
+            )
+        elif method == "logsumexp":
+            temperature = jnp.asarray(logsumexp_temperature, dtype=residuals.dtype)
+            tail = temperature * (
+                jsp.special.logsumexp(residuals / temperature)
+                - jnp.log(residuals.size)
+            )
+        else:
+            tail = _hard_cvar(residuals, quantile)
+        return tail + 1e-4 * jnp.sum(parameters**2)
+
+    return objective
+
+
+def _memory(compiled) -> dict[str, int | str]:
+    analysis = compiled.memory_analysis()
+    if analysis is None:
+        return {"status": "unavailable"}
+    return {
+        "status": "available",
+        "argument_bytes": int(analysis.argument_size_in_bytes),
+        "output_bytes": int(analysis.output_size_in_bytes),
+        "temporary_bytes": int(analysis.temp_size_in_bytes),
+        "alias_bytes": int(analysis.alias_size_in_bytes),
+    }
+
+
+def _block(value: Any) -> Any:
+    return jax.tree.map(lambda leaf: leaf.block_until_ready(), value)
+
+
+def _adam_step(objective, learning_rate: float):
+    beta1 = 0.9
+    beta2 = 0.999
+    stability = 1e-8
+
+    def step(state):
+        parameters, first_moment, second_moment, iteration = state
+        value, gradient = jax.value_and_grad(objective)(parameters)
+        next_iteration = iteration + 1
+        first_moment = beta1 * first_moment + (1.0 - beta1) * gradient
+        second_moment = beta2 * second_moment + (1.0 - beta2) * gradient**2
+        corrected_first = first_moment / (1.0 - beta1**next_iteration)
+        corrected_second = second_moment / (1.0 - beta2**next_iteration)
+        parameters = parameters - learning_rate * corrected_first / (
+            jnp.sqrt(corrected_second) + stability
+        )
+        return (
+            parameters,
+            first_moment,
+            second_moment,
+            next_iteration,
+        ), value, gradient
+
+    return step
+
+
+def _transport_diagnostics(
+    residuals: jax.Array,
+    epsilon: float,
+    solver_iterations: int,
+) -> dict[str, Any]:
+    solver = phx.transport.Sinkhorn(
+        epsilon,
+        max_iterations=solver_iterations,
+        tolerance=1e-7,
+        check_every=5,
+        early_stop=False,
+    )
+    result = phx.transport.soft_order_transport(residuals, solver=solver)
+    return {
+        "converged": bool(result.converged),
+        "normalized_marginal_residual": float(
+            result.diagnostics.normalized_marginal_residual
+        ),
+        "physical_marginal_residual": float(
+            result.diagnostics.physical_marginal_residual
+        ),
+    }
+
+
+def _sensitivity(
+    residuals: jax.Array,
+    quantile: float,
+    epsilon: float,
+    solver_iterations: int,
+) -> dict[str, float]:
+    values = {}
+    for candidate in (0.5 * epsilon, epsilon, 2.0 * epsilon):
+        solver = phx.transport.Sinkhorn(
+            candidate,
+            max_iterations=solver_iterations,
+            tolerance=1e-7,
+            check_every=5,
+            early_stop=False,
+        )
+        estimate = phx.transport.soft_quantile(
+            residuals,
+            quantile,
+            solver=solver,
+        )
+        values[f"{candidate:.8g}"] = float(estimate)
+    return values
+
+
+def _train(
+    problem: _Problem,
+    method: str,
+    *,
+    seed: int,
+    quantile: float,
+    epsilon: float,
+    solver_iterations: int,
+    logsumexp_temperature: float,
+    learning_rate: float,
+    steps: int,
+) -> dict[str, Any]:
+    key = jax.random.fold_in(jax.random.key(seed), len(problem.name))
+    parameters = problem.initial_parameters + 0.02 * jax.random.normal(
+        key,
+        problem.initial_parameters.shape,
+        dtype=problem.initial_parameters.dtype,
+    )
+    initial_parameters = parameters
+    objective = _objective(
+        method,
+        problem,
+        quantile=quantile,
+        epsilon=epsilon,
+        solver_iterations=solver_iterations,
+        logsumexp_temperature=logsumexp_temperature,
+    )
+    step = _adam_step(objective, learning_rate)
+    state = (
+        parameters,
+        jnp.zeros_like(parameters),
+        jnp.zeros_like(parameters),
+        jnp.asarray(0, dtype=jnp.int32),
+    )
+
+    started = time.perf_counter_ns()
+    compiled = jax.jit(step).lower(state).compile()
+    compile_ms = (time.perf_counter_ns() - started) / 1e6
+
+    started = time.perf_counter_ns()
+    state, value, gradient = _block(compiled(state))
+    first_step_ms = (time.perf_counter_ns() - started) / 1e6
+    started = time.perf_counter_ns()
+    for _ in range(steps - 1):
+        state, value, gradient = _block(compiled(state))
+    remaining_ms = (time.perf_counter_ns() - started) / 1e6
+
+    parameters = state[0]
+    final_value, final_gradient = _block(jax.value_and_grad(objective)(parameters))
+    residuals = _block(problem.residuals(parameters))
+    initial_residuals = _block(problem.residuals(initial_parameters))
+    hard_cvar = _hard_cvar(residuals, quantile)
+    initial_hard_cvar = _hard_cvar(initial_residuals, quantile)
+    physical_metrics = {
+        name: float(metric)
+        for name, metric in problem.physical_metrics(parameters).items()
+    }
+    initial_physical_metrics = {
+        name: float(metric)
+        for name, metric in problem.physical_metrics(initial_parameters).items()
+    }
+    return {
+        "status": "ok",
+        "workload": problem.name,
+        "method": method,
+        "seed": seed,
+        "steps": steps,
+        "compile_ms": compile_ms,
+        "first_step_ms": first_step_ms,
+        "remaining_training_ms": remaining_ms,
+        "total_training_ms": first_step_ms + remaining_ms,
+        "compiled_memory": _memory(compiled),
+        "initial_hard_quantile": float(jnp.quantile(initial_residuals, quantile)),
+        "initial_maximum_residual": float(jnp.max(initial_residuals)),
+        "initial_hard_cvar": float(initial_hard_cvar),
+        "initial_mean_residual": float(jnp.mean(initial_residuals)),
+        "final_objective": float(final_value),
+        "final_hard_quantile": float(jnp.quantile(residuals, quantile)),
+        "final_maximum_residual": float(jnp.max(residuals)),
+        "final_hard_cvar": float(hard_cvar),
+        "final_mean_residual": float(jnp.mean(residuals)),
+        "gradient_norm": float(jnp.linalg.norm(final_gradient)),
+        "nonfinite_gradient_count": int(jnp.sum(~jnp.isfinite(final_gradient))),
+        "soft_quantile_sensitivity": _sensitivity(
+            residuals,
+            quantile,
+            epsilon,
+            solver_iterations,
+        ),
+        "transport_diagnostics": _transport_diagnostics(
+            residuals,
+            epsilon,
+            solver_iterations,
+        ),
+        "physical_metrics": physical_metrics,
+        "initial_physical_metrics": initial_physical_metrics,
+        "parameters": [float(value) for value in parameters],
+    }
+
+
+def _summary(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    groups = sorted(
+        {
+            (record["workload"], record["method"])
+            for record in records
+            if record["status"] == "ok"
+        }
+    )
+    result = []
+    for workload, method in groups:
+        group = [
+            record
+            for record in records
+            if record["status"] == "ok"
+            and record["workload"] == workload
+            and record["method"] == method
+        ]
+        hard_quantiles = [record["final_hard_quantile"] for record in group]
+        initial_quantiles = [record["initial_hard_quantile"] for record in group]
+        hard_cvars = [record["final_hard_cvar"] for record in group]
+        maxima = [record["final_maximum_residual"] for record in group]
+        training_times = [record["total_training_ms"] for record in group]
+        count = len(group)
+        mean_quantile = sum(hard_quantiles) / count
+        variance = sum((value - mean_quantile) ** 2 for value in hard_quantiles) / count
+        physical_metric_means = {
+            name: sum(record["physical_metrics"][name] for record in group) / count
+            for name in group[0]["physical_metrics"]
+        }
+        result.append(
+            {
+                "workload": workload,
+                "method": method,
+                "successful_seeds": count,
+                "mean_initial_hard_quantile": sum(initial_quantiles) / count,
+                "mean_final_hard_quantile": mean_quantile,
+                "mean_hard_quantile_improvement": (
+                    sum(initial_quantiles) / count - mean_quantile
+                ),
+                "std_final_hard_quantile": variance**0.5,
+                "mean_final_hard_cvar": sum(hard_cvars) / count,
+                "mean_final_maximum_residual": sum(maxima) / count,
+                "mean_training_ms": sum(training_times) / count,
+                "mean_physical_metrics": physical_metric_means,
+                "nonfinite_gradient_count": sum(
+                    record["nonfinite_gradient_count"] for record in group
+                ),
+            }
+        )
+    return result
+
+
+def _metadata() -> dict[str, Any]:
+    device = jax.devices()[0]
+    return {
+        "python": platform.python_version(),
+        "jax": jax.__version__,
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+        "device": {
+            "platform": device.platform,
+            "device_kind": device.device_kind,
+            "id": device.id,
+        },
+    }
+
+
+def main() -> None:
+    arguments = _parser().parse_args()
+    _validate(arguments)
+    size = 12 if arguments.smoke else int(arguments.size)
+    steps = 2 if arguments.smoke else int(arguments.steps)
+    seeds = (0,) if arguments.smoke else tuple(arguments.seeds)
+    dtype = _DTYPES[arguments.dtype]
+    records: list[dict[str, Any]] = []
+
+    for problem in _problems(size, dtype):
+        for method in arguments.methods:
+            for seed in seeds:
+                records.append(
+                    _train(
+                        problem,
+                        method,
+                        seed=seed,
+                        quantile=float(arguments.quantile),
+                        epsilon=float(arguments.epsilon),
+                        solver_iterations=int(arguments.sinkhorn_iterations),
+                        logsumexp_temperature=float(
+                            arguments.logsumexp_temperature
+                        ),
+                        learning_rate=float(arguments.learning_rate),
+                        steps=steps,
+                    )
+                )
+
+    payload = {
+        "schema": "phydrax.soft-quantile-objectives.v1",
+        "metadata": _metadata(),
+        "configuration": {
+            "methods": list(arguments.methods),
+            "size": size,
+            "quantile": float(arguments.quantile),
+            "epsilon": float(arguments.epsilon),
+            "sinkhorn_iterations": int(arguments.sinkhorn_iterations),
+            "logsumexp_temperature": float(arguments.logsumexp_temperature),
+            "learning_rate": float(arguments.learning_rate),
+            "steps": steps,
+            "seeds": list(seeds),
+            "dtype": arguments.dtype,
+            "smoke": bool(arguments.smoke),
+        },
+        "records": records,
+        "summary": _summary(records),
+    }
+    rendered = json.dumps(payload, indent=2, sort_keys=True)
+    if arguments.output is not None:
+        arguments.output.parent.mkdir(parents=True, exist_ok=True)
+        arguments.output.write_text(rendered + "\n", encoding="utf-8")
+    print(rendered)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/soft_transport_benchmarks.py
+++ b/tools/soft_transport_benchmarks.py
@@ -6,91 +6,637 @@ from __future__ import annotations
 
 import argparse
 import json
+import platform
+import sys
 import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
 
+import coordax as cx
 import jax
 import jax.numpy as jnp
 
 import phydrax as phx
 
 
+_OPERATIONS = ("sort", "rank", "topk", "quantile")
+_WORKLOADS = (
+    "sinusoidal",
+    "nearly-tied",
+    "repeated",
+    "heavy-tailed",
+    "nonuniform-zero-weight",
+    "batched",
+    "named-field",
+)
+_DTYPES = {"float32": jnp.float32, "float64": jnp.float64}
+_QUANTILES = jnp.asarray([0.1, 0.5, 0.9])
+
+
+@dataclass(frozen=True)
+class _Workload:
+    values: jax.Array
+    weights: jax.Array | None
+    named: bool
+
+
+@dataclass(frozen=True)
+class _Case:
+    operation: str
+    size: int
+    epsilon: float
+    block_size: int | None
+    dtype_name: str
+    workload: str
+
+
+def _block_size(value: str) -> int | None:
+    if value.lower() in ("dense", "none"):
+        return None
+    size = int(value)
+    if size < 1:
+        raise argparse.ArgumentTypeError("block sizes must be positive or 'dense'.")
+    return size
+
+
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Benchmark differentiable native transport ordering operators."
+        description="Benchmark native differentiable transport ordering operators."
+    )
+    parser.add_argument(
+        "--operations",
+        nargs="+",
+        choices=_OPERATIONS,
+        default=_OPERATIONS,
     )
     parser.add_argument("--sizes", type=int, nargs="+", default=(64, 256, 1024))
-    parser.add_argument("--epsilon", type=float, default=0.1)
+    parser.add_argument(
+        "--epsilons",
+        type=float,
+        nargs="+",
+        default=(0.2, 0.1, 0.05, 0.02),
+    )
+    parser.add_argument(
+        "--block-sizes",
+        type=_block_size,
+        nargs="+",
+        default=(None, 64, 128),
+        metavar="{dense,N}",
+    )
+    parser.add_argument(
+        "--dtypes",
+        nargs="+",
+        choices=tuple(_DTYPES),
+        default=tuple(_DTYPES),
+    )
+    parser.add_argument(
+        "--workloads",
+        nargs="+",
+        choices=_WORKLOADS,
+        default=_WORKLOADS,
+    )
+    parser.add_argument("--warmups", type=int, default=1)
     parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument(
+        "--max-pairs",
+        type=int,
+        default=None,
+        help="Explicit resource limit; skipped cases remain in JSON records.",
+    )
     parser.add_argument("--smoke", action="store_true")
     return parser
 
 
-def _record(size: int, epsilon: float, repeats: int):
-    values = jnp.sin(jnp.arange(size, dtype=float) * 1.61803398875)
-    sort = jax.jit(lambda candidate: phx.transport.soft_sort(candidate, epsilon=epsilon))
+def _validate_arguments(arguments: argparse.Namespace) -> None:
+    if any(size < 2 for size in arguments.sizes):
+        raise ValueError("sizes must contain integers of at least two.")
+    if any(not jnp.isfinite(value) or value <= 0.0 for value in arguments.epsilons):
+        raise ValueError("epsilons must be finite and positive.")
+    if arguments.warmups < 0:
+        raise ValueError("warmups must be nonnegative.")
+    if arguments.repeats < 1:
+        raise ValueError("repeats must be positive.")
+    if arguments.max_pairs is not None and arguments.max_pairs < 1:
+        raise ValueError("max-pairs must be positive or omitted.")
 
-    started = time.perf_counter()
-    ordered = sort(values)
-    jax.block_until_ready(ordered)
-    compile_first_ms = 1e3 * (time.perf_counter() - started)
 
-    started = time.perf_counter()
+def _normal_cases(arguments: argparse.Namespace) -> list[_Case]:
+    return [
+        _Case(operation, size, epsilon, block_size, dtype_name, workload)
+        for operation in arguments.operations
+        for size in arguments.sizes
+        for epsilon in arguments.epsilons
+        for block_size in arguments.block_sizes
+        for dtype_name in arguments.dtypes
+        for workload in arguments.workloads
+    ]
+
+
+def _smoke_cases() -> list[_Case]:
+    return [
+        _Case("sort", 8, 0.2, None, "float32", "sinusoidal"),
+        _Case("rank", 8, 0.2, 4, "float32", "nearly-tied"),
+        _Case("topk", 8, 0.2, None, "float32", "nonuniform-zero-weight"),
+        _Case("quantile", 8, 0.2, 4, "float32", "named-field"),
+    ]
+
+
+def _workload(name: str, size: int, dtype: jnp.dtype, seed: int) -> _Workload:
+    index = jnp.arange(size, dtype=dtype)
+    phase = jnp.asarray(1.61803398875, dtype=dtype) * index
+    base = jnp.sin(phase) + jnp.asarray(0.1, dtype=dtype) * jnp.cos(0.37 * phase)
+
+    if name == "sinusoidal":
+        return _Workload(base, None, False)
+    if name == "nearly-tied":
+        scale = jnp.asarray(1e-3 if dtype == jnp.float32 else 1e-7, dtype=dtype)
+        values = jnp.ones((size,), dtype=dtype) + scale * (base + index / size)
+        return _Workload(values, None, False)
+    if name == "repeated":
+        values = jnp.mod(jnp.arange(size), min(size, 8)).astype(dtype)
+        return _Workload(values, None, False)
+    if name == "heavy-tailed":
+        key = jax.random.fold_in(jax.random.key(seed), size)
+        uniform = jax.random.uniform(
+            key,
+            (size,),
+            dtype=dtype,
+            minval=jnp.asarray(1e-3, dtype=dtype),
+            maxval=jnp.asarray(1.0 - 1e-3, dtype=dtype),
+        )
+        values = jnp.tan(jnp.pi * (uniform - 0.5))
+        return _Workload(values, None, False)
+    if name == "nonuniform-zero-weight":
+        weights = 1.0 + jnp.mod(jnp.arange(size), 11).astype(dtype)
+        weights = jnp.where(jnp.mod(jnp.arange(size), 7) == 0, 0.0, weights)
+        return _Workload(base, weights, False)
+    if name == "batched":
+        values = jnp.stack((base, base + 0.2, -0.7 * base + 0.4))
+        return _Workload(values, None, False)
+    if name == "named-field":
+        values = jnp.stack((base, jnp.roll(base, 1)))
+        return _Workload(values, None, True)
+    raise ValueError(f"Unsupported workload {name!r}.")
+
+
+def _solver(epsilon: float, block_size: int | None) -> phx.transport.Sinkhorn:
+    return phx.transport.Sinkhorn(
+        epsilon,
+        max_iterations=300,
+        min_iterations=1,
+        tolerance=1e-7,
+        check_every=5,
+        block_size=block_size,
+        early_stop=False,
+        store_history=False,
+    )
+
+
+def _operation(
+    case: _Case,
+    workload: _Workload,
+    solver: phx.transport.Sinkhorn,
+):
+    count = case.size
+    selected = max(1, count // 4)
+
+    def apply(values):
+        if workload.named:
+            value = cx.Field(values, dims=("case", "sample"))
+            weights = (
+                None
+                if workload.weights is None
+                else cx.Field(workload.weights, dims=("case", "sample"))
+            )
+            axis: int | str = "sample"
+        else:
+            value = values
+            weights = workload.weights
+            axis = -1
+
+        if case.operation == "sort":
+            output = phx.transport.soft_sort(
+                value,
+                weights=weights,
+                axis=axis,
+                solver=solver,
+            )
+        elif case.operation == "rank":
+            output = phx.transport.soft_rank(
+                value,
+                weights=weights,
+                axis=axis,
+                solver=solver,
+            )
+        elif case.operation == "topk":
+            output = phx.transport.soft_topk_mask(
+                value,
+                selected,
+                weights=weights,
+                axis=axis,
+                solver=solver,
+            )
+        else:
+            output = phx.transport.soft_quantile(
+                value,
+                _QUANTILES.astype(values.dtype),
+                weights=weights,
+                axis=axis,
+                solver=solver,
+                quantile_dim="quantile",
+            )
+        return output.data if isinstance(output, cx.Field) else output
+
+    return apply
+
+
+def _block(value: Any) -> Any:
+    return jax.tree.map(lambda leaf: leaf.block_until_ready(), value)
+
+
+def _compile(function, example: jax.Array):
+    started = time.perf_counter_ns()
+    compiled = jax.jit(function).lower(example).compile()
+    elapsed_ms = (time.perf_counter_ns() - started) / 1e6
+    return compiled, elapsed_ms
+
+
+def _execute(compiled, example: jax.Array):
+    started = time.perf_counter_ns()
+    result = _block(compiled(example))
+    elapsed_ms = (time.perf_counter_ns() - started) / 1e6
+    return result, elapsed_ms
+
+
+def _steady_ms(compiled, example: jax.Array, warmups: int, repeats: int) -> float:
+    for _ in range(warmups):
+        _block(compiled(example))
+    started = time.perf_counter_ns()
     for _ in range(repeats):
-        ordered = sort(values)
-        jax.block_until_ready(ordered)
-    steady_ms = 1e3 * (time.perf_counter() - started) / repeats
+        _block(compiled(example))
+    return (time.perf_counter_ns() - started) / (1e6 * repeats)
 
-    gradient_function = jax.jit(
-        jax.grad(
-            lambda candidate: jnp.sum(
-                phx.transport.soft_sort(candidate, epsilon=epsilon) ** 2
+
+def _memory(compiled) -> dict[str, int | str]:
+    analysis = compiled.memory_analysis()
+    if analysis is None:
+        return {"status": "unavailable"}
+    return {
+        "status": "available",
+        "generated_code_bytes": int(analysis.generated_code_size_in_bytes),
+        "argument_bytes": int(analysis.argument_size_in_bytes),
+        "output_bytes": int(analysis.output_size_in_bytes),
+        "alias_bytes": int(analysis.alias_size_in_bytes),
+        "temporary_bytes": int(analysis.temp_size_in_bytes),
+        "host_generated_code_bytes": int(analysis.host_generated_code_size_in_bytes),
+        "host_argument_bytes": int(analysis.host_argument_size_in_bytes),
+        "host_output_bytes": int(analysis.host_output_size_in_bytes),
+        "host_alias_bytes": int(analysis.host_alias_size_in_bytes),
+        "host_temporary_bytes": int(analysis.host_temp_size_in_bytes),
+    }
+
+
+def _rows(values: jax.Array, size: int) -> jax.Array:
+    return values.reshape((-1, size))
+
+
+def _weight_rows(workload: _Workload, size: int) -> jax.Array:
+    rows = _rows(workload.values, size)
+    if workload.weights is None:
+        return jnp.ones_like(rows)
+    return jnp.broadcast_to(workload.weights, workload.values.shape).reshape((-1, size))
+
+
+def _hard_output(case: _Case, workload: _Workload) -> jax.Array:
+    rows = _rows(workload.values, case.size)
+    weights = _weight_rows(workload, case.size)
+    target_index = jnp.arange(case.size, dtype=workload.values.dtype)
+    target_lower = target_index / case.size
+    target_upper = (target_index + 1.0) / case.size
+
+    def hard_row(row, row_weights):
+        probabilities = row_weights / jnp.sum(row_weights)
+        active = probabilities > 0.0
+        order = jnp.argsort(jnp.where(active, row, jnp.inf), stable=True)
+        ordered_values = row[order]
+        ordered_probabilities = probabilities[order]
+        source_upper = jnp.cumsum(ordered_probabilities)
+        source_lower = source_upper - ordered_probabilities
+        overlap = jnp.maximum(
+            0.0,
+            jnp.minimum(source_upper[:, None], target_upper[None, :])
+            - jnp.maximum(source_lower[:, None], target_lower[None, :]),
+        )
+
+        if case.operation == "sort":
+            return case.size * jnp.sum(
+                overlap * ordered_values[:, None],
+                axis=0,
+            )
+
+        target_payload = target_index
+        if case.operation == "topk":
+            selected = max(1, case.size // 4)
+            target_payload = target_index >= case.size - selected
+        source_payload = jnp.sum(
+            overlap * target_payload.astype(row.dtype)[None, :],
+            axis=1,
+        )
+        safe_probabilities = jnp.where(
+            ordered_probabilities > 0.0,
+            ordered_probabilities,
+            1.0,
+        )
+        source_payload = jnp.where(
+            ordered_probabilities > 0.0,
+            source_payload / safe_probabilities,
+            0.0,
+        )
+        restored = jnp.zeros_like(row).at[order].set(source_payload)
+        if case.operation in ("rank", "topk"):
+            return restored
+
+        sorted_values = case.size * jnp.sum(
+            overlap * ordered_values[:, None],
+            axis=0,
+        )
+        quantiles = _QUANTILES.astype(row.dtype)
+        result = jnp.interp(
+            quantiles * (case.size - 1),
+            target_index,
+            sorted_values,
+        )
+        lower = jnp.min(jnp.where(active, row, jnp.inf))
+        upper = jnp.max(jnp.where(active, row, -jnp.inf))
+        result = jnp.where(quantiles == 0.0, lower, result)
+        return jnp.where(quantiles == 1.0, upper, result)
+
+    result = jax.vmap(hard_row)(rows, weights)
+    leading = workload.values.shape[:-1]
+    return result.reshape(leading + result.shape[1:])
+
+
+def _accuracy(
+    case: _Case,
+    workload: _Workload,
+    output: jax.Array,
+) -> dict[str, float | int | None]:
+    hard = _hard_output(case, workload)
+    denominator = jnp.maximum(jnp.linalg.norm(hard), jnp.asarray(1e-12))
+    relative_error = jnp.linalg.norm(output - hard) / denominator
+    values = _rows(workload.values, case.size)
+    output_rows = output.reshape((values.shape[0], -1))
+    tolerance = 10.0 * jnp.finfo(workload.values.dtype).eps
+    weights = _weight_rows(workload, case.size)
+    active = weights > 0.0
+
+    if case.operation == "sort":
+        monotonicity = jnp.sum(jnp.diff(output_rows, axis=-1) < -tolerance)
+        lower = jnp.min(jnp.where(active, values, jnp.inf), axis=-1, keepdims=True)
+        upper = jnp.max(jnp.where(active, values, -jnp.inf), axis=-1, keepdims=True)
+        range_violations = jnp.sum(
+            (output_rows < lower - tolerance) | (output_rows > upper + tolerance)
+        )
+    elif case.operation == "quantile":
+        monotonicity = jnp.sum(jnp.diff(output_rows, axis=-1) < -tolerance)
+        lower = jnp.min(jnp.where(active, values, jnp.inf), axis=-1, keepdims=True)
+        upper = jnp.max(jnp.where(active, values, -jnp.inf), axis=-1, keepdims=True)
+        range_violations = jnp.sum(
+            (output_rows < lower - tolerance) | (output_rows > upper + tolerance)
+        )
+    else:
+        order = jnp.argsort(jnp.where(active, values, jnp.inf), axis=-1, stable=True)
+        ordered_output = jnp.take_along_axis(output_rows, order, axis=-1)
+        ordered_weights = jnp.take_along_axis(weights, order, axis=-1)
+        active_pairs = (ordered_weights[:, :-1] > 0.0) & (
+            ordered_weights[:, 1:] > 0.0
+        )
+        monotonicity = jnp.sum(
+            active_pairs & (jnp.diff(ordered_output, axis=-1) < -tolerance)
+        )
+        maximum = float(case.size - 1) if case.operation == "rank" else 1.0
+        range_violations = jnp.sum(
+            (output_rows < -tolerance) | (output_rows > maximum + tolerance)
+        )
+
+    rank_sum_error: float | None = None
+    if case.operation == "rank":
+        probabilities = weights / jnp.sum(weights, axis=-1, keepdims=True)
+        expected = 0.5 * (case.size - 1)
+        conserved = jnp.sum(probabilities * output_rows, axis=-1)
+        rank_sum_error = float(jnp.max(jnp.abs(conserved - expected)))
+
+    topk_mass_error: float | None = None
+    if case.operation == "topk":
+        selected = max(1, case.size // 4)
+        probabilities = weights / jnp.sum(weights, axis=-1, keepdims=True)
+        conserved = jnp.sum(probabilities * output_rows, axis=-1)
+        topk_mass_error = float(jnp.max(jnp.abs(conserved - selected / case.size)))
+
+    return {
+        "relative_hard_error": float(relative_error),
+        "monotonicity_violations": int(monotonicity),
+        "range_violations": int(range_violations),
+        "rank_sum_error": rank_sum_error,
+        "topk_mass_error": topk_mass_error,
+    }
+
+
+def _convergence(
+    workload: _Workload,
+    size: int,
+    solver: phx.transport.Sinkhorn,
+) -> dict[str, Any]:
+    values = _rows(workload.values, size)
+    weights = _weight_rows(workload, size)
+    solve = jax.jit(
+        jax.vmap(
+            lambda row, row_weights: phx.transport.soft_order_transport(
+                row,
+                weights=row_weights,
+                solver=solver,
             )
         )
     )
-    gradient = gradient_function(values)
-    jax.block_until_ready(gradient)
-    started = time.perf_counter()
-    gradient = gradient_function(values)
-    jax.block_until_ready(gradient)
-    backward_ms = 1e3 * (time.perf_counter() - started)
-
-    hard = jnp.sort(values)
-    ranks = phx.transport.soft_rank(values, epsilon=epsilon)
-    quantiles = phx.transport.soft_quantile(
-        values,
-        jnp.asarray([0.1, 0.5, 0.9]),
-        epsilon=epsilon,
-    )
+    result = _block(solve(values, weights))
+    diagnostics = result.diagnostics
     return {
-        "size": size,
-        "epsilon": epsilon,
-        "compile_first_ms": compile_first_ms,
-        "steady_ms": steady_ms,
-        "backward_ms": backward_ms,
-        "relative_hard_error": float(
-            jnp.linalg.norm(ordered - hard) / jnp.maximum(jnp.linalg.norm(hard), 1e-12)
+        "all_converged": bool(jnp.all(result.converged)),
+        "status_codes": [int(value) for value in diagnostics.status],
+        "max_iterations_executed": int(jnp.max(diagnostics.num_iterations)),
+        "max_normalized_marginal_residual": float(
+            jnp.max(diagnostics.normalized_marginal_residual)
         ),
-        "monotonicity_violations": int(jnp.sum(jnp.diff(ordered) < 0.0)),
-        "range_violations": int(
-            jnp.sum((ordered < jnp.min(values)) | (ordered > jnp.max(values)))
+        "max_physical_marginal_residual": float(
+            jnp.max(diagnostics.physical_marginal_residual)
         ),
-        "rank_sum_error": float(
-            jnp.abs(jnp.sum(ranks) - 0.5 * size * (size - 1))
-        ),
-        "quantiles": [float(value) for value in quantiles],
+    }
+
+
+def _identity(case: _Case) -> dict[str, Any]:
+    return {
+        "operation": case.operation,
+        "size": case.size,
+        "epsilon": case.epsilon,
+        "block_size": case.block_size,
+        "execution": "dense" if case.block_size is None else "blockwise",
+        "dtype": case.dtype_name,
+        "workload": case.workload,
+    }
+
+
+def _record(case: _Case, *, seed: int, warmups: int, repeats: int) -> dict[str, Any]:
+    dtype = _DTYPES[case.dtype_name]
+    workload = _workload(case.workload, case.size, dtype, seed)
+    solver = _solver(case.epsilon, case.block_size)
+    operation = _operation(case, workload, solver)
+    values = workload.values
+
+    forward, forward_compile_ms = _compile(operation, values)
+    output, first_forward_ms = _execute(forward, values)
+    steady_forward_ms = _steady_ms(forward, values, warmups, repeats)
+
+    def objective(candidate):
+        transformed = operation(candidate)
+        coefficients = jnp.linspace(
+            0.5,
+            1.5,
+            transformed.size,
+            dtype=transformed.dtype,
+        ).reshape(transformed.shape)
+        return jnp.sum(coefficients * transformed)
+
+    reverse, reverse_compile_ms = _compile(jax.grad(objective), values)
+    gradient, first_reverse_ms = _execute(reverse, values)
+    steady_reverse_ms = _steady_ms(reverse, values, warmups, repeats)
+
+    direction = jnp.cos(jnp.arange(values.size, dtype=dtype)).reshape(values.shape)
+
+    def jvp(candidate):
+        return jax.jvp(operation, (candidate,), (direction,))[1]
+
+    forward_mode, jvp_compile_ms = _compile(jvp, values)
+    tangent, first_jvp_ms = _execute(forward_mode, values)
+    steady_jvp_ms = _steady_ms(forward_mode, values, warmups, repeats)
+
+    return {
+        **_identity(case),
+        "status": "ok",
+        "seed": seed,
+        "warmups": warmups,
+        "repeats": repeats,
+        "timing_ms": {
+            "forward_compile": forward_compile_ms,
+            "first_forward_execution": first_forward_ms,
+            "steady_forward": steady_forward_ms,
+            "reverse_compile": reverse_compile_ms,
+            "first_reverse_execution": first_reverse_ms,
+            "steady_reverse": steady_reverse_ms,
+            "jvp_compile": jvp_compile_ms,
+            "first_jvp_execution": first_jvp_ms,
+            "steady_jvp": steady_jvp_ms,
+        },
+        "compiled_memory": _memory(forward),
+        "convergence": _convergence(workload, case.size, solver),
+        "accuracy": _accuracy(case, workload, output),
         "gradient_norm": float(jnp.linalg.norm(gradient)),
+        "nonfinite_gradient_count": int(jnp.sum(~jnp.isfinite(gradient))),
+        "jvp_norm": float(jnp.linalg.norm(tangent)),
+        "nonfinite_jvp_count": int(jnp.sum(~jnp.isfinite(tangent))),
+    }
+
+
+def _metadata() -> dict[str, Any]:
+    devices = [
+        {
+            "id": device.id,
+            "platform": device.platform,
+            "device_kind": device.device_kind,
+            "process_index": device.process_index,
+        }
+        for device in jax.devices()
+    ]
+    return {
+        "python": platform.python_version(),
+        "jax": jax.__version__,
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+        "byteorder": sys.byteorder,
+        "default_backend": jax.default_backend(),
+        "jax_enable_x64": bool(jax.config.read("jax_enable_x64")),
+        "devices": devices,
     }
 
 
 def main() -> None:
     arguments = _parser().parse_args()
-    sizes = (8, 16) if arguments.smoke else tuple(arguments.sizes)
+    _validate_arguments(arguments)
+    cases = _smoke_cases() if arguments.smoke else _normal_cases(arguments)
+    warmups = 0 if arguments.smoke else int(arguments.warmups)
     repeats = 1 if arguments.smoke else int(arguments.repeats)
-    records = [
-        _record(size, float(arguments.epsilon), repeats)
-        for size in sizes
-    ]
-    print(json.dumps({"records": records}, indent=2, sort_keys=True))
+    records: list[dict[str, Any]] = []
+
+    for case in cases:
+        if (
+            arguments.max_pairs is not None
+            and case.size * case.size > arguments.max_pairs
+        ):
+            records.append(
+                {
+                    **_identity(case),
+                    "status": "resource-limit",
+                    "reason": (
+                        f"size^2={case.size * case.size} exceeds explicit "
+                        f"max_pairs={arguments.max_pairs}"
+                    ),
+                }
+            )
+            continue
+        try:
+            records.append(
+                _record(
+                    case,
+                    seed=int(arguments.seed),
+                    warmups=warmups,
+                    repeats=repeats,
+                )
+            )
+        except Exception as error:
+            records.append(
+                {
+                    **_identity(case),
+                    "status": "failed",
+                    "error_type": type(error).__name__,
+                    "error": str(error),
+                }
+            )
+
+    payload = {
+        "schema": "phydrax.soft-order-benchmark.v1",
+        "metadata": _metadata(),
+        "configuration": {
+            "smoke": bool(arguments.smoke),
+            "operations": list(arguments.operations),
+            "sizes": list(arguments.sizes),
+            "epsilons": list(arguments.epsilons),
+            "block_sizes": list(arguments.block_sizes),
+            "dtypes": list(arguments.dtypes),
+            "workloads": list(arguments.workloads),
+            "warmups": warmups,
+            "repeats": repeats,
+            "seed": int(arguments.seed),
+            "max_pairs": arguments.max_pairs,
+        },
+        "records": records,
+    }
+    rendered = json.dumps(payload, indent=2, sort_keys=True)
+    if arguments.output is not None:
+        arguments.output.parent.mkdir(parents=True, exist_ok=True)
+        arguments.output.write_text(rendered + "\n", encoding="utf-8")
+    print(rendered)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This PR introduces a fast, explicitly unweighted differentiable sorting/ranking backend; corrects the canonical geometry and reconstruction contract of weighted Sinkhorn ordering; hardens the existing ML soft-discrete and soft-quantile semantics; and makes the boundaries between these mathematically different relaxations explicit throughout the API and documentation.

## Motivation

Phydrax already had several differentiable relaxations, but they answered different scientific questions and did not share interchangeable semantics:

- weighted entropic ordering over empirical measures;
- lightweight pairwise ranking losses in the ML layer;
- relaxed feature-selection gates;
- soft empirical quantiles used as scientific objectives;
- smooth CSG geometry approximations.

A broad SoftJAX dependency or drop-in `mode=` abstraction would collapse those distinctions. It would also narrow Phydrax's Python support and couple the package to an additional optimization/transport stack.

This change instead preserves each mathematical contract and adds only the missing formulation that demonstrated a clear Phydrax use case: fast unweighted ordering via an L2 permutahedron projection.

## Core changes

### 1. Fast unweighted differentiable ordering

Adds two public APIs:

- `phydrax.transport.fast_soft_sort`
- `phydrax.transport.fast_soft_rank`

The implementation follows Blondel, Teboul, Berthet, and Djolonga's fast differentiable sorting/ranking formulation:

- stable sorting followed by an L2 permutahedron projection;
- a pool-adjacent-violators stack with O(n) working state;
- O(n log n) total work, dominated by sorting;
- a custom JVP that differentiates block averages over the active PAV partition;
- forward-, JVP-, reverse-mode, `jit`, and `vmap` compatibility;
- raw array axes and named `coordax.Field` dimensions;
- ascending and descending variants;
- input dtype preservation for floating inputs.

Rows are centered and variance-standardized before projection, making `temperature` dimensionless. Constant rows remain finite. The resulting contracts are intentionally narrow:

- `fast_soft_sort` returns monotone relaxed values and preserves the unweighted sum;
- `fast_soft_rank` returns zero-based ranks in `[0, n - 1]` with sum `n × (n - 1) / 2`;
- neither API accepts weights, returns a coupling, transports payloads, or reports solver diagnostics;
- the map is continuous and piecewise smooth, not globally smooth.

This remains a separate backend rather than a hidden `method=` branch on the weighted Sinkhorn API.

### 2. Canonical weighted Sinkhorn ordering

`soft_order_transport` remains the general finite-measure ordering primitive and now exposes a precise dimensionless geometry:

1. normalize source weights into probabilities;
2. compute the weighted center and weighted variance scale;
3. map standardized values through a sigmoid to canonical source locations;
4. construct target locations from cumulative-probability bin midpoints;
5. solve the monotone entropic transport problem in that canonical geometry.

The returned transport result retains source and target supports, masses, coupling, convergence evidence, and explicit provenance identifiers:

- `soft-order-source:weighted-standardize-sigmoid`
- `soft-order-target:probability-midpoints`

Physical sorted values are reconstructed by transporting the original values as payloads through `result.barycentric_source_to_target(values)`. The implementation deliberately removes the prior numerical inverse-sigmoid reconstruction: without the original payload, the canonical transport result makes no physical-value reconstruction claim.

The API also makes solver precedence explicit. A supplied `solver=` owns epsilon, iteration limits, tolerances, block size, and differentiation behavior; the convenience `epsilon=` argument configures only the default solver.

### 3. Explicit rank, top-k, and quantile semantics

The public guidance now distinguishes the available families instead of implying artificial equivalence:

| API family | Mathematical object | Rank convention | Weight semantics |
| --- | --- | --- | --- |
| `phydrax.ml.soft_ranks` | pairwise logistic comparisons | one-based | unweighted |
| `phydrax.ml.soft_topk_weights` | logistic membership gate | not a rank output | unweighted |
| `phydrax.transport.fast_soft_rank` | L2 permutahedron projection | zero-based | unweighted |
| `phydrax.transport.soft_rank` | Sinkhorn barycentric rank | zero-based | weighted empirical measure |
| `phydrax.transport.soft_topk_mask` | transported top-bin membership | not a rank output | coupling-preserving weighted mass |

Additional hardening covers:

- empty-mask behavior for masked softmax;
- temperature-softmax and temperature-sigmoid boundaries;
- Gumbel-softmax replay and key sensitivity;
- one-based pairwise rank invariants;
- separate rank and gate temperatures for relaxed top-k feature selection;
- finite gradients and explicit rejection of invalid values, axes, and dtypes;
- exact quantile endpoint masks and the effective transport epsilon in diagnostics;
- accurate gradient contracts for conditionally differentiable feature-selection gates.

No API hardens its forward value or installs a straight-through gradient.

### 4. Scientific-objective and geometry policy

The new benchmark harnesses separate three questions that should not be conflated:

- approximation quality and transformation invariants of ordering operators;
- performance scaling of dense Sinkhorn and fast PAV ordering;
- downstream scientific behavior of soft empirical-quantile objectives.

`tools/soft_quantile_objective_benchmarks.py` compares soft quantiles, hard quantiles, log-sum-exp tails, and hard CVaR across deterministic heavy-tail, localized Poisson-residual, and heteroskedastic ensemble workloads. It reports terminal hard-tail metrics, physical metrics, gradient finiteness, solver diagnostics, compilation/execution cost, and retained memory.

The CSG benchmark guidance similarly treats blend width as a geometry approximation parameter rather than optimizer policy. Fixed-width blend CSG solves a different geometric problem. If continuation is used, its schedule remains outside geometry and solver abstractions, and terminal metrics are evaluated on the sharp geometry.

### 5. Integration hardening

The repository-wide validation exposed several adjacent issues, fixed here so the complete branch remains internally coherent:

- finite-feature kernel composition now dispatches through `InputTransformedKernel._transform_input` and respects arbitrary declared input rank;
- lattice-equivariant CNO layers disable affine bias automatically when a hidden layout has no ordinary scalar channel;
- operator architecture tier expectations include the current recurrent, weight-space, and lattice-equivariant models;
- runtime validation assertions accept the current JAX/Equinox callback wrapper while retaining message checks;
- parameter-subspace and graph spectral-GP documentation examples are complete and executable;
- pytest uses importlib mode so same-named modules in separate test domains cannot collide during distributed collection.

## API and compatibility impact

- Adds `fast_soft_sort` and `fast_soft_rank` to `phydrax.transport`.
- Retains the existing weighted soft-order API names while correcting and documenting their canonicalization and reconstruction semantics.
- Adds no runtime dependency.
- Preserves Phydrax's existing Python support range.
- Keeps `coordax.Field` named-axis behavior and caller dimension order.
- Keeps weighted Sinkhorn ordering as the required path for nonuniform weights, zero-mass atoms, reusable couplings, payload transport, convergence evidence, and scientific finite-measure semantics.

## Deliberate non-goals

This PR does **not** add:

- generic hard/smooth/regularizer mode dispatch;
- straight-through estimators;
- a weighted PAV approximation;
- a generic relaxed random-sampling namespace;
- numerical inverse-sigmoid payload reconstruction;
- automatic CSG smoothing or continuation policy;
- a replacement for the weighted Sinkhorn ordering family.

## Review guide

A useful review order is:

1. `phydrax/transport/_fast_order.py` for the PAV projection and custom JVP;
2. `phydrax/transport/_soft.py` and `_results.py` for canonical weighted transport and payload reconstruction;
3. `phydrax/ml/_soft_discrete.py`, feature selection, and transport terms for semantic hardening;
4. `tools/fast_order_benchmarks.py`, `tools/soft_transport_benchmarks.py`, and `tools/soft_quantile_objective_benchmarks.py` for the evaluation contracts;
5. `docs/api/transport/soft.md`, `docs/guides_transport.md`, and `docs/appendix/ml_differentiability.md` for the public mathematical boundaries.

## Attribution

The fast unweighted formulation is based on [Fast Differentiable Sorting and Ranking](https://arxiv.org/abs/2002.08871) and the Apache-2.0 Google reference implementation. The broader design evaluation drew on [SoftJAX](https://github.com/a-paulus/softjax) and its accompanying [paper](https://arxiv.org/abs/2603.08824).