### PR TITLE
fix: reuse Equinox filtered transforms and JAX initializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,3 +38,6 @@
 - Galerkin and smoothed-aggregation hierarchies now retain sparse assembly recipes and refresh coarse coefficients without rebuilding symbolic routes or silently densifying downstream levels.
 - The linear benchmark harnesses now cover block-Jacobi preparation, sparse assembly planning/refresh/action, structured Kronecker-sum solves, and the advanced reusable and higher-operator lifecycles against dense, exact, finite-difference, or invariant references.
 - Tensor contractions across the package, tests, benchmarks, and tools now consistently use `opt_einsum.contract` instead of direct `jax.numpy.einsum` calls.
+- Closure-converted matrix-free SVD, eigensolve, spectral-projector, density-kernel, and spectral-function derivatives now support filtered JVP, reverse mode, and JIT.
+- Named truncated-normal initializers now produce their conventional target variance, while rectangular orthogonal initialization avoids max-dimension square samples.
+- `phydrax.nn.layers.inference_mode` now switches every inference-aware Equinox or Phydrax leaf in mixed model trees.

--- a/docs/api/linalg.md
+++ b/docs/api/linalg.md
@@ -592,6 +592,13 @@ or unresolved clusters reject individual gradients rather than returning
 values. Algorithmic differentiation through locking, deflation, ordering, and
 restart decisions is not exposed.
 
+Closure-converted `FunctionLinearOperator` actions may capture differentiable
+arrays. Filtered derivative boundaries preserve their callable and static
+leaves, so singular-value, isolated-eigenvalue, projector, density-kernel, and
+smooth spectral-function derivatives support these matrix-free problems under
+JIT, JVP, and reverse mode. The same convergence, isolation, selection-gap, and
+domain requirements still apply.
+
 ### Prepared self-adjoint spectra and differentiable spectral calculus
 
 `prepare_self_adjoint_spectrum` materializes one bounded dense standard or

--- a/docs/api/nn/layers.md
+++ b/docs/api/nn/layers.md
@@ -8,6 +8,11 @@ Low-level model building blocks.
     - `Linear` supports Random Weight Factorization (RWF) or one explicit
       shape-preserving physical weight transform.
     - `Dropout(mode="feature")` shares one feature/channel mask over leading field axes.
+    - Named LeCun, He/Kaiming, and Glorot/Xavier initializers follow JAX's
+      post-truncation target-variance definitions; orthogonal initialization
+      factors only the smaller rectangular orientation.
+    - `inference_mode` switches every inference-aware leaf in mixed
+      Phydrax/Equinox trees.
     - `AdaptiveResidual` starts exactly at the identity when `alpha=0`.
     - Recurrent cells consume a canonical `RecurrentBatch`; serial and associative
       execution share one reset and padding contract.

--- a/phydrax/linalg/_svd.py
+++ b/phydrax/linalg/_svd.py
@@ -640,14 +640,14 @@ def svd(
         ).astype(jnp.int32)
         values = jax.lax.cond(
             differentiation_valid,
-            lambda payload: _mathematical_singular_values(*payload),
-            lambda payload: jax.lax.stop_gradient(payload[1]),
-            (
+            lambda payload: _mathematical_singular_values(
                 prepared.problem,
-                jax.lax.stop_gradient(values),
-                jax.lax.stop_gradient(left),
-                jax.lax.stop_gradient(right),
+                jax.lax.stop_gradient(payload[0]),
+                jax.lax.stop_gradient(payload[1]),
+                jax.lax.stop_gradient(payload[2]),
             ),
+            lambda payload: jax.lax.stop_gradient(payload[0]),
+            (values, left, right),
         )
     if prepared.plan.policy.failure.mode == "error":
         failed = status != int(SVDSolveStatus.SUCCESS)
@@ -872,7 +872,7 @@ def _unflatten_columns(space: AbstractVectorSpace, columns: Array, /) -> PyTree[
     return jax.vmap(space.unflatten, in_axes=1, out_axes=-1)(columns)
 
 
-@jax.custom_jvp
+@eqx.filter_custom_jvp
 def _mathematical_singular_values(
     problem: SVDProblem,
     values: Array,
@@ -884,7 +884,7 @@ def _mathematical_singular_values(
     return values
 
 
-@_mathematical_singular_values.defjvp
+@_mathematical_singular_values.def_jvp
 def _mathematical_singular_values_jvp(primals, tangents):
     problem, values, left, right = primals
     problem_tangent, _, _, _ = tangents
@@ -899,11 +899,13 @@ def _mathematical_singular_values_jvp(primals, tangents):
             contributions.append(jnp.real(target.inner(left_vector, image)))
         return jnp.stack(contributions)
 
-    _, tangent = jax.jvp(
+    _, tangent = eqx.filter_jvp(
         perturbation,
         (problem,),
         (problem_tangent,),
     )
+    if tangent is None:
+        tangent = jnp.zeros_like(values)
     return values, tangent
 
 

--- a/phydrax/linalg/eigen/_runtime.py
+++ b/phydrax/linalg/eigen/_runtime.py
@@ -755,7 +755,7 @@ def _metric_denominators(problem: EigenproblemLike, vectors: Array, /) -> Array:
     )(vectors, metric_vectors)
 
 
-@jax.custom_jvp
+@eqx.filter_custom_jvp
 def _mathematical_eigenvalues(
     problem: EigenproblemLike,
     values: Array,
@@ -767,7 +767,7 @@ def _mathematical_eigenvalues(
     return values
 
 
-@_mathematical_eigenvalues.defjvp
+@_mathematical_eigenvalues.def_jvp
 def _mathematical_eigenvalues_jvp(primals, tangents):
     problem, values, vectors, denominators = primals
     problem_tangent, _, _, _ = tangents
@@ -789,11 +789,13 @@ def _mathematical_eigenvalues_jvp(primals, tangents):
             contributions.append(jnp.real(numerator) / denominators[index])
         return jnp.stack(contributions)
 
-    _, value_tangent = jax.jvp(
+    _, value_tangent = eqx.filter_jvp(
         perturbation,
         (problem,),
         (problem_tangent,),
     )
+    if value_tangent is None:
+        value_tangent = jnp.zeros_like(values)
     return values, value_tangent
 
 

--- a/phydrax/linalg/eigen/_spectral_derivatives.py
+++ b/phydrax/linalg/eigen/_spectral_derivatives.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from typing import Any
 
+import equinox as eqx
 import jax
 import jax.numpy as jnp
 from jaxtyping import Array
@@ -114,13 +115,20 @@ def perturbation_in_eigenbasis(
             )
         return operator_images, metric_images, _paired_metric(current_problem)
 
-    (_, _, _), (operator_tangent, metric_images_tangent, paired_metric_tangent) = (
-        jax.jvp(
-            operator_and_metric_images,
-            (problem,),
-            (problem_tangent,),
-        )
+    (
+        (operator_images, metric_images, paired_metric),
+        (operator_tangent, metric_images_tangent, paired_metric_tangent),
+    ) = eqx.filter_jvp(
+        operator_and_metric_images,
+        (problem,),
+        (problem_tangent,),
     )
+    if operator_tangent is None:
+        operator_tangent = jnp.zeros_like(operator_images)
+    if metric_images_tangent is None:
+        metric_images_tangent = jnp.zeros_like(metric_images)
+    if paired_metric_tangent is None:
+        paired_metric_tangent = jnp.zeros_like(paired_metric)
     space = problem.operator.source
     pairing = _coordinate_pairing_matrix(space)
     residual_tangent = (
@@ -177,7 +185,7 @@ def projector_derivative_residuals(
     return cross_residual, commutator_residual, tangent_residual
 
 
-@jax.custom_jvp
+@eqx.filter_custom_jvp
 def attach_projector_derivative(
     problem: EigenproblemLike,
     projector: Array,
@@ -192,7 +200,7 @@ def attach_projector_derivative(
     return projector
 
 
-@attach_projector_derivative.defjvp
+@attach_projector_derivative.def_jvp
 def _attach_projector_derivative_jvp(primals, tangents):
     problem, projector, eigenvalues, eigenvectors, inverse_basis, selected_mask = primals
     problem_tangent, _, _, _, _, _ = tangents
@@ -207,7 +215,7 @@ def _attach_projector_derivative_jvp(primals, tangents):
     return projector, derivative
 
 
-@jax.custom_jvp
+@eqx.filter_custom_jvp
 def attach_density_derivative(
     problem: EigenproblemLike,
     density: Array,
@@ -232,7 +240,7 @@ def attach_density_derivative(
     return density
 
 
-@attach_density_derivative.defjvp
+@attach_density_derivative.def_jvp
 def _attach_density_derivative_jvp(primals, tangents):
     (
         problem,

--- a/phydrax/linalg/eigen/_spectral_functions.py
+++ b/phydrax/linalg/eigen/_spectral_functions.py
@@ -465,7 +465,7 @@ def self_adjoint_spectral_operator(
     )
 
 
-@jax.custom_jvp
+@eqx.filter_custom_jvp
 def _attach_spectral_operator_derivative(
     problem,
     function,
@@ -478,7 +478,7 @@ def _attach_spectral_operator_derivative(
     return operator
 
 
-@_attach_spectral_operator_derivative.defjvp
+@_attach_spectral_operator_derivative.def_jvp
 def _spectral_operator_jvp(primals, tangents):
     problem, function, operator, eigenvalues, eigenvectors, inverse_basis = primals
     problem_tangent, function_tangent, _, _, _, _ = tangents
@@ -494,7 +494,7 @@ def _spectral_operator_jvp(primals, tangents):
     return operator, derivative
 
 
-@jax.custom_jvp
+@eqx.filter_custom_jvp
 def _attach_spectral_density_derivative(
     problem,
     function,
@@ -517,7 +517,7 @@ def _attach_spectral_density_derivative(
     return density
 
 
-@_attach_spectral_density_derivative.defjvp
+@_attach_spectral_density_derivative.def_jvp
 def _spectral_density_jvp(primals, tangents):
     (
         problem,
@@ -569,11 +569,13 @@ def _spectral_operator_tangent(
     left = eigenvalues[..., :, None]
     right = eigenvalues[..., None, :]
     loewner = function.divided_difference(left, right).astype(eigenvectors.dtype)
-    _, parameter_tangent = jax.jvp(
+    function_values, parameter_tangent = eqx.filter_jvp(
         lambda current: current.value(eigenvalues),
         (function,),
         (function_tangent,),
     )
+    if parameter_tangent is None:
+        parameter_tangent = jnp.zeros_like(function_values)
     derivative_in_basis = (
         loewner * perturbation
         + parameter_tangent.astype(eigenvectors.dtype)[..., None, :]

--- a/phydrax/nn/_initializers.py
+++ b/phydrax/nn/_initializers.py
@@ -2,144 +2,17 @@
 #  Copyright © 2026 PHYDRA, Inc. All rights reserved.
 #
 
-from typing import Literal
-
-import jax.numpy as jnp
-import jax.random as jr
-from jaxtyping import Array, Float, Key
-
-
-_FanMode = Literal["fan_in", "fan_avg"]
-
-
-def _fan_denominator(in_size: int, out_size: int, /, *, mode: _FanMode) -> float:
-    if mode == "fan_in":
-        return float(in_size)
-    if mode == "fan_avg":
-        return (in_size + out_size) / 2.0
-    raise ValueError(f"Unknown mode {mode!r}. Expected 'fan_in' or 'fan_avg'.")
-
-
-def _variance(in_size: int, out_size: int, /, *, scale: float, mode: _FanMode) -> float:
-    return scale / _fan_denominator(in_size, out_size, mode=mode)
-
-
-def _truncated_normal(
-    shape: tuple[int, int],
-    /,
-    *,
-    key: Key[Array, ""],
-    stddev: Float[Array, ""] | float,
-) -> Float[Array, "rows cols"]:
-    return stddev * jr.truncated_normal(key, shape=shape, lower=-2, upper=2)
-
-
-def _uniform(
-    shape: tuple[int, int],
-    /,
-    *,
-    key: Key[Array, ""],
-    limit: Float[Array, ""] | float,
-) -> Float[Array, "rows cols"]:
-    return jr.uniform(key, shape=shape, minval=-limit, maxval=limit)
-
-
-def _variance_scaling_truncated_normal_init(
-    in_size: int,
-    out_size: int,
-    /,
-    *,
-    key: Key[Array, ""],
-    scale: float,
-    mode: _FanMode,
-) -> Float[Array, "out_size in_size"]:
-    shape = (out_size, in_size)
-    stddev = jnp.sqrt(_variance(in_size, out_size, scale=scale, mode=mode))
-    return _truncated_normal(shape, key=key, stddev=stddev)
-
-
-def _variance_scaling_uniform_init(
-    in_size: int,
-    out_size: int,
-    /,
-    *,
-    key: Key[Array, ""],
-    scale: float,
-    mode: _FanMode,
-) -> Float[Array, "out_size in_size"]:
-    shape = (out_size, in_size)
-    limit = jnp.sqrt(3.0 * _variance(in_size, out_size, scale=scale, mode=mode))
-    return _uniform(shape, key=key, limit=limit)
-
-
-def _lecun_normal_init(
-    in_size: int, out_size: int, /, *, key: Key[Array, ""]
-) -> Float[Array, "out_size in_size"]:
-    return _variance_scaling_truncated_normal_init(
-        in_size, out_size, key=key, scale=1.0, mode="fan_in"
-    )
-
-
-def _lecun_uniform_init(
-    in_size: int, out_size: int, /, *, key: Key[Array, ""]
-) -> Float[Array, "out_size in_size"]:
-    return _variance_scaling_uniform_init(
-        in_size, out_size, key=key, scale=1.0, mode="fan_in"
-    )
-
-
-def _he_normal_init(
-    in_size: int, out_size: int, /, *, key: Key[Array, ""]
-) -> Float[Array, "out_size in_size"]:
-    return _variance_scaling_truncated_normal_init(
-        in_size, out_size, key=key, scale=2.0, mode="fan_in"
-    )
-
-
-def _he_uniform_init(
-    in_size: int, out_size: int, /, *, key: Key[Array, ""]
-) -> Float[Array, "out_size in_size"]:
-    return _variance_scaling_uniform_init(
-        in_size, out_size, key=key, scale=2.0, mode="fan_in"
-    )
-
-
-def _glorot_normal_init(
-    in_size: int, out_size: int, /, *, key: Key[Array, ""]
-) -> Float[Array, "out_size in_size"]:
-    return _variance_scaling_truncated_normal_init(
-        in_size, out_size, key=key, scale=1.0, mode="fan_avg"
-    )
-
-
-def _glorot_uniform_init(
-    in_size: int, out_size: int, /, *, key: Key[Array, ""]
-) -> Float[Array, "out_size in_size"]:
-    return _variance_scaling_uniform_init(
-        in_size, out_size, key=key, scale=1.0, mode="fan_avg"
-    )
-
-
-def _orthogonal_init(
-    in_size: int, out_size: int, /, *, key: Key[Array, ""]
-) -> Float[Array, "out_size in_size"]:
-    bigger_dim = max(out_size, in_size)
-    a = jr.normal(key, shape=(bigger_dim, bigger_dim))
-    q, r = jnp.linalg.qr(a)
-    d = jnp.diag(r)
-    ph = jnp.sign(d)
-    q *= ph
-    return q[:out_size, :in_size]
+from jax.nn import initializers
 
 
 _initializer_dict = {
-    "lecun_normal": _lecun_normal_init,
-    "lecun_uniform": _lecun_uniform_init,
-    "he_normal": _he_normal_init,
-    "he_uniform": _he_uniform_init,
-    "glorot_normal": _glorot_normal_init,
-    "glorot_uniform": _glorot_uniform_init,
-    "orthogonal": _orthogonal_init,
+    "lecun_normal": initializers.lecun_normal(in_axis=1, out_axis=0),
+    "lecun_uniform": initializers.lecun_uniform(in_axis=1, out_axis=0),
+    "he_normal": initializers.he_normal(in_axis=1, out_axis=0),
+    "he_uniform": initializers.he_uniform(in_axis=1, out_axis=0),
+    "glorot_normal": initializers.glorot_normal(in_axis=1, out_axis=0),
+    "glorot_uniform": initializers.glorot_uniform(in_axis=1, out_axis=0),
+    "orthogonal": initializers.orthogonal(column_axis=1),
 }
 
 _initializer_dict.update(

--- a/phydrax/nn/layers/_dropout.py
+++ b/phydrax/nn/layers/_dropout.py
@@ -6,7 +6,6 @@ from collections.abc import Sequence
 from typing import cast, Literal
 
 import equinox as eqx
-import jax
 import jax.numpy as jnp
 import jax.random as jr
 from jaxtyping import Array
@@ -91,20 +90,9 @@ class Dropout(_AbstractBaseModel):
 
 
 def inference_mode(tree, value: bool = True):
-    """Return a PyTree with every Phydrax Dropout switched to inference mode."""
+    """Switch every inference-aware Equinox or Phydrax leaf in a PyTree."""
 
-    inference = bool(value)
-
-    def replace(layer):
-        if isinstance(layer, Dropout):
-            return eqx.tree_at(lambda item: item.inference, layer, inference)
-        return layer
-
-    return jax.tree_util.tree_map(
-        replace,
-        tree,
-        is_leaf=lambda item: isinstance(item, Dropout),
-    )
+    return eqx.nn.inference_mode(tree, value)
 
 
 __all__ = ["Dropout", "inference_mode"]

--- a/phydrax/nn/layers/_linear.py
+++ b/phydrax/nn/layers/_linear.py
@@ -90,7 +90,10 @@ class Linear(_AbstractBaseModel):
         wkey, skey, bkey = jr.split(key, 3)
 
         # Base weights (V in RWF; full W otherwise)
-        self.weight = _initializer_dict[initializer](in_size_, out_size_, key=wkey)
+        self.weight = _initializer_dict[initializer](
+            wkey,
+            (out_size_, in_size_),
+        )
 
         # Random Weight Factorization setup
         if use_random_weight_factorization is not None and rwf is True:

--- a/phydrax/nn/operator/sharding.py
+++ b/phydrax/nn/operator/sharding.py
@@ -215,12 +215,7 @@ def shard_operator_targets(
 
 def replicate_operator_model(model, policy: OperatorShardingPolicy, /):
     """Replicate every array leaf of a model on the policy mesh."""
-    return jax.tree_util.tree_map(
-        lambda leaf: (
-            jax.device_put(leaf, policy.replicated) if eqx.is_array(leaf) else leaf
-        ),
-        model,
-    )
+    return eqx.filter_shard(model, policy.replicated)
 
 
 __all__ = [

--- a/tests/unit/nn/test_equinox_wrappers.py
+++ b/tests/unit/nn/test_equinox_wrappers.py
@@ -6,6 +6,7 @@ import equinox as eqx
 import jax.numpy as jnp
 import jax.random as jr
 
+from phydrax.nn.layers import Dropout, inference_mode
 from phydrax.nn.models import EquinoxModel, EquinoxStructuredModel
 
 
@@ -65,3 +66,26 @@ def test_equinox_structured_model_value_layout_concatenates_tuple():
 
     y = model((jnp.array(1.0), jnp.array(2.0)))
     assert y.shape == ()
+
+
+def test_inference_mode_switches_mixed_phydrax_and_equinox_tree():
+    tree = {
+        "phydrax": Dropout(4, p=0.5, inference=False),
+        "equinox": eqx.nn.Dropout(p=0.5, inference=False),
+        "label": "fixed",
+    }
+
+    converted = inference_mode(tree)
+    restored = inference_mode(converted, False)
+    values = jnp.ones((4,))
+
+    assert converted is not tree
+    assert converted["phydrax"].inference
+    assert converted["equinox"].inference
+    assert not tree["phydrax"].inference
+    assert not tree["equinox"].inference
+    assert converted["label"] == "fixed"
+    assert jnp.array_equal(converted["phydrax"](values), values)
+    assert jnp.array_equal(converted["equinox"](values), values)
+    assert not restored["phydrax"].inference
+    assert not restored["equinox"].inference

--- a/tests/unit/nn/test_initializers.py
+++ b/tests/unit/nn/test_initializers.py
@@ -1,0 +1,98 @@
+#
+#  Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+from phydrax.nn.layers import Linear
+
+
+@pytest.mark.parametrize(
+    ("initializer", "scale", "mode"),
+    (
+        ("lecun_normal", 1.0, "fan_in"),
+        ("lecun_uniform", 1.0, "fan_in"),
+        ("he_normal", 2.0, "fan_in"),
+        ("he_uniform", 2.0, "fan_in"),
+        ("glorot_normal", 1.0, "fan_avg"),
+        ("glorot_uniform", 1.0, "fan_avg"),
+    ),
+)
+def test_named_initializers_match_target_variance(initializer, scale, mode):
+    in_size = 192
+    out_size = 640
+    layer = Linear(
+        in_size=in_size,
+        out_size=out_size,
+        initializer=initializer,
+        rwf=False,
+        use_bias=False,
+        key=jr.key(0),
+    )
+    denominator = in_size if mode == "fan_in" else (in_size + out_size) / 2
+    target_variance = scale / denominator
+
+    assert jnp.isclose(jnp.var(layer.weight), target_variance, rtol=0.03)
+    assert jnp.abs(jnp.mean(layer.weight)) < 0.02 * jnp.sqrt(target_variance)
+
+
+@pytest.mark.parametrize(
+    ("canonical", "alias"),
+    (
+        ("he_normal", "kaiming_normal"),
+        ("he_uniform", "kaiming_uniform"),
+        ("glorot_normal", "xavier_normal"),
+        ("glorot_uniform", "xavier_uniform"),
+    ),
+)
+def test_initializer_aliases_are_exact(canonical, alias):
+    def weight(initializer):
+        return Linear(
+            in_size=17,
+            out_size=29,
+            initializer=initializer,
+            rwf=False,
+            use_bias=False,
+            key=jr.key(1),
+        ).weight
+
+    assert jnp.array_equal(weight(canonical), weight(alias))
+
+
+@pytest.mark.parametrize(("in_size", "out_size"), ((3, 8), (8, 3)))
+def test_orthogonal_initializer_handles_rectangular_weights(in_size, out_size):
+    def weight():
+        return Linear(
+            in_size=in_size,
+            out_size=out_size,
+            initializer="orthogonal",
+            rwf=False,
+            use_bias=False,
+            key=jr.key(2),
+        ).weight
+
+    first = weight()
+    second = weight()
+    gram = first.T @ first if out_size >= in_size else first @ first.T
+
+    assert first.shape == (out_size, in_size)
+    assert jnp.all(jnp.isfinite(first))
+    assert jnp.array_equal(first, second)
+    assert jnp.allclose(gram, jnp.eye(min(in_size, out_size)), atol=1e-5)
+
+
+def test_default_initializer_remains_glorot_normal():
+    kwargs = {
+        "in_size": 11,
+        "out_size": 7,
+        "rwf": False,
+        "use_bias": False,
+        "key": jr.key(3),
+    }
+
+    default = Linear(**kwargs)
+    explicit = Linear(initializer="glorot_normal", **kwargs)
+
+    assert jnp.array_equal(default.weight, explicit.weight)

--- a/tests/unit/test_linalg_eigen.py
+++ b/tests/unit/test_linalg_eigen.py
@@ -180,6 +180,34 @@ def test_isolated_eigenvalue_gradient_uses_mathematical_derivative():
     assert jnp.allclose(jax.grad(smallest_eigenvalue)(1.25), 1.0, atol=1e-8)
 
 
+def test_matrix_free_eigenvalue_gradient_supports_closure_converted_operator():
+    properties = _self_adjoint_properties()
+    policy = eigen.EigenSolvePolicy(
+        eigen.LOBPCG(block_dimension=2),
+        count=1,
+        initial_basis=jnp.eye(2),
+        differentiation="eigenvalues",
+    )
+
+    def smallest_eigenvalue(coefficient):
+        diagonal = jnp.stack((coefficient, jnp.asarray(3.0)))
+        space = la.ArraySpace((2,), dtype=diagonal.dtype)
+        operator = la.FunctionLinearOperator(
+            lambda vector: diagonal * vector,
+            source=space,
+            target=space,
+            properties=properties,
+        )
+        return eigen.eigensolve(
+            eigen.Eigenproblem(operator),
+            policy=policy,
+        ).eigenvalues[0]
+
+    gradient = jax.jit(jax.grad(smallest_eigenvalue))(jnp.asarray(1.25))
+
+    assert jnp.allclose(gradient, 1.0, atol=1e-8)
+
+
 def test_lobpcg_repairs_rank_deficient_initial_basis_deterministically():
     operator = la.DiagonalLinearOperator(
         jnp.asarray([1.0, 2.0, 3.0, 4.0]),

--- a/tests/unit/test_linalg_self_adjoint_spectrum.py
+++ b/tests/unit/test_linalg_self_adjoint_spectrum.py
@@ -57,6 +57,40 @@ def _generalized_problem(operator_matrix, metric_matrix, *, space=None):
     )
 
 
+def _matrix_free_standard_problem(matrix):
+    space = la.ArraySpace((matrix.shape[-1],), dtype=matrix.dtype)
+    return eigen.Eigenproblem(
+        la.FunctionLinearOperator(
+            lambda vector: matrix @ vector,
+            source=space,
+            target=space,
+            properties=_self_adjoint_properties(),
+        )
+    )
+
+
+def _matrix_free_generalized_problem(operator_matrix, metric_matrix, *, space=None):
+    space_ = (
+        la.ArraySpace((operator_matrix.shape[-1],), dtype=operator_matrix.dtype)
+        if space is None
+        else space
+    )
+    return eigen.GeneralizedEigenproblem(
+        la.FunctionLinearOperator(
+            lambda vector: operator_matrix @ vector,
+            source=space_,
+            target=space_,
+            properties=_self_adjoint_properties(),
+        ),
+        la.FunctionLinearOperator(
+            lambda vector: metric_matrix @ vector,
+            source=space_,
+            target=space_,
+            properties=_self_adjoint_properties(positive_definite=True),
+        ),
+    )
+
+
 def test_self_adjoint_spectrum_reuses_dense_state_and_refreshes_numeric_values():
     matrix = jnp.asarray(
         [
@@ -212,7 +246,13 @@ def test_projector_is_basis_invariant_for_repeated_internal_eigenvalues():
     assert subspace.diagnostics.idempotence_error < 1e-12
 
 
-def test_projector_derivatives_match_explicit_kernel_forward_reverse_and_finite_difference():
+@pytest.mark.parametrize(
+    "problem_factory",
+    (_standard_problem, _matrix_free_standard_problem),
+)
+def test_projector_derivatives_match_explicit_kernel_forward_reverse_and_finite_difference(
+    problem_factory,
+):
     matrix = jnp.asarray(
         [
             [1.0, 0.0, 0.1, 0.0],
@@ -234,7 +274,7 @@ def test_projector_derivatives_match_explicit_kernel_forward_reverse_and_finite_
 
     def projector(current):
         return eigen.self_adjoint_spectral_subspace(
-            _standard_problem(current),
+            problem_factory(current),
             selection,
             policy=policy,
         ).projector
@@ -244,7 +284,7 @@ def test_projector_derivatives_match_explicit_kernel_forward_reverse_and_finite_
         (matrix,),
         (perturbation,),
     )
-    prepared = eigen.prepare_self_adjoint_spectrum(_standard_problem(matrix))
+    prepared = eigen.prepare_self_adjoint_spectrum(problem_factory(matrix))
     explicit = eigen.self_adjoint_spectral_projector_derivative(
         prepared,
         selection,
@@ -319,7 +359,13 @@ def test_complex_hermitian_projector_derivative_is_cluster_safe_and_matches_fini
     assert jnp.allclose(tangent, finite_difference, rtol=3e-6, atol=3e-7)
 
 
-def test_generalized_projector_and_density_derivatives_include_metric_perturbations():
+@pytest.mark.parametrize(
+    "problem_factory",
+    (_generalized_problem, _matrix_free_generalized_problem),
+)
+def test_generalized_projector_and_density_derivatives_include_metric_perturbations(
+    problem_factory,
+):
     operator = jnp.diag(jnp.asarray([1.0, 4.0, 12.0, 28.0]))
     metric = jnp.diag(jnp.asarray([1.0, 2.0, 3.0, 4.0]))
     operator_perturbation = jnp.asarray(
@@ -343,7 +389,7 @@ def test_generalized_projector_and_density_derivatives_include_metric_perturbati
 
     def outputs(current_operator, current_metric):
         result = eigen.self_adjoint_spectral_subspace(
-            _generalized_problem(current_operator, current_metric),
+            problem_factory(current_operator, current_metric),
             selection,
             policy=policy,
         )
@@ -355,7 +401,7 @@ def test_generalized_projector_and_density_derivatives_include_metric_perturbati
         (operator_perturbation, metric_perturbation),
     )
     prepared = eigen.prepare_self_adjoint_spectrum(
-        _generalized_problem(operator, metric)
+        problem_factory(operator, metric)
     )
     explicit = eigen.self_adjoint_spectral_projector_derivative(
         prepared,

--- a/tests/unit/test_linalg_spectral_functions.py
+++ b/tests/unit/test_linalg_spectral_functions.py
@@ -52,6 +52,39 @@ def _generalized_problem(operator_matrix, metric_matrix):
     )
 
 
+def _matrix_free_standard_problem(matrix):
+    space = la.ArraySpace((matrix.shape[-1],), dtype=matrix.dtype)
+    return eigen.Eigenproblem(
+        la.FunctionLinearOperator(
+            lambda vector: matrix @ vector,
+            source=space,
+            target=space,
+            properties=_self_adjoint_properties(),
+        )
+    )
+
+
+def _matrix_free_generalized_problem(operator_matrix, metric_matrix):
+    space = la.ArraySpace(
+        (operator_matrix.shape[-1],),
+        dtype=operator_matrix.dtype,
+    )
+    return eigen.GeneralizedEigenproblem(
+        la.FunctionLinearOperator(
+            lambda vector: operator_matrix @ vector,
+            source=space,
+            target=space,
+            properties=_self_adjoint_properties(),
+        ),
+        la.FunctionLinearOperator(
+            lambda vector: metric_matrix @ vector,
+            source=space,
+            target=space,
+            properties=_self_adjoint_properties(positive_definite=True),
+        ),
+    )
+
+
 def test_polynomial_spectral_operator_matches_direct_matrix_polynomial_and_reuses_spectrum():
     matrix = jnp.asarray(
         [
@@ -141,7 +174,13 @@ def test_fermi_dirac_values_and_trainable_parameters_match_scalar_reference():
         eigen.FermiDiracSpectralFunction(jnp.asarray(0.0), jnp.asarray(0.0))
 
 
-def test_loewner_derivative_is_finite_at_repeated_eigenvalues_and_matches_finite_difference():
+@pytest.mark.parametrize(
+    "problem_factory",
+    (_standard_problem, _matrix_free_standard_problem),
+)
+def test_loewner_derivative_is_finite_at_repeated_eigenvalues_and_matches_finite_difference(
+    problem_factory,
+):
     matrix = jnp.asarray(
         [
             [1.0, 0.0, 0.1, 0.0],
@@ -164,7 +203,7 @@ def test_loewner_derivative_is_finite_at_repeated_eigenvalues_and_matches_finite
 
     def operator(current_matrix, current_coefficients):
         return eigen.self_adjoint_spectral_operator(
-            _standard_problem(current_matrix),
+            problem_factory(current_matrix),
             eigen.PolynomialSpectralFunction(current_coefficients),
             policy=policy,
         ).operator
@@ -216,7 +255,13 @@ def test_loewner_derivative_is_finite_at_repeated_eigenvalues_and_matches_finite
     )
 
 
-def test_generalized_loewner_derivative_and_density_include_metric_tangent():
+@pytest.mark.parametrize(
+    "problem_factory",
+    (_generalized_problem, _matrix_free_generalized_problem),
+)
+def test_generalized_loewner_derivative_and_density_include_metric_tangent(
+    problem_factory,
+):
     operator = jnp.diag(jnp.asarray([1.0, 4.0, 12.0, 28.0]))
     metric = jnp.diag(jnp.asarray([1.0, 2.0, 3.0, 4.0]))
     operator_tangent = jnp.asarray(
@@ -240,7 +285,7 @@ def test_generalized_loewner_derivative_and_density_include_metric_tangent():
 
     def outputs(current_operator, current_metric):
         result = eigen.self_adjoint_spectral_operator(
-            _generalized_problem(current_operator, current_metric),
+            problem_factory(current_operator, current_metric),
             function,
             policy=policy,
         )

--- a/tests/unit/test_linalg_svd.py
+++ b/tests/unit/test_linalg_svd.py
@@ -139,3 +139,29 @@ def test_singular_value_derivatives_require_nonzero_isolated_values():
                 ),
             ),
         )
+
+
+def test_matrix_free_singular_value_gradient_supports_closure_converted_operator():
+    policy = svd.SVDSolvePolicy(
+        count=2,
+        differentiation="singular-values",
+    )
+
+    def nuclear_norm(coefficient):
+        diagonal = jnp.stack((coefficient, jnp.asarray(3.0)))
+        space = la.ArraySpace((2,), dtype=diagonal.dtype)
+        operator = la.FunctionLinearOperator(
+            lambda vector: diagonal * vector,
+            source=space,
+            target=space,
+        )
+        return jnp.sum(
+            svd.svd(
+                svd.SVDProblem(operator),
+                policy=policy,
+            ).singular_values
+        )
+
+    gradient = jax.jit(jax.grad(nuclear_norm))(jnp.asarray(1.25))
+
+    assert jnp.allclose(gradient, 1.0, atol=1e-8)


### PR DESCRIPTION
## Summary

- move mixed-PyTree spectral derivative boundaries from raw JAX custom JVPs to Equinox filtered transforms
- replace duplicated neural initializer mathematics with configured `jax.nn.initializers`
- delegate mixed-tree inference mode and replicated model placement to their Equinox equivalents
- document the resulting matrix-free differentiation and initialization contracts

## Problem

Phydrax had several boundaries where a mathematical derivative accepted a full operator problem PyTree but used `jax.custom_jvp` and `jax.jvp`. This worked for dense operators whose differentiable structure was entirely array-valued, but failed for closure-converted `FunctionLinearOperator` values. Equinox closure conversion deliberately retains a `jaxpr` as a non-array leaf, which raw JAX transformations reject as an operand.

The neural initializer layer also duplicated JAX variance-scaling and orthogonal initializer implementations. The truncated-normal paths multiplied a unit truncated sample by the requested standard deviation without compensating for truncation, so their realized variance was below the named LeCun, He, and Glorot contracts. The orthogonal path always sampled and factorized a `max(in_size, out_size)` square matrix, even for strongly rectangular weights.

Two small utility wrappers independently reproduced Equinox behavior: Phydrax-only inference traversal and manual array-leaf replication.

## Filtered spectral derivatives

The singular-value, eigenvalue, projector, density-kernel, spectral-operator, and spectral-density derivative attachments now use `eqx.filter_custom_jvp` with `eqx.filter_jvp` inside their rules.

Key details:

- non-array callable, policy, shape, and closure-conversion leaves remain static instead of being presented to JAX as invalid operands
- absent problem or spectral-function tangents are materialized explicitly as zero arrays before entering numerical formulas
- the SVD differentiation conditional closes over the operator problem and passes only array-valued operands through `jax.lax.cond`
- the existing isolation, convergence, rank, selection-gap, domain, and failure-status contracts remain unchanged
- eigenvectors and singular vectors remain stopped; the change only repairs the declared mathematical scalar, projector, density, and Fréchet derivatives

This makes closure-converted matrix-free operators first-class inputs to the same JIT, JVP, and reverse-mode contracts already supported by dense operators.

## Initializer delegation

`phydrax.nn._initializers` now contains only configured JAX initializer factories:

- LeCun normal and uniform
- He/Kaiming normal and uniform
- Glorot/Xavier normal and uniform
- orthogonal

The factories declare `in_axis=1` and `out_axis=0` for Phydrax's `(out_size, in_size)` weight layout. Orthogonal initialization declares `column_axis=1`, allowing JAX to factor the smaller rectangular orientation rather than a max-dimension square sample.

All existing public initializer strings and aliases remain available. `Linear` now invokes the standard JAX initializer signature with `(key, shape)` while preserving key splitting, Random Weight Factorization, bias initialization, and weight transforms.

## Equinox utility reuse

- `phydrax.nn.layers.inference_mode` remains the public Phydrax entry point but delegates traversal to `eqx.nn.inference_mode`. Mixed Phydrax/Equinox model trees now switch every inference-aware leaf immutably rather than only Phydrax `Dropout` instances.
- `replicate_operator_model` remains the policy-aware public wrapper but delegates array placement to `eqx.filter_shard`, preserving non-array leaves and canonical Equinox filtering semantics.

## Compatibility and behavior changes

- Public signatures and import paths are unchanged.
- Existing serialized parameter values and model PyTree layouts are unchanged.
- Newly initialized truncated-normal and orthogonal weights change for identical random keys because they now follow JAX's named statistical contracts and rectangular algorithm.
- Inference traversal intentionally broadens to include Equinox inference-aware modules inside mixed trees.
- Operator-training checkpoint format version 2 remains unchanged.

The private HOFNO `_RMSNorm` implementation is deliberately retained. `eqx.nn.RMSNorm` has a different static/dynamic field layout, so replacing it would alter sequential Equinox checkpoint leaves and requires a separate checkpoint-version migration.

## Scope

This is a surgical reuse change, not a broad transform rewrite:

- raw JAX transforms remain in array-only paths where filtering adds no semantic value
- Phydrax `Linear`, `MLP`, `Sequential`, recurrent, attention, dropout, and operator architecture contracts remain intact
- no jaxmore dependency or copied wrapper layer is introduced
- no `StrictModule`, abstract-field, status-enum, serialization, or trainability redesign is included

## Documentation

The linear algebra API now states that closure-converted matrix-free problems participate in filtered singular-value, isolated-eigenvalue, projector, density-kernel, and spectral-function differentiation. Neural layer documentation records the JAX target-variance definitions, rectangular orthogonal behavior, and mixed-tree inference semantics. The changelog records each user-visible behavior change.