### PR TITLE
Add native exponential-family geometry and conjugate inference

### DIFF
--- a/docs/all-of-phydrax.md
+++ b/docs/all-of-phydrax.md
@@ -136,6 +136,12 @@ errors-in-variables likelihoods account jointly for uncertain predictors and
 observations. Probability domains, static random fields, and joint QMC propagate
 full uncertain-input distributions. Global Wiener, Poisson-clock, composite, and
 coefficient-process realizations provide replayable process paths.
+
+Regular Bernoulli, Poisson, exponential-rate, and Normal families expose typed natural
+and mean coordinates, normalized laws, weighted sufficient-statistic projection, and
+exact matrix-free Fisher pullbacks. Boundary maximum-likelihood estimates and invalid
+support or weight inputs remain explicit statuses rather than clipped parameters.
+
 State-space inference binds each physical case and schedule step to one canonical
 `StateSpaceStepContext`. `SampledStateSpaceInput` and `BSplineStateSpaceInput`
 provide case-indexed exogenous signals with explicit support, breakpoint masks,

--- a/docs/api/uq/exponential_families.md
+++ b/docs/api/uq/exponential_families.md
@@ -1,0 +1,416 @@
+# Exponential families
+
+Phydrax represents a regular exponential family by the normalized density
+
+`log p(x; η) = ⟨η, T(x)⟩ - A(η) + log h(x)`
+
+relative to an explicit reference measure. `NaturalCoordinates`, `MeanCoordinates`,
+and `StatisticBatch` are different semantic objects even when their arrays have the
+same shape:
+
+- `NaturalCoordinates.values` contains `η`.
+- `MeanCoordinates.values` contains `μ = Eη[T(X)] = ∇A(η)`.
+- `StatisticBatch.values` contains realized sufficient statistics `T(x)` and a
+  support-validity mask.
+
+The final axis is always the intrinsic statistic dimension. All preceding axes are
+batch axes. A static `ExponentialFamilySignature` records the family, intrinsic
+dimension, event shape, density measure, support, and coordinate chart. Operations
+such as KL divergence reject mismatched signatures rather than combining arrays that
+happen to have equal shapes.
+
+## Supported families
+
+| Family | Reference measure | Natural coordinate | Sufficient statistic |
+| --- | --- | --- | --- |
+| `BernoulliFamily` | counting | log odds | `x` |
+| `CategoricalFamily(K)` | counting | `K - 1` log odds relative to category `K - 1` | first `K - 1` one-hot entries |
+| `PoissonFamily` | counting | log rate | `x` |
+| `ExponentialRateFamily` | Lebesgue | negative rate | `x` |
+| `GammaFamily` | Lebesgue | `(shape - 1, -rate)` | `(log(x), x)` |
+| `NormalFamily` | Lebesgue | `(location / variance, -1 / (2 variance))` | `(x, x²)` |
+| `MultivariateNormalFamily(d)` | Lebesgue | linear coordinate and orthonormal symmetric quadratic chart | `(x, svec(xxᵀ))` |
+| `DirichletFamily(K)` | simplex Hausdorff measure | `concentration - 1` | `log(x)` |
+
+A mean-domain boundary can be a valid empirical sufficient-statistic average while
+having no finite natural coordinate in the regular family. All-zero Bernoulli data,
+zero-variance Gaussian data, and a simplex point mass are examples. Phydrax returns
+`EXPONENTIAL_FAMILY_MEAN_BOUNDARY` and `valid=False`; it does not add pseudocounts,
+clip a probability, or jitter a covariance.
+
+## Normalized laws and likelihoods
+
+```python
+import jax.numpy as jnp
+import jax.random as jr
+import phydrax as phx
+
+bernoulli = phx.uq.BernoulliFamily()
+log_odds = jnp.asarray([0.4])
+law = bernoulli.law(log_odds)
+
+log_probability = law.log_prob(jnp.asarray([0.0, 1.0]))
+samples = law.sample(jr.key(1), sample_shape=(128,))
+mean = law.mean_coordinates
+```
+
+`ExponentialFamilyLaw` implements `AbstractProbabilityLaw`. It can therefore be a
+factorized `ParameterSpace` prior. A scalar law, with empty batch and event shapes, is
+applied independently to every element of an array-valued parameter leaf. A shaped
+law must have `batch_shape + event_shape` exactly equal to that leaf's shape.
+
+`ScalarNaturalExponentialFamilyLikelihood` adapts a scalar-event family with one
+natural coordinate to the existing elementwise observation-likelihood protocol. The
+model output is interpreted as the natural coordinate, not as a conventional mean or
+probability:
+
+```python
+poisson_likelihood = phx.uq.ScalarNaturalExponentialFamilyLikelihood(
+    phx.uq.PoissonFamily()
+)
+log_rate = jnp.asarray([0.0, jnp.log(2.0)])
+counts = jnp.asarray([0.0, 3.0])
+log_probability = poisson_likelihood.log_prob(log_rate, counts)
+```
+
+Use an explicit link before this adapter if a model emits conventional parameters.
+Do not pass categorical logits or the two natural coordinates of `NormalFamily`
+through the scalar adapter.
+
+`CategoricalExponentialFamilyLikelihood` takes `CategoricalFamily(K)` plus the
+required `prediction_coordinates` convention. Model output may use either `K` full
+logits (`"full_logits"`) or the identified `K - 1` natural coordinates
+(`"natural"`). Full logits are reduced by subtracting the last-category logit.
+Integer labels remain scalar events.
+
+## Weighted projection and maximum likelihood
+
+`project_exponential_family` computes sufficient statistics, combines them with
+normalized log weights through the mergeable `LogWeightedAccumulator`, classifies the
+resulting mean coordinates, and converts only interior means to natural coordinates.
+`fit_exponential_family` is the statistical-weight counterpart.
+
+```python
+observations = jnp.asarray([0.0, 1.0, 1.0, 0.0])
+log_weights = jnp.asarray([-0.4, 0.2, 0.8, -0.1])
+
+estimate = phx.uq.project_exponential_family(
+    phx.uq.BernoulliFamily(),
+    observations,
+    log_weights=log_weights,
+)
+
+assert estimate.valid
+probability = estimate.mean_coordinates.values[0]
+```
+
+For streaming or distributed data, build
+`ExponentialFamilyProjectionAccumulator.from_log_weights(...)` for each aligned
+chunk, merge the accumulators, and call `finalize()`. Merging retains the stable
+log-weight scale, effective sample size, maximum normalized weight, entropy, and
+log-weight range. One-shot and merged projections have the same estimator semantics.
+
+Numerical outcomes are explicit:
+
+- `-inf` log weight means legitimate zero weight.
+- `nan` or positive-infinite active weight returns `EXPONENTIAL_FAMILY_NONFINITE`.
+- An active observation outside support returns `EXPONENTIAL_FAMILY_INVALID_EVENT`.
+- No positive finite weight returns `EXPONENTIAL_FAMILY_INSUFFICIENT_WEIGHT`.
+- An exterior statistic mean returns `EXPONENTIAL_FAMILY_OUTSIDE_MEAN_DOMAIN`.
+- A realizable boundary mean returns `EXPONENTIAL_FAMILY_MEAN_BOUNDARY`.
+
+A mask excludes an observation before these active-observation checks. No invalid
+active datum or weight is silently discarded.
+
+## Structured and simplex-valued laws
+
+`GammaFamily` and `DirichletFamily` invert expected sufficient statistics with
+family-specific safeguarded solvers. `ExponentialFamilyConversionResult` reports the
+iteration count, residual, method identifier, and a distinct
+`EXPONENTIAL_FAMILY_NONCONVERGED` status. The solver is never a hidden fallback for
+an arbitrary family.
+
+```python
+gamma = phx.uq.GammaFamily()
+gamma_natural = gamma.natural_from_shape_rate(2.5, 1.7)
+gamma_mean = gamma.mean_from_natural(gamma_natural)
+gamma_round_trip = gamma.natural_from_mean(gamma_mean)
+
+gaussian = phx.uq.MultivariateNormalFamily(3)
+gaussian_natural = gaussian.natural_from_location_covariance(
+    jnp.zeros(3),
+    jnp.asarray([[1.0, 0.2, 0.0], [0.2, 0.8, 0.1], [0.0, 0.1, 1.2]]),
+)
+location, covariance = gaussian.location_covariance_from_natural(gaussian_natural)
+```
+
+The multivariate Normal uses the orthonormal `svec` chart: off-diagonal symmetric
+entries are scaled by the square root of two. Euclidean dot products in this chart
+therefore equal Frobenius products of symmetric matrices. No dense Fisher matrix is
+stored. `gaussian_factor_from_multivariate_normal` and
+`multivariate_normal_from_gaussian_factor` bridge the family law to the existing
+square-root `GaussianFactor` covariance representation without introducing a second
+Gaussian algebra.
+
+`DirichletFamily(K)` is normalized relative to the intrinsic Hausdorff measure on
+the `K - 1` dimensional simplex, not ambient `K` dimensional Lebesgue measure.
+`SimplexBijector(K)` maps `K - 1` additive-log-ratio coordinates to `K` positive
+components and returns the corresponding Hausdorff volume factor.
+
+```python
+simplex_family = phx.uq.DirichletFamily(4)
+simplex_prior = simplex_family.law_from_concentration(
+    jnp.asarray([1.0, 2.0, 1.5, 3.0])
+)
+simplex_space = phx.uq.ParameterSpace(
+    jnp.zeros(3),
+    priors=simplex_prior,
+    bijectors=phx.uq.SimplexBijector(4),
+)
+
+assert simplex_space.raw_shapes == ((3,),)
+assert simplex_space.physical_shapes == ((4,),)
+```
+
+`ParameterSpace` validates raw and physical leaf shapes separately. A
+shape-changing bijector is therefore explicit rather than being smuggled through a
+shape-preserving transform. Gaussian-prior whitening rejects such a leaf because its
+raw-space prior is not Gaussian.
+
+## Explicit conjugate pairs
+
+Conjugacy is represented by likelihood-prior pairs, not by a universal operation on
+natural-coordinate arrays:
+
+```python
+gamma_poisson = phx.uq.GammaPoissonConjugacy(shape=2.0, rate=1.5)
+rate_update = gamma_poisson.update(
+    jnp.asarray([0, 2, 3]),
+    exposure=jnp.asarray([1.0, 0.5, 2.0]),
+)
+
+dirichlet_categorical = phx.uq.DirichletCategoricalConjugacy(
+    jnp.asarray([1.0, 1.0, 1.0])
+)
+composition_update = dirichlet_categorical.update(
+    jnp.asarray([0, 2, 1, 2, 2])
+)
+```
+
+Each update exposes the posterior law, exact ordered-observation log evidence,
+posterior predictive probabilities or log probabilities, and mergeable sufficient
+statistics. Gamma-Poisson exposure is part of both the posterior rate and the
+Poisson base-measure term. Dirichlet-categorical evidence is for an ordered
+categorical sequence; it deliberately does not insert the multinomial coefficient
+of an unordered count observation.
+
+## Exact matrix-free information geometry
+
+For a regular family, the Fisher information in natural coordinates is the Jacobian
+of the mean map: `F(η) v = Jμ(η) v`. `exponential_family_fisher_action` evaluates this
+JVP directly. It does not construct, invert, or take a determinant of a dense Fisher
+matrix.
+
+```python
+family = phx.uq.NormalFamily()
+natural = family.natural(jnp.asarray([0.2, -0.7]))
+direction = jnp.asarray([0.4, -0.3])
+
+information_direction = phx.uq.exponential_family_fisher_action(
+    family,
+    natural,
+    direction,
+)
+```
+
+If model parameters `θ` produce natural coordinates `η(θ)`,
+`exponential_family_parameter_fisher_action` applies
+`Jη(θ)ᵀ F(η(θ)) Jη(θ) v` using one natural-map JVP, the exact family action, and one
+transpose pullback. Optional regularization adds exactly the declared parameter-space
+`regularization * v`. Both results retain operator, method, approximation, validity,
+and status provenance.
+
+## Domains and statuses
+
+Natural and mean domains are different. `natural_domain(...)` classifies whether a
+normalized finite law exists. `mean_domain(...)` additionally separates interior,
+boundary, and exterior expected-statistic coordinates. `natural_from_mean(...)`
+returns an `ExponentialFamilyConversionResult`; it never hides a boundary, invalid
+coordinate, or nonfinite analytical result.
+
+Analytical families convert directly. Gamma and Dirichlet use only their explicit,
+family-specific numerical inversion hooks. A failed numerical solve returns
+`EXPONENTIAL_FAMILY_NONCONVERGED`; it is not conflated with a boundary, an exterior
+mean, or nonfinite input.
+
+## Core contracts
+
+::: phydrax.uq.AbstractProbabilityLaw
+
+---
+
+::: phydrax.uq.AbstractExponentialFamily
+
+---
+
+::: phydrax.uq.ExponentialFamilySignature
+
+---
+
+::: phydrax.uq.NaturalCoordinates
+
+---
+
+::: phydrax.uq.MeanCoordinates
+
+---
+
+::: phydrax.uq.StatisticBatch
+
+---
+
+::: phydrax.uq.ExponentialFamilyDomainResult
+
+---
+
+::: phydrax.uq.ExponentialFamilyConversionResult
+
+---
+
+::: phydrax.uq.ExponentialFamilyLaw
+
+## Families
+
+::: phydrax.uq.BernoulliFamily
+
+---
+
+::: phydrax.uq.PoissonFamily
+
+---
+
+::: phydrax.uq.ExponentialRateFamily
+
+---
+
+::: phydrax.uq.NormalFamily
+
+---
+
+::: phydrax.uq.CategoricalFamily
+
+---
+
+::: phydrax.uq.GammaFamily
+
+---
+
+::: phydrax.uq.MultivariateNormalFamily
+
+---
+
+::: phydrax.uq.DirichletFamily
+
+## Conjugacy
+
+::: phydrax.uq.GammaPoissonConjugacy
+
+---
+
+::: phydrax.uq.GammaPoissonStatistics
+
+---
+
+::: phydrax.uq.GammaPoissonUpdate
+
+---
+
+::: phydrax.uq.DirichletCategoricalConjugacy
+
+---
+
+::: phydrax.uq.DirichletCategoricalStatistics
+
+---
+
+::: phydrax.uq.DirichletCategoricalUpdate
+
+## Coordinate and representation bridges
+
+::: phydrax.uq.SimplexBijector
+
+---
+
+::: phydrax.uq.gaussian_factor_from_multivariate_normal
+
+---
+
+::: phydrax.uq.multivariate_normal_from_gaussian_factor
+
+## Projection and fitting
+
+::: phydrax.uq.ExponentialFamilyProjectionAccumulator
+
+---
+
+::: phydrax.uq.ExponentialFamilyEstimateResult
+
+---
+
+::: phydrax.uq.project_exponential_family
+
+---
+
+::: phydrax.uq.fit_exponential_family
+
+## Likelihood and Fisher adapters
+
+::: phydrax.uq.ScalarNaturalExponentialFamilyLikelihood
+
+---
+
+::: phydrax.uq.CategoricalExponentialFamilyLikelihood
+
+---
+
+::: phydrax.uq.exponential_family_fisher_action
+
+---
+
+::: phydrax.uq.exponential_family_parameter_fisher_action
+
+## Status codes
+
+::: phydrax.uq.exponential_family_status_name
+
+---
+
+::: phydrax.uq.EXPONENTIAL_FAMILY_SUCCESS
+
+---
+
+::: phydrax.uq.EXPONENTIAL_FAMILY_NONFINITE
+
+---
+
+::: phydrax.uq.EXPONENTIAL_FAMILY_NONCONVERGED
+
+---
+
+::: phydrax.uq.EXPONENTIAL_FAMILY_INVALID_EVENT
+
+---
+
+::: phydrax.uq.EXPONENTIAL_FAMILY_OUTSIDE_NATURAL_DOMAIN
+
+---
+
+::: phydrax.uq.EXPONENTIAL_FAMILY_OUTSIDE_MEAN_DOMAIN
+
+---
+
+::: phydrax.uq.EXPONENTIAL_FAMILY_MEAN_BOUNDARY
+
+---
+
+::: phydrax.uq.EXPONENTIAL_FAMILY_INSUFFICIENT_WEIGHT

--- a/docs/api/uq/index.md
+++ b/docs/api/uq/index.md
@@ -1,7 +1,9 @@
 # Uncertainty quantification
 
-`phydrax.uq` provides covariance-factor and conditional Gaussian algebra, guarded
-nonlinear moment transforms, covariance- and square-root-form Kalman methods,
+`phydrax.uq` provides normalized exponential-family laws, typed natural/mean/statistic
+coordinates, weighted maximum-likelihood projection, and exact matrix-free family
+Fisher actions. It also provides covariance-factor and conditional Gaussian algebra,
+guarded nonlinear moment transforms, covariance- and square-root-form Kalman methods,
 continuous-discrete Gaussian filtering and smoothing, and stationary stochastic
 spectra. Its sensitivity layer covers global Sobol indices, stochastic pathwise and
 score gradients, matrix-free Fisher and Gauss--Newton actions, empirical directions,
@@ -42,6 +44,7 @@ spectral routes. Singular positive-semidefinite factors remain singular, and com
 covariances and spectra use conjugate adjoints.
 
 - [Predictive results](predictive.md)
+- [Exponential families](exponential_families.md)
 - [Native optimal transport](../transport/index.md)
 - [Shared positive-definite kernels](../kernels.md)
 - [Inference and ensembles](inference.md)

--- a/docs/api/uq/sensitivity.md
+++ b/docs/api/uq/sensitivity.md
@@ -88,11 +88,26 @@ assert curvature_direction.method_id == "jax_jvp_vjp"
 The returned action records `operator_id`, `method_id`, approximation, explicit
 regularization, sample count when applicable, validity, and status.
 
+For a declared exponential family,
+`exponential_family_fisher_action` applies the exact natural-coordinate Fisher as a
+JVP of the mean map. `exponential_family_parameter_fisher_action` wraps this with the
+natural-parameter JVP and transpose pullback to apply `Jηᵀ F(η) Jη`. These actions are
+exact for the declared family geometry and do not require score samples.
+
+
 ::: phydrax.uq.SensitivityActionResult
 
 ---
 
 ::: phydrax.uq.fisher_information_action
+
+---
+
+::: phydrax.uq.exponential_family_fisher_action
+
+---
+
+::: phydrax.uq.exponential_family_parameter_fisher_action
 
 ---
 

--- a/docs/guides_uncertainty.md
+++ b/docs/guides_uncertainty.md
@@ -803,6 +803,116 @@ width. `GaussianScaleCalibrator.fit` estimates one positive multiplier by the
 closed-form held-out Gaussian-NLL optimum. It calibrates scale under a Gaussian
 likelihood; it does not provide a finite-sample coverage guarantee.
 
+## Exponential-family laws, geometry, and conjugacy
+
+Phydrax keeps natural coordinates, expected sufficient statistics, and realized
+sufficient statistics as distinct semantic objects. Their arrays reserve the final
+axis for the intrinsic family dimension. Static signatures prevent accidental
+operations between equal-shaped coordinates from different families or reference
+measures.
+
+The scalar families are `BernoulliFamily`, `PoissonFamily`,
+`ExponentialRateFamily`, and `NormalFamily`. Structured families add:
+
+- `CategoricalFamily(K)`: `K - 1` last-category-reference log odds.
+- `GammaFamily`: full shape-rate geometry with sufficient statistics
+  `(log(x), x)`.
+- `MultivariateNormalFamily(d)`: exact dense Gaussian geometry in an orthonormal
+  symmetric matrix chart.
+- `DirichletFamily(K)`: concentration geometry relative to intrinsic simplex
+  Hausdorff measure.
+
+For scalar Bernoulli-logit and Poisson-log-rate models, use the family kernel through
+the ordinary observation-likelihood protocol:
+
+```python
+count_likelihood = phx.uq.ScalarNaturalExponentialFamilyLikelihood(
+    phx.uq.PoissonFamily()
+)
+log_rate = jnp.asarray([0.0, jnp.log(2.0), jnp.log(3.0)])
+counts = jnp.asarray([0.0, 1.0, 4.0])
+count_log_probability = count_likelihood.log_prob(log_rate, counts)
+```
+
+The model output above is the natural parameter itself. Apply an explicit link first
+if a model emits a probability, rate, location, or scale. Pass
+`CategoricalFamily(K)` to `CategoricalExponentialFamilyLikelihood` and declare
+`prediction_coordinates="full_logits"` for full categorical logits or `"natural"`
+for identified `K - 1` coordinates.
+
+Weighted sample clouds and ensembles project onto a family by averaging sufficient
+statistics with stable normalized log weights:
+
+```python
+projection = phx.uq.project_exponential_family(
+    phx.uq.GammaFamily(),
+    jnp.asarray([0.3, 0.7, 1.8, 3.2]),
+    log_weights=jnp.asarray([-0.7, 0.2, 0.8, -0.1]),
+)
+```
+
+`ExponentialFamilyProjectionAccumulator` supports exact chunk merging without
+reinterpreting frequency weights as importance weights. Diagnostics retain effective
+sample size, maximum normalized weight, entropy, and log-weight range.
+`fit_exponential_family` accepts ordinary nonnegative statistical weights.
+
+Boundary maximum-likelihood estimates remain explicit. Phydrax does not add
+pseudocounts, clip coordinates, or jitter a covariance. Invalid observations,
+nonfinite weights, zero total weight, exterior means, regular-family boundaries, and
+failed Gamma or Dirichlet numerical inversion have separate statuses.
+
+Simplex posterior leaves require different raw and physical shapes:
+
+```python
+simplex_family = phx.uq.DirichletFamily(3)
+simplex_space = phx.uq.ParameterSpace(
+    jnp.zeros(2),
+    priors=simplex_family.law_from_concentration(jnp.asarray([1.0, 2.0, 3.0])),
+    bijectors=phx.uq.SimplexBijector(3),
+)
+physical_composition = simplex_space.constrain(jnp.asarray([0.2, -0.4]))
+```
+
+The additive-log-ratio map includes its Hausdorff volume factor. This is a true
+`2 -> 3` shape change, not a shape-preserving transform with an implicit redundant
+component.
+
+Use explicit conjugate pairs for online or conditionally conjugate scientific
+updates:
+
+```python
+rate_update = phx.uq.GammaPoissonConjugacy(2.0, 1.5).update(
+    jnp.asarray([0, 2, 3]),
+    exposure=jnp.asarray([1.0, 0.5, 2.0]),
+)
+composition_update = phx.uq.DirichletCategoricalConjugacy(
+    jnp.asarray([1.0, 1.0, 1.0])
+).update(jnp.asarray([0, 2, 1, 2, 2]))
+```
+
+Both pairs expose mergeable statistics, exact evidence, and posterior predictive
+operations. They do not imply that arbitrary exponential families are conjugate.
+
+Exact information geometry remains matrix-free:
+
+```python
+family = phx.uq.MultivariateNormalFamily(3)
+natural = family.natural_from_location_covariance(jnp.zeros(3), jnp.eye(3))
+direction = jnp.ones(family.signature.dimension)
+fisher_direction = phx.uq.exponential_family_fisher_action(
+    family,
+    natural,
+    direction,
+)
+```
+
+For a parameter-to-natural map, use
+`exponential_family_parameter_fisher_action` to apply `Jηᵀ F(η) Jη` by JVP and
+transpose pullback. Neither operation materializes or inverts a dense Fisher matrix.
+See the [exponential-family API](api/uq/exponential_families.md) for coordinate,
+measure, solver, posterior-prior, and status semantics.
+
+
 ## Uncertain predictors and normalized measurement error
 
 When both a measured predictor \(x_i\) and response \(y_i\) are uncertain, an

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -235,6 +235,7 @@ nav:
             - Geometry-preserving solvers: "api/solver/geometric.md"
         - Uncertainty quantification:
             - Overview: "api/uq/index.md"
+            - Exponential families: "api/uq/exponential_families.md"
             - Predictive results: "api/uq/predictive.md"
             - Neural-operator uncertainty: "api/uq/operator.md"
             - Inference and ensembles: "api/uq/inference.md"

--- a/phydrax/_exponential_family/__init__.py
+++ b/phydrax/_exponential_family/__init__.py
@@ -1,0 +1,78 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from ._categorical import CategoricalFamily
+from ._conjugacy import (
+    DirichletCategoricalConjugacy,
+    DirichletCategoricalStatistics,
+    DirichletCategoricalUpdate,
+    GammaPoissonConjugacy,
+    GammaPoissonStatistics,
+    GammaPoissonUpdate,
+)
+from ._contracts import (
+    AbstractExponentialFamily,
+    EXPONENTIAL_FAMILY_INSUFFICIENT_WEIGHT,
+    EXPONENTIAL_FAMILY_INVALID_EVENT,
+    EXPONENTIAL_FAMILY_MEAN_BOUNDARY,
+    EXPONENTIAL_FAMILY_NONCONVERGED,
+    EXPONENTIAL_FAMILY_NONFINITE,
+    EXPONENTIAL_FAMILY_OUTSIDE_MEAN_DOMAIN,
+    EXPONENTIAL_FAMILY_OUTSIDE_NATURAL_DOMAIN,
+    exponential_family_status_name,
+    EXPONENTIAL_FAMILY_SUCCESS,
+    ExponentialFamilyConversionResult,
+    ExponentialFamilyDomainResult,
+    ExponentialFamilyLaw,
+    ExponentialFamilySignature,
+    ExponentialFamilyStatus,
+    MeanCoordinates,
+    NaturalCoordinates,
+    StatisticBatch,
+)
+from ._dirichlet import DirichletFamily
+from ._elementary import (
+    BernoulliFamily,
+    ExponentialRateFamily,
+    NormalFamily,
+    PoissonFamily,
+)
+from ._gamma import GammaFamily
+from ._multivariate_normal import MultivariateNormalFamily
+
+
+__all__ = [
+    "AbstractExponentialFamily",
+    "CategoricalFamily",
+    "BernoulliFamily",
+    "DirichletCategoricalConjugacy",
+    "DirichletCategoricalStatistics",
+    "DirichletCategoricalUpdate",
+    "EXPONENTIAL_FAMILY_INSUFFICIENT_WEIGHT",
+    "EXPONENTIAL_FAMILY_INVALID_EVENT",
+    "EXPONENTIAL_FAMILY_MEAN_BOUNDARY",
+    "EXPONENTIAL_FAMILY_NONFINITE",
+    "EXPONENTIAL_FAMILY_NONCONVERGED",
+    "EXPONENTIAL_FAMILY_OUTSIDE_MEAN_DOMAIN",
+    "DirichletFamily",
+    "EXPONENTIAL_FAMILY_OUTSIDE_NATURAL_DOMAIN",
+    "EXPONENTIAL_FAMILY_SUCCESS",
+    "ExponentialFamilyConversionResult",
+    "ExponentialFamilyDomainResult",
+    "ExponentialFamilyLaw",
+    "GammaFamily",
+    "GammaPoissonConjugacy",
+    "GammaPoissonStatistics",
+    "GammaPoissonUpdate",
+    "ExponentialFamilySignature",
+    "ExponentialFamilyStatus",
+    "ExponentialRateFamily",
+    "MeanCoordinates",
+    "MultivariateNormalFamily",
+    "NaturalCoordinates",
+    "NormalFamily",
+    "PoissonFamily",
+    "StatisticBatch",
+    "exponential_family_status_name",
+]

--- a/phydrax/_exponential_family/_categorical.py
+++ b/phydrax/_exponential_family/_categorical.py
@@ -1,0 +1,144 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+from jaxtyping import Array, ArrayLike
+
+from ._contracts import (
+    _AbstractAnalyticExponentialFamily,
+    _mean_domain_result,
+    _natural_domain_result,
+    ExponentialFamilyDomainResult,
+    ExponentialFamilySignature,
+    NaturalCoordinates,
+    StatisticBatch,
+)
+
+
+class CategoricalFamily(_AbstractAnalyticExponentialFamily):
+    """Categorical laws in last-category-reference log-odds coordinates."""
+
+    num_categories: int = eqx.field(static=True)
+    _signature: ExponentialFamilySignature = eqx.field(static=True)
+
+    def __init__(self, num_categories: int):
+        categories = int(num_categories)
+        if categories < 2:
+            raise ValueError("num_categories must be at least two.")
+        self.num_categories = categories
+        self._signature = ExponentialFamilySignature(
+            "categorical",
+            categories - 1,
+            (),
+            "counting",
+            f"integer-categories-{categories}",
+            f"last-category-reference-log-odds-{categories}",
+        )
+
+    @property
+    def signature(self) -> ExponentialFamilySignature:
+        return self._signature
+
+    def natural_from_logits(self, logits: ArrayLike, /) -> NaturalCoordinates:
+        """Convert conventional full logits to the identified natural chart."""
+        values = jnp.asarray(logits)
+        if jnp.issubdtype(values.dtype, jnp.complexfloating):
+            raise TypeError("Categorical logits must be real-valued.")
+        if values.ndim == 0 or int(values.shape[-1]) != self.num_categories:
+            raise ValueError(
+                "Categorical full logits must end in num_categories="
+                f"{self.num_categories}; got {values.shape}."
+            )
+        values = values.astype(jnp.result_type(values, 0.0))
+        return self.natural(values[..., :-1] - values[..., -1, None])
+
+    def probabilities_from_natural(self, natural: NaturalCoordinates, /) -> Array:
+        """Return conventional full category probabilities."""
+        domain = self.natural_domain(natural)
+        logits = jnp.concatenate(
+            (natural.values, jnp.zeros_like(natural.values[..., :1])), axis=-1
+        )
+        probabilities = jax.nn.softmax(logits, axis=-1)
+        return jnp.where(domain.valid[..., None], probabilities, jnp.nan)
+
+    def _natural_domain(self, values: Array, /) -> ExponentialFamilyDomainResult:
+        shape = values.shape[:-1]
+        return _natural_domain_result(
+            self.signature,
+            values,
+            interior=jnp.ones(shape, dtype=bool),
+            boundary=jnp.zeros(shape, dtype=bool),
+        )
+
+    def _mean_domain(self, values: Array, /) -> ExponentialFamilyDomainResult:
+        reference = 1.0 - jnp.sum(values, axis=-1)
+        nonnegative = jnp.all(values >= 0.0, axis=-1) & (reference >= 0.0)
+        positive = jnp.all(values > 0.0, axis=-1) & (reference > 0.0)
+        return _mean_domain_result(
+            self.signature,
+            values,
+            interior=positive,
+            boundary=nonnegative & ~positive,
+        )
+
+    def _sufficient_statistics(self, value: ArrayLike, /) -> StatisticBatch:
+        raw = jnp.asarray(value)
+        if jnp.issubdtype(raw.dtype, jnp.complexfloating):
+            raise TypeError("Categorical observations must be real-valued labels.")
+        observation = raw.astype(jnp.result_type(raw, 0.0))
+        valid = (
+            jnp.isfinite(observation)
+            & (observation >= 0.0)
+            & (observation < self.num_categories)
+            & (observation == jnp.floor(observation))
+        )
+        safe = jnp.where(valid, observation, 0.0).astype(jnp.int32)
+        one_hot = jax.nn.one_hot(safe, self.num_categories, dtype=observation.dtype)
+        return StatisticBatch(one_hot[..., :-1], valid, self.signature)
+
+    def _log_base_density(self, value: ArrayLike, /) -> Array:
+        return jnp.zeros_like(jnp.asarray(value, dtype=float))
+
+    def _log_normalizer(self, natural_values: Array, /) -> Array:
+        logits = jnp.concatenate(
+            (natural_values, jnp.zeros_like(natural_values[..., :1])), axis=-1
+        )
+        return jax.nn.logsumexp(logits, axis=-1)
+
+    def _mean_values(self, natural_values: Array, /) -> Array:
+        logits = jnp.concatenate(
+            (natural_values, jnp.zeros_like(natural_values[..., :1])), axis=-1
+        )
+        return jax.nn.softmax(logits, axis=-1)[..., :-1]
+
+    def _natural_from_mean_values(self, mean_values: Array, /) -> Array:
+        reference = 1.0 - jnp.sum(mean_values, axis=-1, keepdims=True)
+        safe_values = jnp.where(mean_values > 0.0, mean_values, 1.0)
+        safe_reference = jnp.where(reference > 0.0, reference, 1.0)
+        return jnp.log(safe_values) - jnp.log(safe_reference)
+
+    def _sample(
+        self,
+        key,
+        natural_values: Array,
+        sample_shape: tuple[int, ...],
+        /,
+    ) -> Array:
+        logits = jnp.concatenate(
+            (natural_values, jnp.zeros_like(natural_values[..., :1])), axis=-1
+        )
+        return jr.categorical(
+            key,
+            logits,
+            axis=-1,
+            shape=sample_shape + natural_values.shape[:-1],
+        )
+
+
+__all__ = ["CategoricalFamily"]

--- a/phydrax/_exponential_family/_conjugacy.py
+++ b/phydrax/_exponential_family/_conjugacy.py
@@ -1,0 +1,650 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from math import prod
+from typing import TypeAlias
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import jax.scipy as jsp
+from jaxtyping import Array, ArrayLike
+
+from .._strict import StrictModule
+from ._categorical import CategoricalFamily
+from ._contracts import ExponentialFamilyLaw, NaturalCoordinates
+from ._dirichlet import DirichletFamily
+from ._gamma import GammaFamily
+
+
+SampleAxes: TypeAlias = int | tuple[int, ...] | None
+
+
+def _normalize_sample_axes(ndim: int, sample_axes: SampleAxes, /) -> tuple[int, ...]:
+    if sample_axes is None:
+        return tuple(range(ndim))
+    raw_axes = (sample_axes,) if isinstance(sample_axes, int) else tuple(sample_axes)
+    axes = tuple(axis + ndim if axis < 0 else axis for axis in raw_axes)
+    if any(axis < 0 or axis >= ndim for axis in axes):
+        raise ValueError(f"sample_axes {raw_axes} are invalid for rank {ndim}.")
+    if len(set(axes)) != len(axes):
+        raise ValueError("sample_axes must not contain duplicates.")
+    return tuple(sorted(axes))
+
+
+class GammaPoissonStatistics(StrictModule):
+    """Mergeable sufficient statistics for conditionally Poisson observations."""
+
+    total_count: Array
+    total_exposure: Array
+    log_base_measure: Array
+    num_observations: Array
+    valid: Array
+
+    def __init__(
+        self,
+        total_count: ArrayLike,
+        total_exposure: ArrayLike,
+        log_base_measure: ArrayLike,
+        num_observations: ArrayLike,
+        valid: ArrayLike,
+    ):
+        arrays = tuple(
+            jnp.asarray(value)
+            for value in (
+                total_count,
+                total_exposure,
+                log_base_measure,
+                num_observations,
+            )
+        )
+        if any(jnp.issubdtype(value.dtype, jnp.complexfloating) for value in arrays):
+            raise TypeError("Gamma-Poisson statistics must be real-valued.")
+        count, exposure, base_measure, observations = jnp.broadcast_arrays(*arrays)
+        declared_valid = jnp.broadcast_to(jnp.asarray(valid, dtype=bool), count.shape)
+        canonical_valid = (
+            declared_valid
+            & jnp.isfinite(count)
+            & (count >= 0.0)
+            & (count == jnp.floor(count))
+            & jnp.isfinite(exposure)
+            & (exposure >= 0.0)
+            & jnp.isfinite(base_measure)
+            & jnp.isfinite(observations)
+            & (observations >= 0.0)
+            & (observations == jnp.floor(observations))
+            & jnp.where(
+                observations > 0.0,
+                exposure > 0.0,
+                (count == 0.0) & (exposure == 0.0) & (base_measure == 0.0),
+            )
+        )
+        self.total_count = count
+        self.total_exposure = exposure
+        self.log_base_measure = base_measure
+        self.num_observations = observations
+        self.valid = canonical_valid
+
+    def merge(self, other: "GammaPoissonStatistics", /) -> "GammaPoissonStatistics":
+        if not isinstance(other, GammaPoissonStatistics):
+            raise TypeError("other must be GammaPoissonStatistics.")
+        return GammaPoissonStatistics(
+            self.total_count + other.total_count,
+            self.total_exposure + other.total_exposure,
+            self.log_base_measure + other.log_base_measure,
+            self.num_observations + other.num_observations,
+            self.valid & other.valid,
+        )
+
+
+class GammaPoissonUpdate(StrictModule):
+    """Audited Gamma posterior, evidence, and predictive Poisson law."""
+
+    family: GammaFamily
+    prior_natural: NaturalCoordinates
+    posterior_natural: NaturalCoordinates
+    statistics: GammaPoissonStatistics
+    log_evidence: Array
+    valid: Array
+
+    def __init__(
+        self,
+        family: GammaFamily,
+        prior_natural: NaturalCoordinates,
+        posterior_natural: NaturalCoordinates,
+        statistics: GammaPoissonStatistics,
+        log_evidence: Array,
+        valid: Array,
+    ):
+        self.family = family
+        self.prior_natural = prior_natural
+        self.posterior_natural = posterior_natural
+        self.statistics = statistics
+        self.log_evidence = log_evidence
+        self.valid = valid
+
+    @property
+    def posterior_law(self) -> ExponentialFamilyLaw:
+        return self.family.law(self.posterior_natural)
+
+    @property
+    def posterior_shape_rate(self) -> tuple[Array, Array]:
+        return self.family.shape_rate_from_natural(self.posterior_natural)
+
+    def predictive_log_prob(
+        self, count: ArrayLike, /, *, exposure: ArrayLike = 1.0
+    ) -> Array:
+        shape, rate = self.posterior_shape_rate
+        count_array, exposure_array, shape, rate = jnp.broadcast_arrays(
+            jnp.asarray(count), jnp.asarray(exposure), shape, rate
+        )
+        dtype = jnp.result_type(count_array, exposure_array, shape, rate, 0.0)
+        count_array = count_array.astype(dtype)
+        exposure_array = exposure_array.astype(dtype)
+        observation_valid = (
+            jnp.isfinite(count_array)
+            & (count_array >= 0.0)
+            & (count_array == jnp.floor(count_array))
+            & jnp.isfinite(exposure_array)
+            & (exposure_array > 0.0)
+        )
+        safe_count = jnp.where(observation_valid, count_array, 0.0)
+        safe_exposure = jnp.where(observation_valid, exposure_array, 1.0)
+        value = (
+            jsp.special.gammaln(shape + safe_count)
+            - jsp.special.gammaln(shape)
+            - jsp.special.gammaln(safe_count + 1.0)
+            + shape * (jnp.log(rate) - jnp.log(rate + safe_exposure))
+            + safe_count * (jnp.log(safe_exposure) - jnp.log(rate + safe_exposure))
+        )
+        return jnp.where(
+            self.valid,
+            jnp.where(observation_valid, value, -jnp.inf),
+            jnp.nan,
+        )
+
+    def sample_predictive(
+        self,
+        key,
+        sample_shape: tuple[int, ...] = (),
+        *,
+        exposure: ArrayLike = 1.0,
+    ) -> Array:
+        shape, rate = self.posterior_shape_rate
+        exposure_array, shape, rate = jnp.broadcast_arrays(
+            jnp.asarray(exposure), shape, rate
+        )
+        dtype = jnp.result_type(exposure_array, shape, rate, 0.0)
+        exposure_array = exposure_array.astype(dtype)
+        checked_exposure = eqx.error_if(
+            exposure_array,
+            jnp.any(~jnp.isfinite(exposure_array) | (exposure_array <= 0.0)),
+            "Predictive exposure must be finite and strictly positive.",
+        )
+        checked_shape = eqx.error_if(
+            shape,
+            jnp.any(~self.valid),
+            "Cannot sample an invalid Gamma-Poisson update.",
+        )
+        rate_key, count_key = jr.split(key)
+        latent_rate = (
+            jr.gamma(
+                rate_key,
+                checked_shape,
+                shape=tuple(sample_shape) + checked_shape.shape,
+                dtype=dtype,
+            )
+            / rate
+        )
+        return jr.poisson(count_key, checked_exposure * latent_rate)
+
+
+class GammaPoissonConjugacy(StrictModule):
+    """Explicit Gamma-prior/Poisson-likelihood conjugate pair."""
+
+    family: GammaFamily
+    prior_natural: NaturalCoordinates
+
+    def __init__(
+        self,
+        shape: ArrayLike,
+        rate: ArrayLike,
+        *,
+        family: GammaFamily | None = None,
+    ):
+        selected_family = GammaFamily() if family is None else family
+        if not isinstance(selected_family, GammaFamily):
+            raise TypeError("family must be a GammaFamily.")
+        prior_natural = selected_family.natural_from_shape_rate(shape, rate)
+        if not bool(jnp.all(selected_family.natural_domain(prior_natural).valid)):
+            raise ValueError("Gamma prior shape and rate must be finite and positive.")
+        self.family = selected_family
+        self.prior_natural = prior_natural
+
+    @property
+    def prior_law(self) -> ExponentialFamilyLaw:
+        return self.family.law(self.prior_natural)
+
+    def summarize(
+        self,
+        counts: ArrayLike,
+        /,
+        *,
+        exposure: ArrayLike = 1.0,
+        sample_axes: SampleAxes = None,
+    ) -> GammaPoissonStatistics:
+        count_array, exposure_array = jnp.broadcast_arrays(
+            jnp.asarray(counts), jnp.asarray(exposure)
+        )
+        dtype = jnp.result_type(count_array, exposure_array, 0.0)
+        count_array = count_array.astype(dtype)
+        exposure_array = exposure_array.astype(dtype)
+        observation_valid = (
+            jnp.isfinite(count_array)
+            & (count_array >= 0.0)
+            & (count_array == jnp.floor(count_array))
+            & jnp.isfinite(exposure_array)
+            & (exposure_array > 0.0)
+        )
+        safe_count = jnp.where(observation_valid, count_array, 0.0)
+        safe_exposure = jnp.where(observation_valid, exposure_array, 1.0)
+        axes = _normalize_sample_axes(count_array.ndim, sample_axes)
+        result_shape = tuple(
+            size for axis, size in enumerate(count_array.shape) if axis not in axes
+        )
+        count = jnp.sum(safe_count, axis=axes)
+        total_exposure = jnp.sum(safe_exposure, axis=axes)
+        base_measure = jnp.sum(
+            jnp.where(safe_count == 0.0, 0.0, safe_count * jnp.log(safe_exposure))
+            - jsp.special.gammaln(safe_count + 1.0),
+            axis=axes,
+        )
+        valid = jnp.all(observation_valid, axis=axes)
+        observation_count = jnp.full(
+            result_shape,
+            prod(count_array.shape[axis] for axis in axes),
+            dtype=jnp.int32,
+        )
+        return GammaPoissonStatistics(
+            count, total_exposure, base_measure, observation_count, valid
+        )
+
+    def update(
+        self,
+        counts: ArrayLike,
+        /,
+        *,
+        exposure: ArrayLike = 1.0,
+        sample_axes: SampleAxes = None,
+    ) -> GammaPoissonUpdate:
+        return self.update_statistics(
+            self.summarize(counts, exposure=exposure, sample_axes=sample_axes)
+        )
+
+    def update_statistics(
+        self, statistics: GammaPoissonStatistics, /
+    ) -> GammaPoissonUpdate:
+        if not isinstance(statistics, GammaPoissonStatistics):
+            raise TypeError("statistics must be GammaPoissonStatistics.")
+        statistic_arrays = (
+            statistics.total_count,
+            statistics.total_exposure,
+            statistics.log_base_measure,
+            statistics.num_observations,
+        )
+        if any(
+            jnp.issubdtype(jnp.asarray(value).dtype, jnp.complexfloating)
+            for value in statistic_arrays
+        ):
+            raise TypeError("Gamma-Poisson statistics must be real-valued.")
+        prior_shape, prior_rate = self.family.shape_rate_from_natural(self.prior_natural)
+        (
+            prior_shape,
+            prior_rate,
+            total_count,
+            total_exposure,
+            log_base_measure,
+            num_observations,
+        ) = jnp.broadcast_arrays(
+            prior_shape,
+            prior_rate,
+            statistics.total_count,
+            statistics.total_exposure,
+            statistics.log_base_measure,
+            statistics.num_observations,
+        )
+        declared_valid = jnp.broadcast_to(
+            jnp.asarray(statistics.valid, dtype=bool), prior_shape.shape
+        )
+        statistics_valid = (
+            declared_valid
+            & jnp.isfinite(total_count)
+            & (total_count >= 0.0)
+            & (total_count == jnp.floor(total_count))
+            & jnp.isfinite(total_exposure)
+            & (total_exposure >= 0.0)
+            & jnp.isfinite(log_base_measure)
+            & jnp.isfinite(num_observations)
+            & (num_observations >= 0.0)
+            & (num_observations == jnp.floor(num_observations))
+            & jnp.where(
+                num_observations > 0.0,
+                total_exposure > 0.0,
+                (total_count == 0.0)
+                & (total_exposure == 0.0)
+                & (log_base_measure == 0.0),
+            )
+        )
+        posterior_shape = prior_shape + total_count
+        posterior_rate = prior_rate + total_exposure
+        posterior_natural = self.family.natural_from_shape_rate(
+            posterior_shape, posterior_rate
+        )
+        posterior_natural = self.family.natural(
+            jnp.where(statistics_valid[..., None], posterior_natural.values, jnp.nan)
+        )
+        log_evidence = (
+            jsp.special.gammaln(posterior_shape)
+            - jsp.special.gammaln(prior_shape)
+            + prior_shape * jnp.log(prior_rate)
+            - posterior_shape * jnp.log(posterior_rate)
+            + log_base_measure
+        )
+        return GammaPoissonUpdate(
+            self.family,
+            self.prior_natural,
+            posterior_natural,
+            statistics,
+            jnp.where(statistics_valid, log_evidence, jnp.nan),
+            statistics_valid,
+        )
+
+
+class DirichletCategoricalStatistics(StrictModule):
+    """Mergeable category counts for an ordered categorical sample."""
+
+    category_counts: Array
+    num_observations: Array
+    valid: Array
+
+    def __init__(
+        self,
+        category_counts: ArrayLike,
+        num_observations: ArrayLike,
+        valid: ArrayLike,
+    ):
+        counts = jnp.asarray(category_counts)
+        observations = jnp.asarray(num_observations)
+        if counts.ndim == 0 or int(counts.shape[-1]) < 2:
+            raise ValueError(
+                "Dirichlet-categorical counts require at least two categories."
+            )
+        if jnp.issubdtype(counts.dtype, jnp.complexfloating) or jnp.issubdtype(
+            observations.dtype, jnp.complexfloating
+        ):
+            raise TypeError("Dirichlet-categorical statistics must be real-valued.")
+        result_shape = jnp.broadcast_shapes(counts.shape[:-1], observations.shape)
+        counts = jnp.broadcast_to(counts, result_shape + (counts.shape[-1],))
+        observations = jnp.broadcast_to(observations, result_shape)
+        declared_valid = jnp.broadcast_to(jnp.asarray(valid, dtype=bool), result_shape)
+        canonical_valid = (
+            declared_valid
+            & jnp.all(jnp.isfinite(counts), axis=-1)
+            & jnp.all(counts >= 0.0, axis=-1)
+            & jnp.all(counts == jnp.floor(counts), axis=-1)
+            & jnp.isfinite(observations)
+            & (observations >= 0.0)
+            & (observations == jnp.floor(observations))
+            & (jnp.sum(counts, axis=-1) == observations)
+        )
+        self.category_counts = counts
+        self.num_observations = observations
+        self.valid = canonical_valid
+
+    def merge(
+        self, other: "DirichletCategoricalStatistics", /
+    ) -> "DirichletCategoricalStatistics":
+        if not isinstance(other, DirichletCategoricalStatistics):
+            raise TypeError("other must be DirichletCategoricalStatistics.")
+        if self.category_counts.shape[-1] != other.category_counts.shape[-1]:
+            raise ValueError("Categorical statistics have different category counts.")
+        return DirichletCategoricalStatistics(
+            self.category_counts + other.category_counts,
+            self.num_observations + other.num_observations,
+            self.valid & other.valid,
+        )
+
+
+class DirichletCategoricalUpdate(StrictModule):
+    """Audited Dirichlet posterior, evidence, and categorical predictive law."""
+
+    dirichlet_family: DirichletFamily
+    categorical_family: CategoricalFamily
+    prior_natural: NaturalCoordinates
+    posterior_natural: NaturalCoordinates
+    statistics: DirichletCategoricalStatistics
+    log_evidence: Array
+    valid: Array
+
+    def __init__(
+        self,
+        dirichlet_family: DirichletFamily,
+        categorical_family: CategoricalFamily,
+        prior_natural: NaturalCoordinates,
+        posterior_natural: NaturalCoordinates,
+        statistics: DirichletCategoricalStatistics,
+        log_evidence: Array,
+        valid: Array,
+    ):
+        self.dirichlet_family = dirichlet_family
+        self.categorical_family = categorical_family
+        self.prior_natural = prior_natural
+        self.posterior_natural = posterior_natural
+        self.statistics = statistics
+        self.log_evidence = log_evidence
+        self.valid = valid
+
+    @property
+    def posterior_law(self) -> ExponentialFamilyLaw:
+        return self.dirichlet_family.law(self.posterior_natural)
+
+    @property
+    def posterior_concentration(self) -> Array:
+        return self.dirichlet_family.concentration_from_natural(self.posterior_natural)
+
+    @property
+    def predictive_probabilities(self) -> Array:
+        concentration = self.posterior_concentration
+        probabilities = concentration / jnp.sum(concentration, axis=-1, keepdims=True)
+        return jnp.where(self.valid[..., None], probabilities, jnp.nan)
+
+    @property
+    def predictive_law(self) -> ExponentialFamilyLaw:
+        natural = self.categorical_family.natural_from_logits(
+            jnp.log(self.posterior_concentration)
+        )
+        return self.categorical_family.law(natural)
+
+    def predictive_log_prob(self, label: ArrayLike, /) -> Array:
+        probabilities = self.predictive_probabilities
+        raw_label = jnp.asarray(label)
+        label_array, batch_value = jnp.broadcast_arrays(raw_label, probabilities[..., 0])
+        label_valid = (
+            jnp.isfinite(label_array)
+            & (label_array >= 0)
+            & (label_array < self.dirichlet_family.num_categories)
+            & (label_array == jnp.floor(label_array))
+        )
+        safe_label = jnp.where(label_valid, label_array, 0).astype(jnp.int32)
+        broadcast_probabilities = jnp.broadcast_to(
+            probabilities, batch_value.shape + (self.dirichlet_family.num_categories,)
+        )
+        value = jnp.log(
+            jnp.take_along_axis(broadcast_probabilities, safe_label[..., None], axis=-1)[
+                ..., 0
+            ]
+        )
+        return jnp.where(
+            self.valid,
+            jnp.where(label_valid, value, -jnp.inf),
+            jnp.nan,
+        )
+
+    def sample_predictive(self, key, sample_shape: tuple[int, ...] = ()) -> Array:
+        return self.predictive_law.sample(key, tuple(sample_shape))
+
+
+class DirichletCategoricalConjugacy(StrictModule):
+    """Explicit Dirichlet-prior/categorical-likelihood conjugate pair."""
+
+    dirichlet_family: DirichletFamily
+    categorical_family: CategoricalFamily
+    prior_natural: NaturalCoordinates
+
+    def __init__(
+        self,
+        concentration: ArrayLike,
+        *,
+        family: DirichletFamily | None = None,
+    ):
+        concentration_array = jnp.asarray(concentration)
+        if concentration_array.ndim == 0:
+            raise ValueError("Dirichlet concentration must have a category axis.")
+        selected_family = (
+            DirichletFamily(int(concentration_array.shape[-1]))
+            if family is None
+            else family
+        )
+        if not isinstance(selected_family, DirichletFamily):
+            raise TypeError("family must be a DirichletFamily.")
+        prior_natural = selected_family.natural_from_concentration(concentration_array)
+        if not bool(jnp.all(selected_family.natural_domain(prior_natural).valid)):
+            raise ValueError("Dirichlet concentrations must be finite and positive.")
+        self.dirichlet_family = selected_family
+        self.categorical_family = CategoricalFamily(selected_family.num_categories)
+        self.prior_natural = prior_natural
+
+    @property
+    def prior_law(self) -> ExponentialFamilyLaw:
+        return self.dirichlet_family.law(self.prior_natural)
+
+    def summarize(
+        self,
+        labels: ArrayLike,
+        /,
+        *,
+        sample_axes: SampleAxes = None,
+    ) -> DirichletCategoricalStatistics:
+        raw_labels = jnp.asarray(labels)
+        dtype = jnp.result_type(raw_labels, 0.0)
+        label_values = raw_labels.astype(dtype)
+        valid_labels = (
+            jnp.isfinite(label_values)
+            & (label_values >= 0.0)
+            & (label_values < self.dirichlet_family.num_categories)
+            & (label_values == jnp.floor(label_values))
+        )
+        safe_labels = jnp.where(valid_labels, label_values, 0.0).astype(jnp.int32)
+        encoded = jax.nn.one_hot(
+            safe_labels,
+            self.dirichlet_family.num_categories,
+            dtype=dtype,
+        )
+        axes = _normalize_sample_axes(label_values.ndim, sample_axes)
+        result_shape = tuple(
+            size for axis, size in enumerate(label_values.shape) if axis not in axes
+        )
+        counts = jnp.sum(encoded, axis=axes)
+        valid = jnp.all(valid_labels, axis=axes)
+        observation_count = jnp.full(
+            result_shape,
+            prod(label_values.shape[axis] for axis in axes),
+            dtype=jnp.int32,
+        )
+        return DirichletCategoricalStatistics(counts, observation_count, valid)
+
+    def update(
+        self,
+        labels: ArrayLike,
+        /,
+        *,
+        sample_axes: SampleAxes = None,
+    ) -> DirichletCategoricalUpdate:
+        return self.update_statistics(self.summarize(labels, sample_axes=sample_axes))
+
+    def update_statistics(
+        self, statistics: DirichletCategoricalStatistics, /
+    ) -> DirichletCategoricalUpdate:
+        if not isinstance(statistics, DirichletCategoricalStatistics):
+            raise TypeError("statistics must be DirichletCategoricalStatistics.")
+        if (
+            statistics.category_counts.ndim == 0
+            or statistics.category_counts.shape[-1]
+            != self.dirichlet_family.num_categories
+        ):
+            raise ValueError("Categorical statistics have an incompatible category axis.")
+        if jnp.issubdtype(
+            statistics.category_counts.dtype, jnp.complexfloating
+        ) or jnp.issubdtype(
+            jnp.asarray(statistics.num_observations).dtype, jnp.complexfloating
+        ):
+            raise TypeError("Dirichlet-categorical statistics must be real-valued.")
+        prior_concentration = self.dirichlet_family.concentration_from_natural(
+            self.prior_natural
+        )
+        prior_concentration, counts = jnp.broadcast_arrays(
+            prior_concentration, statistics.category_counts
+        )
+        result_shape = prior_concentration.shape[:-1]
+        num_observations = jnp.broadcast_to(
+            jnp.asarray(statistics.num_observations), result_shape
+        )
+        declared_valid = jnp.broadcast_to(
+            jnp.asarray(statistics.valid, dtype=bool), result_shape
+        )
+        valid = (
+            declared_valid
+            & jnp.all(jnp.isfinite(counts), axis=-1)
+            & jnp.all(counts >= 0.0, axis=-1)
+            & jnp.all(counts == jnp.floor(counts), axis=-1)
+            & jnp.isfinite(num_observations)
+            & (num_observations >= 0.0)
+            & (num_observations == jnp.floor(num_observations))
+            & (jnp.sum(counts, axis=-1) == num_observations)
+        )
+        posterior_concentration = prior_concentration + counts
+        posterior_natural = self.dirichlet_family.natural_from_concentration(
+            posterior_concentration
+        )
+        posterior_natural = self.dirichlet_family.natural(
+            jnp.where(valid[..., None], posterior_natural.values, jnp.nan)
+        )
+        log_beta_prior = jnp.sum(
+            jsp.special.gammaln(prior_concentration), axis=-1
+        ) - jsp.special.gammaln(jnp.sum(prior_concentration, axis=-1))
+        log_beta_posterior = jnp.sum(
+            jsp.special.gammaln(posterior_concentration), axis=-1
+        ) - jsp.special.gammaln(jnp.sum(posterior_concentration, axis=-1))
+        return DirichletCategoricalUpdate(
+            self.dirichlet_family,
+            self.categorical_family,
+            self.prior_natural,
+            posterior_natural,
+            statistics,
+            jnp.where(valid, log_beta_posterior - log_beta_prior, jnp.nan),
+            valid,
+        )
+
+
+__all__ = [
+    "DirichletCategoricalConjugacy",
+    "DirichletCategoricalStatistics",
+    "DirichletCategoricalUpdate",
+    "GammaPoissonConjugacy",
+    "GammaPoissonStatistics",
+    "GammaPoissonUpdate",
+]

--- a/phydrax/_exponential_family/_contracts.py
+++ b/phydrax/_exponential_family/_contracts.py
@@ -1,0 +1,620 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import Literal, TypeAlias
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array, ArrayLike
+
+from .._probability import AbstractProbabilityLaw
+from .._strict import StrictModule
+from ..domain._measure import MeasureKind
+
+
+ExponentialFamilyStatus: TypeAlias = Literal[0, 1, 2, 3, 4, 5, 6, 7]
+EXPONENTIAL_FAMILY_SUCCESS: ExponentialFamilyStatus = 0
+EXPONENTIAL_FAMILY_NONFINITE: ExponentialFamilyStatus = 1
+EXPONENTIAL_FAMILY_INVALID_EVENT: ExponentialFamilyStatus = 2
+EXPONENTIAL_FAMILY_OUTSIDE_NATURAL_DOMAIN: ExponentialFamilyStatus = 3
+EXPONENTIAL_FAMILY_OUTSIDE_MEAN_DOMAIN: ExponentialFamilyStatus = 4
+EXPONENTIAL_FAMILY_MEAN_BOUNDARY: ExponentialFamilyStatus = 5
+EXPONENTIAL_FAMILY_INSUFFICIENT_WEIGHT: ExponentialFamilyStatus = 6
+EXPONENTIAL_FAMILY_NONCONVERGED: ExponentialFamilyStatus = 7
+
+
+def exponential_family_status_name(status: int, /) -> str:
+    """Return the stable name of one exponential-family status code."""
+    names = (
+        "success",
+        "nonfinite",
+        "invalid_event",
+        "outside_natural_domain",
+        "outside_mean_domain",
+        "mean_boundary",
+        "insufficient_weight",
+        "nonconverged",
+    )
+    code = int(status)
+    if code < 0 or code >= len(names):
+        raise ValueError(f"Unknown exponential-family status {code}.")
+    return names[code]
+
+
+class ExponentialFamilySignature(StrictModule):
+    """Static identity of one intrinsic exponential-family coordinate system."""
+
+    family_id: str = eqx.field(static=True)
+    dimension: int = eqx.field(static=True)
+    event_shape: tuple[int, ...] = eqx.field(static=True)
+    density_measure_kind: MeasureKind = eqx.field(static=True)
+    support_id: str = eqx.field(static=True)
+    coordinate_chart_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        family_id: str,
+        dimension: int,
+        event_shape: tuple[int, ...],
+        density_measure_kind: MeasureKind,
+        support_id: str,
+        coordinate_chart_id: str,
+    ):
+        dimensions = int(dimension)
+        events = tuple(int(size) for size in event_shape)
+        if not family_id or not support_id or not coordinate_chart_id:
+            raise ValueError("Exponential-family signature IDs must be non-empty.")
+        if dimensions <= 0:
+            raise ValueError("Exponential-family coordinate dimension must be positive.")
+        if any(size < 0 for size in events):
+            raise ValueError("Exponential-family event dimensions must be non-negative.")
+        if density_measure_kind not in (
+            "lebesgue",
+            "hausdorff",
+            "probability",
+            "counting",
+            "dirac",
+            "trajectory",
+            "riemannian",
+            "external",
+        ):
+            raise ValueError(f"Unknown density measure kind {density_measure_kind!r}.")
+        self.family_id = str(family_id)
+        self.dimension = dimensions
+        self.event_shape = events
+        self.density_measure_kind = density_measure_kind
+        self.support_id = str(support_id)
+        self.coordinate_chart_id = str(coordinate_chart_id)
+
+    @property
+    def key(self) -> tuple[str, int, tuple[int, ...], str, str, str]:
+        return (
+            self.family_id,
+            self.dimension,
+            self.event_shape,
+            self.density_measure_kind,
+            self.support_id,
+            self.coordinate_chart_id,
+        )
+
+
+def _coordinate_array(values: ArrayLike, signature: ExponentialFamilySignature) -> Array:
+    array = jnp.asarray(values)
+    if not jnp.issubdtype(array.dtype, jnp.floating):
+        if array.weak_type:
+            array = array.astype(float)
+        else:
+            raise TypeError(
+                "Exponential-family coordinates must be real floating arrays."
+            )
+    if array.ndim == 0 or int(array.shape[-1]) != signature.dimension:
+        raise ValueError(
+            "Exponential-family coordinates must end in intrinsic dimension "
+            f"{signature.dimension}; got {array.shape}."
+        )
+    return array
+
+
+def _require_signature(
+    actual: ExponentialFamilySignature,
+    expected: ExponentialFamilySignature,
+) -> None:
+    if actual.key != expected.key:
+        raise ValueError(
+            "Exponential-family coordinate signature does not match the family."
+        )
+
+
+class NaturalCoordinates(StrictModule):
+    """Finite-dimensional natural coordinates tagged by family identity."""
+
+    values: Array
+    signature: ExponentialFamilySignature = eqx.field(static=True)
+
+    def __init__(self, values: ArrayLike, signature: ExponentialFamilySignature):
+        if not isinstance(signature, ExponentialFamilySignature):
+            raise TypeError("signature must be an ExponentialFamilySignature.")
+        self.values = _coordinate_array(values, signature)
+        self.signature = signature
+
+    @property
+    def batch_shape(self) -> tuple[int, ...]:
+        return tuple(self.values.shape[:-1])
+
+
+class MeanCoordinates(StrictModule):
+    """Expected sufficient-statistic coordinates tagged by family identity."""
+
+    values: Array
+    signature: ExponentialFamilySignature = eqx.field(static=True)
+
+    def __init__(self, values: ArrayLike, signature: ExponentialFamilySignature):
+        if not isinstance(signature, ExponentialFamilySignature):
+            raise TypeError("signature must be an ExponentialFamilySignature.")
+        self.values = _coordinate_array(values, signature)
+        self.signature = signature
+
+    @property
+    def batch_shape(self) -> tuple[int, ...]:
+        return tuple(self.values.shape[:-1])
+
+
+class StatisticBatch(StrictModule):
+    """Sufficient statistics and support validity for one observation batch."""
+
+    values: Array
+    valid: Array
+    signature: ExponentialFamilySignature = eqx.field(static=True)
+
+    def __init__(
+        self,
+        values: ArrayLike,
+        valid: ArrayLike,
+        signature: ExponentialFamilySignature,
+    ):
+        if not isinstance(signature, ExponentialFamilySignature):
+            raise TypeError("signature must be an ExponentialFamilySignature.")
+        statistics = _coordinate_array(values, signature)
+        validity = jnp.broadcast_to(jnp.asarray(valid, dtype=bool), statistics.shape[:-1])
+        self.values = statistics
+        self.valid = validity
+        self.signature = signature
+
+
+class ExponentialFamilyDomainResult(StrictModule):
+    """Interior, boundary, and validity classification of family coordinates."""
+
+    interior: Array
+    boundary: Array
+    valid: Array
+    status: Array
+    signature: ExponentialFamilySignature = eqx.field(static=True)
+    domain_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        interior: ArrayLike,
+        boundary: ArrayLike,
+        valid: ArrayLike,
+        status: ArrayLike,
+        signature: ExponentialFamilySignature,
+        domain_id: str,
+    ):
+        interior_array = jnp.asarray(interior, dtype=bool)
+        shape = interior_array.shape
+        if not domain_id:
+            raise ValueError("domain_id must be non-empty.")
+        self.interior = interior_array
+        self.boundary = jnp.broadcast_to(jnp.asarray(boundary, dtype=bool), shape)
+        self.valid = jnp.broadcast_to(jnp.asarray(valid, dtype=bool), shape)
+        self.status = jnp.broadcast_to(jnp.asarray(status, dtype=jnp.int32), shape)
+        self.signature = signature
+        self.domain_id = str(domain_id)
+
+
+class ExponentialFamilyConversionResult(StrictModule):
+    """Audited conversion from mean coordinates to natural coordinates."""
+
+    mean: MeanCoordinates
+    natural: NaturalCoordinates
+    valid: Array
+    status: Array
+    residual: Array
+    iterations: Array
+    method_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        mean: MeanCoordinates,
+        natural: NaturalCoordinates,
+        valid: ArrayLike,
+        status: ArrayLike,
+        residual: ArrayLike,
+        iterations: ArrayLike,
+        method_id: str,
+    ):
+        _require_signature(natural.signature, mean.signature)
+        if natural.batch_shape != mean.batch_shape:
+            raise ValueError("Mean and natural coordinate batch shapes must match.")
+        if not method_id:
+            raise ValueError("method_id must be non-empty.")
+        shape = mean.batch_shape
+        self.mean = mean
+        self.natural = natural
+        self.valid = jnp.broadcast_to(jnp.asarray(valid, dtype=bool), shape)
+        self.status = jnp.broadcast_to(jnp.asarray(status, dtype=jnp.int32), shape)
+        self.residual = jnp.broadcast_to(jnp.asarray(residual), shape)
+        self.iterations = jnp.broadcast_to(
+            jnp.asarray(iterations, dtype=jnp.int32), shape
+        )
+        self.method_id = str(method_id)
+
+
+def _natural_domain_result(
+    signature: ExponentialFamilySignature,
+    values: Array,
+    /,
+    *,
+    interior: ArrayLike,
+    boundary: ArrayLike,
+) -> ExponentialFamilyDomainResult:
+    finite = jnp.all(jnp.isfinite(values), axis=-1)
+    interior_array = finite & jnp.asarray(interior, dtype=bool)
+    boundary_array = finite & jnp.asarray(boundary, dtype=bool)
+    status = jnp.where(
+        ~finite,
+        EXPONENTIAL_FAMILY_NONFINITE,
+        jnp.where(
+            interior_array,
+            EXPONENTIAL_FAMILY_SUCCESS,
+            EXPONENTIAL_FAMILY_OUTSIDE_NATURAL_DOMAIN,
+        ),
+    )
+    return ExponentialFamilyDomainResult(
+        interior=interior_array,
+        boundary=boundary_array,
+        valid=interior_array,
+        status=status,
+        signature=signature,
+        domain_id="natural",
+    )
+
+
+def _mean_domain_result(
+    signature: ExponentialFamilySignature,
+    values: Array,
+    /,
+    *,
+    interior: ArrayLike,
+    boundary: ArrayLike,
+) -> ExponentialFamilyDomainResult:
+    finite = jnp.all(jnp.isfinite(values), axis=-1)
+    interior_array = finite & jnp.asarray(interior, dtype=bool)
+    boundary_array = finite & jnp.asarray(boundary, dtype=bool)
+    status = jnp.where(
+        ~finite,
+        EXPONENTIAL_FAMILY_NONFINITE,
+        jnp.where(
+            interior_array,
+            EXPONENTIAL_FAMILY_SUCCESS,
+            jnp.where(
+                boundary_array,
+                EXPONENTIAL_FAMILY_MEAN_BOUNDARY,
+                EXPONENTIAL_FAMILY_OUTSIDE_MEAN_DOMAIN,
+            ),
+        ),
+    )
+    return ExponentialFamilyDomainResult(
+        interior=interior_array,
+        boundary=boundary_array,
+        valid=interior_array,
+        status=status,
+        signature=signature,
+        domain_id="mean",
+    )
+
+
+class AbstractExponentialFamily(StrictModule):
+    """Regular exponential family in one explicit intrinsic coordinate chart."""
+
+    @property
+    @abstractmethod
+    def signature(self) -> ExponentialFamilySignature:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _natural_domain(self, values: Array, /) -> ExponentialFamilyDomainResult:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _mean_domain(self, values: Array, /) -> ExponentialFamilyDomainResult:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _sufficient_statistics(self, value: ArrayLike, /) -> StatisticBatch:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _log_base_density(self, value: ArrayLike, /) -> Array:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _log_normalizer(self, natural_values: Array, /) -> Array:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _mean_values(self, natural_values: Array, /) -> Array:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _natural_from_mean_values(self, mean_values: Array, /) -> Array:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _sample(
+        self,
+        key,
+        natural_values: Array,
+        sample_shape: tuple[int, ...],
+        /,
+    ) -> Array:
+        raise NotImplementedError
+
+    def natural(self, values: ArrayLike, /) -> NaturalCoordinates:
+        return NaturalCoordinates(values, self.signature)
+
+    def mean(self, values: ArrayLike, /) -> MeanCoordinates:
+        return MeanCoordinates(values, self.signature)
+
+    def natural_domain(
+        self, natural: NaturalCoordinates, /
+    ) -> ExponentialFamilyDomainResult:
+        _require_signature(natural.signature, self.signature)
+        return self._natural_domain(natural.values)
+
+    def mean_domain(self, mean: MeanCoordinates, /) -> ExponentialFamilyDomainResult:
+        _require_signature(mean.signature, self.signature)
+        return self._mean_domain(mean.values)
+
+    def sufficient_statistics(self, value: ArrayLike, /) -> StatisticBatch:
+        statistics = self._sufficient_statistics(value)
+        _require_signature(statistics.signature, self.signature)
+        return statistics
+
+    def log_base_density(self, value: ArrayLike, /) -> Array:
+        return self._log_base_density(value)
+
+    def log_normalizer(self, natural: NaturalCoordinates, /) -> Array:
+        _require_signature(natural.signature, self.signature)
+        return self._log_normalizer(natural.values)
+
+    def mean_from_natural(self, natural: NaturalCoordinates, /) -> MeanCoordinates:
+        _require_signature(natural.signature, self.signature)
+        return MeanCoordinates(self._mean_values(natural.values), self.signature)
+
+    @abstractmethod
+    def _natural_from_mean_result(
+        self,
+        mean: MeanCoordinates,
+        domain: ExponentialFamilyDomainResult,
+        /,
+    ) -> ExponentialFamilyConversionResult:
+        candidate_values = self._natural_from_mean_values(mean.values)
+        candidate_values = jnp.where(
+            domain.interior[..., None], candidate_values, jnp.nan
+        )
+        natural = NaturalCoordinates(candidate_values, self.signature)
+        reconstructed = self._mean_values(candidate_values)
+        residual = jnp.linalg.norm(reconstructed - mean.values, axis=-1)
+        candidate_finite = jnp.all(jnp.isfinite(candidate_values), axis=-1)
+        residual_finite = jnp.isfinite(residual)
+        valid = domain.valid & candidate_finite & residual_finite
+        status = jnp.where(
+            domain.valid & ~valid,
+            EXPONENTIAL_FAMILY_NONFINITE,
+            domain.status,
+        )
+        return ExponentialFamilyConversionResult(
+            mean=mean,
+            natural=natural,
+            valid=valid,
+            status=status,
+            residual=jnp.where(valid, residual, jnp.inf),
+            iterations=jnp.zeros(mean.batch_shape, dtype=jnp.int32),
+            method_id=f"{self.signature.family_id}-analytic",
+        )
+
+    def natural_from_mean(
+        self, mean: MeanCoordinates, /
+    ) -> ExponentialFamilyConversionResult:
+        _require_signature(mean.signature, self.signature)
+        domain = self.mean_domain(mean)
+        return self._natural_from_mean_result(mean, domain)
+
+    def log_prob(
+        self,
+        natural: NaturalCoordinates,
+        value: ArrayLike,
+        /,
+    ) -> Array:
+        domain = self.natural_domain(natural)
+        statistics = self.sufficient_statistics(value)
+        pairing = jnp.sum(natural.values * statistics.values, axis=-1)
+        result = pairing - self.log_normalizer(natural) + self.log_base_density(value)
+        return jnp.where(domain.valid & statistics.valid, result, -jnp.inf)
+
+    def canonical_loss(
+        self,
+        natural: NaturalCoordinates,
+        value: ArrayLike,
+        /,
+    ) -> Array:
+        domain = self.natural_domain(natural)
+        statistics = self.sufficient_statistics(value)
+        pairing = jnp.sum(natural.values * statistics.values, axis=-1)
+        result = self.log_normalizer(natural) - pairing
+        return jnp.where(domain.valid & statistics.valid, result, jnp.inf)
+
+    def canonical_score(
+        self,
+        natural: NaturalCoordinates,
+        value: ArrayLike,
+        /,
+    ) -> Array:
+        statistics = self.sufficient_statistics(value)
+        mean = self.mean_from_natural(natural)
+        score = mean.values - statistics.values
+        return jnp.where(statistics.valid[..., None], score, jnp.nan)
+
+    def fisher_action(
+        self,
+        natural: NaturalCoordinates,
+        direction: ArrayLike,
+        /,
+    ) -> Array:
+        _require_signature(natural.signature, self.signature)
+        vector = jnp.asarray(direction)
+        if vector.shape != natural.values.shape:
+            raise ValueError("Fisher direction must match natural-coordinate shape.")
+        _, action = jax.jvp(
+            self._mean_values,
+            (natural.values,),
+            (vector,),
+        )
+        return action
+
+    def kl_divergence(
+        self,
+        left: NaturalCoordinates,
+        right: NaturalCoordinates,
+        /,
+    ) -> Array:
+        _require_signature(left.signature, self.signature)
+        _require_signature(right.signature, self.signature)
+        mean = self._mean_values(left.values)
+        return (
+            self._log_normalizer(right.values)
+            - self._log_normalizer(left.values)
+            - jnp.sum((right.values - left.values) * mean, axis=-1)
+        )
+
+    def law(self, natural: NaturalCoordinates | ArrayLike, /) -> "ExponentialFamilyLaw":
+        coordinates = (
+            natural
+            if isinstance(natural, NaturalCoordinates)
+            else NaturalCoordinates(natural, self.signature)
+        )
+        return ExponentialFamilyLaw(self, coordinates)
+
+    def sample(
+        self,
+        key,
+        natural: NaturalCoordinates,
+        sample_shape: tuple[int, ...] = (),
+    ) -> Array:
+        domain = self.natural_domain(natural)
+        checked = eqx.error_if(
+            natural.values,
+            jnp.any(~domain.valid),
+            "Cannot sample an invalid exponential-family law.",
+        )
+        return self._sample(key, checked, tuple(sample_shape))
+
+
+class _AbstractAnalyticExponentialFamily(AbstractExponentialFamily):
+    def _natural_from_mean_result(
+        self,
+        mean: MeanCoordinates,
+        domain: ExponentialFamilyDomainResult,
+        /,
+    ) -> ExponentialFamilyConversionResult:
+        return super()._natural_from_mean_result(mean, domain)
+
+
+class ExponentialFamilyLaw(AbstractProbabilityLaw):
+    """Normalized exponential-family law with audited natural coordinates."""
+
+    family: AbstractExponentialFamily
+    natural: NaturalCoordinates
+
+    def __init__(
+        self,
+        family: AbstractExponentialFamily,
+        natural: NaturalCoordinates,
+    ):
+        if not isinstance(family, AbstractExponentialFamily):
+            raise TypeError("family must implement AbstractExponentialFamily.")
+        _require_signature(natural.signature, family.signature)
+        self.family = family
+        self.natural = natural
+
+    @property
+    def event_shape(self) -> tuple[int, ...]:
+        return self.family.signature.event_shape
+
+    @property
+    def batch_shape(self) -> tuple[int, ...]:
+        return self.natural.batch_shape
+
+    @property
+    def density_measure_kind(self) -> MeasureKind:
+        return self.family.signature.density_measure_kind
+
+    @property
+    def valid(self) -> Array:
+        return self.family.natural_domain(self.natural).valid
+
+    @property
+    def status(self) -> Array:
+        return self.family.natural_domain(self.natural).status
+
+    @property
+    def mean_coordinates(self) -> MeanCoordinates:
+        return self.family.mean_from_natural(self.natural)
+
+    def contains(self, value: ArrayLike, /) -> Array:
+        return self.family.sufficient_statistics(value).valid
+
+    def log_prob(self, value: ArrayLike, /) -> Array:
+        return self.family.log_prob(self.natural, value)
+
+    def sample(self, key, sample_shape: tuple[int, ...] = ()) -> Array:
+        return self.family.sample(key, self.natural, tuple(sample_shape))
+
+    def kl_divergence(self, other: "ExponentialFamilyLaw", /) -> Array:
+        if not isinstance(other, ExponentialFamilyLaw):
+            raise TypeError("other must be an ExponentialFamilyLaw.")
+        _require_signature(other.family.signature, self.family.signature)
+        return self.family.kl_divergence(self.natural, other.natural)
+
+    def fisher_action(self, direction: ArrayLike, /) -> Array:
+        return self.family.fisher_action(self.natural, direction)
+
+
+__all__ = [
+    "AbstractExponentialFamily",
+    "EXPONENTIAL_FAMILY_INSUFFICIENT_WEIGHT",
+    "EXPONENTIAL_FAMILY_INVALID_EVENT",
+    "EXPONENTIAL_FAMILY_MEAN_BOUNDARY",
+    "EXPONENTIAL_FAMILY_NONFINITE",
+    "EXPONENTIAL_FAMILY_NONCONVERGED",
+    "EXPONENTIAL_FAMILY_OUTSIDE_MEAN_DOMAIN",
+    "EXPONENTIAL_FAMILY_OUTSIDE_NATURAL_DOMAIN",
+    "EXPONENTIAL_FAMILY_SUCCESS",
+    "ExponentialFamilyConversionResult",
+    "ExponentialFamilyDomainResult",
+    "ExponentialFamilyLaw",
+    "ExponentialFamilySignature",
+    "ExponentialFamilyStatus",
+    "MeanCoordinates",
+    "NaturalCoordinates",
+    "StatisticBatch",
+    "exponential_family_status_name",
+]

--- a/phydrax/_exponential_family/_dirichlet.py
+++ b/phydrax/_exponential_family/_dirichlet.py
@@ -1,0 +1,389 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import jax.scipy as jsp
+from jaxtyping import Array, ArrayLike
+
+from ._contracts import (
+    _mean_domain_result,
+    _natural_domain_result,
+    AbstractExponentialFamily,
+    EXPONENTIAL_FAMILY_NONCONVERGED,
+    EXPONENTIAL_FAMILY_NONFINITE,
+    ExponentialFamilyConversionResult,
+    ExponentialFamilyDomainResult,
+    ExponentialFamilySignature,
+    MeanCoordinates,
+    NaturalCoordinates,
+    StatisticBatch,
+)
+
+
+_EULER_MASCHERONI = 0.5772156649015329
+
+
+def _dirichlet_residual(concentration: Array, mean: Array, /) -> Array:
+    total = jnp.sum(concentration, axis=-1, keepdims=True)
+    return jsp.special.digamma(concentration) - jsp.special.digamma(total) - mean
+
+
+def _inverse_digamma(value: Array, /) -> Array:
+    initial = jnp.where(
+        value >= -2.22,
+        jnp.exp(value) + 0.5,
+        -1.0 / (value + _EULER_MASCHERONI),
+    )
+    initial = jnp.maximum(initial, jnp.sqrt(jnp.finfo(value.dtype).tiny))
+
+    def step(_, current):
+        update = (jsp.special.digamma(current) - value) / jsp.special.polygamma(
+            1, current
+        )
+        candidate = current - update
+        return jnp.where(
+            jnp.isfinite(candidate) & (candidate > 0.0),
+            candidate,
+            0.5 * current,
+        )
+
+    return jax.lax.fori_loop(0, 5, step, initial)
+
+
+def _solve_dirichlet_concentration(
+    mean: Array,
+    /,
+    *,
+    atol: float,
+    rtol: float,
+    max_iterations: int,
+) -> tuple[Array, Array, Array]:
+    dtype = mean.dtype
+    categories = int(mean.shape[-1])
+    gap = -jax.nn.logsumexp(mean, axis=-1)
+    initial_total = jnp.maximum((categories - 1.0) / (2.0 * gap), 0.01)
+    lower = jnp.log(initial_total) - 4.0
+    upper = jnp.log(initial_total) + 4.0
+
+    def concentration_from_log_total(log_total):
+        total = jnp.exp(log_total)[..., None]
+        shifted_mean = mean + jsp.special.digamma(total)
+        return _inverse_digamma(shifted_mean)
+
+    def total_residual(log_total):
+        total = jnp.exp(log_total)
+        concentration = concentration_from_log_total(log_total)
+        return jnp.sum(concentration, axis=-1) / total - 1.0
+
+    def bracket_step(_, bounds):
+        lower_value, upper_value = bounds
+        lower_residual = total_residual(lower_value)
+        upper_residual = total_residual(upper_value)
+        return (
+            jnp.where(lower_residual <= 0.0, lower_value - 4.0, lower_value),
+            jnp.where(upper_residual >= 0.0, upper_value + 4.0, upper_value),
+        )
+
+    lower, upper = jax.lax.fori_loop(0, 16, bracket_step, (lower, upper))
+    concentration = concentration_from_log_total(0.5 * (lower + upper))
+    iterations = jnp.zeros(mean.shape[:-1], dtype=jnp.int32)
+    converged = jnp.zeros(mean.shape[:-1], dtype=bool)
+    coordinate_scale = jnp.maximum(jnp.abs(mean), 1.0)
+    coordinate_tolerance = (
+        jnp.maximum(atol, 64.0 * jnp.finfo(dtype).eps * coordinate_scale)
+        + rtol * coordinate_scale
+    )
+
+    def condition(state):
+        _, _, _, _, converged_values, loop_iteration = state
+        return (loop_iteration < max_iterations) & jnp.any(~converged_values)
+
+    def step(state):
+        (
+            lower_value,
+            upper_value,
+            concentration_value,
+            iteration_values,
+            converged_values,
+            loop_iteration,
+        ) = state
+        midpoint = 0.5 * (lower_value + upper_value)
+        candidate = concentration_from_log_total(midpoint)
+        root_residual = total_residual(midpoint)
+        residual = jnp.max(
+            jnp.abs(_dirichlet_residual(candidate, mean)) / coordinate_tolerance,
+            axis=-1,
+        )
+        active = ~converged_values
+        newly_converged = active & (residual <= 1.0)
+        lower_value = jnp.where(active & (root_residual > 0.0), midpoint, lower_value)
+        upper_value = jnp.where(active & (root_residual <= 0.0), midpoint, upper_value)
+        concentration_value = jnp.where(active[..., None], candidate, concentration_value)
+        iteration_values = iteration_values + active.astype(jnp.int32)
+        return (
+            lower_value,
+            upper_value,
+            concentration_value,
+            iteration_values,
+            converged_values | newly_converged,
+            loop_iteration + 1,
+        )
+
+    _, _, concentration, iterations, converged, _ = jax.lax.while_loop(
+        condition,
+        step,
+        (
+            lower,
+            upper,
+            concentration,
+            iterations,
+            converged,
+            jnp.asarray(0, dtype=jnp.int32),
+        ),
+    )
+    final_residual = jnp.max(
+        jnp.abs(_dirichlet_residual(concentration, mean)) / coordinate_tolerance,
+        axis=-1,
+    )
+    converged = converged | (final_residual <= 1.0)
+    return concentration, iterations, converged
+
+
+@jax.custom_jvp
+def _implicit_dirichlet_concentration(mean: Array, concentration: Array, /) -> Array:
+    """Attach the inverse-Fisher derivative to a converged concentration."""
+    del mean
+    return concentration
+
+
+@_implicit_dirichlet_concentration.defjvp
+def _implicit_dirichlet_concentration_jvp(primals, tangents):
+    mean, concentration = primals
+    mean_tangent, _ = tangents
+    del mean
+    diagonal = jsp.special.polygamma(1, concentration)
+    inverse_diagonal = 1.0 / diagonal
+    total = jnp.sum(concentration, axis=-1)
+    shared = jsp.special.polygamma(1, total)
+    weighted = mean_tangent * inverse_diagonal
+    denominator = 1.0 / shared - jnp.sum(inverse_diagonal, axis=-1)
+    correction = jnp.sum(weighted, axis=-1) / denominator
+    concentration_tangent = weighted + correction[..., None] * inverse_diagonal
+    return concentration, concentration_tangent
+
+
+class DirichletFamily(AbstractExponentialFamily):
+    """Dirichlet laws relative to Hausdorff measure on the unit simplex."""
+
+    num_categories: int = eqx.field(static=True)
+    atol: float = eqx.field(static=True)
+    rtol: float = eqx.field(static=True)
+    max_iterations: int = eqx.field(static=True)
+    _signature: ExponentialFamilySignature = eqx.field(static=True)
+
+    def __init__(
+        self,
+        num_categories: int,
+        *,
+        atol: float = 1e-12,
+        rtol: float = 1e-12,
+        max_iterations: int = 100,
+    ):
+        categories = int(num_categories)
+        absolute = float(atol)
+        relative = float(rtol)
+        iterations = int(max_iterations)
+        if categories < 2:
+            raise ValueError("num_categories must be at least two.")
+        if not jnp.isfinite(absolute) or absolute <= 0.0:
+            raise ValueError("atol must be finite and strictly positive.")
+        if not jnp.isfinite(relative) or relative < 0.0:
+            raise ValueError("rtol must be finite and non-negative.")
+        if iterations <= 0:
+            raise ValueError("max_iterations must be positive.")
+        self.num_categories = categories
+        self.atol = absolute
+        self.rtol = relative
+        self.max_iterations = iterations
+        self._signature = ExponentialFamilySignature(
+            "dirichlet",
+            categories,
+            (categories,),
+            "hausdorff",
+            f"positive-unit-simplex-{categories}",
+            f"log-simplex-statistics-{categories}",
+        )
+
+    @property
+    def signature(self) -> ExponentialFamilySignature:
+        return self._signature
+
+    def natural_from_concentration(
+        self, concentration: ArrayLike, /
+    ) -> NaturalCoordinates:
+        values = jnp.asarray(concentration)
+        if jnp.issubdtype(values.dtype, jnp.complexfloating):
+            raise TypeError("Dirichlet concentrations must be real-valued.")
+        if values.ndim == 0 or int(values.shape[-1]) != self.num_categories:
+            raise ValueError(
+                "Dirichlet concentration must end in num_categories="
+                f"{self.num_categories}; got {values.shape}."
+            )
+        values = values.astype(jnp.result_type(values, 0.0))
+        return self.natural(values - 1.0)
+
+    def law_from_concentration(self, concentration: ArrayLike, /):
+        """Return a Dirichlet law from conventional concentration parameters."""
+        return self.law(self.natural_from_concentration(concentration))
+
+    def concentration_from_natural(self, natural: NaturalCoordinates, /) -> Array:
+        domain = self.natural_domain(natural)
+        return jnp.where(domain.valid[..., None], natural.values + 1.0, jnp.nan)
+
+    def _natural_domain(self, values: Array, /) -> ExponentialFamilyDomainResult:
+        concentration = values + 1.0
+        minimum = jnp.min(concentration, axis=-1)
+        return _natural_domain_result(
+            self.signature,
+            values,
+            interior=minimum > 0.0,
+            boundary=minimum == 0.0,
+        )
+
+    def _mean_domain(self, values: Array, /) -> ExponentialFamilyDomainResult:
+        log_total = jax.nn.logsumexp(values, axis=-1)
+        scale = jnp.maximum(jnp.max(jnp.abs(values), axis=-1), 1.0)
+        tolerance = 64.0 * jnp.finfo(values.dtype).eps * scale
+        return _mean_domain_result(
+            self.signature,
+            values,
+            interior=log_total < -tolerance,
+            boundary=jnp.abs(log_total) <= tolerance,
+        )
+
+    def _sufficient_statistics(self, value: ArrayLike, /) -> StatisticBatch:
+        raw = jnp.asarray(value)
+        if jnp.issubdtype(raw.dtype, jnp.complexfloating):
+            raise TypeError("Dirichlet observations must be real-valued.")
+        if raw.ndim == 0 or int(raw.shape[-1]) != self.num_categories:
+            raise ValueError(
+                "Dirichlet observations must end in simplex dimension "
+                f"{self.num_categories}; got {raw.shape}."
+            )
+        observation = raw.astype(jnp.result_type(raw, 0.0))
+        tolerance = 64.0 * jnp.finfo(observation.dtype).eps
+        valid = (
+            jnp.all(jnp.isfinite(observation), axis=-1)
+            & jnp.all(observation > 0.0, axis=-1)
+            & (jnp.abs(jnp.sum(observation, axis=-1) - 1.0) <= tolerance)
+        )
+        safe = jnp.where(valid[..., None], observation, 1.0 / self.num_categories)
+        return StatisticBatch(jnp.log(safe), valid, self.signature)
+
+    def _log_base_density(self, value: ArrayLike, /) -> Array:
+        values = jnp.asarray(value)
+        if values.ndim == 0 or int(values.shape[-1]) != self.num_categories:
+            raise ValueError("Dirichlet observations have an incompatible event shape.")
+        dtype = jnp.result_type(values, 0.0)
+        return jnp.full(
+            values.shape[:-1],
+            -0.5 * jnp.log(jnp.asarray(self.num_categories, dtype=dtype)),
+            dtype=dtype,
+        )
+
+    def _log_normalizer(self, natural_values: Array, /) -> Array:
+        concentration = natural_values + 1.0
+        return jnp.sum(jsp.special.gammaln(concentration), axis=-1) - jsp.special.gammaln(
+            jnp.sum(concentration, axis=-1)
+        )
+
+    def _mean_values(self, natural_values: Array, /) -> Array:
+        concentration = natural_values + 1.0
+        total = jnp.sum(concentration, axis=-1, keepdims=True)
+        return jsp.special.digamma(concentration) - jsp.special.digamma(total)
+
+    def _natural_from_mean_values(self, mean_values: Array, /) -> Array:
+        concentration, _, _ = _solve_dirichlet_concentration(
+            mean_values,
+            atol=self.atol,
+            rtol=self.rtol,
+            max_iterations=self.max_iterations,
+        )
+        concentration = _implicit_dirichlet_concentration(
+            mean_values, jax.lax.stop_gradient(concentration)
+        )
+        return concentration - 1.0
+
+    def _natural_from_mean_result(
+        self,
+        mean: MeanCoordinates,
+        domain: ExponentialFamilyDomainResult,
+        /,
+    ) -> ExponentialFamilyConversionResult:
+        unit_concentration_mean = jsp.special.digamma(
+            jnp.ones((self.num_categories,), dtype=mean.values.dtype)
+        ) - jsp.special.digamma(jnp.asarray(self.num_categories, dtype=mean.values.dtype))
+        safe_mean = jnp.where(
+            domain.interior[..., None], mean.values, unit_concentration_mean
+        )
+        concentration, iterations, converged = _solve_dirichlet_concentration(
+            safe_mean,
+            atol=self.atol,
+            rtol=self.rtol,
+            max_iterations=self.max_iterations,
+        )
+        concentration = _implicit_dirichlet_concentration(
+            safe_mean, jax.lax.stop_gradient(concentration)
+        )
+        candidate_values = jnp.where(
+            domain.interior[..., None], concentration - 1.0, jnp.nan
+        )
+        natural = NaturalCoordinates(candidate_values, self.signature)
+        reconstructed = self._mean_values(candidate_values)
+        residual = jnp.linalg.norm(reconstructed - mean.values, axis=-1)
+        candidate_finite = jnp.all(jnp.isfinite(candidate_values), axis=-1)
+        residual_finite = jnp.isfinite(residual)
+        finite = candidate_finite & residual_finite
+        valid = domain.valid & finite & converged
+        status = jnp.where(
+            domain.valid & ~finite,
+            EXPONENTIAL_FAMILY_NONFINITE,
+            jnp.where(
+                domain.valid & finite & ~converged,
+                EXPONENTIAL_FAMILY_NONCONVERGED,
+                domain.status,
+            ),
+        )
+        return ExponentialFamilyConversionResult(
+            mean=mean,
+            natural=natural,
+            valid=valid,
+            status=status,
+            residual=jnp.where(domain.valid & residual_finite, residual, jnp.inf),
+            iterations=jnp.where(domain.valid, iterations, 0),
+            method_id="dirichlet-total-concentration-bisection",
+        )
+
+    def _sample(
+        self,
+        key,
+        natural_values: Array,
+        sample_shape: tuple[int, ...],
+        /,
+    ) -> Array:
+        concentration = natural_values + 1.0
+        return jr.dirichlet(
+            key,
+            concentration,
+            shape=sample_shape + concentration.shape[:-1],
+            dtype=natural_values.dtype,
+        )
+
+
+__all__ = ["DirichletFamily"]

--- a/phydrax/_exponential_family/_elementary.py
+++ b/phydrax/_exponential_family/_elementary.py
@@ -1,0 +1,333 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import jax.scipy as jsp
+from jaxtyping import Array, ArrayLike
+
+from ._contracts import (
+    _AbstractAnalyticExponentialFamily,
+    _mean_domain_result,
+    _natural_domain_result,
+    ExponentialFamilyDomainResult,
+    ExponentialFamilySignature,
+    StatisticBatch,
+)
+
+
+_BERNOULLI_SIGNATURE = ExponentialFamilySignature(
+    "bernoulli",
+    1,
+    (),
+    "counting",
+    "binary",
+    "scalar-log-odds",
+)
+_POISSON_SIGNATURE = ExponentialFamilySignature(
+    "poisson",
+    1,
+    (),
+    "counting",
+    "nonnegative-integers",
+    "scalar-log-rate",
+)
+_EXPONENTIAL_RATE_SIGNATURE = ExponentialFamilySignature(
+    "exponential-rate",
+    1,
+    (),
+    "lebesgue",
+    "nonnegative-real",
+    "negative-rate",
+)
+_NORMAL_SIGNATURE = ExponentialFamilySignature(
+    "normal",
+    2,
+    (),
+    "lebesgue",
+    "real-line",
+    "linear-quadratic",
+)
+
+
+def _real_observation(value: ArrayLike, /) -> Array:
+    raw = jnp.asarray(value)
+    if jnp.issubdtype(raw.dtype, jnp.complexfloating):
+        raise TypeError("Exponential-family observations must be real-valued.")
+    return raw.astype(jnp.result_type(raw, 0.0))
+
+
+class BernoulliFamily(_AbstractAnalyticExponentialFamily):
+    """Bernoulli laws in scalar log-odds coordinates."""
+
+    @property
+    def signature(self) -> ExponentialFamilySignature:
+        return _BERNOULLI_SIGNATURE
+
+    def _natural_domain(self, values: Array, /) -> ExponentialFamilyDomainResult:
+        shape = values.shape[:-1]
+        return _natural_domain_result(
+            self.signature,
+            values,
+            interior=jnp.ones(shape, dtype=bool),
+            boundary=jnp.zeros(shape, dtype=bool),
+        )
+
+    def _mean_domain(self, values: Array, /) -> ExponentialFamilyDomainResult:
+        probability = values[..., 0]
+        return _mean_domain_result(
+            self.signature,
+            values,
+            interior=(probability > 0.0) & (probability < 1.0),
+            boundary=(probability == 0.0) | (probability == 1.0),
+        )
+
+    def _sufficient_statistics(self, value: ArrayLike, /) -> StatisticBatch:
+        observation = _real_observation(value)
+        valid = jnp.isfinite(observation) & ((observation == 0.0) | (observation == 1.0))
+        safe = jnp.where(valid, observation, 0.0)
+        return StatisticBatch(safe[..., None], valid, self.signature)
+
+    def _log_base_density(self, value: ArrayLike, /) -> Array:
+        return jnp.zeros_like(_real_observation(value))
+
+    def _log_normalizer(self, natural_values: Array, /) -> Array:
+        return jax.nn.softplus(natural_values[..., 0])
+
+    def _mean_values(self, natural_values: Array, /) -> Array:
+        return jax.nn.sigmoid(natural_values)
+
+    def _natural_from_mean_values(self, mean_values: Array, /) -> Array:
+        probability = mean_values[..., 0]
+        safe = jnp.where((probability > 0.0) & (probability < 1.0), probability, 0.5)
+        return (jnp.log(safe) - jnp.log1p(-safe))[..., None]
+
+    def _sample(
+        self,
+        key,
+        natural_values: Array,
+        sample_shape: tuple[int, ...],
+        /,
+    ) -> Array:
+        probability = jax.nn.sigmoid(natural_values[..., 0])
+        return jr.bernoulli(
+            key,
+            probability,
+            shape=sample_shape + probability.shape,
+        )
+
+
+class PoissonFamily(_AbstractAnalyticExponentialFamily):
+    """Poisson laws in scalar log-rate coordinates."""
+
+    @property
+    def signature(self) -> ExponentialFamilySignature:
+        return _POISSON_SIGNATURE
+
+    def _natural_domain(self, values: Array, /) -> ExponentialFamilyDomainResult:
+        shape = values.shape[:-1]
+        return _natural_domain_result(
+            self.signature,
+            values,
+            interior=jnp.ones(shape, dtype=bool),
+            boundary=jnp.zeros(shape, dtype=bool),
+        )
+
+    def _mean_domain(self, values: Array, /) -> ExponentialFamilyDomainResult:
+        rate = values[..., 0]
+        return _mean_domain_result(
+            self.signature,
+            values,
+            interior=rate > 0.0,
+            boundary=rate == 0.0,
+        )
+
+    def _sufficient_statistics(self, value: ArrayLike, /) -> StatisticBatch:
+        observation = _real_observation(value)
+        valid = (
+            jnp.isfinite(observation)
+            & (observation >= 0.0)
+            & (observation == jnp.floor(observation))
+        )
+        safe = jnp.where(valid, observation, 0.0)
+        return StatisticBatch(safe[..., None], valid, self.signature)
+
+    def _log_base_density(self, value: ArrayLike, /) -> Array:
+        statistics = self._sufficient_statistics(value)
+        return -jsp.special.gammaln(statistics.values[..., 0] + 1.0)
+
+    def _log_normalizer(self, natural_values: Array, /) -> Array:
+        return jnp.exp(natural_values[..., 0])
+
+    def _mean_values(self, natural_values: Array, /) -> Array:
+        return jnp.exp(natural_values)
+
+    def _natural_from_mean_values(self, mean_values: Array, /) -> Array:
+        rate = mean_values[..., 0]
+        safe = jnp.where(rate > 0.0, rate, 1.0)
+        return jnp.log(safe)[..., None]
+
+    def _sample(
+        self,
+        key,
+        natural_values: Array,
+        sample_shape: tuple[int, ...],
+        /,
+    ) -> Array:
+        rate = jnp.exp(natural_values[..., 0])
+        return jr.poisson(key, rate, shape=sample_shape + rate.shape)
+
+
+class ExponentialRateFamily(_AbstractAnalyticExponentialFamily):
+    """Exponential laws in the negative-rate natural coordinate."""
+
+    @property
+    def signature(self) -> ExponentialFamilySignature:
+        return _EXPONENTIAL_RATE_SIGNATURE
+
+    def _natural_domain(self, values: Array, /) -> ExponentialFamilyDomainResult:
+        rate_coordinate = values[..., 0]
+        return _natural_domain_result(
+            self.signature,
+            values,
+            interior=rate_coordinate < 0.0,
+            boundary=rate_coordinate == 0.0,
+        )
+
+    def _mean_domain(self, values: Array, /) -> ExponentialFamilyDomainResult:
+        mean = values[..., 0]
+        return _mean_domain_result(
+            self.signature,
+            values,
+            interior=mean > 0.0,
+            boundary=mean == 0.0,
+        )
+
+    def _sufficient_statistics(self, value: ArrayLike, /) -> StatisticBatch:
+        observation = _real_observation(value)
+        valid = jnp.isfinite(observation) & (observation >= 0.0)
+        safe = jnp.where(valid, observation, 0.0)
+        return StatisticBatch(safe[..., None], valid, self.signature)
+
+    def _log_base_density(self, value: ArrayLike, /) -> Array:
+        return jnp.zeros_like(_real_observation(value))
+
+    def _log_normalizer(self, natural_values: Array, /) -> Array:
+        return -jnp.log(-natural_values[..., 0])
+
+    def _mean_values(self, natural_values: Array, /) -> Array:
+        return -1.0 / natural_values
+
+    def _natural_from_mean_values(self, mean_values: Array, /) -> Array:
+        mean = mean_values[..., 0]
+        safe = jnp.where(mean > 0.0, mean, 1.0)
+        return (-1.0 / safe)[..., None]
+
+    def _sample(
+        self,
+        key,
+        natural_values: Array,
+        sample_shape: tuple[int, ...],
+        /,
+    ) -> Array:
+        rate = -natural_values[..., 0]
+        standard = jr.exponential(
+            key,
+            shape=sample_shape + rate.shape,
+            dtype=natural_values.dtype,
+        )
+        return standard / rate
+
+
+class NormalFamily(_AbstractAnalyticExponentialFamily):
+    """Univariate Normal laws in linear-quadratic natural coordinates."""
+
+    @property
+    def signature(self) -> ExponentialFamilySignature:
+        return _NORMAL_SIGNATURE
+
+    def _natural_domain(self, values: Array, /) -> ExponentialFamilyDomainResult:
+        quadratic = values[..., 1]
+        return _natural_domain_result(
+            self.signature,
+            values,
+            interior=quadratic < 0.0,
+            boundary=quadratic == 0.0,
+        )
+
+    def _mean_domain(self, values: Array, /) -> ExponentialFamilyDomainResult:
+        first = values[..., 0]
+        second = values[..., 1]
+        variance = second - first * first
+        scale = jnp.maximum(jnp.maximum(jnp.abs(second), first * first), 1.0)
+        tolerance = 64.0 * jnp.finfo(values.dtype).eps * scale
+        return _mean_domain_result(
+            self.signature,
+            values,
+            interior=variance > tolerance,
+            boundary=jnp.abs(variance) <= tolerance,
+        )
+
+    def _sufficient_statistics(self, value: ArrayLike, /) -> StatisticBatch:
+        observation = _real_observation(value)
+        valid = jnp.isfinite(observation)
+        safe = jnp.where(valid, observation, 0.0)
+        return StatisticBatch(
+            jnp.stack((safe, safe * safe), axis=-1),
+            valid,
+            self.signature,
+        )
+
+    def _log_base_density(self, value: ArrayLike, /) -> Array:
+        return jnp.zeros_like(_real_observation(value))
+
+    def _log_normalizer(self, natural_values: Array, /) -> Array:
+        linear = natural_values[..., 0]
+        quadratic = natural_values[..., 1]
+        return -(linear * linear) / (4.0 * quadratic) + 0.5 * jnp.log(-jnp.pi / quadratic)
+
+    def _mean_values(self, natural_values: Array, /) -> Array:
+        linear = natural_values[..., 0]
+        quadratic = natural_values[..., 1]
+        location = -linear / (2.0 * quadratic)
+        variance = -1.0 / (2.0 * quadratic)
+        return jnp.stack((location, location * location + variance), axis=-1)
+
+    def _natural_from_mean_values(self, mean_values: Array, /) -> Array:
+        location = mean_values[..., 0]
+        variance = mean_values[..., 1] - location * location
+        safe_variance = jnp.where(variance > 0.0, variance, 1.0)
+        return jnp.stack(
+            (location / safe_variance, -0.5 / safe_variance),
+            axis=-1,
+        )
+
+    def _sample(
+        self,
+        key,
+        natural_values: Array,
+        sample_shape: tuple[int, ...],
+        /,
+    ) -> Array:
+        linear = natural_values[..., 0]
+        quadratic = natural_values[..., 1]
+        location = -linear / (2.0 * quadratic)
+        scale = jnp.sqrt(-1.0 / (2.0 * quadratic))
+        noise = jr.normal(
+            key,
+            shape=sample_shape + location.shape,
+            dtype=natural_values.dtype,
+        )
+        return location + scale * noise
+
+
+__all__ = [
+    "BernoulliFamily",
+    "ExponentialRateFamily",
+    "NormalFamily",
+    "PoissonFamily",
+]

--- a/phydrax/_exponential_family/_gamma.py
+++ b/phydrax/_exponential_family/_gamma.py
@@ -1,0 +1,346 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import jax.scipy as jsp
+from jaxtyping import Array, ArrayLike
+
+from ._contracts import (
+    _mean_domain_result,
+    _natural_domain_result,
+    AbstractExponentialFamily,
+    EXPONENTIAL_FAMILY_NONCONVERGED,
+    EXPONENTIAL_FAMILY_NONFINITE,
+    ExponentialFamilyConversionResult,
+    ExponentialFamilyDomainResult,
+    ExponentialFamilySignature,
+    MeanCoordinates,
+    NaturalCoordinates,
+    StatisticBatch,
+)
+
+
+_GAMMA_SIGNATURE = ExponentialFamilySignature(
+    "gamma",
+    2,
+    (),
+    "lebesgue",
+    "positive-real",
+    "log-linear-shape-rate",
+)
+
+
+def _gamma_shape_residual(shape: Array, delta: Array, /) -> Array:
+    return jnp.log(shape) - jsp.special.digamma(shape) - delta
+
+
+def _initial_gamma_shape(delta: Array, /) -> Array:
+    discriminant = (delta - 3.0) ** 2 + 24.0 * delta
+    return (3.0 - delta + jnp.sqrt(discriminant)) / (12.0 * delta)
+
+
+def _solve_gamma_shape(
+    delta: Array,
+    /,
+    *,
+    atol: float,
+    rtol: float,
+    max_iterations: int,
+) -> tuple[Array, Array, Array]:
+    dtype = delta.dtype
+    tiny = jnp.finfo(dtype).tiny
+    initial = jnp.maximum(_initial_gamma_shape(delta), jnp.sqrt(tiny))
+    lower = jnp.maximum(0.5 * initial, tiny)
+    upper = jnp.maximum(2.0 * initial, 1.0)
+
+    def bracket_step(_, bounds):
+        lower_value, upper_value = bounds
+        lower_residual = _gamma_shape_residual(lower_value, delta)
+        upper_residual = _gamma_shape_residual(upper_value, delta)
+        lower_value = jnp.where(lower_residual <= 0.0, 0.5 * lower_value, lower_value)
+        upper_value = jnp.where(upper_residual >= 0.0, 2.0 * upper_value, upper_value)
+        return jnp.maximum(lower_value, tiny), upper_value
+
+    lower, upper = jax.lax.fori_loop(0, 64, bracket_step, (lower, upper))
+    shape = jnp.clip(initial, lower, upper)
+    iterations = jnp.zeros(delta.shape, dtype=jnp.int32)
+    converged = jnp.zeros(delta.shape, dtype=bool)
+
+    def condition(state):
+        _, _, _, _, converged_values, loop_iteration = state
+        return (loop_iteration < max_iterations) & jnp.any(~converged_values)
+
+    def step(state):
+        (
+            shape_value,
+            lower_value,
+            upper_value,
+            iteration_values,
+            converged_values,
+            loop_iteration,
+        ) = state
+        residual = _gamma_shape_residual(shape_value, delta)
+        tolerance = jnp.maximum(atol, 64.0 * jnp.finfo(dtype).eps) + rtol * delta
+        newly_converged = jnp.abs(residual) <= tolerance
+        active = ~(converged_values | newly_converged)
+        lower_candidate = jnp.where((residual > 0.0) & active, shape_value, lower_value)
+        upper_candidate = jnp.where((residual < 0.0) & active, shape_value, upper_value)
+        derivative = 1.0 / shape_value - jsp.special.polygamma(1, shape_value)
+        newton = shape_value - residual / derivative
+        midpoint = 0.5 * (lower_candidate + upper_candidate)
+        acceptable = (
+            jnp.isfinite(newton) & (newton > lower_candidate) & (newton < upper_candidate)
+        )
+        next_shape = jnp.where(acceptable, newton, midpoint)
+        shape_value = jnp.where(active, next_shape, shape_value)
+        iteration_values = iteration_values + active.astype(jnp.int32)
+        return (
+            shape_value,
+            lower_candidate,
+            upper_candidate,
+            iteration_values,
+            converged_values | newly_converged,
+            loop_iteration + 1,
+        )
+
+    shape, _, _, iterations, converged, _ = jax.lax.while_loop(
+        condition,
+        step,
+        (
+            shape,
+            lower,
+            upper,
+            iterations,
+            converged,
+            jnp.asarray(0, dtype=jnp.int32),
+        ),
+    )
+    final_residual = jnp.abs(_gamma_shape_residual(shape, delta))
+    effective_atol = jnp.maximum(atol, 64.0 * jnp.finfo(dtype).eps)
+    converged = converged | (final_residual <= effective_atol + rtol * delta)
+    return shape, iterations, converged
+
+
+@jax.custom_jvp
+def _implicit_gamma_shape(delta: Array, shape: Array, /) -> Array:
+    """Attach the implicit inverse-map derivative to a converged shape."""
+    del delta
+    return shape
+
+
+@_implicit_gamma_shape.defjvp
+def _implicit_gamma_shape_jvp(primals, tangents):
+    delta, shape = primals
+    delta_tangent, _ = tangents
+    del delta
+    derivative = 1.0 / shape - jsp.special.polygamma(1, shape)
+    return shape, delta_tangent / derivative
+
+
+class GammaFamily(AbstractExponentialFamily):
+    """Gamma laws in full shape-rate natural coordinates."""
+
+    atol: float = eqx.field(static=True)
+    rtol: float = eqx.field(static=True)
+    max_iterations: int = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        atol: float = 1e-10,
+        rtol: float = 1e-10,
+        max_iterations: int = 64,
+    ):
+        absolute = float(atol)
+        relative = float(rtol)
+        iterations = int(max_iterations)
+        if not jnp.isfinite(absolute) or absolute <= 0.0:
+            raise ValueError("atol must be finite and strictly positive.")
+        if not jnp.isfinite(relative) or relative < 0.0:
+            raise ValueError("rtol must be finite and non-negative.")
+        if iterations <= 0:
+            raise ValueError("max_iterations must be positive.")
+        self.atol = absolute
+        self.rtol = relative
+        self.max_iterations = iterations
+
+    @property
+    def signature(self) -> ExponentialFamilySignature:
+        return _GAMMA_SIGNATURE
+
+    def natural_from_shape_rate(
+        self, shape: ArrayLike, rate: ArrayLike, /
+    ) -> NaturalCoordinates:
+        """Return natural coordinates from conventional shape and rate."""
+        shape_array, rate_array = jnp.broadcast_arrays(
+            jnp.asarray(shape), jnp.asarray(rate)
+        )
+        dtype = jnp.result_type(shape_array, rate_array, 0.0)
+        return self.natural(
+            jnp.stack(
+                (shape_array.astype(dtype) - 1.0, -rate_array.astype(dtype)),
+                axis=-1,
+            )
+        )
+
+    def law_from_shape_rate(self, shape: ArrayLike, rate: ArrayLike, /):
+        """Return a Gamma law from conventional shape and rate."""
+        return self.law(self.natural_from_shape_rate(shape, rate))
+
+    def shape_rate_from_natural(
+        self, natural: NaturalCoordinates, /
+    ) -> tuple[Array, Array]:
+        domain = self.natural_domain(natural)
+        shape = natural.values[..., 0] + 1.0
+        rate = -natural.values[..., 1]
+        return (
+            jnp.where(domain.valid, shape, jnp.nan),
+            jnp.where(domain.valid, rate, jnp.nan),
+        )
+
+    def _natural_domain(self, values: Array, /) -> ExponentialFamilyDomainResult:
+        shape_coordinate = values[..., 0]
+        rate_coordinate = values[..., 1]
+        closure = (shape_coordinate >= -1.0) & (rate_coordinate <= 0.0)
+        return _natural_domain_result(
+            self.signature,
+            values,
+            interior=(shape_coordinate > -1.0) & (rate_coordinate < 0.0),
+            boundary=closure & ((shape_coordinate == -1.0) | (rate_coordinate == 0.0)),
+        )
+
+    def _mean_domain(self, values: Array, /) -> ExponentialFamilyDomainResult:
+        expected_log = values[..., 0]
+        expected_value = values[..., 1]
+        safe_value = jnp.where(expected_value > 0.0, expected_value, 1.0)
+        delta = jnp.log(safe_value) - expected_log
+        scale = jnp.maximum(
+            jnp.maximum(jnp.abs(jnp.log(safe_value)), jnp.abs(expected_log)), 1.0
+        )
+        tolerance = 64.0 * jnp.finfo(values.dtype).eps * scale
+        positive = expected_value > 0.0
+        return _mean_domain_result(
+            self.signature,
+            values,
+            interior=positive & (delta > tolerance),
+            boundary=positive & (jnp.abs(delta) <= tolerance),
+        )
+
+    def _sufficient_statistics(self, value: ArrayLike, /) -> StatisticBatch:
+        raw = jnp.asarray(value)
+        if jnp.issubdtype(raw.dtype, jnp.complexfloating):
+            raise TypeError("Gamma observations must be real-valued.")
+        observation = raw.astype(jnp.result_type(raw, 0.0))
+        valid = jnp.isfinite(observation) & (observation > 0.0)
+        safe = jnp.where(valid, observation, 1.0)
+        return StatisticBatch(
+            jnp.stack((jnp.log(safe), safe), axis=-1),
+            valid,
+            self.signature,
+        )
+
+    def _log_base_density(self, value: ArrayLike, /) -> Array:
+        return jnp.zeros_like(jnp.asarray(value, dtype=float))
+
+    def _log_normalizer(self, natural_values: Array, /) -> Array:
+        shape = natural_values[..., 0] + 1.0
+        rate = -natural_values[..., 1]
+        return jsp.special.gammaln(shape) - shape * jnp.log(rate)
+
+    def _mean_values(self, natural_values: Array, /) -> Array:
+        shape = natural_values[..., 0] + 1.0
+        rate = -natural_values[..., 1]
+        return jnp.stack(
+            (jsp.special.digamma(shape) - jnp.log(rate), shape / rate), axis=-1
+        )
+
+    def _natural_from_mean_values(self, mean_values: Array, /) -> Array:
+        expected_log = mean_values[..., 0]
+        expected_value = mean_values[..., 1]
+        delta = jnp.log(expected_value) - expected_log
+        shape, _, _ = _solve_gamma_shape(
+            delta,
+            atol=self.atol,
+            rtol=self.rtol,
+            max_iterations=self.max_iterations,
+        )
+        rate = shape / expected_value
+        return jnp.stack((shape - 1.0, -rate), axis=-1)
+
+    def _natural_from_mean_result(
+        self,
+        mean: MeanCoordinates,
+        domain: ExponentialFamilyDomainResult,
+        /,
+    ) -> ExponentialFamilyConversionResult:
+        safe_mean = jnp.where(
+            domain.interior[..., None],
+            mean.values,
+            jnp.asarray([-0.5772156649015329, 1.0], dtype=mean.values.dtype),
+        )
+        expected_log = safe_mean[..., 0]
+        expected_value = safe_mean[..., 1]
+        delta = jnp.log(expected_value) - expected_log
+        shape, iterations, converged = _solve_gamma_shape(
+            delta,
+            atol=self.atol,
+            rtol=self.rtol,
+            max_iterations=self.max_iterations,
+        )
+        shape = _implicit_gamma_shape(delta, jax.lax.stop_gradient(shape))
+        rate = shape / expected_value
+        candidate_values = jnp.stack((shape - 1.0, -rate), axis=-1)
+        candidate_values = jnp.where(
+            domain.interior[..., None], candidate_values, jnp.nan
+        )
+        natural = NaturalCoordinates(candidate_values, self.signature)
+        reconstructed = self._mean_values(candidate_values)
+        residual = jnp.linalg.norm(reconstructed - mean.values, axis=-1)
+        candidate_finite = jnp.all(jnp.isfinite(candidate_values), axis=-1)
+        residual_finite = jnp.isfinite(residual)
+        finite = candidate_finite & residual_finite
+        valid = domain.valid & finite & converged
+        status = jnp.where(
+            domain.valid & ~finite,
+            EXPONENTIAL_FAMILY_NONFINITE,
+            jnp.where(
+                domain.valid & finite & ~converged,
+                EXPONENTIAL_FAMILY_NONCONVERGED,
+                domain.status,
+            ),
+        )
+        return ExponentialFamilyConversionResult(
+            mean=mean,
+            natural=natural,
+            valid=valid,
+            status=status,
+            residual=jnp.where(domain.valid & residual_finite, residual, jnp.inf),
+            iterations=jnp.where(domain.valid, iterations, 0),
+            method_id="gamma-safeguarded-newton",
+        )
+
+    def _sample(
+        self,
+        key,
+        natural_values: Array,
+        sample_shape: tuple[int, ...],
+        /,
+    ) -> Array:
+        shape = natural_values[..., 0] + 1.0
+        rate = -natural_values[..., 1]
+        standard = jr.gamma(
+            key,
+            shape,
+            shape=sample_shape + shape.shape,
+            dtype=natural_values.dtype,
+        )
+        return standard / rate
+
+
+__all__ = ["GammaFamily"]

--- a/phydrax/_exponential_family/_multivariate_normal.py
+++ b/phydrax/_exponential_family/_multivariate_normal.py
@@ -1,0 +1,236 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import equinox as eqx
+import jax.numpy as jnp
+import jax.random as jr
+from jaxtyping import Array, ArrayLike
+
+from ._contracts import (
+    _AbstractAnalyticExponentialFamily,
+    _mean_domain_result,
+    _natural_domain_result,
+    ExponentialFamilyDomainResult,
+    ExponentialFamilySignature,
+    NaturalCoordinates,
+    StatisticBatch,
+)
+from ._symmetric_coordinates import smat, svec, symmetric_packed_dimension
+
+
+class MultivariateNormalFamily(_AbstractAnalyticExponentialFamily):
+    """Multivariate Normal laws in orthonormal linear-quadratic coordinates."""
+
+    event_size: int = eqx.field(static=True)
+    packed_size: int = eqx.field(static=True)
+    _signature: ExponentialFamilySignature = eqx.field(static=True)
+
+    def __init__(self, event_size: int):
+        dimension = int(event_size)
+        if dimension <= 0:
+            raise ValueError("event_size must be positive.")
+        packed = symmetric_packed_dimension(dimension)
+        self.event_size = dimension
+        self.packed_size = packed
+        self._signature = ExponentialFamilySignature(
+            "multivariate-normal",
+            dimension + packed,
+            (dimension,),
+            "lebesgue",
+            f"real-vector-{dimension}",
+            f"linear-svec-quadratic-{dimension}",
+        )
+
+    @property
+    def signature(self) -> ExponentialFamilySignature:
+        return self._signature
+
+    def natural_from_location_covariance(
+        self, location: ArrayLike, covariance: ArrayLike, /
+    ) -> NaturalCoordinates:
+        """Return natural coordinates from a location and dense covariance."""
+        location_array = jnp.asarray(location)
+        covariance_array = jnp.asarray(covariance)
+        if jnp.issubdtype(location_array.dtype, jnp.complexfloating) or jnp.issubdtype(
+            covariance_array.dtype, jnp.complexfloating
+        ):
+            raise TypeError("Multivariate Normal parameters must be real-valued.")
+        if location_array.ndim == 0 or int(location_array.shape[-1]) != self.event_size:
+            raise ValueError(
+                f"location must end in event_size={self.event_size}; got {location_array.shape}."
+            )
+        if covariance_array.ndim < 2 or covariance_array.shape[-2:] != (
+            self.event_size,
+            self.event_size,
+        ):
+            raise ValueError(
+                "covariance must end in square event axes "
+                f"({self.event_size}, {self.event_size}); got {covariance_array.shape}."
+            )
+        dtype = jnp.result_type(location_array, covariance_array, 0.0)
+        location_array = location_array.astype(dtype)
+        covariance_array = covariance_array.astype(dtype)
+        symmetry_scale = jnp.max(jnp.abs(covariance_array), axis=(-2, -1))
+        symmetry_tolerance = 64.0 * jnp.finfo(dtype).eps * symmetry_scale[..., None, None]
+        covariance_array = eqx.error_if(
+            covariance_array,
+            jnp.any(
+                jnp.abs(covariance_array - jnp.swapaxes(covariance_array, -1, -2))
+                > symmetry_tolerance
+            ),
+            "covariance must be symmetric.",
+        )
+        batch_shape = jnp.broadcast_shapes(
+            location_array.shape[:-1], covariance_array.shape[:-2]
+        )
+        location_array = jnp.broadcast_to(
+            location_array, batch_shape + (self.event_size,)
+        )
+        covariance_array = jnp.broadcast_to(
+            covariance_array,
+            batch_shape + (self.event_size, self.event_size),
+        )
+        identity = jnp.broadcast_to(
+            jnp.eye(self.event_size, dtype=dtype), covariance_array.shape
+        )
+        precision = jnp.linalg.solve(covariance_array, identity)
+        linear = jnp.einsum("...ij,...j->...i", precision, location_array)
+        return self.natural(jnp.concatenate((linear, svec(-0.5 * precision)), axis=-1))
+
+    def law_from_location_covariance(self, location: ArrayLike, covariance: ArrayLike, /):
+        """Return a multivariate Normal law from conventional parameters."""
+        return self.law(self.natural_from_location_covariance(location, covariance))
+
+    def location_covariance_from_natural(
+        self, natural: NaturalCoordinates, /
+    ) -> tuple[Array, Array]:
+        domain = self.natural_domain(natural)
+        location, covariance = self._location_covariance(natural.values)
+        return (
+            jnp.where(domain.valid[..., None], location, jnp.nan),
+            jnp.where(domain.valid[..., None, None], covariance, jnp.nan),
+        )
+
+    def _split(self, values: Array, /) -> tuple[Array, Array]:
+        return values[..., : self.event_size], values[..., self.event_size :]
+
+    def _precision(self, natural_values: Array, /) -> Array:
+        _, quadratic = self._split(natural_values)
+        return -2.0 * smat(quadratic, matrix_dimension=self.event_size)
+
+    def _location_covariance(self, natural_values: Array, /) -> tuple[Array, Array]:
+        linear, _ = self._split(natural_values)
+        precision = self._precision(natural_values)
+        identity = jnp.broadcast_to(
+            jnp.eye(self.event_size, dtype=natural_values.dtype), precision.shape
+        )
+        covariance = jnp.linalg.solve(precision, identity)
+        location = jnp.einsum("...ij,...j->...i", covariance, linear)
+        return location, covariance
+
+    def _natural_domain(self, values: Array, /) -> ExponentialFamilyDomainResult:
+        precision = self._precision(values)
+        eigenvalues = jnp.linalg.eigvalsh(precision)
+        scale = jnp.max(jnp.abs(eigenvalues), axis=-1)
+        tolerance = 64.0 * jnp.finfo(values.dtype).eps * scale
+        minimum = eigenvalues[..., 0]
+        return _natural_domain_result(
+            self.signature,
+            values,
+            interior=minimum > tolerance,
+            boundary=(minimum >= -tolerance) & (minimum <= tolerance),
+        )
+
+    def _mean_domain(self, values: Array, /) -> ExponentialFamilyDomainResult:
+        location, second_packed = self._split(values)
+        second = smat(second_packed, matrix_dimension=self.event_size)
+        covariance = second - jnp.einsum("...i,...j->...ij", location, location)
+        covariance = 0.5 * (covariance + jnp.swapaxes(covariance, -1, -2))
+        eigenvalues = jnp.linalg.eigvalsh(covariance)
+        scale = jnp.max(jnp.abs(eigenvalues), axis=-1)
+        tolerance = 64.0 * jnp.finfo(values.dtype).eps * scale
+        minimum = eigenvalues[..., 0]
+        return _mean_domain_result(
+            self.signature,
+            values,
+            interior=minimum > tolerance,
+            boundary=(minimum >= -tolerance) & (minimum <= tolerance),
+        )
+
+    def _sufficient_statistics(self, value: ArrayLike, /) -> StatisticBatch:
+        raw = jnp.asarray(value)
+        if jnp.issubdtype(raw.dtype, jnp.complexfloating):
+            raise TypeError("Multivariate Normal observations must be real-valued.")
+        if raw.ndim == 0 or int(raw.shape[-1]) != self.event_size:
+            raise ValueError(
+                "Multivariate Normal observations must end in event dimension "
+                f"{self.event_size}; got {raw.shape}."
+            )
+        observation = raw.astype(jnp.result_type(raw, 0.0))
+        valid = jnp.all(jnp.isfinite(observation), axis=-1)
+        safe = jnp.where(valid[..., None], observation, 0.0)
+        outer = jnp.einsum("...i,...j->...ij", safe, safe)
+        return StatisticBatch(
+            jnp.concatenate((safe, svec(outer)), axis=-1),
+            valid,
+            self.signature,
+        )
+
+    def _log_base_density(self, value: ArrayLike, /) -> Array:
+        values = jnp.asarray(value)
+        if values.ndim == 0 or int(values.shape[-1]) != self.event_size:
+            raise ValueError(
+                "Multivariate Normal observations have an incompatible event shape."
+            )
+        return jnp.zeros(values.shape[:-1], dtype=jnp.result_type(values, 0.0))
+
+    def _log_normalizer(self, natural_values: Array, /) -> Array:
+        linear, _ = self._split(natural_values)
+        precision = self._precision(natural_values)
+        location = jnp.linalg.solve(precision, linear[..., None])[..., 0]
+        _, log_determinant = jnp.linalg.slogdet(precision)
+        quadratic = jnp.sum(linear * location, axis=-1)
+        return (
+            0.5 * quadratic
+            - 0.5 * log_determinant
+            + 0.5 * self.event_size * jnp.log(2.0 * jnp.pi)
+        )
+
+    def _mean_values(self, natural_values: Array, /) -> Array:
+        location, covariance = self._location_covariance(natural_values)
+        second = covariance + jnp.einsum("...i,...j->...ij", location, location)
+        return jnp.concatenate((location, svec(second)), axis=-1)
+
+    def _natural_from_mean_values(self, mean_values: Array, /) -> Array:
+        location, second_packed = self._split(mean_values)
+        second = smat(second_packed, matrix_dimension=self.event_size)
+        covariance = second - jnp.einsum("...i,...j->...ij", location, location)
+        identity = jnp.broadcast_to(
+            jnp.eye(self.event_size, dtype=mean_values.dtype), covariance.shape
+        )
+        precision = jnp.linalg.solve(covariance, identity)
+        linear = jnp.einsum("...ij,...j->...i", precision, location)
+        return jnp.concatenate((linear, svec(-0.5 * precision)), axis=-1)
+
+    def _sample(
+        self,
+        key,
+        natural_values: Array,
+        sample_shape: tuple[int, ...],
+        /,
+    ) -> Array:
+        location, covariance = self._location_covariance(natural_values)
+        factor = jnp.linalg.cholesky(covariance)
+        noise = jr.normal(
+            key,
+            shape=sample_shape + location.shape,
+            dtype=natural_values.dtype,
+        )
+        transformed = jnp.einsum("...ij,...j->...i", factor, noise)
+        return location + transformed
+
+
+__all__ = ["MultivariateNormalFamily"]

--- a/phydrax/_exponential_family/_symmetric_coordinates.py
+++ b/phydrax/_exponential_family/_symmetric_coordinates.py
@@ -1,0 +1,73 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from math import isqrt
+
+import jax.numpy as jnp
+from jaxtyping import Array, ArrayLike
+
+
+def symmetric_packed_dimension(matrix_dimension: int, /) -> int:
+    dimension = int(matrix_dimension)
+    if dimension <= 0:
+        raise ValueError("matrix_dimension must be positive.")
+    return dimension * (dimension + 1) // 2
+
+
+def symmetric_matrix_dimension(packed_dimension: int, /) -> int:
+    packed = int(packed_dimension)
+    if packed <= 0:
+        raise ValueError("packed_dimension must be positive.")
+    discriminant = 1 + 8 * packed
+    root = isqrt(discriminant)
+    if root * root != discriminant or (root - 1) % 2:
+        raise ValueError("packed_dimension must be triangular: d * (d + 1) / 2.")
+    return (root - 1) // 2
+
+
+def svec(matrix: ArrayLike, /) -> Array:
+    """Pack a real symmetric matrix in Frobenius-orthonormal coordinates."""
+    values = jnp.asarray(matrix)
+    if jnp.issubdtype(values.dtype, jnp.complexfloating):
+        raise TypeError("svec requires real-valued matrices.")
+    if values.ndim < 2 or values.shape[-2] != values.shape[-1]:
+        raise ValueError("svec requires square trailing matrix axes.")
+    values = values.astype(jnp.result_type(values, 0.0))
+    dimension = int(values.shape[-1])
+    rows, columns = jnp.triu_indices(dimension)
+    packed = values[..., rows, columns]
+    scale = jnp.where(rows == columns, 1.0, jnp.sqrt(2.0)).astype(packed.dtype)
+    return packed * scale
+
+
+def smat(vector: ArrayLike, /, *, matrix_dimension: int | None = None) -> Array:
+    """Unpack Frobenius-orthonormal coordinates to a real symmetric matrix."""
+    values = jnp.asarray(vector)
+    if jnp.issubdtype(values.dtype, jnp.complexfloating):
+        raise TypeError("smat requires real-valued coordinates.")
+    if values.ndim == 0:
+        raise ValueError("smat requires a trailing packed-coordinate axis.")
+    values = values.astype(jnp.result_type(values, 0.0))
+    dimension = (
+        symmetric_matrix_dimension(int(values.shape[-1]))
+        if matrix_dimension is None
+        else int(matrix_dimension)
+    )
+    expected = symmetric_packed_dimension(dimension)
+    if int(values.shape[-1]) != expected:
+        raise ValueError(
+            f"smat expected trailing packed dimension {expected}; got {values.shape}."
+        )
+    rows, columns = jnp.triu_indices(dimension)
+    scale = jnp.where(rows == columns, 1.0, jnp.sqrt(2.0)).astype(values.dtype)
+    unscaled = values / scale
+    matrix = jnp.zeros(values.shape[:-1] + (dimension, dimension), dtype=values.dtype)
+    matrix = matrix.at[..., rows, columns].set(unscaled)
+    matrix = matrix.at[..., columns, rows].set(unscaled)
+    return matrix
+
+
+__all__ = ["smat", "svec", "symmetric_matrix_dimension", "symmetric_packed_dimension"]

--- a/phydrax/_likelihoods.py
+++ b/phydrax/_likelihoods.py
@@ -5,13 +5,15 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import Any
+from typing import Any, Literal
 
+import equinox as eqx
 import jax.numpy as jnp
 import jax.random as jr
 import jax.scipy as jsp
 from jaxtyping import Array, ArrayLike
 
+from ._exponential_family import AbstractExponentialFamily, CategoricalFamily
 from ._strict import StrictModule
 
 
@@ -28,8 +30,169 @@ class AbstractLikelihood(StrictModule):
     def sample(self, key, location: ArrayLike, /, **parameters: Any) -> Array:
         raise NotImplementedError
 
+    @abstractmethod
+    def align_observations(
+        self, location: ArrayLike, target: ArrayLike, /
+    ) -> tuple[Array, Array]:
+        """Align model outputs and observations under this likelihood's event contract."""
+        location_array = jnp.asarray(location)
+        target_array = jnp.asarray(target)
+        if location_array.shape == target_array.shape:
+            return location_array, target_array
+        if (
+            location_array.ndim == 2
+            and target_array.ndim == 1
+            and int(location_array.shape[1]) == 1
+        ):
+            location_array = location_array[:, 0]
+        elif (
+            target_array.ndim == 2
+            and location_array.ndim == 1
+            and int(target_array.shape[1]) == 1
+        ):
+            target_array = target_array[:, 0]
+        if location_array.shape != target_array.shape:
+            raise ValueError(
+                "Likelihood prediction and target shapes are incompatible: "
+                f"prediction={location_array.shape}, target={target_array.shape}."
+            )
+        return location_array, target_array
 
-class GaussianLikelihood(AbstractLikelihood):
+
+class _AbstractElementwiseLikelihood(AbstractLikelihood):
+    def align_observations(
+        self, location: ArrayLike, target: ArrayLike, /
+    ) -> tuple[Array, Array]:
+        return super().align_observations(location, target)
+
+
+class ScalarNaturalExponentialFamilyLikelihood(_AbstractElementwiseLikelihood):
+    """Elementwise likelihood whose model output is one scalar natural parameter."""
+
+    family: AbstractExponentialFamily
+
+    def __init__(self, family: AbstractExponentialFamily):
+        if not isinstance(family, AbstractExponentialFamily):
+            raise TypeError("family must implement AbstractExponentialFamily.")
+        signature = family.signature
+        if signature.dimension != 1 or signature.event_shape:
+            raise ValueError(
+                "ScalarNaturalExponentialFamilyLikelihood requires a scalar-event "
+                "family with one natural coordinate."
+            )
+        self.family = family
+
+    def _natural(self, location: ArrayLike, /):
+        values = jnp.asarray(location)
+        if jnp.issubdtype(values.dtype, jnp.complexfloating):
+            raise TypeError("Natural-parameter predictions must be real-valued.")
+        values = values.astype(jnp.result_type(values, 0.0))
+        return self.family.natural(values[..., None])
+
+    def log_prob(
+        self, location: ArrayLike, target: ArrayLike, /, **parameters: Any
+    ) -> Array:
+        if parameters:
+            raise TypeError(
+                "ScalarNaturalExponentialFamilyLikelihood received unknown parameters "
+                f"{tuple(parameters)!r}."
+            )
+        return self.family.log_prob(self._natural(location), target)
+
+    def sample(self, key, location: ArrayLike, /, **parameters: Any) -> Array:
+        if parameters:
+            raise TypeError(
+                "ScalarNaturalExponentialFamilyLikelihood received unknown parameters "
+                f"{tuple(parameters)!r}."
+            )
+        return self.family.sample(key, self._natural(location))
+
+
+class CategoricalExponentialFamilyLikelihood(AbstractLikelihood):
+    """Categorical likelihood with an explicit model-output coordinate convention."""
+
+    family: CategoricalFamily
+    prediction_coordinates: Literal["natural", "full_logits"] = eqx.field(static=True)
+
+    def __init__(
+        self,
+        family: CategoricalFamily,
+        *,
+        prediction_coordinates: Literal["natural", "full_logits"],
+    ):
+        if not isinstance(family, CategoricalFamily):
+            raise TypeError("family must be a CategoricalFamily.")
+        if prediction_coordinates not in ("natural", "full_logits"):
+            raise ValueError("prediction_coordinates must be 'natural' or 'full_logits'.")
+        self.family = family
+        self.prediction_coordinates = prediction_coordinates
+
+    @property
+    def prediction_dimension(self) -> int:
+        return (
+            self.family.signature.dimension
+            if self.prediction_coordinates == "natural"
+            else self.family.num_categories
+        )
+
+    def align_observations(
+        self, location: ArrayLike, target: ArrayLike, /
+    ) -> tuple[Array, Array]:
+        location_array = jnp.asarray(location)
+        target_array = jnp.asarray(target)
+        if location_array.ndim == 0 or int(location_array.shape[-1]) != (
+            self.prediction_dimension
+        ):
+            raise ValueError(
+                "Categorical predictions must end in coordinate dimension "
+                f"{self.prediction_dimension}; got {location_array.shape}."
+            )
+        target_shape = location_array.shape[:-1]
+        if target_array.shape == target_shape + (1,):
+            target_array = target_array[..., 0]
+        if target_array.shape != target_shape:
+            raise ValueError(
+                "Categorical prediction and target shapes are incompatible: "
+                f"prediction={location_array.shape}, target={target_array.shape}."
+            )
+        return location_array, target_array
+
+    def _natural(self, location: ArrayLike, /):
+        values = jnp.asarray(location)
+        if jnp.issubdtype(values.dtype, jnp.complexfloating):
+            raise TypeError("Categorical predictions must be real-valued.")
+        values = values.astype(jnp.result_type(values, 0.0))
+        if self.prediction_coordinates == "natural":
+            if values.ndim == 0 or int(values.shape[-1]) != (
+                self.family.signature.dimension
+            ):
+                raise ValueError(
+                    "Categorical natural predictions have an incompatible shape."
+                )
+            return self.family.natural(values)
+        return self.family.natural_from_logits(values)
+
+    def log_prob(
+        self, location: ArrayLike, target: ArrayLike, /, **parameters: Any
+    ) -> Array:
+        if parameters:
+            raise TypeError(
+                "CategoricalExponentialFamilyLikelihood received unknown parameters "
+                f"{tuple(parameters)!r}."
+            )
+        aligned_location, aligned_target = self.align_observations(location, target)
+        return self.family.log_prob(self._natural(aligned_location), aligned_target)
+
+    def sample(self, key, location: ArrayLike, /, **parameters: Any) -> Array:
+        if parameters:
+            raise TypeError(
+                "CategoricalExponentialFamilyLikelihood received unknown parameters "
+                f"{tuple(parameters)!r}."
+            )
+        return self.family.sample(key, self._natural(location))
+
+
+class GaussianLikelihood(_AbstractElementwiseLikelihood):
     """Gaussian observation likelihood with a fixed positive scale."""
 
     scale: Array
@@ -63,7 +226,7 @@ class GaussianLikelihood(AbstractLikelihood):
         return location_array + self.scale * noise
 
 
-class GaussianLocationScaleLikelihood(AbstractLikelihood):
+class GaussianLocationScaleLikelihood(_AbstractElementwiseLikelihood):
     """Heteroscedastic Gaussian with a softplus-transformed raw scale."""
 
     min_scale: float
@@ -123,7 +286,7 @@ class GaussianLocationScaleLikelihood(AbstractLikelihood):
         )
 
 
-class StudentTLikelihood(AbstractLikelihood):
+class StudentTLikelihood(_AbstractElementwiseLikelihood):
     """Student-t observation likelihood with fixed degrees of freedom and scale."""
 
     df: Array
@@ -178,6 +341,8 @@ def jax_softplus(value: Array, /) -> Array:
 
 __all__ = [
     "AbstractLikelihood",
+    "CategoricalExponentialFamilyLikelihood",
+    "ScalarNaturalExponentialFamilyLikelihood",
     "GaussianLikelihood",
     "GaussianLocationScaleLikelihood",
     "StudentTLikelihood",

--- a/phydrax/_numerics/_weighted_moments.py
+++ b/phydrax/_numerics/_weighted_moments.py
@@ -299,6 +299,25 @@ class WeightedMomentsDiagnostics(StrictModule):
     log_weight_range: Array
     finite_count: Array
 
+    def __init__(
+        self,
+        *,
+        weight_ess: Array,
+        relative_weight_ess: Array,
+        coefficient_of_variation: Array,
+        maximum_normalized_weight: Array,
+        entropy: Array,
+        log_weight_range: Array,
+        finite_count: Array,
+    ):
+        self.weight_ess = jnp.asarray(weight_ess)
+        self.relative_weight_ess = jnp.asarray(relative_weight_ess)
+        self.coefficient_of_variation = jnp.asarray(coefficient_of_variation)
+        self.maximum_normalized_weight = jnp.asarray(maximum_normalized_weight)
+        self.entropy = jnp.asarray(entropy)
+        self.log_weight_range = jnp.asarray(log_weight_range)
+        self.finite_count = jnp.asarray(finite_count, dtype=jnp.int32)
+
 
 def weighted_diagnostics(
     accumulator: LogWeightedAccumulator,

--- a/phydrax/_probability.py
+++ b/phydrax/_probability.py
@@ -1,0 +1,46 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from abc import abstractmethod
+
+from jaxtyping import Array, ArrayLike
+
+from ._strict import StrictModule
+from .domain._measure import MeasureKind
+
+
+class AbstractProbabilityLaw(StrictModule):
+    """Probability law with explicit sample, batch, event, and measure semantics."""
+
+    @property
+    @abstractmethod
+    def event_shape(self) -> tuple[int, ...]:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def batch_shape(self) -> tuple[int, ...]:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def density_measure_kind(self) -> MeasureKind:
+        raise NotImplementedError
+
+    @abstractmethod
+    def sample(self, key, sample_shape: tuple[int, ...] = ()) -> Array:
+        raise NotImplementedError
+
+    @abstractmethod
+    def log_prob(self, value: ArrayLike, /) -> Array:
+        raise NotImplementedError
+
+    @abstractmethod
+    def contains(self, value: ArrayLike, /) -> Array:
+        raise NotImplementedError
+
+
+__all__ = ["AbstractProbabilityLaw"]

--- a/phydrax/ml/linear/_glm.py
+++ b/phydrax/ml/linear/_glm.py
@@ -11,6 +11,7 @@ import jax
 import jax.numpy as jnp
 from jaxtyping import Array, ArrayLike
 
+from ..._exponential_family import BernoulliFamily, PoissonFamily
 from .._batch import MLBatch, WeightPolicy
 from .._contracts import AbstractRecipe, FitResult
 from ._base import (
@@ -27,6 +28,10 @@ from ._base import (
     prepare_supervised,
     unrolled_contract,
 )
+
+
+_BERNOULLI_FAMILY = BernoulliFamily()
+_POISSON_FAMILY = PoissonFamily()
 
 
 def _scalar(value: ArrayLike, name: str, /, *, positive: bool = False) -> Array:
@@ -101,7 +106,8 @@ def _fit_binary_logistic(
 
     def objective(beta, bias):
         scores = design_matmul(prepared.design, beta) + bias[:, None, :]
-        loss = jax.nn.softplus(scores) - targets * scores
+        natural = _BERNOULLI_FAMILY.natural(scores[..., None])
+        loss = _BERNOULLI_FAMILY.canonical_loss(natural, targets)
         return jnp.sum(
             prepared.weights * loss, axis=(1, 2)
         ) + 0.5 * recipe.l2_strength * jnp.sum(beta * beta, axis=(1, 2))
@@ -110,7 +116,10 @@ def _fit_binary_logistic(
         del iteration
         beta, bias = state
         scores = design_matmul(prepared.design, beta) + bias[:, None, :]
-        derivative = prepared.weights * (jax.nn.sigmoid(scores) - targets)
+        natural = _BERNOULLI_FAMILY.natural(scores[..., None])
+        derivative = (
+            prepared.weights * _BERNOULLI_FAMILY.canonical_score(natural, targets)[..., 0]
+        )
         beta_candidate = beta - learning_rate * (
             design_transpose_matmul(prepared.design, derivative)
             + recipe.l2_strength * beta
@@ -350,17 +359,22 @@ def _fit_log_glm(recipe, batch: MLBatch, /, *, family: str, power: float) -> Fit
     learning_rate = recipe.learning_rate
     active = prepared.weights > 0.0
     if family == "poisson":
-        domain = prepared.targets >= 0.0
+        domain = _POISSON_FAMILY.sufficient_statistics(prepared.targets).valid
+        family_targets = jnp.where(domain, prepared.targets, 0.0)
     elif family == "gamma":
         domain = prepared.targets > 0.0
+        family_targets = prepared.targets
     else:
         domain = prepared.targets > 0.0 if power == 2.0 else prepared.targets >= 0.0
+        family_targets = prepared.targets
     domain_valid = jnp.all(domain | (~active), axis=(1, 2))
 
     def loss_and_derivative(eta):
         if family == "poisson":
-            mean_value = jnp.exp(eta)
-            return mean_value - prepared.targets * eta, mean_value - prepared.targets
+            natural = _POISSON_FAMILY.natural(eta[..., None])
+            loss = _POISSON_FAMILY.canonical_loss(natural, family_targets)
+            derivative = _POISSON_FAMILY.canonical_score(natural, family_targets)[..., 0]
+            return loss, derivative
         if family == "gamma":
             inverse_mean = jnp.exp(-eta)
             return (

--- a/phydrax/terms/_likelihood.py
+++ b/phydrax/terms/_likelihood.py
@@ -110,7 +110,6 @@ class SupervisedLikelihoodTerm(AbstractSamplingTerm):
             raise TypeError("Likelihood term domain is not a DatasetDomain.")
         return domain
 
-
     def sample(self, *, key: Key[Array, ""] = DOC_KEY0) -> Any:
         indices = sample_case_indices(
             size=self.domain.size,
@@ -151,7 +150,7 @@ class SupervisedLikelihoodTerm(AbstractSamplingTerm):
         **kwargs: Any,
     ) -> Array:
         """Return unreduced per-case observation log probabilities for a fixed batch."""
-        location, target = _align_observations(
+        location, target = self.likelihood.align_observations(
             self._location(functions, batch, key=key, **kwargs),
             batch.target,
         )
@@ -160,7 +159,9 @@ class SupervisedLikelihoodTerm(AbstractSamplingTerm):
             raw_scale_field = functions[self.scale_var](batch.points, key=key, **kwargs)
             if not isinstance(raw_scale_field, cx.Field):
                 raise TypeError("Likelihood scale must evaluate to a coordax.Field.")
-            raw_scale, _ = _align_observations(jnp.asarray(raw_scale_field.data), target)
+            raw_scale, _ = self.likelihood.align_observations(
+                jnp.asarray(raw_scale_field.data), target
+            )
             parameters["raw_scale"] = raw_scale
         log_prob = jnp.asarray(
             self.likelihood.log_prob(location, target, **parameters), dtype=float
@@ -213,31 +214,6 @@ class SupervisedLikelihoodTerm(AbstractSamplingTerm):
         else:
             reduced = jnp.sum(per_case)
         return self.weight * jnp.asarray(reduced, dtype=float).reshape(())
-
-
-def _align_observations(prediction: ArrayLike, target: ArrayLike) -> tuple[Array, Array]:
-    prediction_array = jnp.asarray(prediction, dtype=float)
-    target_array = jnp.asarray(target, dtype=float)
-    if prediction_array.shape == target_array.shape:
-        return prediction_array, target_array
-    if (
-        prediction_array.ndim == 2
-        and target_array.ndim == 1
-        and prediction_array.shape[1] == 1
-    ):
-        prediction_array = prediction_array[:, 0]
-    elif (
-        target_array.ndim == 2
-        and prediction_array.ndim == 1
-        and target_array.shape[1] == 1
-    ):
-        target_array = target_array[:, 0]
-    if prediction_array.shape != target_array.shape:
-        raise ValueError(
-            "Likelihood prediction and target shapes are incompatible: "
-            f"prediction={prediction_array.shape}, target={target_array.shape}."
-        )
-    return prediction_array, target_array
 
 
 __all__ = ["SupervisedLikelihoodTerm"]

--- a/phydrax/uq/__init__.py
+++ b/phydrax/uq/__init__.py
@@ -4,12 +4,49 @@
 
 """Native uncertainty-quantification tools for Phydrax."""
 
+from .._exponential_family import (
+    AbstractExponentialFamily,
+    BernoulliFamily,
+    CategoricalFamily,
+    DirichletCategoricalConjugacy,
+    DirichletCategoricalStatistics,
+    DirichletCategoricalUpdate,
+    DirichletFamily,
+    EXPONENTIAL_FAMILY_INSUFFICIENT_WEIGHT,
+    EXPONENTIAL_FAMILY_INVALID_EVENT,
+    EXPONENTIAL_FAMILY_MEAN_BOUNDARY,
+    EXPONENTIAL_FAMILY_NONCONVERGED,
+    EXPONENTIAL_FAMILY_NONFINITE,
+    EXPONENTIAL_FAMILY_OUTSIDE_MEAN_DOMAIN,
+    EXPONENTIAL_FAMILY_OUTSIDE_NATURAL_DOMAIN,
+    exponential_family_status_name,
+    EXPONENTIAL_FAMILY_SUCCESS,
+    ExponentialFamilyConversionResult,
+    ExponentialFamilyDomainResult,
+    ExponentialFamilyLaw,
+    ExponentialFamilySignature,
+    ExponentialFamilyStatus,
+    ExponentialRateFamily,
+    GammaFamily,
+    GammaPoissonConjugacy,
+    GammaPoissonStatistics,
+    GammaPoissonUpdate,
+    MeanCoordinates,
+    MultivariateNormalFamily,
+    NaturalCoordinates,
+    NormalFamily,
+    PoissonFamily,
+    StatisticBatch,
+)
 from .._likelihoods import (
     AbstractLikelihood,
+    CategoricalExponentialFamilyLikelihood,
     GaussianLikelihood,
     GaussianLocationScaleLikelihood,
+    ScalarNaturalExponentialFamilyLikelihood,
     StudentTLikelihood,
 )
+from .._probability import AbstractProbabilityLaw
 from ._bellman import (
     bellman_filter,
     bellman_filter_status_name,
@@ -127,6 +164,16 @@ from ._ensemble_filter import (
     EnsembleSmootherResult,
     initialize_ensemble_filter,
 )
+from ._exponential_family_gaussian import (
+    gaussian_factor_from_multivariate_normal,
+    multivariate_normal_from_gaussian_factor,
+)
+from ._exponential_family_projection import (
+    ExponentialFamilyEstimateResult,
+    ExponentialFamilyProjectionAccumulator,
+    fit_exponential_family,
+    project_exponential_family,
+)
 from ._filter_checkpoint import (
     FilterCheckpointAlgorithm,
     FilterState,
@@ -167,7 +214,6 @@ from ._gaussian_factor import (
     GaussianFactorStatus,
     solve_triangular_rank_aware,
 )
-from ._gp_condition import GaussianProcessCondition, GaussianProcessConditioner
 from ._gp_classification import (
     BernoulliGaussianProcessLikelihood,
     BernoulliGaussianProcessPosterior,
@@ -176,6 +222,7 @@ from ._gp_classification import (
     condition_bernoulli_gaussian_process,
     condition_categorical_gaussian_process,
 )
+from ._gp_condition import GaussianProcessCondition, GaussianProcessConditioner
 from ._gp_functional import (
     directional_derivative_functional,
     functional_kernel_diagonal,
@@ -330,16 +377,6 @@ from ._operator_metrics import (
     operator_interval_coverage,
     operator_interval_width,
 )
-from ._transport_metrics import (
-    operator_ensemble_sinkhorn_divergence,
-    operator_ensemble_sliced_wasserstein,
-    predictive_sinkhorn_divergence,
-    PredictiveTransportMetricResult,
-)
-from ._transport_resampling import (
-    optimal_transport_ensemble_transform,
-    OptimalTransportEnsembleTransformResult,
-)
 from ._particle import (
     bootstrap_particle_filter,
     effective_sample_size,
@@ -396,6 +433,7 @@ from ._posterior import (
     ParameterSpace,
     PosteriorProblem,
     SigmoidIntervalBijector,
+    SimplexBijector,
 )
 from ._posterior_coreset import PosteriorCoreset, SteinThinning, thin_posterior
 from ._posterior_diagnostics import (
@@ -492,6 +530,8 @@ from ._sensitivity import (
     EmpiricalDirectionsResult,
     experiment_design_objective,
     ExperimentDesignResult,
+    exponential_family_fisher_action,
+    exponential_family_parameter_fisher_action,
     fisher_information_action,
     fixed_noise_pathwise_gradient,
     gauss_newton_action,
@@ -568,6 +608,16 @@ from ._stochastic_spectra import (
     state_output_cross_spectral_density,
     state_spectral_density,
 )
+from ._transport_metrics import (
+    operator_ensemble_sinkhorn_divergence,
+    operator_ensemble_sliced_wasserstein,
+    predictive_sinkhorn_divergence,
+    PredictiveTransportMetricResult,
+)
+from ._transport_resampling import (
+    optimal_transport_ensemble_transform,
+    OptimalTransportEnsembleTransformResult,
+)
 from ._whitening import GaussianPriorWhitening
 
 
@@ -633,6 +683,8 @@ __all__ = [
     "gaussian_cross_covariance",
     "gaussian_factor_from_covariance",
     "gaussian_factor_log_determinant",
+    "gaussian_factor_from_multivariate_normal",
+    "multivariate_normal_from_gaussian_factor",
     "gaussian_factor_quadratic_form",
     "solve_triangular_rank_aware",
     "NONLINEAR_GAUSSIAN_INPUT_FACTOR_INVALID",
@@ -663,11 +715,50 @@ __all__ = [
     "gauss_newton_action",
     "likelihood_ratio_gradient",
     "resampling_score_gradient",
+    "exponential_family_fisher_action",
+    "exponential_family_parameter_fisher_action",
     "AbstractDistribution",
     "EmpiricalDistribution",
     "LogNormal",
     "Normal",
     "Uniform",
+    "AbstractProbabilityLaw",
+    "DirichletFamily",
+    "AbstractExponentialFamily",
+    "BernoulliFamily",
+    "CategoricalFamily",
+    "DirichletCategoricalConjugacy",
+    "DirichletCategoricalStatistics",
+    "DirichletCategoricalUpdate",
+    "EXPONENTIAL_FAMILY_INSUFFICIENT_WEIGHT",
+    "EXPONENTIAL_FAMILY_INVALID_EVENT",
+    "EXPONENTIAL_FAMILY_MEAN_BOUNDARY",
+    "EXPONENTIAL_FAMILY_NONFINITE",
+    "EXPONENTIAL_FAMILY_NONCONVERGED",
+    "EXPONENTIAL_FAMILY_OUTSIDE_MEAN_DOMAIN",
+    "EXPONENTIAL_FAMILY_OUTSIDE_NATURAL_DOMAIN",
+    "EXPONENTIAL_FAMILY_SUCCESS",
+    "exponential_family_status_name",
+    "ExponentialFamilyConversionResult",
+    "ExponentialFamilyDomainResult",
+    "ExponentialFamilyEstimateResult",
+    "ExponentialFamilyLaw",
+    "GammaFamily",
+    "GammaPoissonConjugacy",
+    "GammaPoissonStatistics",
+    "GammaPoissonUpdate",
+    "ExponentialFamilyProjectionAccumulator",
+    "ExponentialFamilySignature",
+    "ExponentialFamilyStatus",
+    "ExponentialRateFamily",
+    "fit_exponential_family",
+    "MultivariateNormalFamily",
+    "MeanCoordinates",
+    "NaturalCoordinates",
+    "NormalFamily",
+    "PoissonFamily",
+    "project_exponential_family",
+    "StatisticBatch",
     "propagate",
     "RandomSampleBatch",
     "sample_joint",
@@ -826,9 +917,11 @@ __all__ = [
     "ParticleMarginalMetropolisHastingsResult",
     "sample_conditional_particle_path",
     "AbstractLikelihood",
+    "CategoricalExponentialFamilyLikelihood",
     "GaussianLikelihood",
     "GaussianLocationScaleLikelihood",
     "StudentTLikelihood",
+    "ScalarNaturalExponentialFamilyLikelihood",
     "CovarianceBatching",
     "LinearizedGaussianMeasurementLikelihood",
     "GaussianScaleCalibrator",
@@ -935,6 +1028,7 @@ __all__ = [
     "ExpBijector",
     "IdentityBijector",
     "SigmoidIntervalBijector",
+    "SimplexBijector",
     "ParameterSpace",
     "PosteriorProblem",
     "diagnose_posterior",

--- a/phydrax/uq/_distributions.py
+++ b/phydrax/uq/_distributions.py
@@ -12,11 +12,23 @@ import jax.random as jr
 import jax.scipy as jsp
 from jaxtyping import Array, ArrayLike
 
-from .._strict import StrictModule
+from .._probability import AbstractProbabilityLaw
 
 
-class AbstractDistribution(StrictModule):
+class AbstractDistribution(AbstractProbabilityLaw):
     """Minimal scalar distribution protocol for native uncertain inputs."""
+
+    @property
+    def event_shape(self) -> tuple[int, ...]:
+        return ()
+
+    @property
+    def batch_shape(self) -> tuple[int, ...]:
+        return ()
+
+    @property
+    def density_measure_kind(self) -> Literal["lebesgue"]:
+        return "lebesgue"
 
     @abstractmethod
     def sample(self, key, sample_shape: tuple[int, ...] = ()) -> Array:
@@ -68,6 +80,10 @@ class Uniform(AbstractDistribution):
             raise ValueError("Uniform low must be less than high.")
         self.low = low_array
         self.high = high_array
+
+    @property
+    def density_measure_kind(self) -> Literal["lebesgue"]:
+        return "lebesgue"
 
     def sample(self, key, sample_shape: tuple[int, ...] = ()) -> Array:
         return jr.uniform(
@@ -130,6 +146,10 @@ class Normal(AbstractDistribution):
         self.location = location_array
         self.scale = scale_array
 
+    @property
+    def density_measure_kind(self) -> Literal["lebesgue"]:
+        return "lebesgue"
+
     def sample(self, key, sample_shape: tuple[int, ...] = ()) -> Array:
         return self.location + self.scale * jr.normal(
             key, shape=tuple(sample_shape), dtype=self.location.dtype
@@ -184,6 +204,10 @@ class LogNormal(AbstractDistribution):
             raise ValueError("LogNormal scale must be finite and positive.")
         self.location = location_array
         self.scale = scale_array
+
+    @property
+    def density_measure_kind(self) -> Literal["lebesgue"]:
+        return "lebesgue"
 
     def sample(self, key, sample_shape: tuple[int, ...] = ()) -> Array:
         normal = self.location + self.scale * jr.normal(
@@ -278,6 +302,10 @@ class EmpiricalDistribution(AbstractDistribution):
         order = jnp.argsort(values_array)
         self.values = values_array[order]
         self.probabilities = probability_array[order]
+
+    @property
+    def density_measure_kind(self) -> Literal["counting"]:
+        return "counting"
 
     def sample(self, key, sample_shape: tuple[int, ...] = ()) -> Array:
         indices = jr.choice(

--- a/phydrax/uq/_exponential_family_gaussian.py
+++ b/phydrax/uq/_exponential_family_gaussian.py
@@ -1,0 +1,98 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import equinox as eqx
+import jax.numpy as jnp
+from jaxtyping import Array, ArrayLike
+
+from .._exponential_family import (
+    ExponentialFamilyConversionResult,
+    ExponentialFamilyLaw,
+    MultivariateNormalFamily,
+)
+from .._exponential_family._symmetric_coordinates import svec
+from ._gaussian_factor import gaussian_factor_from_covariance, GaussianFactor
+
+
+def multivariate_normal_from_gaussian_factor(
+    family: MultivariateNormalFamily,
+    location: ArrayLike,
+    factor: GaussianFactor,
+    /,
+) -> ExponentialFamilyConversionResult:
+    """Convert a location and unregularized Gaussian factor to family coordinates."""
+    if not isinstance(family, MultivariateNormalFamily):
+        raise TypeError("family must be a MultivariateNormalFamily.")
+    if not isinstance(factor, GaussianFactor):
+        raise TypeError("factor must be a GaussianFactor.")
+    if factor.event_size != family.event_size:
+        raise ValueError("factor event_size does not match the family.")
+    if jnp.issubdtype(factor.factor.dtype, jnp.complexfloating):
+        raise TypeError("MultivariateNormalFamily requires a real GaussianFactor.")
+    location_array = jnp.asarray(location)
+    if jnp.issubdtype(location_array.dtype, jnp.complexfloating):
+        raise TypeError("location must be real-valued.")
+    if location_array.ndim == 0 or int(location_array.shape[-1]) != family.event_size:
+        raise ValueError(
+            f"location must end in event_size={family.event_size}; got {location_array.shape}."
+        )
+    checked_factor = eqx.error_if(
+        factor.factor,
+        jnp.any(~factor.valid),
+        "Cannot convert an invalid GaussianFactor.",
+    )
+    checked_factor = eqx.error_if(
+        checked_factor,
+        factor.regularization != 0.0,
+        "GaussianFactor regularization must be zero for an exact family conversion.",
+    )
+    batch_shape = jnp.broadcast_shapes(
+        location_array.shape[:-1], checked_factor.shape[:-2]
+    )
+    dtype = jnp.result_type(location_array, checked_factor, 0.0)
+    location_array = jnp.broadcast_to(
+        location_array.astype(dtype), batch_shape + (family.event_size,)
+    )
+    checked_factor = jnp.broadcast_to(
+        checked_factor.astype(dtype),
+        batch_shape + (family.event_size, checked_factor.shape[-1]),
+    )
+    covariance = checked_factor @ jnp.swapaxes(checked_factor, -1, -2)
+    second = covariance + jnp.einsum("...i,...j->...ij", location_array, location_array)
+    mean = family.mean(jnp.concatenate((location_array, svec(second)), axis=-1))
+    return family.natural_from_mean(mean)
+
+
+def gaussian_factor_from_multivariate_normal(
+    law: ExponentialFamilyLaw,
+    /,
+    *,
+    rank_tolerance: ArrayLike = 0.0,
+) -> tuple[Array, GaussianFactor]:
+    """Return the location and exact covariance factor of a Normal family law."""
+    if not isinstance(law, ExponentialFamilyLaw) or not isinstance(
+        law.family, MultivariateNormalFamily
+    ):
+        raise TypeError(
+            "law must be an ExponentialFamilyLaw backed by MultivariateNormalFamily."
+        )
+    location, covariance = law.family.location_covariance_from_natural(law.natural)
+    dtype = covariance.dtype
+    scale = jnp.maximum(jnp.max(jnp.abs(covariance)), 1.0)
+    tolerance = 64.0 * jnp.finfo(dtype).eps * scale
+    factor = gaussian_factor_from_covariance(
+        covariance,
+        rank_tolerance=rank_tolerance,
+        hermitian_tolerance=tolerance,
+        factor_id="multivariate-normal-covariance-factor",
+    )
+    return location, factor
+
+
+__all__ = [
+    "gaussian_factor_from_multivariate_normal",
+    "multivariate_normal_from_gaussian_factor",
+]

--- a/phydrax/uq/_exponential_family_projection.py
+++ b/phydrax/uq/_exponential_family_projection.py
@@ -1,0 +1,404 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import equinox as eqx
+import jax.numpy as jnp
+from jaxtyping import Array, ArrayLike
+
+from .._exponential_family import (
+    AbstractExponentialFamily,
+    EXPONENTIAL_FAMILY_INSUFFICIENT_WEIGHT,
+    EXPONENTIAL_FAMILY_INVALID_EVENT,
+    EXPONENTIAL_FAMILY_NONFINITE,
+    ExponentialFamilyLaw,
+    MeanCoordinates,
+)
+from .._numerics._weighted_moments import (
+    _canonical_values,
+    LogWeightedAccumulator,
+    WeightedMomentsDiagnostics,
+)
+from .._strict import StrictModule
+
+
+class ExponentialFamilyEstimateResult(StrictModule):
+    """Weighted sufficient-statistic projection with explicit MLE diagnostics."""
+
+    law: ExponentialFamilyLaw
+    mean_coordinates: MeanCoordinates
+    statistic_standard_error: Array
+    diagnostics: WeightedMomentsDiagnostics
+    conversion_residual: Array
+    conversion_iterations: Array
+    valid: Array
+    status: Array
+    estimator_id: str = eqx.field(static=True)
+    method_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        law: ExponentialFamilyLaw,
+        mean_coordinates: MeanCoordinates,
+        statistic_standard_error: ArrayLike,
+        diagnostics: WeightedMomentsDiagnostics,
+        conversion_residual: ArrayLike,
+        conversion_iterations: ArrayLike,
+        valid: ArrayLike,
+        status: ArrayLike,
+        estimator_id: str,
+        method_id: str,
+    ):
+        if not estimator_id or not method_id:
+            raise ValueError("Estimator provenance IDs must be non-empty.")
+        shape = mean_coordinates.batch_shape
+        if law.batch_shape != shape:
+            raise ValueError("Estimated law and mean-coordinate batch shapes must match.")
+        self.law = law
+        self.mean_coordinates = mean_coordinates
+        self.statistic_standard_error = jnp.asarray(statistic_standard_error)
+        self.diagnostics = diagnostics
+        self.conversion_residual = jnp.broadcast_to(
+            jnp.asarray(conversion_residual), shape
+        )
+        self.conversion_iterations = jnp.broadcast_to(
+            jnp.asarray(conversion_iterations, dtype=jnp.int32), shape
+        )
+        self.valid = jnp.broadcast_to(jnp.asarray(valid, dtype=bool), shape)
+        self.status = jnp.broadcast_to(jnp.asarray(status, dtype=jnp.int32), shape)
+        self.estimator_id = str(estimator_id)
+        self.method_id = str(method_id)
+
+
+class ExponentialFamilyProjectionAccumulator(StrictModule):
+    """Mergeable log-weighted sufficient-statistic accumulator."""
+
+    family: AbstractExponentialFamily
+    moments: LogWeightedAccumulator
+    nonfinite_observation_count: Array
+    invalid_event_count: Array
+    invalid_weight_count: Array
+    minimum_log_weight: Array
+    weighted_log_weight_sum: Array
+
+    def __init__(
+        self,
+        *,
+        family: AbstractExponentialFamily,
+        moments: LogWeightedAccumulator,
+        nonfinite_observation_count: ArrayLike,
+        invalid_event_count: ArrayLike,
+        invalid_weight_count: ArrayLike,
+        minimum_log_weight: ArrayLike,
+        weighted_log_weight_sum: ArrayLike,
+    ):
+        if not isinstance(family, AbstractExponentialFamily):
+            raise TypeError("family must implement AbstractExponentialFamily.")
+        batch_shape = moments.log_scale.shape
+        if moments.weighted_value_sum.shape != batch_shape + (
+            family.signature.dimension,
+        ):
+            raise ValueError("Weighted moments do not match the family dimension.")
+        self.family = family
+        self.moments = moments
+        self.nonfinite_observation_count = jnp.broadcast_to(
+            jnp.asarray(nonfinite_observation_count, dtype=jnp.int32), batch_shape
+        )
+        self.invalid_event_count = jnp.broadcast_to(
+            jnp.asarray(invalid_event_count, dtype=jnp.int32), batch_shape
+        )
+        self.invalid_weight_count = jnp.broadcast_to(
+            jnp.asarray(invalid_weight_count, dtype=jnp.int32), batch_shape
+        )
+        self.minimum_log_weight = jnp.broadcast_to(
+            jnp.asarray(minimum_log_weight), batch_shape
+        )
+        self.weighted_log_weight_sum = jnp.broadcast_to(
+            jnp.asarray(weighted_log_weight_sum), batch_shape
+        )
+
+    @classmethod
+    def from_log_weights(
+        cls,
+        family: AbstractExponentialFamily,
+        observations: ArrayLike,
+        log_weights: ArrayLike,
+        /,
+        *,
+        sample_axes: int | tuple[int, ...] = 0,
+        mask: ArrayLike | None = None,
+    ) -> "ExponentialFamilyProjectionAccumulator":
+        if not isinstance(family, AbstractExponentialFamily):
+            raise TypeError("family must implement AbstractExponentialFamily.")
+        observation_array = jnp.asarray(observations)
+        weight_array = jnp.asarray(log_weights, dtype=float)
+        event_shape = family.signature.event_shape
+        expected_observation_shape = weight_array.shape + event_shape
+        if observation_array.shape != expected_observation_shape:
+            raise ValueError(
+                "observations must have shape log_weights.shape + event_shape; "
+                f"got {observation_array.shape} and {weight_array.shape}."
+            )
+        statistics = family.sufficient_statistics(observation_array)
+        if (
+            statistics.values.shape != weight_array.shape + (family.signature.dimension,)
+            or statistics.valid.shape != weight_array.shape
+        ):
+            raise ValueError(
+                "Family sufficient statistics do not align with the observation batch."
+            )
+        if event_shape:
+            event_axes = tuple(
+                range(observation_array.ndim - len(event_shape), observation_array.ndim)
+            )
+            observation_finite = jnp.all(jnp.isfinite(observation_array), axis=event_axes)
+        else:
+            observation_finite = jnp.isfinite(observation_array)
+        packed = jnp.concatenate(
+            (
+                statistics.values,
+                statistics.valid[..., None].astype(statistics.values.dtype),
+                observation_finite[..., None].astype(statistics.values.dtype),
+            ),
+            axis=-1,
+        )
+        canonical, canonical_weights, included = _canonical_values(
+            packed,
+            weight_array,
+            sample_axes,
+            None if mask is None else jnp.asarray(mask, dtype=bool),
+        )
+        dimension = family.signature.dimension
+        statistic_values = canonical[..., :dimension]
+        event_valid = canonical[..., dimension] != 0.0
+        finite_observation = canonical[..., dimension + 1] != 0.0
+        invalid_weight = included & (
+            jnp.isnan(canonical_weights) | jnp.isposinf(canonical_weights)
+        )
+        active = included & jnp.isfinite(canonical_weights)
+        nonfinite_observation = active & ~finite_observation
+        invalid_event = active & finite_observation & ~event_valid
+        valid_active = active & event_valid & finite_observation
+        moments = LogWeightedAccumulator.from_values(
+            statistic_values,
+            canonical_weights,
+            sample_axes=0,
+            mask=valid_active,
+        )
+        safe_scale = jnp.where(jnp.isfinite(moments.log_scale), moments.log_scale, 0.0)
+        scaled_weights = jnp.where(
+            valid_active,
+            jnp.exp(canonical_weights - safe_scale[None, ...]),
+            0.0,
+        )
+        safe_log_weights = jnp.where(valid_active, canonical_weights, 0.0)
+        minimum_log_weight = jnp.min(
+            jnp.where(valid_active, canonical_weights, jnp.inf),
+            axis=0,
+            initial=jnp.inf,
+        )
+        return cls(
+            family=family,
+            moments=moments,
+            nonfinite_observation_count=jnp.sum(
+                nonfinite_observation, axis=0, dtype=jnp.int32
+            ),
+            invalid_event_count=jnp.sum(invalid_event, axis=0, dtype=jnp.int32),
+            invalid_weight_count=jnp.sum(invalid_weight, axis=0, dtype=jnp.int32),
+            minimum_log_weight=minimum_log_weight,
+            weighted_log_weight_sum=jnp.sum(scaled_weights * safe_log_weights, axis=0),
+        )
+
+    def merge(
+        self, other: "ExponentialFamilyProjectionAccumulator", /
+    ) -> "ExponentialFamilyProjectionAccumulator":
+        if not isinstance(other, ExponentialFamilyProjectionAccumulator):
+            raise TypeError("other must be an ExponentialFamilyProjectionAccumulator.")
+        if self.family.signature.key != other.family.signature.key:
+            raise ValueError(
+                "Projection accumulators must use identical family signatures."
+            )
+        merged_moments = self.moments.merge(other.moments)
+        scale = merged_moments.log_scale
+        left_scale = jnp.where(
+            jnp.isfinite(self.moments.log_scale), self.moments.log_scale, 0.0
+        )
+        right_scale = jnp.where(
+            jnp.isfinite(other.moments.log_scale), other.moments.log_scale, 0.0
+        )
+        left_factor = jnp.where(
+            jnp.isfinite(self.moments.log_scale), jnp.exp(left_scale - scale), 0.0
+        )
+        right_factor = jnp.where(
+            jnp.isfinite(other.moments.log_scale), jnp.exp(right_scale - scale), 0.0
+        )
+        return ExponentialFamilyProjectionAccumulator(
+            family=self.family,
+            moments=merged_moments,
+            nonfinite_observation_count=(
+                self.nonfinite_observation_count + other.nonfinite_observation_count
+            ),
+            invalid_event_count=self.invalid_event_count + other.invalid_event_count,
+            invalid_weight_count=self.invalid_weight_count + other.invalid_weight_count,
+            minimum_log_weight=jnp.minimum(
+                self.minimum_log_weight, other.minimum_log_weight
+            ),
+            weighted_log_weight_sum=(
+                left_factor * self.weighted_log_weight_sum
+                + right_factor * other.weighted_log_weight_sum
+            ),
+        )
+
+    @property
+    def diagnostics(self) -> WeightedMomentsDiagnostics:
+        count = self.moments.count
+        ess = self.moments.weight_ess
+        positive_mass = self.moments.weight_sum > 0.0
+        log_total_weight = self.moments.log_scale + jnp.log(
+            jnp.maximum(self.moments.weight_sum, jnp.finfo(float).tiny)
+        )
+        mean_log_weight = self.weighted_log_weight_sum / jnp.maximum(
+            self.moments.weight_sum, jnp.finfo(float).tiny
+        )
+        entropy = jnp.where(
+            positive_mass,
+            jnp.maximum(log_total_weight - mean_log_weight, 0.0),
+            0.0,
+        )
+        coefficient = jnp.sqrt(
+            jnp.maximum(
+                count / jnp.maximum(ess, jnp.finfo(float).tiny) - 1.0,
+                0.0,
+            )
+        )
+        return WeightedMomentsDiagnostics(
+            weight_ess=ess,
+            relative_weight_ess=self.moments.relative_weight_ess,
+            coefficient_of_variation=coefficient,
+            maximum_normalized_weight=self.moments.maximum_normalized_weight,
+            entropy=entropy,
+            log_weight_range=jnp.where(
+                positive_mass,
+                self.moments.log_scale - self.minimum_log_weight,
+                jnp.inf,
+            ),
+            finite_count=count,
+        )
+
+    def finalize(self) -> ExponentialFamilyEstimateResult:
+        mean = self.family.mean(self.moments.normalized_mean)
+        conversion = self.family.natural_from_mean(mean)
+        law = self.family.law(conversion.natural)
+        sufficient_weight = self.moments.weight_sum > 0.0
+        no_nonfinite = (self.nonfinite_observation_count == 0) & (
+            self.invalid_weight_count == 0
+        )
+        events_valid = self.invalid_event_count == 0
+        valid = no_nonfinite & events_valid & sufficient_weight & conversion.valid
+        status = conversion.status
+        status = jnp.where(
+            ~sufficient_weight,
+            EXPONENTIAL_FAMILY_INSUFFICIENT_WEIGHT,
+            status,
+        )
+        status = jnp.where(
+            ~events_valid,
+            EXPONENTIAL_FAMILY_INVALID_EVENT,
+            status,
+        )
+        status = jnp.where(
+            ~no_nonfinite,
+            EXPONENTIAL_FAMILY_NONFINITE,
+            status,
+        )
+        return ExponentialFamilyEstimateResult(
+            law=law,
+            mean_coordinates=mean,
+            statistic_standard_error=self.moments.normalized_standard_error,
+            diagnostics=self.diagnostics,
+            conversion_residual=conversion.residual,
+            conversion_iterations=conversion.iterations,
+            valid=valid,
+            status=status,
+            estimator_id="weighted_sufficient_statistics",
+            method_id=conversion.method_id,
+        )
+
+
+def _observation_batch_shape(
+    family: AbstractExponentialFamily,
+    observations: ArrayLike,
+    /,
+) -> tuple[int, ...]:
+    shape = jnp.asarray(observations).shape
+    event_shape = family.signature.event_shape
+    if event_shape:
+        if len(shape) < len(event_shape) or shape[-len(event_shape) :] != event_shape:
+            raise ValueError("Observation trailing dimensions do not match event_shape.")
+        return tuple(shape[: -len(event_shape)])
+    return tuple(shape)
+
+
+def project_exponential_family(
+    family: AbstractExponentialFamily,
+    observations: ArrayLike,
+    /,
+    *,
+    log_weights: ArrayLike | None = None,
+    sample_axes: int | tuple[int, ...] = 0,
+    mask: ArrayLike | None = None,
+) -> ExponentialFamilyEstimateResult:
+    """Project weighted observations onto a regular exponential family."""
+    batch_shape = _observation_batch_shape(family, observations)
+    configured_weights = (
+        jnp.zeros(batch_shape, dtype=float)
+        if log_weights is None
+        else jnp.asarray(log_weights, dtype=float)
+    )
+    return ExponentialFamilyProjectionAccumulator.from_log_weights(
+        family,
+        observations,
+        configured_weights,
+        sample_axes=sample_axes,
+        mask=mask,
+    ).finalize()
+
+
+def fit_exponential_family(
+    family: AbstractExponentialFamily,
+    observations: ArrayLike,
+    /,
+    *,
+    weights: ArrayLike | None = None,
+    sample_axes: int | tuple[int, ...] = 0,
+    mask: ArrayLike | None = None,
+) -> ExponentialFamilyEstimateResult:
+    """Fit a regular exponential family by weighted sufficient-statistic MLE."""
+    batch_shape = _observation_batch_shape(family, observations)
+    if weights is None:
+        log_weights = jnp.zeros(batch_shape, dtype=float)
+    else:
+        weight_array = jnp.asarray(weights, dtype=float)
+        log_weights = jnp.where(
+            weight_array > 0.0,
+            jnp.log(weight_array),
+            jnp.where(weight_array == 0.0, -jnp.inf, jnp.nan),
+        )
+    return project_exponential_family(
+        family,
+        observations,
+        log_weights=log_weights,
+        sample_axes=sample_axes,
+        mask=mask,
+    )
+
+
+__all__ = [
+    "ExponentialFamilyEstimateResult",
+    "ExponentialFamilyProjectionAccumulator",
+    "fit_exponential_family",
+    "project_exponential_family",
+]

--- a/phydrax/uq/_observation.py
+++ b/phydrax/uq/_observation.py
@@ -136,7 +136,7 @@ class LikelihoodObservationModel(AbstractObservationModel):
         values = jax.vmap(
             lambda sample_key: self.likelihood.sample(sample_key, location, **parameters)
         )(keys)
-        return values.reshape(shape + location.shape)
+        return values.reshape(shape + tuple(values.shape[1:]))
 
 
 __all__ = ["LikelihoodObservationModel"]

--- a/phydrax/uq/_posterior.py
+++ b/phydrax/uq/_posterior.py
@@ -14,8 +14,8 @@ import jax.numpy as jnp
 import jax.random as jr
 from jaxtyping import Array, ArrayLike, PyTree
 
+from .._probability import AbstractProbabilityLaw
 from .._strict import StrictModule
-from ._distributions import AbstractDistribution
 
 
 class AbstractBijector(StrictModule):
@@ -33,8 +33,24 @@ class AbstractBijector(StrictModule):
     def forward_log_det_jacobian(self, value: ArrayLike, /) -> Array:
         raise NotImplementedError
 
+    @abstractmethod
+    def forward_shape(self, raw_shape: tuple[int, ...], /) -> tuple[int, ...]:
+        raise NotImplementedError
 
-class IdentityBijector(AbstractBijector):
+    @abstractmethod
+    def inverse_shape(self, physical_shape: tuple[int, ...], /) -> tuple[int, ...]:
+        raise NotImplementedError
+
+
+class _AbstractShapePreservingBijector(AbstractBijector):
+    def forward_shape(self, raw_shape: tuple[int, ...], /) -> tuple[int, ...]:
+        return tuple(int(size) for size in raw_shape)
+
+    def inverse_shape(self, physical_shape: tuple[int, ...], /) -> tuple[int, ...]:
+        return tuple(int(size) for size in physical_shape)
+
+
+class IdentityBijector(_AbstractShapePreservingBijector):
     """Identity map for unconstrained real parameters."""
 
     def forward(self, value: ArrayLike, /) -> Array:
@@ -47,7 +63,7 @@ class IdentityBijector(AbstractBijector):
         return jnp.zeros_like(jnp.asarray(value), dtype=float)
 
 
-class ExpBijector(AbstractBijector):
+class ExpBijector(_AbstractShapePreservingBijector):
     """Exponential map from the real line to positive values."""
 
     def forward(self, value: ArrayLike, /) -> Array:
@@ -63,7 +79,7 @@ class ExpBijector(AbstractBijector):
         return jnp.asarray(value, dtype=float)
 
 
-class SigmoidIntervalBijector(AbstractBijector):
+class SigmoidIntervalBijector(_AbstractShapePreservingBijector):
     """Logistic map from the real line to an open finite interval."""
 
     lower: Array
@@ -101,16 +117,83 @@ class SigmoidIntervalBijector(AbstractBijector):
         )
 
 
+class SimplexBijector(AbstractBijector):
+    """Additive-log-ratio map to a simplex with the last category as reference."""
+
+    num_categories: int = eqx.field(static=True)
+
+    def __init__(self, num_categories: int):
+        categories = int(num_categories)
+        if categories < 2:
+            raise ValueError("num_categories must be at least two.")
+        self.num_categories = categories
+
+    def forward_shape(self, raw_shape: tuple[int, ...], /) -> tuple[int, ...]:
+        shape = tuple(int(size) for size in raw_shape)
+        expected = self.num_categories - 1
+        if not shape or shape[-1] != expected:
+            raise ValueError(f"Simplex raw shape must end in {expected}; got {shape}.")
+        return shape[:-1] + (self.num_categories,)
+
+    def inverse_shape(self, physical_shape: tuple[int, ...], /) -> tuple[int, ...]:
+        shape = tuple(int(size) for size in physical_shape)
+        if not shape or shape[-1] != self.num_categories:
+            raise ValueError(
+                f"Simplex physical shape must end in {self.num_categories}; got {shape}."
+            )
+        return shape[:-1] + (self.num_categories - 1,)
+
+    def forward(self, value: ArrayLike, /) -> Array:
+        raw = jnp.asarray(value)
+        if jnp.issubdtype(raw.dtype, jnp.complexfloating):
+            raise TypeError("Simplex coordinates must be real-valued.")
+        if raw.ndim == 0 or int(raw.shape[-1]) != self.num_categories - 1:
+            raise ValueError(
+                "Simplex coordinates have an incompatible trailing dimension."
+            )
+        raw = raw.astype(jnp.result_type(raw, 0.0))
+        logits = jnp.concatenate((raw, jnp.zeros_like(raw[..., :1])), axis=-1)
+        return jax.nn.softmax(logits, axis=-1)
+
+    def inverse(self, value: ArrayLike, /) -> Array:
+        physical = jnp.asarray(value)
+        if jnp.issubdtype(physical.dtype, jnp.complexfloating):
+            raise TypeError("Simplex values must be real-valued.")
+        if physical.ndim == 0 or int(physical.shape[-1]) != self.num_categories:
+            raise ValueError("Simplex values have an incompatible trailing dimension.")
+        physical = physical.astype(jnp.result_type(physical, 0.0))
+        tolerance = 64.0 * jnp.finfo(physical.dtype).eps * self.num_categories
+        invalid = (
+            jnp.any(~jnp.isfinite(physical))
+            | jnp.any(physical <= 0.0)
+            | jnp.any(jnp.abs(jnp.sum(physical, axis=-1) - 1.0) > tolerance)
+        )
+        checked = eqx.error_if(
+            physical,
+            invalid,
+            "SimplexBijector inverse requires a strictly positive unit-sum simplex.",
+        )
+        return jnp.log(checked[..., :-1]) - jnp.log(checked[..., -1, None])
+
+    def forward_log_det_jacobian(self, value: ArrayLike, /) -> Array:
+        physical = self.forward(value)
+        return jnp.sum(jnp.log(physical), axis=-1) + 0.5 * jnp.log(
+            jnp.asarray(self.num_categories, dtype=physical.dtype)
+        )
+
+
 _BIJECTOR_LEAF = lambda value: isinstance(value, AbstractBijector)
-_PRIOR_LEAF = lambda value: isinstance(value, AbstractDistribution)
+_PRIOR_LEAF = lambda value: isinstance(value, AbstractProbabilityLaw)
 
 
 class ParameterSpace(StrictModule):
     """Unconstrained posterior coordinates, priors, and physical transformations."""
 
     initial: PyTree[Any]
-    priors: PyTree[AbstractDistribution] | None
+    priors: PyTree[AbstractProbabilityLaw] | None
     bijectors: PyTree[AbstractBijector]
+    raw_shapes: tuple[tuple[int, ...], ...] = eqx.field(static=True)
+    physical_shapes: tuple[tuple[int, ...], ...] = eqx.field(static=True)
     custom_log_prior: Callable[[PyTree[Any]], ArrayLike] | None = eqx.field(static=True)
 
     def __init__(
@@ -118,7 +201,7 @@ class ParameterSpace(StrictModule):
         initial: PyTree[Any],
         /,
         *,
-        priors: PyTree[AbstractDistribution] | None = None,
+        priors: PyTree[AbstractProbabilityLaw] | None = None,
         bijectors: PyTree[AbstractBijector] | None = None,
         log_prior: Callable[[PyTree[Any]], ArrayLike] | None = None,
     ):
@@ -150,11 +233,36 @@ class ParameterSpace(StrictModule):
             raise ValueError(
                 "initial and bijectors must have identical PyTree structure."
             )
-        if any(
-            not isinstance(value, AbstractBijector)
-            for value in jax.tree_util.tree_leaves(bijector_tree, is_leaf=_BIJECTOR_LEAF)
-        ):
+        bijector_leaves = jax.tree_util.tree_leaves(bijector_tree, is_leaf=_BIJECTOR_LEAF)
+        if any(not isinstance(value, AbstractBijector) for value in bijector_leaves):
             raise TypeError("Every bijectors leaf must implement AbstractBijector.")
+
+        initial_leaves = jax.tree_util.tree_leaves(initial)
+        raw_shapes = tuple(tuple(jnp.asarray(value).shape) for value in initial_leaves)
+        physical_shapes = tuple(
+            bijector.forward_shape(raw_shape)
+            for bijector, raw_shape in zip(bijector_leaves, raw_shapes, strict=True)
+        )
+        for bijector, raw_shape, physical_shape in zip(
+            bijector_leaves, raw_shapes, physical_shapes, strict=True
+        ):
+            if bijector.inverse_shape(physical_shape) != raw_shape:
+                raise ValueError("Bijector forward and inverse shapes are inconsistent.")
+        initial_physical = jax.tree_util.tree_map(
+            lambda bijector, value: bijector.forward(value),
+            bijector_tree,
+            initial,
+            is_leaf=_BIJECTOR_LEAF,
+        )
+        for physical, expected_shape in zip(
+            jax.tree_util.tree_leaves(initial_physical),
+            physical_shapes,
+            strict=True,
+        ):
+            if tuple(jnp.asarray(physical).shape) != expected_shape:
+                raise ValueError(
+                    "Bijector forward output does not match its declared physical shape."
+                )
 
         if priors is not None:
             prior_structure = jax.tree_util.tree_structure(priors, is_leaf=_PRIOR_LEAF)
@@ -162,40 +270,59 @@ class ParameterSpace(StrictModule):
                 raise ValueError(
                     "initial and priors must have identical PyTree structure."
                 )
+            prior_leaves = jax.tree_util.tree_leaves(priors, is_leaf=_PRIOR_LEAF)
             if any(
-                not isinstance(value, AbstractDistribution)
-                for value in jax.tree_util.tree_leaves(priors, is_leaf=_PRIOR_LEAF)
+                not isinstance(value, AbstractProbabilityLaw) for value in prior_leaves
             ):
-                raise TypeError("Every priors leaf must implement AbstractDistribution.")
+                raise TypeError(
+                    "Every priors leaf must implement AbstractProbabilityLaw."
+                )
+            for physical_shape, prior in zip(physical_shapes, prior_leaves, strict=True):
+                prior_shape = tuple(prior.batch_shape) + tuple(prior.event_shape)
+                if prior_shape and prior_shape != physical_shape:
+                    raise ValueError(
+                        "Each shaped prior must have batch_shape + event_shape equal "
+                        "to its physical parameter leaf shape."
+                    )
 
         self.initial = initial
         self.priors = priors
         self.bijectors = bijector_tree
+        self.raw_shapes = raw_shapes
+        self.physical_shapes = physical_shapes
         self.custom_log_prior = log_prior
 
     def constrain(self, position: PyTree[Any], /) -> PyTree[Any]:
         """Map an unconstrained position to physical parameter values."""
-        self._validate_position_structure(position)
-        return jax.tree_util.tree_map(
+        self._validate_position(position, self.raw_shapes, owner="Unconstrained position")
+        physical = jax.tree_util.tree_map(
             lambda bijector, value: bijector.forward(value),
             self.bijectors,
             position,
             is_leaf=_BIJECTOR_LEAF,
         )
+        self._validate_position(
+            physical, self.physical_shapes, owner="Constrained position"
+        )
+        return physical
 
     def unconstrain(self, physical: PyTree[Any], /) -> PyTree[Any]:
         """Map physical parameter values back to unconstrained coordinates."""
-        self._validate_position_structure(physical)
-        return jax.tree_util.tree_map(
+        self._validate_position(
+            physical, self.physical_shapes, owner="Constrained position"
+        )
+        position = jax.tree_util.tree_map(
             lambda bijector, value: bijector.inverse(value),
             self.bijectors,
             physical,
             is_leaf=_BIJECTOR_LEAF,
         )
+        self._validate_position(position, self.raw_shapes, owner="Unconstrained position")
+        return position
 
     def log_abs_det_jacobian(self, position: PyTree[Any], /) -> Array:
         """Return the summed forward log-absolute-determinant Jacobian."""
-        self._validate_position_structure(position)
+        self._validate_position(position, self.raw_shapes, owner="Unconstrained position")
         terms = jax.tree_util.tree_map(
             lambda bijector, value: jnp.sum(bijector.forward_log_det_jacobian(value)),
             self.bijectors,
@@ -206,7 +333,9 @@ class ParameterSpace(StrictModule):
 
     def log_prior(self, physical: PyTree[Any], /) -> Array:
         """Evaluate the declared physical-space prior density."""
-        self._validate_position_structure(physical)
+        self._validate_position(
+            physical, self.physical_shapes, owner="Constrained position"
+        )
         if self.custom_log_prior is not None:
             value = jnp.asarray(self.custom_log_prior(physical), dtype=float)
             if value.ndim != 0:
@@ -240,31 +369,60 @@ class ParameterSpace(StrictModule):
         if count <= 0:
             raise ValueError("num_samples must be positive.")
         if self.priors is None:
-            raise ValueError("Prior sampling requires explicit distribution priors.")
+            raise ValueError("Prior sampling requires explicit probability-law priors.")
         initial_leaves, treedef = jax.tree_util.tree_flatten(self.initial)
         prior_leaves = jax.tree_util.tree_leaves(
             self.priors,
             is_leaf=_PRIOR_LEAF,
         )
         keys = jr.split(key, len(initial_leaves))
+
+        def draw(sample_key, prior, physical_shape):
+            prior_shape = tuple(prior.batch_shape) + tuple(prior.event_shape)
+            sample_shape = (count,) if prior_shape else (count,) + physical_shape
+            samples = prior.sample(sample_key, sample_shape=sample_shape)
+            expected_shape = (count,) + physical_shape
+            if samples.shape != expected_shape:
+                raise ValueError(
+                    "Prior sampling returned shape "
+                    f"{samples.shape}; expected {expected_shape}."
+                )
+            return samples
+
         physical = treedef.unflatten(
-            prior.sample(
-                sample_key,
-                sample_shape=(count,) + tuple(initial.shape),
-            )
-            for sample_key, prior, initial in zip(
+            draw(sample_key, prior, physical_shape)
+            for sample_key, prior, physical_shape in zip(
                 keys,
                 prior_leaves,
-                initial_leaves,
+                self.physical_shapes,
+                strict=True,
             )
         )
         return physical if constrained else self.unconstrain(physical)
 
-    def _validate_position_structure(self, position: PyTree[Any]) -> None:
+    def _validate_position(
+        self,
+        position: PyTree[Any],
+        expected_shapes: tuple[tuple[int, ...], ...],
+        /,
+        *,
+        owner: str,
+    ) -> None:
         if jax.tree_util.tree_structure(position) != jax.tree_util.tree_structure(
             self.initial
         ):
-            raise ValueError("Posterior position has incompatible PyTree structure.")
+            raise ValueError(f"{owner} has incompatible PyTree structure.")
+        leaves = jax.tree_util.tree_leaves(position)
+        for leaf, expected_shape in zip(leaves, expected_shapes, strict=True):
+            actual_shape = tuple(jnp.asarray(leaf).shape)
+            if expected_shape and (
+                len(actual_shape) < len(expected_shape)
+                or actual_shape[-len(expected_shape) :] != expected_shape
+            ):
+                raise ValueError(
+                    f"{owner} leaf has trailing shape {actual_shape}; "
+                    f"expected {expected_shape}."
+                )
 
 
 class PosteriorProblem(StrictModule):
@@ -425,4 +583,5 @@ __all__ = [
     "ParameterSpace",
     "PosteriorProblem",
     "SigmoidIntervalBijector",
+    "SimplexBijector",
 ]

--- a/phydrax/uq/_posterior_terms.py
+++ b/phydrax/uq/_posterior_terms.py
@@ -86,7 +86,7 @@ class FixedObservationLikelihood(AbstractPosteriorTerm):
         self.label = _label(label)
 
     def per_case_log_prob(self, parameters: PyTree[Any], /) -> Array:
-        prediction, target = _align_observations(
+        prediction, target = self.likelihood.align_observations(
             _field_data(self.predict_fn(parameters)),
             self.target,
         )
@@ -309,19 +309,6 @@ def _reduce_cases(values: Array, case_count: int, /, *, label: str) -> Array:
     return values.reshape((case_count, -1)).sum(axis=1)
 
 
-def _align_observations(prediction: Array, target: Array) -> tuple[Array, Array]:
-    if prediction.shape == target.shape:
-        return prediction, target
-    if prediction.ndim == 2 and target.ndim == 1 and int(prediction.shape[1]) == 1:
-        prediction = prediction[:, 0]
-    elif target.ndim == 2 and prediction.ndim == 1 and int(target.shape[1]) == 1:
-        target = target[:, 0]
-    if prediction.shape != target.shape:
-        raise ValueError(
-            "Fixed likelihood prediction and target shapes are incompatible: "
-            f"prediction={prediction.shape}, target={target.shape}."
-        )
-    return prediction, target
 
 
 __all__ = [

--- a/phydrax/uq/_sensitivity.py
+++ b/phydrax/uq/_sensitivity.py
@@ -14,6 +14,10 @@ import jax
 import jax.numpy as jnp
 from jaxtyping import Array, ArrayLike, PyTree
 
+from .._exponential_family import (
+    AbstractExponentialFamily,
+    NaturalCoordinates,
+)
 from .._frozendict import frozendict
 from .._sampling import get_sampler
 from .._strict import StrictModule
@@ -767,6 +771,128 @@ def fisher_information_action(
     )
 
 
+def exponential_family_fisher_action(
+    family: AbstractExponentialFamily,
+    natural: NaturalCoordinates,
+    direction: ArrayLike,
+    /,
+    *,
+    regularization: float = 0.0,
+    method_id: str = "jax_jvp_mean_map",
+) -> SensitivityActionResult:
+    """Apply an exact family Fisher action as the JVP of the mean map."""
+    if not isinstance(family, AbstractExponentialFamily):
+        raise TypeError("family must implement AbstractExponentialFamily.")
+    if not isinstance(natural, NaturalCoordinates):
+        raise TypeError("natural must be NaturalCoordinates.")
+    if not method_id:
+        raise ValueError("method_id must be non-empty.")
+    penalty = _validate_regularization(regularization)
+    vector = jnp.asarray(direction)
+    if vector.shape != natural.values.shape:
+        raise ValueError("direction must match the natural-coordinate shape.")
+    domain = family.natural_domain(natural)
+    action = family.fisher_action(natural, vector) + penalty * vector
+    inputs_finite = jnp.all(jnp.isfinite(natural.values)) & jnp.all(jnp.isfinite(vector))
+    action_finite = jnp.all(jnp.isfinite(action))
+    domain_valid = jnp.all(domain.valid)
+    valid = inputs_finite & domain_valid & action_finite
+    status = jnp.where(
+        ~inputs_finite,
+        SENSITIVITY_NONFINITE,
+        jnp.where(
+            ~domain_valid,
+            SENSITIVITY_INVALID_INFORMATION,
+            jnp.where(
+                action_finite,
+                SENSITIVITY_SUCCESS,
+                SENSITIVITY_NONFINITE,
+            ),
+        ),
+    )
+    return SensitivityActionResult(
+        action,
+        valid=valid,
+        status=status,
+        operator_id="fisher_information",
+        method_id=method_id,
+        approximation="exact_exponential_family",
+        regularization=penalty,
+        num_samples=None,
+    )
+
+
+def exponential_family_parameter_fisher_action(
+    family: AbstractExponentialFamily,
+    natural_fn: Callable[[PyTree[Array]], NaturalCoordinates | ArrayLike],
+    parameters: PyTree[Array],
+    vector: PyTree[Array],
+    /,
+    *,
+    regularization: float = 0.0,
+    method_id: str = "jax_jvp_family_pullback",
+) -> SensitivityActionResult:
+    """Apply ``Jηᵀ F(η) Jη`` without dense Jacobian or Fisher materialization."""
+    if not isinstance(family, AbstractExponentialFamily):
+        raise TypeError("family must implement AbstractExponentialFamily.")
+    if not callable(natural_fn):
+        raise TypeError("natural_fn must be callable.")
+    if not method_id:
+        raise ValueError("method_id must be non-empty.")
+    penalty = _validate_regularization(regularization)
+
+    def natural_values_fn(values):
+        coordinates = natural_fn(values)
+        if isinstance(coordinates, NaturalCoordinates):
+            family.natural_domain(coordinates)
+            return coordinates.values
+        return family.natural(coordinates).values
+
+    natural_values, linearized = jax.linearize(natural_values_fn, parameters)
+    natural = family.natural(natural_values)
+    natural_direction = linearized(vector)
+    family_direction = family.fisher_action(natural, natural_direction)
+    action = jax.linear_transpose(linearized, parameters)(family_direction)[0]
+    action = jax.tree_util.tree_map(
+        lambda value, direction_value: value + penalty * direction_value,
+        action,
+        vector,
+    )
+    domain = family.natural_domain(natural)
+    inputs_finite = (
+        _tree_all_finite(parameters)
+        & _tree_all_finite(vector)
+        & jnp.all(jnp.isfinite(natural_values))
+        & jnp.all(jnp.isfinite(natural_direction))
+    )
+    action_finite = _tree_all_finite(action)
+    domain_valid = jnp.all(domain.valid)
+    valid = inputs_finite & domain_valid & action_finite
+    status = jnp.where(
+        ~inputs_finite,
+        SENSITIVITY_NONFINITE,
+        jnp.where(
+            ~domain_valid,
+            SENSITIVITY_INVALID_INFORMATION,
+            jnp.where(
+                action_finite,
+                SENSITIVITY_SUCCESS,
+                SENSITIVITY_NONFINITE,
+            ),
+        ),
+    )
+    return SensitivityActionResult(
+        action,
+        valid=valid,
+        status=status,
+        operator_id="fisher_information_pullback",
+        method_id=method_id,
+        approximation="exact_exponential_family",
+        regularization=penalty,
+        num_samples=None,
+    )
+
+
 def gauss_newton_action(
     residual_fn: Callable[[PyTree[Array]], PyTree[Array]],
     parameters: PyTree[Array],
@@ -1053,6 +1179,8 @@ __all__ = [
     "empirical_controllability_directions",
     "empirical_observability_directions",
     "experiment_design_objective",
+    "exponential_family_fisher_action",
+    "exponential_family_parameter_fisher_action",
     "fisher_information_action",
     "fixed_noise_pathwise_gradient",
     "gauss_newton_action",

--- a/phydrax/uq/_whitening.py
+++ b/phydrax/uq/_whitening.py
@@ -10,8 +10,9 @@ import jax
 import jax.numpy as jnp
 from jaxtyping import Array, PyTree
 
+from .._probability import AbstractProbabilityLaw
 from .._strict import StrictModule
-from ._distributions import AbstractDistribution, LogNormal, Normal
+from ._distributions import LogNormal, Normal
 from ._posterior import (
     AbstractBijector,
     ExpBijector,
@@ -50,7 +51,7 @@ class GaussianPriorWhitening(StrictModule):
         initial_leaves, treedef = jax.tree_util.tree_flatten(space.initial)
         prior_leaves = jax.tree_util.tree_leaves(
             space.priors,
-            is_leaf=lambda value: isinstance(value, AbstractDistribution),
+            is_leaf=lambda value: isinstance(value, AbstractProbabilityLaw),
         )
         bijector_leaves = jax.tree_util.tree_leaves(
             space.bijectors,

--- a/tests/unit/ml/linear/test_glm.py
+++ b/tests/unit/ml/linear/test_glm.py
@@ -5,8 +5,10 @@
 import equinox as eqx
 import jax
 import jax.numpy as jnp
+import numpy as np
 import pytest
 
+import phydrax as phx
 from phydrax.ml import (
     ML_INFEASIBLE,
     ML_NONCONVERGED,
@@ -66,6 +68,44 @@ def _assert_model_gradients(model, point):
     assert jnp.all(jnp.isfinite(input_gradient))
     assert jnp.all(jnp.isfinite(coefficient_gradient))
     assert jnp.all(jnp.isfinite(intercept_gradient))
+
+
+@pytest.mark.parametrize("dtype", (jnp.float32, jnp.float64))
+def test_bernoulli_and_poisson_family_kernels_match_glm_score_equations(dtype):
+    scores = jnp.asarray([[-1.4, 0.2], [0.8, 2.1]], dtype=dtype)
+    binary = jnp.asarray([[0.0, 1.0], [1.0, 0.0]], dtype=dtype)
+    counts = jnp.asarray([[0.0, 2.0], [3.0, 1.0]], dtype=dtype)
+    bernoulli = phx.uq.BernoulliFamily()
+    poisson = phx.uq.PoissonFamily()
+    bernoulli_natural = bernoulli.natural(scores[..., None])
+    poisson_natural = poisson.natural(scores[..., None])
+
+    np_bernoulli_loss = jax.nn.softplus(scores) - binary * scores
+    np_poisson_loss = jnp.exp(scores) - counts * scores
+    np.testing.assert_allclose(
+        bernoulli.canonical_loss(bernoulli_natural, binary),
+        np_bernoulli_loss,
+        rtol=3e-7,
+        atol=3e-7,
+    )
+    np.testing.assert_allclose(
+        bernoulli.canonical_score(bernoulli_natural, binary)[..., 0],
+        jax.nn.sigmoid(scores) - binary,
+        rtol=3e-7,
+        atol=3e-7,
+    )
+    np.testing.assert_allclose(
+        poisson.canonical_loss(poisson_natural, counts),
+        np_poisson_loss,
+        rtol=3e-7,
+        atol=3e-7,
+    )
+    np.testing.assert_allclose(
+        poisson.canonical_score(poisson_natural, counts)[..., 0],
+        jnp.exp(scores) - counts,
+        rtol=3e-7,
+        atol=3e-7,
+    )
 
 
 def test_one_step_glm_updates_match_weighted_score_equations():

--- a/tests/unit/uq/test_advanced_sensitivity.py
+++ b/tests/unit/uq/test_advanced_sensitivity.py
@@ -9,13 +9,20 @@ import numpy as np
 import pytest
 
 from phydrax.uq import (
+    BernoulliFamily,
     empirical_controllability_directions,
     empirical_observability_directions,
     experiment_design_objective,
+    exponential_family_fisher_action,
+    EXPONENTIAL_FAMILY_OUTSIDE_NATURAL_DOMAIN,
+    exponential_family_parameter_fisher_action,
+    ExponentialRateFamily,
     fisher_information_action,
     fixed_noise_pathwise_gradient,
     gauss_newton_action,
     likelihood_ratio_gradient,
+    NormalFamily,
+    PoissonFamily,
     resampling_score_gradient,
 )
 
@@ -127,6 +134,93 @@ def test_matrix_free_actions_are_jit_compatible():
         )
     )(scores, vector)
     np.testing.assert_allclose(action, scores.T @ scores @ vector / 3.0, atol=2e-15)
+
+
+def test_exact_exponential_family_fisher_actions_match_dense_hessians():
+    cases = (
+        (BernoulliFamily(), jnp.asarray([0.3])),
+        (PoissonFamily(), jnp.asarray([jnp.log(1.7)])),
+        (ExponentialRateFamily(), jnp.asarray([-1.4])),
+        (NormalFamily(), jnp.asarray([0.2, -0.7])),
+    )
+    for family, natural_values in cases:
+        direction = jnp.linspace(0.2, 0.8, family.signature.dimension)
+        natural = family.natural(natural_values)
+        result = exponential_family_fisher_action(
+            family,
+            natural,
+            direction,
+            regularization=0.07,
+        )
+        hessian = jax.hessian(
+            lambda values: family.log_normalizer(family.natural(values))
+        )(natural_values)
+        expected = hessian @ direction + 0.07 * direction
+        np.testing.assert_allclose(result.action, expected, rtol=2e-12, atol=2e-12)
+        assert bool(result.valid)
+        assert result.operator_id == "fisher_information"
+        assert result.approximation == "exact_exponential_family"
+
+
+def test_parameter_space_family_fisher_pullback_matches_dense_product_and_jit():
+    family = PoissonFamily()
+    matrix = jnp.asarray([[1.0, -0.4, 0.2], [0.3, 0.7, -0.5]])
+    offset = jnp.asarray([-0.2, 0.4])
+    parameters = jnp.asarray([0.1, -0.3, 0.5])
+    direction = jnp.asarray([0.6, -0.2, 0.9])
+    natural_fn = lambda values: (matrix @ values + offset)[..., None]
+    result = exponential_family_parameter_fisher_action(
+        family,
+        natural_fn,
+        parameters,
+        direction,
+        regularization=0.03,
+    )
+    natural_values = matrix @ parameters + offset
+    expected = (
+        matrix.T @ (jnp.exp(natural_values) * (matrix @ direction)) + 0.03 * direction
+    )
+    compiled = jax.jit(
+        lambda values, vector: (
+            exponential_family_parameter_fisher_action(
+                family,
+                natural_fn,
+                values,
+                vector,
+            ).action
+        )
+    )(parameters, direction)
+
+    np.testing.assert_allclose(result.action, expected, rtol=2e-12, atol=2e-12)
+    np.testing.assert_allclose(
+        compiled,
+        matrix.T @ (jnp.exp(natural_values) * (matrix @ direction)),
+        rtol=2e-12,
+        atol=2e-12,
+    )
+    assert bool(result.valid)
+    assert result.operator_id == "fisher_information_pullback"
+
+
+def test_exact_family_fisher_reports_invalid_and_nonfinite_coordinates():
+    family = ExponentialRateFamily()
+    invalid = exponential_family_fisher_action(
+        family,
+        family.natural(jnp.asarray([0.0])),
+        jnp.asarray([1.0]),
+    )
+    nonfinite = exponential_family_fisher_action(
+        family,
+        family.natural(jnp.asarray([jnp.nan])),
+        jnp.asarray([1.0]),
+    )
+    assert not bool(invalid.valid)
+    assert int(invalid.status) == 2
+    assert int(family.natural_domain(family.natural(jnp.asarray([0.0]))).status) == (
+        EXPONENTIAL_FAMILY_OUTSIDE_NATURAL_DOMAIN
+    )
+    assert not bool(nonfinite.valid)
+    assert int(nonfinite.status) == 1
 
 
 def test_empirical_directions_match_dense_observability_and_controllability():

--- a/tests/unit/uq/test_benchmark_report.py
+++ b/tests/unit/uq/test_benchmark_report.py
@@ -120,10 +120,11 @@ def test_stochastic_gradient_benchmark_controls_are_profiled_and_registered():
     smoke = runner.get_configuration("smoke")
     standard = runner.get_configuration("standard")
 
-    assert tuple(runner.SCENARIOS)[-3:] == (
+    assert tuple(runner.SCENARIOS)[-4:] == (
         "stochastic_gradient_regression",
         "linearized_uncertainty_propagation",
         "dynamic_factor_stochastic_volatility",
+        "exponential_family_geometry",
     )
     assert smoke.sgmcmc_burnin > 0
     assert smoke.sgmcmc_draws > 0
@@ -136,23 +137,15 @@ def test_stochastic_gradient_benchmark_controls_are_profiled_and_registered():
     assert 0 < smoke.linearized_factor_rank <= smoke.linearized_input_dimension
     assert smoke.linearized_hutchinson_probes > 1
     assert smoke.linearized_qmc_samples > 0
-    assert (
-        standard.linearized_input_dimension
-        >= smoke.linearized_input_dimension
-    )
-    assert (
-        standard.linearized_output_dimension
-        >= smoke.linearized_output_dimension
-    )
-    assert (
-        standard.linearized_factor_rank
-        >= smoke.linearized_factor_rank
-    )
-    assert (
-        standard.linearized_hutchinson_probes
-        >= smoke.linearized_hutchinson_probes
-    )
+    assert standard.linearized_input_dimension >= smoke.linearized_input_dimension
+    assert standard.linearized_output_dimension >= smoke.linearized_output_dimension
+    assert standard.linearized_factor_rank >= smoke.linearized_factor_rank
+    assert standard.linearized_hutchinson_probes >= smoke.linearized_hutchinson_probes
     assert standard.linearized_qmc_samples >= smoke.linearized_qmc_samples
+    assert smoke.exponential_family_samples > 0
+    assert smoke.exponential_family_repetitions > 0
+    assert standard.exponential_family_samples >= smoke.exponential_family_samples
+    assert standard.exponential_family_repetitions >= smoke.exponential_family_repetitions
     assert smoke.dfsv_assets > smoke.dfsv_factors > 0
     assert smoke.dfsv_steps > 0
     assert smoke.dfsv_particles > 0
@@ -162,4 +155,3 @@ def test_stochastic_gradient_benchmark_controls_are_profiled_and_registered():
     assert standard.dfsv_factors >= smoke.dfsv_factors
     assert standard.dfsv_particles >= smoke.dfsv_particles
     assert standard.dfsv_smoother_paths >= smoke.dfsv_smoother_paths
-

--- a/tests/unit/uq/test_categorical_family.py
+++ b/tests/unit/uq/test_categorical_family.py
@@ -1,0 +1,173 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import numpy as np
+import pytest
+
+import phydrax as phx
+
+
+def test_categorical_duality_normalization_kl_and_fisher():
+    family = phx.uq.CategoricalFamily(4)
+    natural_values = jnp.asarray([0.7, -0.4, 0.2])
+    natural = family.natural(natural_values)
+    mean = family.mean_from_natural(natural)
+    probabilities = family.probabilities_from_natural(natural)
+    gradient = jax.grad(lambda value: family.log_normalizer(family.natural(value)))(
+        natural_values
+    )
+    direction = jnp.asarray([0.3, -0.2, 0.5])
+    hessian = jax.hessian(lambda value: family.log_normalizer(family.natural(value)))(
+        natural_values
+    )
+    conversion = family.natural_from_mean(mean)
+    labels = jnp.arange(4)
+    other = family.natural(jnp.asarray([-0.2, 0.5, -0.7]))
+    other_probabilities = family.probabilities_from_natural(other)
+    expected_kl = jnp.sum(
+        probabilities * (jnp.log(probabilities) - jnp.log(other_probabilities))
+    )
+
+    np.testing.assert_allclose(probabilities[:-1], mean.values, atol=2e-15)
+    np.testing.assert_allclose(mean.values, gradient, atol=2e-15)
+    np.testing.assert_allclose(conversion.natural.values, natural_values, atol=2e-15)
+    np.testing.assert_allclose(
+        family.fisher_action(natural, direction), hessian @ direction, atol=2e-15
+    )
+    np.testing.assert_allclose(jnp.sum(jnp.exp(family.log_prob(natural, labels))), 1.0)
+    np.testing.assert_allclose(family.kl_divergence(natural, natural), 0.0, atol=2e-15)
+    np.testing.assert_allclose(
+        family.kl_divergence(natural, other), expected_kl, atol=2e-15
+    )
+    assert bool(conversion.valid)
+    assert int(conversion.iterations) == 0
+    assert conversion.method_id == "categorical-analytic"
+
+
+def test_categorical_full_logits_are_identified_and_support_is_explicit():
+    family = phx.uq.CategoricalFamily(3)
+    logits = jnp.asarray([1.2, -0.3, 0.7])
+    shifted = logits + 8.0
+    natural = family.natural_from_logits(logits)
+    shifted_natural = family.natural_from_logits(shifted)
+
+    np.testing.assert_allclose(natural.values, shifted_natural.values, atol=2e-15)
+    assert jnp.all(jnp.isfinite(family.log_prob(natural, jnp.arange(3))))
+    assert jnp.isneginf(family.log_prob(natural, -1))
+    assert jnp.isneginf(family.log_prob(natural, 3))
+    assert jnp.isneginf(family.log_prob(natural, 1.5))
+    with pytest.raises(ValueError, match="num_categories"):
+        phx.uq.CategoricalFamily(1)
+    with pytest.raises(ValueError, match="full logits"):
+        family.natural_from_logits(jnp.ones((2,)))
+
+
+def test_categorical_mean_domain_and_projection_report_missing_categories():
+    family = phx.uq.CategoricalFamily(3)
+    interior = family.mean_domain(family.mean(jnp.asarray([0.2, 0.3])))
+    boundary = family.mean_domain(family.mean(jnp.asarray([0.5, 0.5])))
+    exterior = family.mean_domain(family.mean(jnp.asarray([0.7, 0.5])))
+    projected = phx.uq.fit_exponential_family(
+        family, jnp.asarray([0, 1, 0, 1]), sample_axes=0
+    )
+
+    assert bool(interior.valid)
+    assert int(boundary.status) == phx.uq.EXPONENTIAL_FAMILY_MEAN_BOUNDARY
+    assert int(exterior.status) == phx.uq.EXPONENTIAL_FAMILY_OUTSIDE_MEAN_DOMAIN
+    assert not bool(projected.valid)
+    assert int(projected.status) == phx.uq.EXPONENTIAL_FAMILY_MEAN_BOUNDARY
+
+
+def test_categorical_projection_is_weighted_mergeable_and_sampled():
+    family = phx.uq.CategoricalFamily(3)
+    labels = jnp.asarray([0, 1, 2, 1, 0, 2, 1, 2])
+    log_weights = jnp.asarray([-0.5, 0.3, 0.7, -0.1, 0.2, 0.9, -0.4, 0.1])
+    one_shot = phx.uq.project_exponential_family(family, labels, log_weights=log_weights)
+    left = phx.uq.ExponentialFamilyProjectionAccumulator.from_log_weights(
+        family, labels[:4], log_weights[:4]
+    )
+    right = phx.uq.ExponentialFamilyProjectionAccumulator.from_log_weights(
+        family, labels[4:], log_weights[4:]
+    )
+    merged = left.merge(right).finalize()
+    samples = one_shot.law.sample(jr.key(3), sample_shape=(20_000,))
+    expected = jax.nn.softmax(log_weights) @ jax.nn.one_hot(labels, 3)
+
+    np.testing.assert_allclose(one_shot.mean_coordinates.values, expected[:-1])
+    np.testing.assert_allclose(
+        merged.law.natural.values, one_shot.law.natural.values, atol=2e-15
+    )
+    np.testing.assert_allclose(
+        jnp.bincount(samples, length=3) / samples.size, expected, atol=0.015
+    )
+    assert samples.shape == (20_000,)
+    assert bool(one_shot.valid)
+
+
+def test_categorical_likelihood_declares_coordinate_and_target_axes():
+    family = phx.uq.CategoricalFamily(3)
+    full = phx.uq.CategoricalExponentialFamilyLikelihood(
+        family, prediction_coordinates="full_logits"
+    )
+    minimal = phx.uq.CategoricalExponentialFamilyLikelihood(
+        family, prediction_coordinates="natural"
+    )
+    logits = jnp.asarray([[1.0, -0.2, 0.4], [-0.5, 0.8, 0.1]])
+    labels = jnp.asarray([0, 1])
+    natural = family.natural_from_logits(logits).values
+    expected = jax.nn.log_softmax(logits, axis=-1)[jnp.arange(2), labels]
+
+    np.testing.assert_allclose(full.log_prob(logits, labels), expected, atol=2e-15)
+    np.testing.assert_allclose(minimal.log_prob(natural, labels), expected, atol=2e-15)
+    assert full.sample(jr.key(4), logits).shape == labels.shape
+    with pytest.raises(ValueError, match="coordinate dimension"):
+        full.align_observations(jnp.ones((2, 2)), labels)
+    with pytest.raises(ValueError, match="incompatible"):
+        full.align_observations(logits, jnp.ones((2, 2)))
+    with pytest.raises(TypeError, match="unknown parameters"):
+        full.log_prob(logits, labels, scale=1.0)
+
+
+def test_categorical_likelihood_integrates_with_fixed_posterior_terms():
+    family = phx.uq.CategoricalFamily(3)
+    likelihood = phx.uq.CategoricalExponentialFamilyLikelihood(
+        family, prediction_coordinates="full_logits"
+    )
+    logits = jnp.asarray([[0.1, 1.0, -0.2], [0.7, -0.3, 0.4], [-0.5, 0.2, 0.9]])
+    labels = jnp.asarray([1, 0, 2])
+    term = phx.uq.FixedObservationLikelihood(
+        lambda parameters: parameters,
+        labels,
+        likelihood,
+    )
+
+    per_case = term.per_case_log_prob(logits)
+    expected = jax.nn.log_softmax(logits, axis=-1)[jnp.arange(3), labels]
+    np.testing.assert_allclose(per_case, expected, atol=2e-15)
+    np.testing.assert_allclose(term.log_prob(logits), jnp.sum(expected), atol=2e-15)
+
+
+def test_categorical_likelihood_matches_multinomial_glm_score_equations():
+    family = phx.uq.CategoricalFamily(4)
+    likelihood = phx.uq.CategoricalExponentialFamilyLikelihood(
+        family, prediction_coordinates="full_logits"
+    )
+    logits = jnp.asarray([[0.2, -0.7, 1.1, 0.4], [-0.1, 0.8, 0.3, -0.6]])
+    labels = jnp.asarray([2, 1])
+    one_hot = jax.nn.one_hot(labels, 4)
+
+    family_loss = -jnp.sum(likelihood.log_prob(logits, labels))
+    glm_loss = jnp.sum(
+        jax.nn.logsumexp(logits, axis=-1) - jnp.sum(one_hot * logits, axis=-1)
+    )
+    family_gradient = jax.grad(
+        lambda value: -jnp.sum(likelihood.log_prob(value, labels))
+    )(logits)
+    glm_gradient = jax.nn.softmax(logits, axis=-1) - one_hot
+
+    np.testing.assert_allclose(family_loss, glm_loss, atol=2e-15)
+    np.testing.assert_allclose(family_gradient, glm_gradient, atol=2e-15)

--- a/tests/unit/uq/test_dirichlet_family.py
+++ b/tests/unit/uq/test_dirichlet_family.py
@@ -1,0 +1,199 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import jax.scipy as jsp
+import numpy as np
+import pytest
+
+import phydrax as phx
+
+
+def test_simplex_bijector_round_trip_shape_and_hausdorff_jacobian():
+    bijector = phx.uq.SimplexBijector(4)
+    raw = jnp.asarray([0.4, -0.7, 1.1])
+    physical = bijector.forward(raw)
+    jacobian = jax.jacobian(bijector.forward)(raw)
+    expected_log_volume = 0.5 * jnp.linalg.slogdet(jacobian.T @ jacobian)[1]
+
+    np.testing.assert_allclose(bijector.inverse(physical), raw, atol=3e-15)
+    np.testing.assert_allclose(
+        bijector.forward_log_det_jacobian(raw), expected_log_volume, atol=3e-15
+    )
+    np.testing.assert_allclose(jnp.sum(physical), 1.0, atol=2e-15)
+    assert jnp.all(physical > 0.0)
+    assert bijector.forward_shape((2, 3)) == (2, 4)
+    assert bijector.inverse_shape((2, 4)) == (2, 3)
+
+
+def test_dirichlet_density_uses_hausdorff_measure_and_normalizes():
+    family = phx.uq.DirichletFamily(2)
+    concentration = jnp.asarray([2.3, 1.7])
+    natural = family.natural_from_concentration(concentration)
+    coordinate = jnp.linspace(1e-6, 1.0 - 1e-6, 100_000)
+    points = jnp.stack((coordinate, 1.0 - coordinate), axis=-1)
+    standard = (
+        jsp.special.gammaln(jnp.sum(concentration))
+        - jnp.sum(jsp.special.gammaln(concentration))
+        + jnp.sum((concentration - 1.0) * jnp.log(points), axis=-1)
+    )
+    hausdorff = family.log_prob(natural, points)
+
+    np.testing.assert_allclose(hausdorff, standard - 0.5 * jnp.log(2.0), atol=3e-14)
+    np.testing.assert_allclose(
+        np.trapezoid(np.exp(hausdorff) * jnp.sqrt(2.0), coordinate),
+        1.0,
+        atol=2e-8,
+    )
+    assert family.signature.density_measure_kind == "hausdorff"
+
+
+def test_dirichlet_duality_inverse_kl_and_fisher():
+    family = phx.uq.DirichletFamily(4)
+    concentration = jnp.asarray([0.4, 1.2, 2.5, 4.0])
+    natural = family.natural_from_concentration(concentration)
+    mean = family.mean_from_natural(natural)
+    conversion = family.natural_from_mean(mean)
+    gradient = jax.grad(lambda value: family.log_normalizer(family.natural(value)))(
+        natural.values
+    )
+    direction = jnp.asarray([0.2, -0.4, 0.5, -0.1])
+    hessian = jax.hessian(lambda value: family.log_normalizer(family.natural(value)))(
+        natural.values
+    )
+    other_concentration = jnp.asarray([1.5, 0.8, 3.2, 2.0])
+    other = family.natural_from_concentration(other_concentration)
+
+    def log_beta(value):
+        return jnp.sum(jsp.special.gammaln(value)) - jsp.special.gammaln(jnp.sum(value))
+
+    expected_kl = (
+        log_beta(other_concentration)
+        - log_beta(concentration)
+        + jnp.sum((concentration - other_concentration) * mean.values)
+    )
+
+    np.testing.assert_allclose(mean.values, gradient, atol=4e-14)
+    np.testing.assert_allclose(
+        conversion.natural.values, natural.values, rtol=2e-9, atol=2e-9
+    )
+    np.testing.assert_allclose(
+        family.fisher_action(natural, direction), hessian @ direction, atol=5e-14
+    )
+    np.testing.assert_allclose(family.kl_divergence(natural, natural), 0.0, atol=4e-14)
+    np.testing.assert_allclose(
+        family.kl_divergence(natural, other), expected_kl, atol=5e-14
+    )
+    assert bool(conversion.valid)
+    assert conversion.method_id == "dirichlet-total-concentration-bisection"
+    assert int(conversion.iterations) > 0
+
+
+def test_dirichlet_inverse_has_implicit_reverse_derivative_and_supports_empty_batches():
+    family = phx.uq.DirichletFamily(3)
+    natural = family.natural_from_concentration(jnp.asarray([0.7, 1.8, 3.1]))
+    mean = family.mean_from_natural(natural)
+    converted = family.natural_from_mean(mean)
+    inverse_jacobian = jax.jacrev(
+        lambda value: family.natural_from_mean(family.mean(value)).natural.values
+    )(mean.values)
+    forward_jacobian = jax.jacfwd(
+        lambda value: family.natural_from_mean(family.mean(value)).natural.values
+    )(mean.values)
+    fisher = jax.jacfwd(
+        lambda value: family.mean_from_natural(family.natural(value)).values
+    )(converted.natural.values)
+    empty = family.natural_from_mean(family.mean(jnp.empty((0, 3))))
+
+    np.testing.assert_allclose(
+        inverse_jacobian @ fisher, jnp.eye(3), rtol=3e-9, atol=3e-9
+    )
+    np.testing.assert_allclose(inverse_jacobian, forward_jacobian, rtol=2e-12, atol=2e-12)
+    assert empty.natural.values.shape == (0, 3)
+    assert empty.valid.shape == (0,)
+
+
+def test_dirichlet_mean_domain_and_solver_failure_are_distinct():
+    family = phx.uq.DirichletFamily(3)
+    boundary_values = jnp.log(jnp.asarray([0.2, 0.3, 0.5]))
+    boundary = family.mean_domain(family.mean(boundary_values))
+    exterior = family.mean_domain(family.mean(boundary_values + 0.1))
+    slow = phx.uq.DirichletFamily(3, atol=1e-14, rtol=0.0, max_iterations=1)
+    source = family.mean_from_natural(
+        family.natural_from_concentration(jnp.asarray([0.08, 1.5, 7.0]))
+    )
+    failed = slow.natural_from_mean(source)
+
+    assert int(boundary.status) == phx.uq.EXPONENTIAL_FAMILY_MEAN_BOUNDARY
+    assert int(exterior.status) == phx.uq.EXPONENTIAL_FAMILY_OUTSIDE_MEAN_DOMAIN
+    assert int(failed.status) == phx.uq.EXPONENTIAL_FAMILY_NONCONVERGED
+    assert not bool(failed.valid)
+    assert jnp.isfinite(failed.residual)
+    assert not bool(family.sufficient_statistics(jnp.asarray([0.0, 0.5, 0.5])).valid)
+    assert not bool(family.sufficient_statistics(jnp.asarray([0.2, 0.2, 0.2])).valid)
+    large_family = phx.uq.DirichletFamily(2048)
+    off_simplex = jnp.full((2048,), jnp.asarray(129.0 / 262144.0, dtype=jnp.float32))
+    assert not bool(large_family.sufficient_statistics(off_simplex).valid)
+
+
+def test_dirichlet_sampling_projection_and_batched_inverse():
+    family = phx.uq.DirichletFamily(3)
+    concentration = jnp.asarray([1.5, 3.0, 5.5])
+    law = family.law_from_concentration(concentration)
+    samples = law.sample(jr.key(30), sample_shape=(40_000,))
+    observations = jnp.asarray(
+        [[0.2, 0.3, 0.5], [0.1, 0.7, 0.2], [0.4, 0.2, 0.4], [0.3, 0.5, 0.2]]
+    )
+    projected = phx.uq.fit_exponential_family(family, observations, sample_axes=0)
+    expected_log = jnp.mean(jnp.log(observations), axis=0)
+    batched_concentrations = jnp.asarray(
+        [[0.3, 0.8, 2.0], [1.0, 1.0, 1.0], [4.0, 2.0, 7.0]]
+    )
+    batched_natural = family.natural_from_concentration(batched_concentrations)
+    converted = jax.jit(
+        lambda value: family.natural_from_mean(
+            family.mean_from_natural(family.natural(value))
+        )
+    )(batched_natural.values)
+
+    np.testing.assert_allclose(
+        jnp.mean(samples, axis=0), concentration / jnp.sum(concentration), atol=0.012
+    )
+    np.testing.assert_allclose(
+        projected.mean_coordinates.values, expected_log, atol=3e-14
+    )
+    np.testing.assert_allclose(
+        converted.natural.values, batched_natural.values, rtol=2e-8, atol=2e-8
+    )
+    assert samples.shape == (40_000, 3)
+    assert bool(projected.valid)
+    assert jnp.all(converted.valid)
+
+
+def test_dirichlet_prior_uses_distinct_raw_and_physical_shapes():
+    family = phx.uq.DirichletFamily(3)
+    prior = family.law_from_concentration(jnp.asarray([1.5, 2.0, 3.0]))
+    bijector = phx.uq.SimplexBijector(3)
+    initial = jnp.asarray([0.2, -0.4])
+    space = phx.uq.ParameterSpace(initial, priors=prior, bijectors=bijector)
+    physical = space.constrain(initial)
+    reconstructed = space.unconstrain(physical)
+    constrained_samples = space.sample_prior(jr.key(31), num_samples=9, constrained=True)
+    raw_samples = space.sample_prior(jr.key(32), num_samples=7, constrained=False)
+    problem = phx.uq.PosteriorProblem(space, lambda simplex: jnp.sum(jnp.log(simplex)))
+    value, gradient = problem.validate()
+
+    np.testing.assert_allclose(reconstructed, initial, atol=3e-15)
+    np.testing.assert_allclose(jnp.sum(physical), 1.0, atol=2e-15)
+    assert space.raw_shapes == ((2,),)
+    assert space.physical_shapes == ((3,),)
+    assert constrained_samples.shape == (9, 3)
+    assert raw_samples.shape == (7, 2)
+    assert jnp.allclose(jnp.sum(constrained_samples, axis=-1), 1.0)
+    assert jnp.isfinite(value)
+    assert jnp.all(jnp.isfinite(gradient))
+    with pytest.raises(ValueError, match="supports only"):
+        phx.uq.GaussianPriorWhitening.from_parameter_space(space)

--- a/tests/unit/uq/test_exponential_families.py
+++ b/tests/unit/uq/test_exponential_families.py
@@ -1,0 +1,375 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import jax.scipy as jsp
+import numpy as np
+import pytest
+
+import phydrax as phx
+
+
+FAMILY_COORDINATES = (
+    (phx.uq.BernoulliFamily(), jnp.asarray([0.4])),
+    (phx.uq.PoissonFamily(), jnp.asarray([jnp.log(2.3)])),
+    (phx.uq.ExponentialRateFamily(), jnp.asarray([-1.7])),
+    (
+        phx.uq.NormalFamily(),
+        jnp.asarray([-0.4 / 1.3**2, -0.5 / 1.3**2]),
+    ),
+)
+
+
+@pytest.mark.parametrize(("family", "natural_values"), FAMILY_COORDINATES)
+def test_family_duality_round_trip_kl_and_fisher_identities(family, natural_values):
+    natural = family.natural(natural_values)
+    mean = family.mean_from_natural(natural)
+    gradient = jax.grad(lambda values: family.log_normalizer(family.natural(values)))(
+        natural_values
+    )
+    conversion = family.natural_from_mean(mean)
+    direction = jnp.linspace(0.2, 0.7, family.signature.dimension)
+    fisher = family.fisher_action(natural, direction)
+    hessian = jax.hessian(lambda values: family.log_normalizer(family.natural(values)))(
+        natural_values
+    )
+    second_direction = jnp.linspace(-0.6, 0.3, family.signature.dimension)
+
+    np.testing.assert_allclose(mean.values, gradient, rtol=2e-12, atol=2e-12)
+    np.testing.assert_allclose(
+        conversion.natural.values,
+        natural_values,
+        rtol=2e-12,
+        atol=2e-12,
+    )
+    np.testing.assert_allclose(fisher, hessian @ direction, rtol=2e-12, atol=2e-12)
+    np.testing.assert_allclose(
+        jnp.vdot(direction, family.fisher_action(natural, second_direction)),
+        jnp.vdot(second_direction, fisher),
+        rtol=2e-12,
+        atol=2e-12,
+    )
+    np.testing.assert_allclose(family.kl_divergence(natural, natural), 0.0, atol=2e-14)
+    assert bool(conversion.valid)
+    assert int(conversion.status) == phx.uq.EXPONENTIAL_FAMILY_SUCCESS
+
+
+def test_normalized_log_probabilities_match_independent_formulas():
+    probability = 0.3
+    bernoulli = phx.uq.BernoulliFamily().law(
+        jnp.asarray([jnp.log(probability) - jnp.log1p(-probability)])
+    )
+    binary = jnp.asarray([0.0, 1.0])
+    expected_binary = binary * jnp.log(probability) + (1.0 - binary) * jnp.log1p(
+        -probability
+    )
+    np.testing.assert_allclose(bernoulli.log_prob(binary), expected_binary, atol=2e-15)
+    np.testing.assert_allclose(jnp.sum(jnp.exp(bernoulli.log_prob(binary))), 1.0)
+
+    rate = 2.1
+    poisson = phx.uq.PoissonFamily().law(jnp.asarray([jnp.log(rate)]))
+    counts = jnp.arange(60.0)
+    expected_counts = counts * jnp.log(rate) - rate - jsp.special.gammaln(counts + 1.0)
+    np.testing.assert_allclose(poisson.log_prob(counts), expected_counts, atol=2e-14)
+    np.testing.assert_allclose(
+        jnp.sum(jnp.exp(poisson.log_prob(counts))), 1.0, atol=2e-14
+    )
+
+    exponential = phx.uq.ExponentialRateFamily().law(jnp.asarray([-1.4]))
+    positive_grid = jnp.linspace(0.0, 25.0, 30_001)
+    expected_exponential = jnp.log(1.4) - 1.4 * positive_grid
+    np.testing.assert_allclose(
+        exponential.log_prob(positive_grid), expected_exponential, atol=2e-15
+    )
+    np.testing.assert_allclose(
+        np.trapezoid(np.exp(exponential.log_prob(positive_grid)), positive_grid),
+        1.0,
+        atol=2e-7,
+    )
+
+    location = -0.2
+    scale = 1.3
+    normal = phx.uq.NormalFamily().law(
+        jnp.asarray([location / scale**2, -0.5 / scale**2])
+    )
+    real_grid = jnp.linspace(location - 10.0 * scale, location + 10.0 * scale, 40_001)
+    expected_normal = jsp.stats.norm.logpdf(real_grid, location, scale)
+    np.testing.assert_allclose(normal.log_prob(real_grid), expected_normal, atol=2e-14)
+    np.testing.assert_allclose(
+        np.trapezoid(np.exp(normal.log_prob(real_grid)), real_grid),
+        1.0,
+        atol=2e-12,
+    )
+
+
+def test_mean_and_natural_domains_distinguish_boundaries_and_exteriors():
+    bernoulli = phx.uq.BernoulliFamily()
+    bernoulli_boundary = bernoulli.mean_domain(
+        bernoulli.mean(jnp.asarray([[0.0], [1.0]]))
+    )
+    bernoulli_exterior = bernoulli.mean_domain(bernoulli.mean(jnp.asarray([[-0.1]])))
+    assert jnp.all(bernoulli_boundary.boundary)
+    assert jnp.all(bernoulli_boundary.status == phx.uq.EXPONENTIAL_FAMILY_MEAN_BOUNDARY)
+    assert (
+        int(bernoulli_exterior.status[0]) == phx.uq.EXPONENTIAL_FAMILY_OUTSIDE_MEAN_DOMAIN
+    )
+
+    poisson = phx.uq.PoissonFamily()
+    assert int(poisson.mean_domain(poisson.mean(jnp.asarray([[0.0]]))).status[0]) == (
+        phx.uq.EXPONENTIAL_FAMILY_MEAN_BOUNDARY
+    )
+    assert not bool(poisson.sufficient_statistics(jnp.asarray(1.5)).valid)
+    assert not bool(poisson.sufficient_statistics(jnp.asarray(-1.0)).valid)
+
+    exponential = phx.uq.ExponentialRateFamily()
+    assert (
+        int(
+            exponential.natural_domain(exponential.natural(jnp.asarray([[0.0]]))).status[
+                0
+            ]
+        )
+        == phx.uq.EXPONENTIAL_FAMILY_OUTSIDE_NATURAL_DOMAIN
+    )
+    assert (
+        int(exponential.mean_domain(exponential.mean(jnp.asarray([[0.0]]))).status[0])
+        == phx.uq.EXPONENTIAL_FAMILY_MEAN_BOUNDARY
+    )
+
+    normal = phx.uq.NormalFamily()
+    boundary = normal.mean_domain(normal.mean(jnp.asarray([[2.0, 4.0]])))
+    exterior = normal.mean_domain(normal.mean(jnp.asarray([[2.0, 3.5]])))
+    invalid_natural = normal.natural_domain(normal.natural(jnp.asarray([[0.0, 0.2]])))
+    assert bool(boundary.boundary[0])
+    assert int(boundary.status[0]) == phx.uq.EXPONENTIAL_FAMILY_MEAN_BOUNDARY
+    assert int(exterior.status[0]) == phx.uq.EXPONENTIAL_FAMILY_OUTSIDE_MEAN_DOMAIN
+    assert int(invalid_natural.status[0]) == (
+        phx.uq.EXPONENTIAL_FAMILY_OUTSIDE_NATURAL_DOMAIN
+    )
+
+    nonfinite = bernoulli.natural_domain(bernoulli.natural(jnp.asarray([[jnp.nan]])))
+    assert int(nonfinite.status[0]) == phx.uq.EXPONENTIAL_FAMILY_NONFINITE
+    assert jnp.isneginf(bernoulli.log_prob(bernoulli.natural(jnp.asarray([0.0])), 2.0))
+
+
+def test_family_signatures_prevent_cross_family_coordinate_use():
+    bernoulli = phx.uq.BernoulliFamily()
+    poisson = phx.uq.PoissonFamily()
+    with pytest.raises(ValueError, match="signature"):
+        poisson.log_normalizer(bernoulli.natural(jnp.asarray([0.2])))
+    with pytest.raises(ValueError, match="signature"):
+        bernoulli.kl_divergence(
+            bernoulli.natural(jnp.asarray([0.2])),
+            poisson.natural(jnp.asarray([0.2])),
+        )
+    with pytest.raises(ValueError, match="Unknown exponential-family status"):
+        phx.uq.exponential_family_status_name(99)
+
+
+def test_batched_laws_preserve_sample_batch_and_intrinsic_axes_under_transforms():
+    family = phx.uq.BernoulliFamily()
+    natural_values = jnp.asarray([[-1.0], [0.0], [1.0]], dtype=jnp.float32)
+    observations = jnp.asarray([[0.0, 1.0, 0.0], [1.0, 0.0, 1.0]], dtype=jnp.float32)
+    natural = family.natural(natural_values)
+    law = family.law(natural)
+    compiled = jax.jit(
+        lambda values, targets: family.log_prob(family.natural(values), targets)
+    )(natural_values, observations)
+    vmapped = jax.vmap(
+        lambda values, target: family.log_prob(family.natural(values), target)
+    )(natural_values, jnp.asarray([0.0, 1.0, 1.0], dtype=jnp.float32))
+    gradient = jax.grad(
+        lambda values: jnp.sum(family.log_prob(family.natural(values), observations))
+    )(natural_values)
+    samples = law.sample(jr.key(4), sample_shape=(7,))
+
+    assert compiled.shape == (2, 3)
+    assert vmapped.shape == (3,)
+    assert gradient.shape == natural_values.shape
+    assert samples.shape == (7, 3)
+    assert compiled.dtype == jnp.float32
+    assert jnp.all(jnp.isfinite(compiled))
+    assert jnp.all(jnp.isfinite(gradient))
+
+
+@pytest.mark.parametrize(
+    ("law", "expected_mean", "expected_variance"),
+    (
+        (
+            phx.uq.BernoulliFamily().law(jnp.asarray([jnp.log(0.35 / 0.65)])),
+            0.35,
+            0.35 * 0.65,
+        ),
+        (phx.uq.PoissonFamily().law(jnp.asarray([jnp.log(1.7)])), 1.7, 1.7),
+        (
+            phx.uq.ExponentialRateFamily().law(jnp.asarray([-1.4])),
+            1.0 / 1.4,
+            1.0 / 1.4**2,
+        ),
+        (
+            phx.uq.NormalFamily().law(jnp.asarray([-0.2 / 1.1**2, -0.5 / 1.1**2])),
+            -0.2,
+            1.1**2,
+        ),
+    ),
+)
+def test_family_sampling_matches_declared_moments(law, expected_mean, expected_variance):
+    samples = law.sample(jr.key(17), sample_shape=(12_000,))
+    np.testing.assert_allclose(jnp.mean(samples), expected_mean, atol=0.04, rtol=0.04)
+    np.testing.assert_allclose(jnp.var(samples), expected_variance, atol=0.06, rtol=0.08)
+    assert isinstance(law, phx.uq.AbstractProbabilityLaw)
+
+
+def test_log_weighted_projection_is_mergeable_and_retains_batch_axes():
+    family = phx.uq.BernoulliFamily()
+    observations = jnp.asarray([0.0, 1.0, 1.0, 0.0, 1.0, 1.0])
+    log_weights = jnp.asarray([-0.7, 0.2, 1.1, -1.3, 0.6, -0.2])
+    one_shot = phx.uq.project_exponential_family(
+        family, observations, log_weights=log_weights
+    )
+    left = phx.uq.ExponentialFamilyProjectionAccumulator.from_log_weights(
+        family, observations[:3], log_weights[:3]
+    )
+    right = phx.uq.ExponentialFamilyProjectionAccumulator.from_log_weights(
+        family, observations[3:], log_weights[3:]
+    )
+    merged = left.merge(right).finalize()
+    normalized = jax.nn.softmax(log_weights)
+    expected_mean = jnp.sum(normalized * observations)
+
+    np.testing.assert_allclose(one_shot.mean_coordinates.values[0], expected_mean)
+    np.testing.assert_allclose(
+        merged.mean_coordinates.values,
+        one_shot.mean_coordinates.values,
+        atol=2e-15,
+    )
+    np.testing.assert_allclose(
+        merged.law.natural.values, one_shot.law.natural.values, atol=2e-15
+    )
+    np.testing.assert_allclose(
+        merged.diagnostics.entropy, one_shot.diagnostics.entropy, atol=2e-15
+    )
+    assert bool(one_shot.valid)
+    assert bool(merged.valid)
+
+    batched_observations = jnp.asarray([[0.0, 1.0], [1.0, 1.0], [0.0, 1.0], [1.0, 0.0]])
+    batched = phx.uq.fit_exponential_family(
+        family,
+        batched_observations,
+        sample_axes=0,
+    )
+    np.testing.assert_allclose(batched.mean_coordinates.values[:, 0], [0.5, 0.75])
+    assert batched.valid.shape == (2,)
+    assert jnp.all(batched.valid)
+
+
+def test_projection_reports_invalid_inputs_zero_weight_and_boundary_mles():
+    family = phx.uq.BernoulliFamily()
+    masked = phx.uq.project_exponential_family(
+        family,
+        jnp.asarray([0.0, 2.0, 1.0]),
+        mask=jnp.asarray([True, False, True]),
+    )
+    zero_weight_nonfinite = phx.uq.project_exponential_family(
+        family,
+        jnp.asarray([0.0, jnp.nan, 1.0]),
+        log_weights=jnp.asarray([0.0, -jnp.inf, 0.0]),
+    )
+    invalid_event = phx.uq.project_exponential_family(
+        family, jnp.asarray([0.0, 2.0, 1.0])
+    )
+    nonfinite_event = phx.uq.project_exponential_family(
+        family, jnp.asarray([0.0, jnp.nan, 1.0])
+    )
+    invalid_weight = phx.uq.project_exponential_family(
+        family,
+        jnp.asarray([0.0, 1.0]),
+        log_weights=jnp.asarray([0.0, jnp.nan]),
+    )
+    no_weight = phx.uq.project_exponential_family(
+        family,
+        jnp.asarray([0.0, 1.0]),
+        log_weights=jnp.asarray([-jnp.inf, -jnp.inf]),
+    )
+    bernoulli_boundary = phx.uq.fit_exponential_family(family, jnp.zeros((4,)))
+    poisson_boundary = phx.uq.fit_exponential_family(
+        phx.uq.PoissonFamily(), jnp.zeros((4,))
+    )
+    normal_boundary = phx.uq.fit_exponential_family(phx.uq.NormalFamily(), jnp.ones((4,)))
+
+    assert bool(masked.valid)
+    assert bool(zero_weight_nonfinite.valid)
+    assert int(invalid_event.status) == phx.uq.EXPONENTIAL_FAMILY_INVALID_EVENT
+    assert int(nonfinite_event.status) == phx.uq.EXPONENTIAL_FAMILY_NONFINITE
+    assert int(invalid_weight.status) == phx.uq.EXPONENTIAL_FAMILY_NONFINITE
+    assert int(no_weight.status) == phx.uq.EXPONENTIAL_FAMILY_INSUFFICIENT_WEIGHT
+    assert int(bernoulli_boundary.status) == phx.uq.EXPONENTIAL_FAMILY_MEAN_BOUNDARY
+    assert int(poisson_boundary.status) == phx.uq.EXPONENTIAL_FAMILY_MEAN_BOUNDARY
+    assert int(normal_boundary.status) == phx.uq.EXPONENTIAL_FAMILY_MEAN_BOUNDARY
+    assert not bool(invalid_event.valid)
+    assert not bool(no_weight.valid)
+
+
+def test_scalar_family_likelihood_delegates_normalized_density_and_sampling():
+    family = phx.uq.PoissonFamily()
+    likelihood = phx.uq.ScalarNaturalExponentialFamilyLikelihood(family)
+    location = jnp.asarray([jnp.log(1.2), jnp.log(2.5)])
+    targets = jnp.asarray([0.0, 3.0])
+    expected = family.log_prob(family.natural(location[..., None]), targets)
+
+    np.testing.assert_allclose(likelihood.log_prob(location, targets), expected)
+    assert likelihood.sample(jr.key(8), location).shape == location.shape
+    with pytest.raises(TypeError, match="unknown parameters"):
+        likelihood.log_prob(location, targets, scale=1.0)
+    with pytest.raises(ValueError, match="one natural coordinate"):
+        phx.uq.ScalarNaturalExponentialFamilyLikelihood(phx.uq.NormalFamily())
+
+
+def test_exponential_family_laws_are_posterior_prior_leaves_with_shape_semantics():
+    scalar_prior = phx.uq.BernoulliFamily().law(jnp.asarray([0.3]))
+    scalar_space = phx.uq.ParameterSpace(
+        jnp.zeros((3,)),
+        priors=scalar_prior,
+    )
+    scalar_samples = scalar_space.sample_prior(
+        jr.key(31), num_samples=5, constrained=True
+    )
+    np.testing.assert_allclose(
+        scalar_space.log_prior(jnp.asarray([0.0, 1.0, 0.0])),
+        jnp.sum(scalar_prior.log_prob(jnp.asarray([0.0, 1.0, 0.0]))),
+    )
+    assert scalar_samples.shape == (5, 3)
+
+    shaped_prior = phx.uq.PoissonFamily().law(
+        jnp.asarray([[jnp.log(0.8)], [jnp.log(1.5)], [jnp.log(2.2)]])
+    )
+    shaped_space = phx.uq.ParameterSpace(
+        jnp.ones((3,)),
+        priors=shaped_prior,
+    )
+    shaped_samples = shaped_space.sample_prior(
+        jr.key(32), num_samples=7, constrained=True
+    )
+    assert shaped_samples.shape == (7, 3)
+
+    with pytest.raises(ValueError, match=r"batch_shape \+ event_shape"):
+        phx.uq.ParameterSpace(jnp.ones((2,)), priors=shaped_prior)
+    with pytest.raises(ValueError, match="supports only Normal/Identity"):
+        phx.uq.GaussianPriorWhitening.from_parameter_space(scalar_space)
+
+
+def test_existing_scalar_distributions_implement_common_probability_law():
+    laws = (
+        phx.uq.Uniform(-1.0, 2.0),
+        phx.uq.Normal(0.0, 1.0),
+        phx.uq.LogNormal(0.0, 0.5),
+        phx.uq.EmpiricalDistribution(jnp.asarray([0.0, 1.0]), jnp.asarray([0.4, 0.6])),
+    )
+    expected_measures = ("lebesgue", "lebesgue", "lebesgue", "counting")
+    for law, expected_measure in zip(laws, expected_measures, strict=True):
+        assert isinstance(law, phx.uq.AbstractProbabilityLaw)
+        assert law.event_shape == ()
+        assert law.batch_shape == ()
+        assert law.density_measure_kind == expected_measure

--- a/tests/unit/uq/test_exponential_family_conjugacy.py
+++ b/tests/unit/uq/test_exponential_family_conjugacy.py
@@ -1,0 +1,204 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import jax.scipy as jsp
+import numpy as np
+import scipy.stats as stats
+
+import phydrax as phx
+
+
+def test_gamma_poisson_update_evidence_predictive_and_merge_are_exact():
+    pair = phx.uq.GammaPoissonConjugacy(2.5, 1.7)
+    counts = jnp.asarray([0.0, 3.0, 1.0, 4.0])
+    exposure = jnp.asarray([0.5, 1.2, 2.0, 0.7])
+    update = pair.update(counts, exposure=exposure)
+    posterior_shape, posterior_rate = update.posterior_shape_rate
+    expected_shape = 2.5 + jnp.sum(counts)
+    expected_rate = 1.7 + jnp.sum(exposure)
+    expected_evidence = (
+        jsp.special.gammaln(expected_shape)
+        - jsp.special.gammaln(2.5)
+        + 2.5 * jnp.log(1.7)
+        - expected_shape * jnp.log(expected_rate)
+        + jnp.sum(counts * jnp.log(exposure) - jsp.special.gammaln(counts + 1.0))
+    )
+    first = pair.summarize(counts[:2], exposure=exposure[:2])
+    second = pair.summarize(counts[2:], exposure=exposure[2:])
+    merged = pair.update_statistics(first.merge(second))
+    predictive_count = 3
+    predictive_exposure = 1.4
+    expected_predictive = stats.nbinom.logpmf(
+        predictive_count,
+        float(expected_shape),
+        float(expected_rate / (expected_rate + predictive_exposure)),
+    )
+
+    np.testing.assert_allclose(posterior_shape, expected_shape, atol=2e-15)
+    np.testing.assert_allclose(posterior_rate, expected_rate, atol=2e-15)
+    np.testing.assert_allclose(update.log_evidence, expected_evidence, atol=2e-15)
+    np.testing.assert_allclose(
+        update.predictive_log_prob(predictive_count, exposure=predictive_exposure),
+        expected_predictive,
+        atol=2e-15,
+    )
+    np.testing.assert_allclose(
+        merged.posterior_natural.values, update.posterior_natural.values, atol=2e-15
+    )
+    np.testing.assert_allclose(merged.log_evidence, update.log_evidence, atol=2e-15)
+    assert bool(update.valid)
+
+
+def test_gamma_poisson_sequential_updates_and_predictive_sampling():
+    pair = phx.uq.GammaPoissonConjugacy(1.8, 2.2)
+    first = pair.update(jnp.asarray([1, 0, 2]), exposure=jnp.asarray([0.5, 1.0, 1.5]))
+    first_shape, first_rate = first.posterior_shape_rate
+    continuation = phx.uq.GammaPoissonConjugacy(first_shape, first_rate)
+    second = continuation.update(jnp.asarray([3, 1]), exposure=jnp.asarray([2.0, 0.7]))
+    direct = pair.update(
+        jnp.asarray([1, 0, 2, 3, 1]),
+        exposure=jnp.asarray([0.5, 1.0, 1.5, 2.0, 0.7]),
+    )
+    samples = direct.sample_predictive(jr.key(40), (80_000,), exposure=1.3)
+    direct_shape, direct_rate = direct.posterior_shape_rate
+
+    np.testing.assert_allclose(
+        second.posterior_natural.values, direct.posterior_natural.values, atol=3e-15
+    )
+    np.testing.assert_allclose(
+        first.log_evidence + second.log_evidence, direct.log_evidence, atol=3e-15
+    )
+    np.testing.assert_allclose(
+        jnp.mean(samples), 1.3 * direct_shape / direct_rate, atol=0.025
+    )
+    assert samples.shape == (80_000,)
+
+
+def test_gamma_poisson_batched_jit_and_invalid_observations():
+    pair = phx.uq.GammaPoissonConjugacy(jnp.asarray([1.0, 2.0]), 3.0)
+    counts = jnp.asarray([[0.0, 1.0, 2.0], [3.0, 1.0, 0.0]])
+    update = jax.jit(lambda values: pair.update(values, sample_axes=1))(counts)
+    invalid = pair.update(jnp.asarray([[0.0, -1.0], [1.5, 2.0]]), sample_axes=1)
+    malformed_statistics = phx.uq.GammaPoissonStatistics(
+        jnp.asarray(-1.0),
+        jnp.asarray(1.0),
+        jnp.asarray(0.0),
+        jnp.asarray(1),
+        jnp.asarray(True),
+    )
+    malformed = pair.update_statistics(malformed_statistics)
+    compensated = pair.update_statistics(
+        malformed_statistics.merge(
+            phx.uq.GammaPoissonStatistics(
+                jnp.asarray(1.0),
+                jnp.asarray(1.0),
+                jnp.asarray(0.0),
+                jnp.asarray(1),
+                jnp.asarray(True),
+            )
+        )
+    )
+    shapes, rates = update.posterior_shape_rate
+
+    np.testing.assert_allclose(shapes, jnp.asarray([4.0, 6.0]), atol=2e-15)
+    np.testing.assert_allclose(rates, jnp.asarray([6.0, 6.0]), atol=2e-15)
+    assert jnp.all(update.valid)
+    assert not jnp.any(invalid.valid)
+    assert jnp.all(jnp.isnan(invalid.posterior_natural.values))
+    assert not jnp.any(malformed.valid)
+    assert jnp.all(jnp.isnan(malformed.posterior_natural.values))
+    assert not jnp.any(compensated.valid)
+    assert jnp.all(jnp.isnan(compensated.posterior_natural.values))
+
+
+def test_dirichlet_categorical_update_evidence_predictive_and_merge_are_exact():
+    concentration = jnp.asarray([0.7, 1.2, 2.1, 3.0])
+    labels = jnp.asarray([0, 3, 1, 3, 2, 3, 1, 3])
+    pair = phx.uq.DirichletCategoricalConjugacy(concentration)
+    update = pair.update(labels)
+    counts = jnp.bincount(labels, length=4)
+    expected = concentration + counts
+
+    def log_beta(value):
+        return jnp.sum(jsp.special.gammaln(value)) - jsp.special.gammaln(jnp.sum(value))
+
+    first = pair.summarize(labels[:3])
+    second = pair.summarize(labels[3:])
+    merged = pair.update_statistics(first.merge(second))
+
+    np.testing.assert_allclose(update.posterior_concentration, expected, atol=2e-15)
+    np.testing.assert_allclose(
+        update.log_evidence, log_beta(expected) - log_beta(concentration), atol=2e-15
+    )
+    np.testing.assert_allclose(
+        update.predictive_probabilities, expected / jnp.sum(expected), atol=2e-15
+    )
+    np.testing.assert_allclose(
+        update.predictive_log_prob(3),
+        jnp.log(expected[3] / jnp.sum(expected)),
+        atol=2e-15,
+    )
+    np.testing.assert_allclose(
+        merged.posterior_natural.values, update.posterior_natural.values, atol=2e-15
+    )
+    np.testing.assert_allclose(merged.log_evidence, update.log_evidence, atol=2e-15)
+    assert bool(update.valid)
+
+
+def test_dirichlet_categorical_sequential_updates_and_predictive_sampling():
+    concentration = jnp.asarray([1.0, 2.0, 1.5])
+    pair = phx.uq.DirichletCategoricalConjugacy(concentration)
+    first = pair.update(jnp.asarray([0, 2, 2, 1]))
+    continuation = phx.uq.DirichletCategoricalConjugacy(first.posterior_concentration)
+    second = continuation.update(jnp.asarray([2, 1, 1]))
+    direct = pair.update(jnp.asarray([0, 2, 2, 1, 2, 1, 1]))
+    samples = direct.sample_predictive(jr.key(41), (100_000,))
+    frequencies = jnp.bincount(samples, length=3) / samples.size
+
+    np.testing.assert_allclose(
+        second.posterior_natural.values, direct.posterior_natural.values, atol=3e-15
+    )
+    np.testing.assert_allclose(
+        first.log_evidence + second.log_evidence, direct.log_evidence, atol=3e-15
+    )
+    np.testing.assert_allclose(frequencies, direct.predictive_probabilities, atol=0.008)
+    assert samples.shape == (100_000,)
+
+
+def test_dirichlet_categorical_batched_jit_and_invalid_labels():
+    pair = phx.uq.DirichletCategoricalConjugacy(jnp.asarray([1.0, 1.0, 1.0]))
+    labels = jnp.asarray([[0, 1, 2, 2], [1, 1, 0, 1]])
+    update = jax.jit(lambda values: pair.update(values, sample_axes=1))(labels)
+    invalid = pair.update(jnp.asarray([[0.0, 3.0], [0.5, 1.0]]), sample_axes=1)
+    malformed_statistics = phx.uq.DirichletCategoricalStatistics(
+        jnp.asarray([-1.0, 1.0, 1.0]),
+        jnp.asarray(1),
+        jnp.asarray(True),
+    )
+    malformed = pair.update_statistics(malformed_statistics)
+    compensated = pair.update_statistics(
+        malformed_statistics.merge(
+            phx.uq.DirichletCategoricalStatistics(
+                jnp.asarray([2.0, 0.0, 0.0]),
+                jnp.asarray(2),
+                jnp.asarray(True),
+            )
+        )
+    )
+
+    np.testing.assert_allclose(
+        update.posterior_concentration,
+        jnp.asarray([[2.0, 2.0, 3.0], [2.0, 4.0, 1.0]]),
+        atol=2e-15,
+    )
+    assert jnp.all(update.valid)
+    assert not jnp.any(invalid.valid)
+    assert jnp.all(jnp.isnan(invalid.posterior_natural.values))
+    assert not bool(malformed.valid)
+    assert jnp.all(jnp.isnan(malformed.posterior_natural.values))
+    assert not bool(compensated.valid)
+    assert jnp.all(jnp.isnan(compensated.posterior_natural.values))

--- a/tests/unit/uq/test_gamma_family.py
+++ b/tests/unit/uq/test_gamma_family.py
@@ -1,0 +1,185 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import jax.scipy as jsp
+import numpy as np
+
+import phydrax as phx
+
+
+def test_gamma_density_duality_kl_and_fisher_are_exact():
+    family = phx.uq.GammaFamily()
+    natural = family.natural_from_shape_rate(2.7, 1.4)
+    mean = family.mean_from_natural(natural)
+    gradient = jax.grad(lambda values: family.log_normalizer(family.natural(values)))(
+        natural.values
+    )
+    direction = jnp.asarray([0.4, -0.3])
+    hessian = jax.hessian(lambda values: family.log_normalizer(family.natural(values)))(
+        natural.values
+    )
+    conversion = family.natural_from_mean(mean)
+    grid = jnp.linspace(1e-6, 30.0, 100_000)
+    expected = jsp.stats.gamma.logpdf(grid, 2.7, scale=1.0 / 1.4)
+    other_shape = 1.4
+    other_rate = 0.7
+    other = family.natural_from_shape_rate(other_shape, other_rate)
+    expected_kl = (
+        2.7 * jnp.log(1.4)
+        - other_shape * jnp.log(other_rate)
+        - jsp.special.gammaln(2.7)
+        + jsp.special.gammaln(other_shape)
+        + (2.7 - other_shape) * (jsp.special.digamma(2.7) - jnp.log(1.4))
+        + (other_rate - 1.4) * 2.7 / 1.4
+    )
+
+    np.testing.assert_allclose(family.log_prob(natural, grid), expected, atol=3e-14)
+    np.testing.assert_allclose(
+        np.trapezoid(np.exp(family.log_prob(natural, grid)), grid), 1.0, atol=2e-7
+    )
+    np.testing.assert_allclose(mean.values, gradient, atol=3e-14)
+    np.testing.assert_allclose(conversion.natural.values, natural.values, atol=5e-10)
+    np.testing.assert_allclose(
+        family.fisher_action(natural, direction), hessian @ direction, atol=3e-14
+    )
+    np.testing.assert_allclose(family.kl_divergence(natural, natural), 0.0, atol=3e-14)
+    np.testing.assert_allclose(
+        family.kl_divergence(natural, other), expected_kl, atol=3e-14
+    )
+    assert bool(conversion.valid)
+    assert conversion.method_id == "gamma-safeguarded-newton"
+    assert int(conversion.iterations) > 0
+
+
+def test_gamma_domains_distinguish_numerical_failure_boundary_and_exterior():
+    family = phx.uq.GammaFamily()
+    boundary = family.mean_domain(family.mean(jnp.asarray([jnp.log(2.0), 2.0])))
+    exterior = family.mean_domain(family.mean(jnp.asarray([1.0, 2.0])))
+    boundary_natural = family.natural_domain(family.natural(jnp.asarray([-1.0, -1.0])))
+    exterior_natural = family.natural_domain(family.natural(jnp.asarray([-1.1, -1.0])))
+    nonconvergent = phx.uq.GammaFamily(atol=1e-14, rtol=0.0, max_iterations=1)
+    source = family.mean_from_natural(family.natural_from_shape_rate(0.03, 2.0))
+    failed = nonconvergent.natural_from_mean(source)
+
+    assert int(boundary.status) == phx.uq.EXPONENTIAL_FAMILY_MEAN_BOUNDARY
+    assert int(exterior.status) == phx.uq.EXPONENTIAL_FAMILY_OUTSIDE_MEAN_DOMAIN
+    assert bool(boundary_natural.boundary)
+    assert not bool(exterior_natural.boundary)
+    assert int(boundary_natural.status) == (
+        phx.uq.EXPONENTIAL_FAMILY_OUTSIDE_NATURAL_DOMAIN
+    )
+    assert int(exterior_natural.status) == (
+        phx.uq.EXPONENTIAL_FAMILY_OUTSIDE_NATURAL_DOMAIN
+    )
+    assert int(failed.status) == phx.uq.EXPONENTIAL_FAMILY_NONCONVERGED
+    assert phx.uq.exponential_family_status_name(int(failed.status)) == "nonconverged"
+    assert not bool(failed.valid)
+    assert int(failed.iterations) == 1
+    assert jnp.isfinite(failed.residual)
+    assert not bool(family.sufficient_statistics(0.0).valid)
+    assert not bool(family.sufficient_statistics(-1.0).valid)
+
+
+def test_gamma_batched_inverse_is_jittable_and_batch_local():
+    family = phx.uq.GammaFamily()
+    shapes = jnp.asarray([0.08, 0.5, 2.0, 25.0], dtype=jnp.float32)
+    rates = jnp.asarray([3.0, 0.7, 1.2, 4.0], dtype=jnp.float32)
+    natural = family.natural_from_shape_rate(shapes, rates)
+    means = family.mean_from_natural(natural)
+    converted = jax.jit(lambda values: family.natural_from_mean(family.mean(values)))(
+        means.values
+    )
+
+    np.testing.assert_allclose(
+        converted.natural.values, natural.values, rtol=8e-5, atol=5e-5
+    )
+    assert converted.valid.shape == shapes.shape
+    assert jnp.all(converted.valid)
+    assert jnp.all(converted.iterations >= 0)
+    assert jnp.any(converted.iterations > 0)
+
+
+def test_gamma_inverse_has_implicit_reverse_derivative_and_supports_empty_batches():
+    family = phx.uq.GammaFamily()
+    natural = family.natural_from_shape_rate(2.0, 1.3)
+    mean = family.mean_from_natural(natural)
+    converted = family.natural_from_mean(mean)
+    inverse_jacobian = jax.jacrev(
+        lambda value: family.natural_from_mean(family.mean(value)).natural.values
+    )(mean.values)
+    forward_jacobian = jax.jacfwd(
+        lambda value: family.natural_from_mean(family.mean(value)).natural.values
+    )(mean.values)
+    fisher = jax.jacfwd(
+        lambda value: family.mean_from_natural(family.natural(value)).values
+    )(converted.natural.values)
+    empty = family.natural_from_mean(family.mean(jnp.empty((0, 2))))
+
+    np.testing.assert_allclose(
+        inverse_jacobian @ fisher, jnp.eye(2), rtol=2e-10, atol=2e-10
+    )
+    np.testing.assert_allclose(inverse_jacobian, forward_jacobian, rtol=2e-12, atol=2e-12)
+    assert empty.natural.values.shape == (0, 2)
+    assert empty.valid.shape == (0,)
+
+
+def test_gamma_sampling_and_weighted_projection_recover_sufficient_statistics():
+    family = phx.uq.GammaFamily()
+    law = family.law_from_shape_rate(3.5, 1.8)
+    samples = law.sample(jr.key(10), sample_shape=(40_000,))
+    expected_mean = 3.5 / 1.8
+    expected_log = jsp.special.digamma(3.5) - jnp.log(1.8)
+    observations = jnp.asarray([0.4, 0.8, 1.3, 2.1, 3.4, 5.5])
+    log_weights = jnp.asarray([-0.4, 0.2, 0.8, -0.1, 0.4, -0.7])
+    one_shot = phx.uq.project_exponential_family(
+        family, observations, log_weights=log_weights
+    )
+    left = phx.uq.ExponentialFamilyProjectionAccumulator.from_log_weights(
+        family, observations[:3], log_weights[:3]
+    )
+    right = phx.uq.ExponentialFamilyProjectionAccumulator.from_log_weights(
+        family, observations[3:], log_weights[3:]
+    )
+    merged = left.merge(right).finalize()
+    normalized = jax.nn.softmax(log_weights)
+    expected_projection = jnp.asarray(
+        [jnp.sum(normalized * jnp.log(observations)), jnp.sum(normalized * observations)]
+    )
+
+    np.testing.assert_allclose(jnp.mean(samples), expected_mean, rtol=0.02)
+    np.testing.assert_allclose(jnp.mean(jnp.log(samples)), expected_log, atol=0.015)
+    np.testing.assert_allclose(
+        one_shot.mean_coordinates.values, expected_projection, atol=2e-14
+    )
+    np.testing.assert_allclose(
+        merged.law.natural.values, one_shot.law.natural.values, atol=2e-10
+    )
+    assert samples.shape == (40_000,)
+    assert bool(one_shot.valid)
+    assert bool(merged.valid)
+
+
+def test_gamma_law_is_a_positive_posterior_prior():
+    prior = phx.uq.GammaFamily().law_from_shape_rate(2.5, 1.2)
+    initial = jnp.log(jnp.asarray(1.7))
+    space = phx.uq.ParameterSpace(
+        initial,
+        priors=prior,
+        bijectors=phx.uq.ExpBijector(),
+    )
+    physical = space.constrain(initial)
+    expected = prior.log_prob(physical) + initial
+    samples = space.sample_prior(jr.key(14), num_samples=8, constrained=False)
+
+    np.testing.assert_allclose(
+        space.log_prior(physical) + space.log_abs_det_jacobian(initial),
+        expected,
+        atol=2e-14,
+    )
+    np.testing.assert_allclose(space.constrain(samples), jnp.exp(samples), atol=2e-14)
+    assert samples.shape == (8,)
+    assert jnp.all(jnp.isfinite(samples))

--- a/tests/unit/uq/test_multivariate_normal_family.py
+++ b/tests/unit/uq/test_multivariate_normal_family.py
@@ -1,0 +1,208 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import jax.scipy as jsp
+import numpy as np
+import pytest
+
+import phydrax as phx
+from phydrax._exponential_family._symmetric_coordinates import smat, svec
+
+
+def test_symmetric_coordinates_preserve_frobenius_geometry():
+    left = jnp.asarray([[1.2, -0.4, 0.7], [-0.4, 2.0, 0.3], [0.7, 0.3, -0.5]])
+    right = jnp.asarray([[0.2, 0.8, -0.1], [0.8, -1.0, 0.6], [-0.1, 0.6, 1.4]])
+
+    np.testing.assert_allclose(smat(svec(left)), left, atol=2e-15)
+    np.testing.assert_allclose(
+        jnp.vdot(svec(left), svec(right)), jnp.sum(left * right), atol=2e-15
+    )
+    integral = jnp.asarray([[0, 1], [1, 0]], dtype=jnp.int32)
+    integral_packed = svec(integral)
+    np.testing.assert_allclose(
+        jnp.vdot(integral_packed, integral_packed),
+        jnp.sum(integral * integral),
+        atol=2e-15,
+    )
+    np.testing.assert_allclose(smat(integral_packed), integral, atol=2e-15)
+    assert jnp.issubdtype(integral_packed.dtype, jnp.floating)
+    with pytest.raises(ValueError, match="triangular"):
+        smat(jnp.ones((5,)))
+
+
+def test_multivariate_normal_density_duality_and_fisher_match_references():
+    family = phx.uq.MultivariateNormalFamily(3)
+    location = jnp.asarray([0.3, -0.8, 0.5])
+    covariance = jnp.asarray([[1.4, 0.2, -0.1], [0.2, 0.9, 0.3], [-0.1, 0.3, 1.1]])
+    natural = family.natural_from_location_covariance(location, covariance)
+    mean = family.mean_from_natural(natural)
+    conversion = family.natural_from_mean(mean)
+    points = jnp.asarray([[0.2, -0.4, 1.0], [-1.0, 0.3, 0.7], [0.8, -1.2, -0.5]])
+    expected = jsp.stats.multivariate_normal.logpdf(points, location, covariance)
+    gradient = jax.grad(lambda value: family.log_normalizer(family.natural(value)))(
+        natural.values
+    )
+    direction = jnp.linspace(-0.4, 0.6, family.signature.dimension)
+    hessian = jax.hessian(lambda value: family.log_normalizer(family.natural(value)))(
+        natural.values
+    )
+
+    other_location = jnp.asarray([-0.4, 0.1, 0.9])
+    other_covariance = jnp.asarray(
+        [[0.8, -0.1, 0.2], [-0.1, 1.6, 0.05], [0.2, 0.05, 1.3]]
+    )
+    other = family.natural_from_location_covariance(other_location, other_covariance)
+    other_precision = jnp.linalg.inv(other_covariance)
+    displacement = other_location - location
+    expected_kl = 0.5 * (
+        jnp.trace(other_precision @ covariance)
+        + displacement @ other_precision @ displacement
+        - family.event_size
+        + jnp.linalg.slogdet(other_covariance)[1]
+        - jnp.linalg.slogdet(covariance)[1]
+    )
+    np.testing.assert_allclose(family.log_prob(natural, points), expected, atol=3e-14)
+    np.testing.assert_allclose(mean.values, gradient, atol=4e-14)
+    np.testing.assert_allclose(conversion.natural.values, natural.values, atol=5e-14)
+    np.testing.assert_allclose(
+        family.fisher_action(natural, direction), hessian @ direction, atol=8e-14
+    )
+    np.testing.assert_allclose(family.kl_divergence(natural, natural), 0.0, atol=3e-14)
+    np.testing.assert_allclose(
+        family.kl_divergence(natural, other), expected_kl, atol=5e-14
+    )
+    assert family.signature.dimension == 9
+    assert bool(conversion.valid)
+
+
+def test_multivariate_normal_sampling_and_projection_recover_moments():
+    family = phx.uq.MultivariateNormalFamily(2)
+    location = jnp.asarray([0.4, -0.7])
+    covariance = jnp.asarray([[1.3, 0.45], [0.45, 0.8]])
+    law = family.law_from_location_covariance(location, covariance)
+    samples = law.sample(jr.key(20), sample_shape=(50_000,))
+    observations = jnp.asarray(
+        [[-1.0, 0.2], [0.3, -0.4], [1.2, 0.8], [0.5, -1.1], [2.0, 0.1]]
+    )
+    log_weights = jnp.asarray([-0.7, 0.2, 0.8, -0.1, 0.4])
+    projected = phx.uq.project_exponential_family(
+        family, observations, log_weights=log_weights
+    )
+    normalized = jax.nn.softmax(log_weights)
+    expected_location = normalized @ observations
+    centered = observations - expected_location
+    expected_covariance = jnp.einsum("n,ni,nj->ij", normalized, centered, centered)
+    actual_location, actual_covariance = family.location_covariance_from_natural(
+        projected.law.natural
+    )
+
+    np.testing.assert_allclose(jnp.mean(samples, axis=0), location, atol=0.018)
+    np.testing.assert_allclose(
+        jnp.cov(samples, rowvar=False, bias=True), covariance, atol=0.025
+    )
+    np.testing.assert_allclose(actual_location, expected_location, atol=3e-14)
+    np.testing.assert_allclose(actual_covariance, expected_covariance, atol=5e-14)
+    assert samples.shape == (50_000, 2)
+    assert bool(projected.valid)
+
+
+def test_multivariate_normal_domain_reports_singular_empirical_covariance():
+    family = phx.uq.MultivariateNormalFamily(2)
+    singular = phx.uq.fit_exponential_family(
+        family,
+        jnp.asarray([[0.0, 0.0], [1.0, 2.0], [2.0, 4.0], [3.0, 6.0]]),
+        sample_axes=0,
+    )
+    indefinite_mean = family.mean(jnp.asarray([0.0, 0.0, 1.0, 0.0, -1.0]))
+    exterior = family.mean_domain(indefinite_mean)
+
+    assert not bool(singular.valid)
+    assert int(singular.status) == phx.uq.EXPONENTIAL_FAMILY_MEAN_BOUNDARY
+    assert int(exterior.status) == phx.uq.EXPONENTIAL_FAMILY_OUTSIDE_MEAN_DOMAIN
+
+
+def test_multivariate_normal_batches_jit_and_preserve_axes():
+    family = phx.uq.MultivariateNormalFamily(2)
+    locations = jnp.asarray([[0.0, 0.5], [1.0, -0.2]])
+    covariances = jnp.asarray([[[1.0, 0.1], [0.1, 0.7]], [[0.8, -0.2], [-0.2, 1.4]]])
+    natural = family.natural_from_location_covariance(locations, covariances)
+    recovered = jax.jit(
+        lambda value: family.natural_from_mean(
+            family.mean_from_natural(family.natural(value))
+        )
+    )(natural.values)
+    samples = family.sample(jr.key(21), natural, sample_shape=(7, 3))
+
+    np.testing.assert_allclose(recovered.natural.values, natural.values, atol=8e-14)
+    assert recovered.valid.shape == (2,)
+    assert samples.shape == (7, 3, 2, 2)
+    assert family.fisher_action(natural, jnp.ones_like(natural.values)).shape == (2, 5)
+
+
+def test_multivariate_normal_validation_is_scale_relative_batch_local_and_empty_safe():
+    scalar_family = phx.uq.MultivariateNormalFamily(1)
+    scalar_location = jnp.asarray([0.0])
+    for variance in (1.0e-15, 1.0e15):
+        natural = scalar_family.natural_from_location_covariance(
+            scalar_location, jnp.asarray([[variance]])
+        )
+        converted = scalar_family.natural_from_mean(
+            scalar_family.mean_from_natural(natural)
+        )
+        np.testing.assert_allclose(
+            converted.natural.values, natural.values, rtol=3e-14, atol=0.0
+        )
+        assert bool(converted.valid)
+
+    family = phx.uq.MultivariateNormalFamily(2)
+    locations = jnp.zeros((2, 2))
+    nonsymmetric = jnp.asarray(
+        [
+            [[1.0e13, 0.0], [0.0, 1.0e13]],
+            [[1.0, 0.1], [0.0, 1.0]],
+        ]
+    )
+    with pytest.raises(eqx.EquinoxRuntimeError, match="symmetric"):
+        family.natural_from_location_covariance(locations, nonsymmetric)
+
+    empty_natural = family.natural_from_location_covariance(
+        jnp.empty((0, 2)), jnp.empty((0, 2, 2))
+    )
+    empty_conversion = family.natural_from_mean(
+        family.mean(jnp.empty((0, family.signature.dimension)))
+    )
+    assert empty_natural.values.shape == (0, family.signature.dimension)
+    assert empty_conversion.natural.values.shape == (
+        0,
+        family.signature.dimension,
+    )
+    assert empty_conversion.valid.shape == (0,)
+
+
+def test_multivariate_normal_bridge_reuses_gaussian_factor_without_jitter():
+    family = phx.uq.MultivariateNormalFamily(2)
+    location = jnp.asarray([0.3, -0.6])
+    covariance = jnp.asarray([[1.1, 0.35], [0.35, 0.7]])
+    law = family.law_from_location_covariance(location, covariance)
+    recovered_location, factor = phx.uq.gaussian_factor_from_multivariate_normal(law)
+    conversion = phx.uq.multivariate_normal_from_gaussian_factor(
+        family, recovered_location, factor
+    )
+    singular_factor = phx.uq.GaussianFactor(jnp.asarray([[1.0], [2.0]]))
+    boundary = phx.uq.multivariate_normal_from_gaussian_factor(
+        family, jnp.zeros(2), singular_factor
+    )
+
+    np.testing.assert_allclose(recovered_location, location, atol=3e-14)
+    np.testing.assert_allclose(factor.covariance, covariance, atol=5e-14)
+    np.testing.assert_allclose(conversion.natural.values, law.natural.values, atol=8e-14)
+    assert bool(factor.valid)
+    assert factor.regularization == 0.0
+    assert bool(conversion.valid)
+    assert not bool(boundary.valid)
+    assert int(boundary.status) == phx.uq.EXPONENTIAL_FAMILY_MEAN_BOUNDARY

--- a/tools/uq_benchmarks/configuration.py
+++ b/tools/uq_benchmarks/configuration.py
@@ -29,6 +29,8 @@ class BenchmarkConfiguration:
     calibration_cases: int
     gp_repeats: int
     jit_warm_repetitions: int
+    exponential_family_samples: int
+    exponential_family_repetitions: int
     linearized_input_dimension: int
     linearized_output_dimension: int
     linearized_factor_rank: int
@@ -67,6 +69,8 @@ PROFILES: dict[ProfileName, BenchmarkConfiguration] = {
         calibration_cases=256,
         gp_repeats=5,
         jit_warm_repetitions=3,
+        exponential_family_samples=16_384,
+        exponential_family_repetitions=3,
         linearized_input_dimension=16,
         linearized_output_dimension=1_024,
         linearized_factor_rank=4,
@@ -100,6 +104,8 @@ PROFILES: dict[ProfileName, BenchmarkConfiguration] = {
         sgmcmc_steps_per_sample=2,
         gp_repeats=12,
         jit_warm_repetitions=10,
+        exponential_family_samples=131_072,
+        exponential_family_repetitions=10,
         linearized_input_dimension=32,
         linearized_output_dimension=4_096,
         linearized_factor_rank=8,

--- a/tools/uq_benchmarks/scenarios.py
+++ b/tools/uq_benchmarks/scenarios.py
@@ -2914,17 +2914,15 @@ def dynamic_factor_stochastic_volatility(
     stationary_volatility_variance = volatility_innovation_variance / (
         1.0 - volatility_persistence**2
     )
-    stationary_factor_variance = jnp.exp(volatility_mean) / (
-        1.0 - factor_persistence**2
-    )
+    stationary_factor_variance = jnp.exp(volatility_mean) / (1.0 - factor_persistence**2)
 
     initial_factor_key, initial_volatility_key = jr.split(initial_key)
     factor = jnp.sqrt(stationary_factor_variance) * jr.normal(
         initial_factor_key, (factors,)
     )
-    volatility = volatility_mean + jnp.sqrt(
-        stationary_volatility_variance
-    ) * jr.normal(initial_volatility_key, (factors,))
+    volatility = volatility_mean + jnp.sqrt(stationary_volatility_variance) * jr.normal(
+        initial_volatility_key, (factors,)
+    )
     true_factors = []
     true_volatilities = []
     observations = []
@@ -2932,17 +2930,18 @@ def dynamic_factor_stochastic_volatility(
     observation_keys = jr.split(observation_key, steps)
     for step in range(steps):
         volatility_noise_key, factor_noise_key = jr.split(transition_keys[step])
-        volatility = volatility_mean + volatility_persistence * (
-            volatility - volatility_mean
-        ) + jnp.sqrt(volatility_innovation_variance) * jr.normal(
-            volatility_noise_key, (factors,)
+        volatility = (
+            volatility_mean
+            + volatility_persistence * (volatility - volatility_mean)
+            + jnp.sqrt(volatility_innovation_variance)
+            * jr.normal(volatility_noise_key, (factors,))
         )
-        factor = factor_persistence * factor + jnp.exp(
-            0.5 * volatility
-        ) * jr.normal(factor_noise_key, (factors,))
-        observation = loadings @ factor + jnp.sqrt(
-            idiosyncratic_variance
-        ) * jr.normal(observation_keys[step], (assets,))
+        factor = factor_persistence * factor + jnp.exp(0.5 * volatility) * jr.normal(
+            factor_noise_key, (factors,)
+        )
+        observation = loadings @ factor + jnp.sqrt(idiosyncratic_variance) * jr.normal(
+            observation_keys[step], (assets,)
+        )
         true_factors.append(factor)
         true_volatilities.append(volatility)
         observations.append(observation)
@@ -2957,9 +2956,7 @@ def dynamic_factor_stochastic_volatility(
     )
     joint_mean = jnp.concatenate((jnp.zeros(factors), volatility_mean))
     joint_covariance = jnp.diag(
-        jnp.concatenate(
-            (stationary_factor_variance, stationary_volatility_variance)
-        )
+        jnp.concatenate((stationary_factor_variance, stationary_volatility_variance))
     )
 
     def joint_sample(key, state, t0, t1, context):
@@ -2967,10 +2964,11 @@ def dynamic_factor_stochastic_volatility(
         factor_key, volatility_key = jr.split(key)
         previous_factor = state[:factors]
         previous_volatility = state[factors:]
-        next_volatility = volatility_mean + volatility_persistence * (
-            previous_volatility - volatility_mean
-        ) + jnp.sqrt(volatility_innovation_variance) * jr.normal(
-            volatility_key, (factors,)
+        next_volatility = (
+            volatility_mean
+            + volatility_persistence * (previous_volatility - volatility_mean)
+            + jnp.sqrt(volatility_innovation_variance)
+            * jr.normal(volatility_key, (factors,))
         )
         next_factor = factor_persistence * previous_factor + jnp.exp(
             0.5 * next_volatility
@@ -2979,9 +2977,7 @@ def dynamic_factor_stochastic_volatility(
 
     def diagonal_gaussian_log_prob(value, mean, variance):
         residual = value - mean
-        return -0.5 * jnp.sum(
-            residual**2 / variance + jnp.log(2.0 * jnp.pi * variance)
-        )
+        return -0.5 * jnp.sum(residual**2 / variance + jnp.log(2.0 * jnp.pi * variance))
 
     def joint_log_prob(next_state, state, t0, t1, context):
         del t0, t1, context
@@ -3022,8 +3018,7 @@ def dynamic_factor_stochastic_volatility(
         observation_log_prob,
         lambda key, state, time, sample_shape, context: (
             loadings @ state[:factors]
-            + jnp.sqrt(idiosyncratic_variance)
-            * jr.normal(key, sample_shape + (assets,))
+            + jnp.sqrt(idiosyncratic_variance) * jr.normal(key, sample_shape + (assets,))
         ),
         state_shape=(2 * factors,),
         observation_shape=(assets,),
@@ -3066,24 +3061,20 @@ def dynamic_factor_stochastic_volatility(
 
     def volatility_sample(key, state, t0, t1, context):
         del t0, t1, context
-        return volatility_mean + volatility_persistence * (
-            state - volatility_mean
-        ) + jnp.sqrt(volatility_innovation_variance) * jr.normal(
-            key, (factors,)
+        return (
+            volatility_mean
+            + volatility_persistence * (state - volatility_mean)
+            + jnp.sqrt(volatility_innovation_variance) * jr.normal(key, (factors,))
         )
 
     def volatility_log_prob(next_state, state, t0, t1, context):
         del t0, t1, context
-        location = volatility_mean + volatility_persistence * (
-            state - volatility_mean
-        )
+        location = volatility_mean + volatility_persistence * (state - volatility_mean)
         return diagonal_gaussian_log_prob(
             next_state, location, volatility_innovation_variance
         )
 
-    diagonal_observation_noise = phx.uq.DiagonalCovariance(
-        idiosyncratic_variance
-    )
+    diagonal_observation_noise = phx.uq.DiagonalCovariance(idiosyncratic_variance)
     rb_model = phx.uq.RaoBlackwellizedStateSpaceModel(
         phx.stochastic.GaussianStatePrior(
             volatility_mean,
@@ -3143,9 +3134,7 @@ def dynamic_factor_stochastic_volatility(
         particle_weights[..., None] * particle_filter.particles, axis=-2
     )
     rb_weights = jnp.exp(rb_filter.log_weights)
-    rb_factor_mean = jnp.sum(
-        rb_weights[..., None] * rb_filter.linear_means, axis=-2
-    )
+    rb_factor_mean = jnp.sum(rb_weights[..., None] * rb_filter.linear_means, axis=-2)
     rb_volatility_mean = jnp.sum(
         rb_weights[..., None] * rb_filter.nonlinear_particles, axis=-2
     )
@@ -3175,14 +3164,11 @@ def dynamic_factor_stochastic_volatility(
 
     def dense_condition(mean, covariance, value):
         innovation = value - loadings @ mean
-        innovation_covariance = (
-            loadings @ covariance @ loadings.T
-            + jnp.diag(idiosyncratic_variance)
+        innovation_covariance = loadings @ covariance @ loadings.T + jnp.diag(
+            idiosyncratic_variance
         )
         scale = jnp.linalg.cholesky(innovation_covariance)
-        gain = jnp.linalg.solve(
-            innovation_covariance, loadings @ covariance
-        ).T
+        gain = jnp.linalg.solve(innovation_covariance, loadings @ covariance).T
         posterior_mean = mean + gain @ innovation
         posterior_covariance = covariance - gain @ loadings @ covariance
         solved = jax.scipy.linalg.solve_triangular(
@@ -3195,9 +3181,7 @@ def dynamic_factor_stochastic_volatility(
         )
         return posterior_mean, posterior_covariance, log_likelihood
 
-    diagonal_output = diagonal_condition(
-        micro_mean, micro_covariance, micro_value
-    )
+    diagonal_output = diagonal_condition(micro_mean, micro_covariance, micro_value)
     dense_output = dense_condition(micro_mean, micro_covariance, micro_value)
     _, _, diagonal_execute = _jit_timings(
         diagonal_condition,
@@ -3226,9 +3210,7 @@ def dynamic_factor_stochastic_volatility(
         )
 
     def status_counts(values):
-        codes = tuple(
-            int(value) for value in jax.device_get(values).reshape(-1).tolist()
-        )
+        codes = tuple(int(value) for value in jax.device_get(values).reshape(-1).tolist())
         return {str(code): codes.count(code) for code in sorted(set(codes))}
 
     metrics = {
@@ -3251,9 +3233,7 @@ def dynamic_factor_stochastic_volatility(
             rmse(particle_mean[..., factors:], true_volatilities_array),
             "diagnostic",
         ),
-        "rb_factor_rmse": metric(
-            rmse(rb_factor_mean, true_factors_array), "diagnostic"
-        ),
+        "rb_factor_rmse": metric(rmse(rb_factor_mean, true_factors_array), "diagnostic"),
         "rb_log_volatility_rmse": metric(
             rmse(rb_volatility_mean, true_volatilities_array), "diagnostic"
         ),
@@ -3270,9 +3250,7 @@ def dynamic_factor_stochastic_volatility(
         "particle_log_likelihood": metric(
             particle_filter.final_state.log_likelihood, "diagnostic"
         ),
-        "rb_log_likelihood": metric(
-            rb_filter.final_state.log_likelihood, "diagnostic"
-        ),
+        "rb_log_likelihood": metric(rb_filter.final_state.log_likelihood, "diagnostic"),
         "particle_mean_effective_sample_size": metric(
             jnp.mean(particle_filter.effective_sample_sizes), "diagnostic"
         ),
@@ -3296,24 +3274,18 @@ def dynamic_factor_stochastic_volatility(
             "convergence",
             minimum=1.0,
         ),
-        "bellman_successful_step_count": metric(
-            jnp.sum(bellman.valid), "diagnostic"
-        ),
+        "bellman_successful_step_count": metric(jnp.sum(bellman.valid), "diagnostic"),
         "particle_successful_step_count": metric(
             jnp.sum(particle_filter.valid), "diagnostic"
         ),
-        "rb_successful_step_count": metric(
-            jnp.sum(rb_filter.valid), "diagnostic"
-        ),
+        "rb_successful_step_count": metric(jnp.sum(rb_filter.valid), "diagnostic"),
         "rb_smoother_successful_step_count": metric(
             jnp.sum(rb_smoother.valid), "diagnostic"
         ),
         "particle_resampling_count": metric(
             jnp.sum(particle_filter.resampled), "diagnostic"
         ),
-        "rb_resampling_count": metric(
-            jnp.sum(rb_filter.resampled), "diagnostic"
-        ),
+        "rb_resampling_count": metric(jnp.sum(rb_filter.resampled), "diagnostic"),
         "conditional_diagonal_dense_max_error": metric(
             conditional_error, "accuracy", maximum=1.0e-10
         ),
@@ -3336,9 +3308,7 @@ def dynamic_factor_stochastic_volatility(
         "rb_smoother_result_memory_bytes": metric(
             array_bytes(rb_smoother), "performance", unit="byte"
         ),
-        "wall_seconds": metric(
-            time.perf_counter() - started, "performance", unit="s"
-        ),
+        "wall_seconds": metric(time.perf_counter() - started, "performance", unit="s"),
     }
     return ScenarioResult(
         name="dynamic_factor_stochastic_volatility",
@@ -3364,6 +3334,520 @@ def dynamic_factor_stochastic_volatility(
     )
 
 
+def exponential_family_geometry(
+    configuration: BenchmarkConfiguration,
+    seed: int,
+) -> ScenarioResult:
+    """Benchmark scalar, structured, simplex, conjugate, and Fisher kernels."""
+    started = time.perf_counter()
+    sample_count = int(configuration.exponential_family_samples)
+    repetitions = int(configuration.exponential_family_repetitions)
+    keys = jr.split(jr.key(seed), 14)
+    bernoulli_family = phx.uq.BernoulliFamily()
+    poisson_family = phx.uq.PoissonFamily()
+    bernoulli_natural = 0.6 * jr.normal(keys[0], (sample_count,))
+    bernoulli_targets = jr.bernoulli(keys[1], jax.nn.sigmoid(bernoulli_natural)).astype(
+        float
+    )
+    poisson_natural = 0.3 + 0.4 * jr.normal(keys[2], (sample_count,))
+    poisson_targets = jr.poisson(keys[3], jnp.exp(poisson_natural)).astype(float)
+
+    def bernoulli_log_prob(natural, targets):
+        return bernoulli_family.log_prob(
+            bernoulli_family.natural(natural[..., None]), targets
+        )
+
+    def poisson_log_prob(natural, targets):
+        return poisson_family.log_prob(
+            poisson_family.natural(natural[..., None]), targets
+        )
+
+    bernoulli_cold, bernoulli_compile, bernoulli_execute = _jit_timings(
+        bernoulli_log_prob,
+        bernoulli_natural,
+        bernoulli_targets,
+        repetitions=repetitions,
+    )
+    poisson_cold, poisson_compile, poisson_execute = _jit_timings(
+        poisson_log_prob,
+        poisson_natural,
+        poisson_targets,
+        repetitions=repetitions,
+    )
+    bernoulli_values = bernoulli_log_prob(bernoulli_natural, bernoulli_targets)
+    poisson_values = poisson_log_prob(poisson_natural, poisson_targets)
+    direct_bernoulli = bernoulli_targets * jax.nn.log_sigmoid(bernoulli_natural) + (
+        1.0 - bernoulli_targets
+    ) * jax.nn.log_sigmoid(-bernoulli_natural)
+    direct_poisson = (
+        poisson_targets * poisson_natural
+        - jnp.exp(poisson_natural)
+        - jsp.special.gammaln(poisson_targets + 1.0)
+    )
+    bernoulli_coordinates = bernoulli_family.natural(bernoulli_natural[..., None])
+    poisson_coordinates = poisson_family.natural(poisson_natural[..., None])
+    bernoulli_loss = bernoulli_family.canonical_loss(
+        bernoulli_coordinates, bernoulli_targets
+    )
+    poisson_loss = poisson_family.canonical_loss(poisson_coordinates, poisson_targets)
+    bernoulli_score = bernoulli_family.canonical_score(
+        bernoulli_coordinates, bernoulli_targets
+    )[..., 0]
+    poisson_score = poisson_family.canonical_score(poisson_coordinates, poisson_targets)[
+        ..., 0
+    ]
+
+    projection_log_weights = 0.7 * jr.normal(keys[4], (sample_count,))
+    one_shot, one_shot_seconds = _timed_call(
+        lambda: phx.uq.project_exponential_family(
+            bernoulli_family,
+            bernoulli_targets,
+            log_weights=projection_log_weights,
+        )
+    )
+    midpoint = sample_count // 2
+
+    def merged_projection():
+        left = phx.uq.ExponentialFamilyProjectionAccumulator.from_log_weights(
+            bernoulli_family,
+            bernoulli_targets[:midpoint],
+            projection_log_weights[:midpoint],
+        )
+        right = phx.uq.ExponentialFamilyProjectionAccumulator.from_log_weights(
+            bernoulli_family,
+            bernoulli_targets[midpoint:],
+            projection_log_weights[midpoint:],
+        )
+        return left.merge(right).finalize()
+
+    merged, merged_seconds = _timed_call(merged_projection)
+    direct_projection_mean = jnp.sum(
+        jax.nn.softmax(projection_log_weights) * bernoulli_targets
+    )
+
+    normal_family = phx.uq.NormalFamily()
+    normal_natural = jnp.asarray([0.2, -0.7])
+    normal_direction = jnp.asarray([0.4, -0.3])
+
+    def family_fisher(natural, direction):
+        return phx.uq.exponential_family_fisher_action(
+            normal_family,
+            normal_family.natural(natural),
+            direction,
+        ).action
+
+    fisher_cold, fisher_compile, fisher_execute = _jit_timings(
+        family_fisher,
+        normal_natural,
+        normal_direction,
+        repetitions=repetitions,
+    )
+    fisher_action = family_fisher(normal_natural, normal_direction)
+    dense_fisher_action = (
+        jax.hessian(
+            lambda values: normal_family.log_normalizer(normal_family.natural(values))
+        )(normal_natural)
+        @ normal_direction
+    )
+
+    parameter_dimension = int(configuration.linearized_input_dimension)
+    natural_dimension = 4 * parameter_dimension
+    design = jr.normal(keys[5], (natural_dimension, parameter_dimension)) / jnp.sqrt(
+        parameter_dimension
+    )
+    parameters = 0.2 * jr.normal(keys[6], (parameter_dimension,))
+    parameter_direction = jr.normal(keys[7], (parameter_dimension,))
+
+    def natural_fn(values):
+        return (design @ values - 0.2)[..., None]
+
+    def parameter_fisher(values, direction):
+        return phx.uq.exponential_family_parameter_fisher_action(
+            poisson_family,
+            natural_fn,
+            values,
+            direction,
+        ).action
+
+    parameter_cold, parameter_compile, parameter_execute = _jit_timings(
+        parameter_fisher,
+        parameters,
+        parameter_direction,
+        repetitions=repetitions,
+    )
+    parameter_action = parameter_fisher(parameters, parameter_direction)
+    rates = jnp.exp(design @ parameters - 0.2)
+    direct_parameter_action = design.T @ (rates * (design @ parameter_direction))
+
+    structured_count = min(sample_count, 2_048)
+    categorical_family = phx.uq.CategoricalFamily(5)
+    categorical_logits = 0.7 * jr.normal(keys[8], (structured_count, 5))
+    categorical_targets = jr.categorical(keys[9], categorical_logits).astype(float)
+
+    def categorical_log_prob(logits, targets):
+        return categorical_family.log_prob(
+            categorical_family.natural_from_logits(logits), targets
+        )
+
+    categorical_cold, categorical_compile, categorical_execute = _jit_timings(
+        categorical_log_prob,
+        categorical_logits,
+        categorical_targets,
+        repetitions=repetitions,
+    )
+    categorical_values = categorical_log_prob(categorical_logits, categorical_targets)
+    direct_categorical = jnp.take_along_axis(
+        jax.nn.log_softmax(categorical_logits, axis=-1),
+        categorical_targets.astype(jnp.int32)[..., None],
+        axis=-1,
+    )[..., 0]
+
+    gamma_family = phx.uq.GammaFamily()
+    gamma_shapes = 0.2 + jnp.exp(0.6 * jr.normal(keys[10], (structured_count,)))
+    gamma_rates = 0.2 + jnp.exp(0.5 * jr.normal(keys[11], (structured_count,)))
+    gamma_natural = gamma_family.natural_from_shape_rate(gamma_shapes, gamma_rates)
+    gamma_mean = gamma_family.mean_from_natural(gamma_natural).values
+    direct_gamma_mean = jnp.stack(
+        (
+            jsp.special.digamma(gamma_shapes) - jnp.log(gamma_rates),
+            gamma_shapes / gamma_rates,
+        ),
+        axis=-1,
+    )
+
+    def gamma_round_trip(values):
+        return gamma_family.natural_from_mean(
+            gamma_family.mean_from_natural(gamma_family.natural(values))
+        )
+
+    gamma_cold, gamma_compile, gamma_execute = _jit_timings(
+        gamma_round_trip,
+        gamma_natural.values,
+        repetitions=repetitions,
+    )
+    gamma_conversion = gamma_round_trip(gamma_natural.values)
+
+    multivariate_family = phx.uq.MultivariateNormalFamily(4)
+    multivariate_location = jnp.asarray([0.2, -0.4, 0.7, 0.1])
+    covariance_root = jnp.asarray(
+        [
+            [1.1, 0.0, 0.0, 0.0],
+            [0.2, 0.9, 0.0, 0.0],
+            [-0.1, 0.3, 1.2, 0.0],
+            [0.1, 0.0, 0.2, 0.8],
+        ]
+    )
+    multivariate_covariance = covariance_root @ covariance_root.T
+    multivariate_natural = multivariate_family.natural_from_location_covariance(
+        multivariate_location, multivariate_covariance
+    )
+    reconstructed_location, reconstructed_covariance = (
+        multivariate_family.location_covariance_from_natural(multivariate_natural)
+    )
+    multivariate_direction = jnp.linspace(
+        -0.4, 0.6, multivariate_family.signature.dimension
+    )
+    multivariate_fisher = multivariate_family.fisher_action(
+        multivariate_natural, multivariate_direction
+    )
+    dense_multivariate_fisher = (
+        jax.hessian(
+            lambda values: multivariate_family.log_normalizer(
+                multivariate_family.natural(values)
+            )
+        )(multivariate_natural.values)
+        @ multivariate_direction
+    )
+    factor_location, gaussian_factor = phx.uq.gaussian_factor_from_multivariate_normal(
+        multivariate_family.law(multivariate_natural)
+    )
+    factor_conversion = phx.uq.multivariate_normal_from_gaussian_factor(
+        multivariate_family, factor_location, gaussian_factor
+    )
+    factor_location, factor_covariance = (
+        multivariate_family.location_covariance_from_natural(factor_conversion.natural)
+    )
+
+    dirichlet_family = phx.uq.DirichletFamily(5)
+    dirichlet_concentration = 0.15 + jnp.exp(
+        0.7 * jr.normal(keys[12], (structured_count, 5))
+    )
+    dirichlet_natural = dirichlet_family.natural_from_concentration(
+        dirichlet_concentration
+    )
+    dirichlet_mean = dirichlet_family.mean_from_natural(dirichlet_natural).values
+    direct_dirichlet_mean = jsp.special.digamma(
+        dirichlet_concentration
+    ) - jsp.special.digamma(jnp.sum(dirichlet_concentration, axis=-1, keepdims=True))
+
+    def dirichlet_round_trip(values):
+        return dirichlet_family.natural_from_mean(
+            dirichlet_family.mean_from_natural(dirichlet_family.natural(values))
+        )
+
+    dirichlet_cold, dirichlet_compile, dirichlet_execute = _jit_timings(
+        dirichlet_round_trip,
+        dirichlet_natural.values,
+        repetitions=repetitions,
+    )
+    dirichlet_conversion = dirichlet_round_trip(dirichlet_natural.values)
+    simplex_bijector = phx.uq.SimplexBijector(5)
+    simplex_raw = 0.5 * jr.normal(keys[13], (4,))
+    simplex_jacobian = jax.jacobian(simplex_bijector.forward)(simplex_raw)
+    direct_simplex_log_volume = (
+        0.5 * jnp.linalg.slogdet(simplex_jacobian.T @ simplex_jacobian)[1]
+    )
+
+    gamma_poisson = phx.uq.GammaPoissonConjugacy(2.0, 1.5).update(
+        jnp.asarray([0.0, 2.0, 3.0]),
+        exposure=jnp.asarray([1.0, 0.5, 2.0]),
+    )
+    gamma_poisson_shape, gamma_poisson_rate = gamma_poisson.posterior_shape_rate
+    dirichlet_categorical = phx.uq.DirichletCategoricalConjugacy(
+        jnp.asarray([1.0, 2.0, 3.0])
+    ).update(jnp.asarray([0, 2, 1, 2, 2]))
+
+    maximum_kernel_error = jnp.maximum(
+        jnp.max(jnp.abs(bernoulli_values - direct_bernoulli)),
+        jnp.max(jnp.abs(poisson_values - direct_poisson)),
+    )
+    maximum_loss_error = jnp.maximum(
+        jnp.max(
+            jnp.abs(
+                bernoulli_loss
+                - (
+                    jax.nn.softplus(bernoulli_natural)
+                    - bernoulli_targets * bernoulli_natural
+                )
+            )
+        ),
+        jnp.max(
+            jnp.abs(
+                poisson_loss
+                - (jnp.exp(poisson_natural) - poisson_targets * poisson_natural)
+            )
+        ),
+    )
+    maximum_score_error = jnp.maximum(
+        jnp.max(
+            jnp.abs(
+                bernoulli_score - (jax.nn.sigmoid(bernoulli_natural) - bernoulli_targets)
+            )
+        ),
+        jnp.max(jnp.abs(poisson_score - (jnp.exp(poisson_natural) - poisson_targets))),
+    )
+    metrics = {
+        "canonical_log_probability_max_error": metric(
+            maximum_kernel_error, "accuracy", maximum=2.0e-12
+        ),
+        "canonical_loss_max_error": metric(
+            maximum_loss_error, "accuracy", maximum=2.0e-12
+        ),
+        "canonical_score_max_error": metric(
+            maximum_score_error, "accuracy", maximum=2.0e-12
+        ),
+        "categorical_log_probability_max_error": metric(
+            jnp.max(jnp.abs(categorical_values - direct_categorical)),
+            "accuracy",
+            maximum=2.0e-12,
+        ),
+        "gamma_mean_coordinates_max_error": metric(
+            jnp.max(jnp.abs(gamma_mean - direct_gamma_mean)),
+            "accuracy",
+            maximum=2.0e-12,
+        ),
+        "gamma_inverse_max_error": metric(
+            jnp.max(jnp.abs(gamma_conversion.natural.values - gamma_natural.values)),
+            "accuracy",
+            maximum=2.0e-8,
+        ),
+        "gamma_inverse_valid_fraction": metric(
+            jnp.mean(gamma_conversion.valid.astype(float)),
+            "convergence",
+            minimum=1.0,
+        ),
+        "multivariate_normal_round_trip_max_error": metric(
+            jnp.maximum(
+                jnp.max(jnp.abs(reconstructed_location - multivariate_location)),
+                jnp.max(jnp.abs(reconstructed_covariance - multivariate_covariance)),
+            ),
+            "accuracy",
+            maximum=2.0e-11,
+        ),
+        "multivariate_normal_fisher_max_error": metric(
+            jnp.max(jnp.abs(multivariate_fisher - dense_multivariate_fisher)),
+            "accuracy",
+            maximum=2.0e-10,
+        ),
+        "gaussian_factor_bridge_max_error": metric(
+            jnp.maximum(
+                jnp.max(jnp.abs(factor_location - multivariate_location)),
+                jnp.max(jnp.abs(factor_covariance - multivariate_covariance)),
+            ),
+            "accuracy",
+            maximum=2.0e-11,
+        ),
+        "dirichlet_mean_coordinates_max_error": metric(
+            jnp.max(jnp.abs(dirichlet_mean - direct_dirichlet_mean)),
+            "accuracy",
+            maximum=2.0e-12,
+        ),
+        "dirichlet_inverse_max_error": metric(
+            jnp.max(
+                jnp.abs(dirichlet_conversion.natural.values - dirichlet_natural.values)
+            ),
+            "accuracy",
+            maximum=3.0e-8,
+        ),
+        "dirichlet_inverse_valid_fraction": metric(
+            jnp.mean(dirichlet_conversion.valid.astype(float)),
+            "convergence",
+            minimum=1.0,
+        ),
+        "simplex_hausdorff_jacobian_error": metric(
+            jnp.abs(
+                simplex_bijector.forward_log_det_jacobian(simplex_raw)
+                - direct_simplex_log_volume
+            ),
+            "accuracy",
+            maximum=2.0e-12,
+        ),
+        "gamma_poisson_posterior_max_error": metric(
+            jnp.maximum(
+                jnp.abs(gamma_poisson_shape - 7.0),
+                jnp.abs(gamma_poisson_rate - 5.0),
+            ),
+            "accuracy",
+            maximum=2.0e-12,
+        ),
+        "dirichlet_categorical_posterior_max_error": metric(
+            jnp.max(
+                jnp.abs(
+                    dirichlet_categorical.posterior_concentration
+                    - jnp.asarray([2.0, 3.0, 6.0])
+                )
+            ),
+            "accuracy",
+            maximum=2.0e-12,
+        ),
+        "conjugate_update_valid_fraction": metric(
+            0.5
+            * (
+                gamma_poisson.valid.astype(float)
+                + dirichlet_categorical.valid.astype(float)
+            ),
+            "convergence",
+            minimum=1.0,
+        ),
+        "projection_mean_max_error": metric(
+            jnp.abs(one_shot.mean_coordinates.values[0] - direct_projection_mean),
+            "accuracy",
+            maximum=2.0e-12,
+        ),
+        "merged_projection_max_error": metric(
+            jnp.max(
+                jnp.abs(merged.mean_coordinates.values - one_shot.mean_coordinates.values)
+            ),
+            "accuracy",
+            maximum=2.0e-12,
+        ),
+        "family_fisher_max_error": metric(
+            jnp.max(jnp.abs(fisher_action - dense_fisher_action)),
+            "accuracy",
+            maximum=2.0e-11,
+        ),
+        "parameter_fisher_max_error": metric(
+            jnp.max(jnp.abs(parameter_action - direct_parameter_action)),
+            "accuracy",
+            maximum=2.0e-11,
+        ),
+        "projection_valid_fraction": metric(
+            0.5 * (one_shot.valid.astype(float) + merged.valid.astype(float)),
+            "convergence",
+            minimum=1.0,
+        ),
+        "bernoulli_cold_seconds": metric(bernoulli_cold, "performance", unit="s"),
+        "bernoulli_compile_seconds": metric(bernoulli_compile, "performance", unit="s"),
+        "bernoulli_execute_seconds": metric(bernoulli_execute, "performance", unit="s"),
+        "bernoulli_throughput": metric(
+            sample_count / bernoulli_execute,
+            "performance",
+            unit="observation/s",
+        ),
+        "poisson_cold_seconds": metric(poisson_cold, "performance", unit="s"),
+        "poisson_compile_seconds": metric(poisson_compile, "performance", unit="s"),
+        "poisson_execute_seconds": metric(poisson_execute, "performance", unit="s"),
+        "poisson_throughput": metric(
+            sample_count / poisson_execute,
+            "performance",
+            unit="observation/s",
+        ),
+        "categorical_cold_seconds": metric(categorical_cold, "performance", unit="s"),
+        "categorical_compile_seconds": metric(
+            categorical_compile, "performance", unit="s"
+        ),
+        "categorical_execute_seconds": metric(
+            categorical_execute, "performance", unit="s"
+        ),
+        "categorical_throughput": metric(
+            structured_count / categorical_execute,
+            "performance",
+            unit="observation/s",
+        ),
+        "gamma_inverse_cold_seconds": metric(gamma_cold, "performance", unit="s"),
+        "gamma_inverse_compile_seconds": metric(gamma_compile, "performance", unit="s"),
+        "gamma_inverse_execute_seconds": metric(gamma_execute, "performance", unit="s"),
+        "dirichlet_inverse_cold_seconds": metric(dirichlet_cold, "performance", unit="s"),
+        "dirichlet_inverse_compile_seconds": metric(
+            dirichlet_compile, "performance", unit="s"
+        ),
+        "dirichlet_inverse_execute_seconds": metric(
+            dirichlet_execute, "performance", unit="s"
+        ),
+        "one_shot_projection_seconds": metric(one_shot_seconds, "performance", unit="s"),
+        "merged_projection_seconds": metric(merged_seconds, "performance", unit="s"),
+        "projection_merge_time_ratio": metric(
+            merged_seconds / one_shot_seconds, "diagnostic"
+        ),
+        "family_fisher_cold_seconds": metric(fisher_cold, "performance", unit="s"),
+        "family_fisher_compile_seconds": metric(fisher_compile, "performance", unit="s"),
+        "family_fisher_execute_seconds": metric(fisher_execute, "performance", unit="s"),
+        "parameter_fisher_cold_seconds": metric(parameter_cold, "performance", unit="s"),
+        "parameter_fisher_compile_seconds": metric(
+            parameter_compile, "performance", unit="s"
+        ),
+        "parameter_fisher_execute_seconds": metric(
+            parameter_execute, "performance", unit="s"
+        ),
+        "dense_parameter_fisher_reference_bytes": metric(
+            parameter_dimension * parameter_dimension * jnp.dtype(float).itemsize,
+            "performance",
+            unit="byte",
+        ),
+        "matrix_free_action_bytes": metric(
+            parameter_action.nbytes, "performance", unit="byte"
+        ),
+        "wall_seconds": metric(time.perf_counter() - started, "performance", unit="s"),
+    }
+    return ScenarioResult(
+        name="exponential_family_geometry",
+        description=exponential_family_geometry.__doc__ or "",
+        seed=seed,
+        metrics=metrics,
+        metadata={
+            "profile": configuration.profile,
+            "sample_count": sample_count,
+            "timing_repetitions": repetitions,
+            "structured_sample_count": structured_count,
+            "symmetric_coordinate_chart": "orthonormal-svec",
+            "simplex_measure": "hausdorff",
+            "parameter_dimension": parameter_dimension,
+            "parameter_natural_dimension": natural_dimension,
+            "fisher_materialization": "matrix_free",
+        },
+    )
+
+
 SCENARIOS: dict[str, Scenario] = {
     "elliptic_coefficient_inverse": elliptic_coefficient_inverse,
     "nonlinear_transformed_ode": nonlinear_transformed_ode,
@@ -3377,6 +3861,7 @@ SCENARIOS: dict[str, Scenario] = {
     "stochastic_gradient_regression": stochastic_gradient_regression,
     "linearized_uncertainty_propagation": linearized_uncertainty_propagation,
     "dynamic_factor_stochastic_volatility": dynamic_factor_stochastic_volatility,
+    "exponential_family_geometry": exponential_family_geometry,
 }
 
 


### PR DESCRIPTION
## Summary

This PR adds a native, normalized exponential-family substrate to Phydrax and integrates it through uncertainty quantification, likelihoods, posterior parameter spaces, exact information geometry, conjugate inference, documentation, and benchmark infrastructure.

The new layer represents each regular family by an explicit natural-coordinate chart, expectation coordinates, sufficient statistics, log normalizer, support, and reference measure. It preserves the distinction between a probability law and its coordinate representation, attaches static family identity to every coordinate object, and reports domain or numerical failures through stable array-valued diagnostics rather than conflating boundaries, invalid observations, nonfinite inputs, and failed inversions.

The initial family set covers Bernoulli, Poisson, exponential-rate, univariate Normal, categorical, Gamma, multivariate Normal, and Dirichlet laws. Structured families include audited family-specific inversions, exact matrix-free Fisher actions, normalized densities, projection from weighted observations, sampling, and interoperability with existing Phydrax posterior and Gaussian-factor abstractions.

## Motivation

Phydrax already exposed probability distributions, observation likelihoods, posterior parameter spaces, sensitivity operators, Gaussian factors, and weighted empirical machinery. What was missing was a shared intrinsic geometry connecting those pieces:

- a normalized density contract of the form `log p(x) = η · T(x) - A(η) + log h(x)`;
- explicit natural and expectation coordinates with family identity;
- support and base-measure semantics that remain correct for discrete, continuous, and manifold-supported laws;
- exact KL and Fisher operations without materializing dense information matrices;
- weighted moment projection into a declared family;
- reusable conjugate sufficient statistics, evidence, and posterior-predictive laws;
- event-aware likelihood alignment for scalar and structured observations;
- non-shape-preserving posterior bijectors such as a simplex map.

Without that substrate, each downstream feature would need its own distribution-specific formulas and failure conventions. This change centralizes the reusable mathematics while keeping family-specific numerical complexity local to the families that need it.

The design is informed by EFAX's separation of natural and expectation parameterizations, but the implementation is Phydrax-native: it uses existing strict modules, JAX transformations, posterior contracts, Gaussian factors, weighted numerics, status semantics, documentation structure, and benchmark runner. EFAX is not introduced as a dependency.

## Core changes

### 1. Normalized family and probability-law contracts

Adds a small probability-law abstraction and a complete exponential-family contract:

- `AbstractProbabilityLaw` defines event shape, reference-measure kind, sampling, and normalized log probability;
- `AbstractExponentialFamily` defines signatures, coordinate constructors, domains, sufficient statistics, log normalizers, mean maps, inverse maps, KL divergence, Fisher actions, and sampling;
- `ExponentialFamilySignature` carries family identity, intrinsic dimension, event shape, density measure, support identity, and sufficient-statistic identity;
- `NaturalCoordinates` and `MeanCoordinates` prevent accidental operations between equal-shaped coordinates from different families;
- `StatisticBatch`, `ExponentialFamilyDomainResult`, `ExponentialFamilyConversionResult`, and estimate results preserve batch-local validity and diagnostics;
- `ExponentialFamilyLaw` binds one family to one natural coordinate without erasing either object's semantics.

Stable status codes distinguish success, nonfinite values, invalid events, outside-natural-domain inputs, outside-mean-domain inputs, mean-domain boundaries, insufficient projection weight, and numerical nonconvergence.

Existing native distributions now participate through `AbstractProbabilityLaw`, allowing posterior priors to consume both legacy distributions and normalized exponential-family laws without adapters or duplicate prior protocols.

### 2. Elementary and categorical families

Adds analytic Bernoulli, Poisson, exponential-rate, and univariate Normal families with exact natural/mean conversions, normalized densities, support checks, sampling, KL divergence, and Fisher actions.

`CategoricalFamily(K)` uses identified last-category-reference log-odds coordinates of dimension `K - 1`. This avoids the translation null direction of unconstrained full logits while retaining explicit conversion from full logits and probabilities.

`CategoricalExponentialFamilyLikelihood` makes model-output coordinates explicit:

- `prediction_coordinates="natural"` accepts identified `K - 1` coordinates;
- `prediction_coordinates="full_logits"` accepts conventional `K` logits and reduces them into the intrinsic chart.

Categorical events remain scalar integer labels even though model outputs carry a coordinate axis. Likelihood alignment therefore owns the event contract rather than relying on generic shape equality.

### 3. Gamma geometry and numerical inversion

`GammaFamily` uses the full shape-rate natural chart:

- natural coordinates `(shape - 1, -rate)`;
- sufficient statistics `(log x, x)`;
- Lebesgue density on the positive real line;
- exact log normalizer, mean map, KL divergence, Fisher action, and sampling.

The expectation-to-natural conversion solves the scalar shape equation with safeguarded Newton steps inside an explicit bracket. It returns per-batch residuals, iteration counts, convergence state, and a stable method identifier.

The numerical solve is isolated from differentiation. A custom JVP applies the exact implicit derivative of the inverse mean map, so forward- and reverse-mode transformations see inverse-Fisher geometry instead of differentiating solver control flow. Empty batches terminate without reductions over empty arrays, and natural-domain closure distinguishes boundary points from true exterior points.

### 4. Multivariate Normal geometry

`MultivariateNormalFamily(d)` introduces an intrinsic linear-quadratic chart using Frobenius-orthonormal symmetric coordinates:

- `svec` packs symmetric matrices with square-root-two off-diagonal scaling;
- `smat` reconstructs the dense symmetric matrix;
- the Euclidean inner product of packed coordinates equals the Frobenius matrix inner product;
- integral and Boolean inputs promote before irrational scaling, preserving the chart exactly.

The family exposes conversion to and from location/covariance parameters, exact normalized density, sampling, dual coordinates, KL divergence, and Fisher actions. Positive-definiteness and symmetry checks are relative to each batch member's own spectrum, remain invariant under changes of physical units, and support empty leading batches.

The Gaussian bridge converts between a `MultivariateNormalFamily` law and the existing `GaussianFactor` representation without hidden jitter or regularization. Rank-deficient factors retain their boundary diagnostics rather than being silently perturbed.

### 5. Dirichlet geometry and simplex measure

`DirichletFamily(K)` models positive simplex interiors with:

- natural coordinates `concentration - 1`;
- sufficient statistics `log x`;
- exact Dirichlet log normalizer and mean map;
- sampling, KL divergence, projection, and Fisher actions;
- density explicitly declared with respect to Hausdorff measure on the simplex hyperplane.

The Hausdorff base-density correction is retained explicitly rather than treating the singular simplex law as an ambient Lebesgue density.

Expectation inversion reduces the coupled problem to a scalar total-concentration root and uses inverse-digamma evaluations inside a safeguarded bracket. As with Gamma, the solver reports batch-local convergence evidence while a custom JVP supplies the exact inverse-Fisher derivative. The implementation remains matrix-free through the diagonal-minus-rank-one Fisher structure.

Simplex support checks require strictly positive coordinates and a bounded floating-point sum tolerance that does not loosen with category count.

### 6. Weighted projection and exact information geometry

Adds stable family projection from empirical observations:

- `ExponentialFamilyProjectionAccumulator` stores mergeable weighted sufficient-statistic state;
- `project_exponential_family` projects observations with normalized log weights;
- `fit_exponential_family` provides the unweighted fitting path;
- insufficient effective weight, invalid events, boundary means, and inversion failures remain distinct.

The sensitivity API gains:

- `exponential_family_fisher_action`, applying the exact natural-coordinate Fisher as a JVP of the mean map;
- `exponential_family_parameter_fisher_action`, applying `Jηᵀ F(η) Jη` through a natural-parameter JVP and transpose pullback.

Neither operation materializes or inverts a dense Fisher matrix.

### 7. Conjugate inference

Adds explicit, mergeable conjugate pairs:

- `GammaPoissonConjugacy`, `GammaPoissonStatistics`, and `GammaPoissonUpdate`;
- `DirichletCategoricalConjugacy`, `DirichletCategoricalStatistics`, and `DirichletCategoricalUpdate`.

Both paths support sample-axis reductions, batch-local validity, associative statistics merges, posterior natural coordinates, conventional posterior parameters, marginal log evidence, predictive log probabilities, and predictive sampling.

Statistics constructors canonicalize validity from their own local invariants. Invalid chunks therefore cannot become valid by merging with compensating chunks; provenance survives distributed or streaming reductions.

The conjugacy layer remains explicit rather than introducing a global prior/likelihood registry or runtime pattern-matching engine.

### 8. Likelihood and posterior integration

`AbstractLikelihood` now exposes observation alignment as part of the likelihood's event contract. Scalar likelihoods preserve the existing scalar/singleton-axis behavior, while categorical likelihoods align a coordinate-valued prediction with scalar labels. Posterior likelihood terms delegate to this contract and retain the leading empirical-case axis before reduction.

`ParameterSpace` now distinguishes raw and physical leaf shapes. Existing identity, exponential, and bounded-sigmoid bijectors remain shape-preserving, while `SimplexBijector(K)` maps `K - 1` additive-log-ratio coordinates to a `K`-component simplex and returns the correct Hausdorff volume factor.

This allows a Dirichlet law to serve directly as a prior over a physical simplex while inference proceeds in unconstrained raw coordinates. Gaussian prior whitening continues to reject non-Gaussian or non-shape-compatible priors explicitly.

### 9. Documentation and benchmark integration

Adds a dedicated exponential-family API reference covering:

- normalization and reference measures;
- coordinate and status contracts;
- all supported families;
- projection, Fisher, likelihood, posterior, Gaussian bridge, and conjugacy APIs;
- failure semantics and JAX transformation behavior.

The uncertainty guide now explains how normalized laws, likelihood scores, posterior priors, exact Fisher actions, and conjugate updates fit into the broader UQ architecture. API navigation and the all-of-Phydrax overview expose the new subsystem.

The UQ benchmark runner gains an `exponential_family_geometry` scenario spanning canonical densities, categorical likelihoods, numerical inversions, structured Gaussian conversion, simplex geometry, conjugacy, projection, and exact Fisher actions. Forward mean coordinates are compared against independent analytic formulas before inverse round trips, preventing self-consistent convention errors from passing accuracy gates.

## API and compatibility impact

New public families and laws:

- `BernoulliFamily`
- `PoissonFamily`
- `ExponentialRateFamily`
- `NormalFamily`
- `CategoricalFamily`
- `GammaFamily`
- `MultivariateNormalFamily`
- `DirichletFamily`
- `ExponentialFamilyLaw`

New coordinate, projection, and diagnostic APIs:

- `ExponentialFamilySignature`
- `NaturalCoordinates`
- `MeanCoordinates`
- `StatisticBatch`
- `ExponentialFamilyDomainResult`
- `ExponentialFamilyConversionResult`
- `ExponentialFamilyProjectionAccumulator`
- `fit_exponential_family`
- `project_exponential_family`
- stable exponential-family status constants and `exponential_family_status_name`

New integration APIs:

- `ScalarNaturalExponentialFamilyLikelihood`
- `CategoricalExponentialFamilyLikelihood`
- `SimplexBijector`
- `exponential_family_fisher_action`
- `exponential_family_parameter_fisher_action`
- Gamma-Poisson and Dirichlet-categorical conjugacy types
- Gaussian-factor conversion helpers

Compatibility notes:

- existing native distributions keep their public names and behavior while implementing the broader probability-law protocol;
- existing shape-preserving posterior bijectors retain their physical behavior;
- custom `AbstractLikelihood` subclasses must now make observation alignment explicit;
- posterior position validation is stricter about declared raw and physical leaf shapes;
- no runtime dependency is added;
- EFAX is not imported, wrapped, or vendored.

## Deliberate non-goals

This PR does **not** add:

- EFAX's full distribution catalog, assembler/flattener hierarchy, or transformed-family machinery;
- a global family registry or automatic conjugacy-dispatch engine;
- dense Fisher materialization as the primary geometry API;
- an ambient Lebesgue-density fiction for simplex-supported laws;
- silent jitter, clipping, or projection of invalid natural parameters;
- aliases or deprecated compatibility paths for the new APIs;
- approximate boundary distributions outside regular-family interiors.

## Review guide

A useful review order is:

1. `phydrax/_probability.py` and `phydrax/_exponential_family/_contracts.py` for the law, coordinate, domain, status, KL, Fisher, and sampling contracts;
2. `_elementary.py` and `_categorical.py` for analytic scalar and finite-discrete families;
3. `_gamma.py`, `_symmetric_coordinates.py`, `_multivariate_normal.py`, and `_dirichlet.py` for structured geometry and family-specific inversion;
4. `_conjugacy.py` and `phydrax/uq/_exponential_family_projection.py` for mergeable inference and weighted projection;
5. `phydrax/_likelihoods.py`, `phydrax/terms/_likelihood.py`, `phydrax/uq/_posterior.py`, and `phydrax/uq/_sensitivity.py` for framework integration;
6. `tools/uq_benchmarks/scenarios.py` for the scientific benchmark contract;
7. `docs/api/uq/exponential_families.md` and `docs/guides_uncertainty.md` for public semantics and usage.

## Attribution

The architectural evaluation was informed by [EFAX](https://github.com/NeilGirdhar/efax), especially its separation of natural and expectation parameterizations and explicit support metadata. This implementation rederives the required mathematics within Phydrax's own contracts and introduces no EFAX code or dependency.