### PR TITLE
feat: add exact finite candidate search for MAP and control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Array-backed finite axes and lazy Cartesian products, exact streaming exhaustive reduction, deterministic finite MAP screening, exact finite control-catalog search, portable MAP candidate archives, and a dense-oracle benchmark harness; independently implemented with [Brutax](https://github.com/michael-0brien/brutax) acknowledged as design inspiration.
 - Typed preconditioner builders, prepared actions, planning costs, refresh provenance, and materialization-aware resource rejection.
 - Additive and multiplicative subspace correction, Chebyshev smoothing, block factorization, and immutable multigrid hierarchy preparation.
 - Native fixed-capacity BlockGMRES and BlockCG with explicit right-hand-side layouts, shared-subspace diagnostics, and block-aware differentiation.

--- a/docs/api/control.md
+++ b/docs/api/control.md
@@ -1,9 +1,10 @@
 # Control
 
 `phydrax.control` provides finite-horizon control problem contracts, linear-system
-analysis, and local or bounded-search solvers. The common contract keeps physical time,
-case axes, validity, status, and numerical provenance explicit. It does not clip inputs,
-repair infeasible iterates, change methods after failure, or hide a fallback.
+analysis, and local, exact finite-catalog, or bounded stochastic solvers. The common
+contract keeps physical time, case axes, validity, status, and numerical provenance
+explicit. It does not clip inputs, repair infeasible iterates, change methods after
+failure, or hide a fallback.
 
 ## Choosing a path
 
@@ -16,7 +17,8 @@ repair infeasible iterates, change methods after failure, or hide a fallback.
 | Receding-horizon affine control | `solve_receding_horizon_mpc` | Re-solves canonical QPs and records every subproblem result and exact state handoff. |
 | One unconstrained nonlinear case | `solve_ilqr` | iLQR with a fixed requested regularization and explicit line-search or curvature failure. |
 | One constrained nonlinear case | `solve_multiple_shooting` | Dense SQP with independent state nodes, exact defect accounting, and sampled path constraints. |
-| A bounded initializer | `search_control` | Finite differential-evolution search; returns the best candidate found, never a global-optimality claim. |
+| An explicit finite control catalog | `search_control_candidates` | Exact minimum over the declared coefficient arrays; retains invalidity, index, signature, and winner-reconstruction evidence. |
+| A bounded stochastic initializer | `search_control` | Differential evolution over a continuous coefficient box; returns the best candidate found, never a global-optimality claim. |
 
 ## Shared axes, callbacks, and provenance
 
@@ -411,7 +413,58 @@ constraints remain sample-node checks and do not certify feasibility between nod
 
 ::: phydrax.control.solve_multiple_shooting
 
-## Bounded global initialization
+## Exact finite control catalogs
+
+`search_control_candidates` evaluates an explicit catalog of complete coefficient
+arrays. The candidate point shape must be exactly
+`case_shape + parameterization.parameter_shape`. Use one correlated `FiniteAxis` so
+that each catalog row remains one complete coefficient array; the adapter deliberately
+rejects a Cartesian product of individual coefficient entries.
+
+```python
+catalog = phx.optim.FiniteProductSpace(
+    phx.optim.FiniteAxis(
+        jnp.asarray(
+            [
+                [[0.0], [0.0]],
+                [[0.5], [0.5]],
+                [[1.0], [0.0]],
+            ]
+        )
+    )
+)
+selected = phx.control.search_control_candidates(
+    problem,
+    parameterization,
+    catalog,
+    search=phx.optim.FiniteExhaustiveSearch(batch_size=2),
+)
+```
+
+Each search evaluation performs the ordinary rollout, sampled cost, and sampled
+feasibility contracts. The scalar catalog score is the sum of `sampled_loss.total`
+across all cases. A candidate is selectable only when every case has a successful
+rollout, every sampled constraint is feasible, and the total score is finite.
+
+The search kernel retains only objective, validity, and index evidence. When a valid
+winner exists, the adapter reconstructs that coefficient array and performs one
+additional full evaluation to return its native `ControlResult` and
+`ControlTrajectory`. Consequently, `objective_evaluations == candidate_count`,
+`winner_evaluations` is one or zero, and `total_control_evaluations` is their sum.
+When all candidates are invalid, no coefficients, evaluation, trajectory, or control
+ID are fabricated; accessing `trajectory` or `controls` raises.
+
+The guarantee is exact only over the declared catalog. Sampled feasibility remains a
+sample-site statement, and a winning piecewise or spline parameterization does not
+certify behavior between those sites.
+
+::: phydrax.control.ControlCandidateSearchResult
+
+---
+
+::: phydrax.control.search_control_candidates
+
+## Bounded stochastic initialization
 
 `search_control` combines a `ControlProblem`, any public control parameterization, and a
 `phydrax.optim.DifferentialEvolutionSearch`. `CoefficientBounds` is the public pair

--- a/docs/api/export.md
+++ b/docs/api/export.md
@@ -45,6 +45,11 @@ whose arrays can be inspected without reconstructing the model. This is distinct
 ONNX deployment: the archive preserves inference output and provenance, not an
 executable solver.
 
+Finite MAP candidate archives use kind `map_candidate_search`. They retain selected
+position/parameters when valid and always retain finite-space layout, signature,
+batching, method identity, exact evaluation counts, and explicit all-invalid evidence.
+The live posterior problem and search configuration object are listed as excluded.
+
 Bellman archives retain filtered modes, local covariances and information matrices,
 curvature diagnostics, optimizer results, status masks, and cumulative
 pseudo-log-likelihood. Rao--Blackwellized full-smoother archives retain nonlinear

--- a/docs/api/optim.md
+++ b/docs/api/optim.md
@@ -11,6 +11,98 @@ Phydrax does not mirror upstream Optax, Evosax, or Optimistix APIs. Import those
 from their native packages. A workflow accepts an external optimizer only when it has an
 explicit adapter for that optimizer family.
 
+## Finite exhaustive search
+
+`FiniteAxis` and `FiniteProductSpace` represent an explicit, array-backed finite
+candidate set. A `FiniteAxis` stores one correlated catalog: every array leaf has the
+same nonempty leading candidate dimension, while all trailing dimensions remain one
+candidate payload. Use separate axes only for choices that should form a Cartesian
+product.
+
+!!! example
+    ```python
+    import jax.numpy as jnp
+    import phydrax as phx
+
+
+    # One correlated catalog of complete two-coefficient choices.
+    coefficient_catalog = phx.optim.FiniteProductSpace(
+        phx.optim.FiniteAxis(
+            jnp.asarray(
+                [
+                    [0.0, 0.0],
+                    [0.5, 0.5],
+                    [1.0, 0.0],
+                ]
+            )
+        )
+    )
+
+    # Two independent coordinate catalogs; this space has 3 × 2 candidates.
+    coordinate_product = phx.optim.FiniteProductSpace(
+        {
+            "offset": phx.optim.FiniteAxis(jnp.asarray([-1.0, 0.0, 1.0])),
+            "slope": phx.optim.FiniteAxis(jnp.asarray([0.0, 2.0])),
+        }
+    )
+    assert coordinate_product.product_shape == (3, 2)
+    assert coordinate_product.size == 6
+    ```
+
+The product is lazy: Phydrax stores the axis arrays, not a materialized Cartesian
+candidate tensor. Candidate order follows deterministic JAX PyTree path order and the
+last axis varies fastest. `ravel_index`, `unravel_index`, and `take` use this same
+row-major convention. Checked public indexing rejects negative and oversized indices;
+it never clips them. `signature()` hashes axis paths, grouping, shapes, dtypes, and
+candidate bytes for content-sensitive provenance.
+
+`FiniteExhaustiveSearch` configures exact enumeration for domain adapters such as
+`phydrax.uq.search_map_candidates` and
+`phydrax.control.search_control_candidates`. `batch_size=None` uses scalar streaming.
+A positive batch size evaluates complete batches plus one exact-size remainder, so no
+candidate is padded, repeated, or omitted. Every declared candidate is evaluated
+exactly once. Invalid or nonfinite values are excluded before reduction, and equal
+finite values select the lowest flat index deterministically.
+
+The guarantee is the minimum over the declared finite set. It is not a certificate of
+continuous global optimality, an integration method, or a marginalization rule.
+Selection is discrete and gradients are stopped through the selected index and
+reconstructed candidate. The current execution kernel is single-device; it makes no
+GPU, TPU, or distributed-sharding scaling claim.
+
+Factorized storage avoids materializing a candidate landscape, but it cannot remove
+Cartesian growth. If axis lengths are `n₁, …, nₖ`, the evaluator still runs
+`n₁ × ⋯ × nₖ` times. Batch size trades transient candidate/output storage for
+throughput. Candidate payloads remain correlated within an axis; split them only when
+the full cross product is intended.
+
+Run the factorized-streaming and bounded dense-oracle benchmark with:
+
+```bash
+python tools/finite_search_benchmarks.py \
+    --axes 3 --axis-length 16 --batch-size 64
+```
+
+The JSON report records candidate cardinality, stored and estimated dense bytes,
+compilation and steady execution time, compiler-reported memory, exact evaluation
+counts, and selected value/index agreement. Dense materialization is skipped when its
+estimate exceeds `--max-dense-bytes`.
+
+The array-backed lazy-product pattern was independently implemented after reviewing
+[Brutax](https://github.com/michael-0brien/brutax) as design inspiration. Phydrax does
+not depend on Brutax; its reducer, validity, evidence, provenance, domain adapters, and
+result contracts are Phydrax-owned.
+
+::: phydrax.optim.FiniteAxis
+
+---
+
+::: phydrax.optim.FiniteProductSpace
+
+---
+
+::: phydrax.optim.FiniteExhaustiveSearch
+
 ## Riemannian optimization
 
 `ParameterGeometry` binds complete trainable PyTree leaves to explicit

--- a/docs/api/phydrax.md
+++ b/docs/api/phydrax.md
@@ -19,8 +19,9 @@ Top-level package namespace. Most functionality lives in subpackages:
   factorizations, and private Lineax iterative backends
 - `phydrax.special`: JAX-native named special functions and integral primitives
 - `phydrax.enforcement`: exact condition transforms and enforcement programs
-- `phydrax.optim`: structured residual KFAC and domain-neutral optimization
-  configurations consumed by bounded geometry and posterior workflows
+- `phydrax.optim`: finite candidate products and exhaustive search, structured
+  residual KFAC, and domain-neutral optimization configurations consumed by
+  geometry, posterior, and control workflows
 - `phydrax.nn`: neural network components and structured models
 - `phydrax.ml`: case-aware native machine-learning batches, fitted models,
   workflows, model selection, metrics, inspection, and artifact interoperability

--- a/docs/api/uq/index.md
+++ b/docs/api/uq/index.md
@@ -10,9 +10,10 @@ score gradients, matrix-free Fisher and Gauss--Newton actions, empirical directi
 and guarded information-design objectives.
 
 The same namespace also provides explicit exact and factorized posterior problems,
-bounded global and gradient-based local MAP optimization, BlackJAX NUTS/HMC,
-fixed-step SGLD/SGNHT with control variates, flow-assisted NUTS, Pathfinder, adaptive
-tempered SMC, dense and structured Laplace approximations, exact, sparse, and
+deterministic finite-candidate screening, bounded stochastic and gradient-based local
+MAP optimization, BlackJAX NUTS/HMC, fixed-step SGLD/SGNHT with control variates,
+flow-assisted NUTS, Pathfinder, adaptive tempered SMC, dense and structured Laplace
+approximations, exact, sparse, and
 correlated-output Gaussian-process model discrepancy, predictive fields, coherent
 stochastic models, likelihoods and proper scores, first-order covariance propagation,
 normalized errors-in-variables inference, conformal calibration, and uncertain-input

--- a/docs/api/uq/inference.md
+++ b/docs/api/uq/inference.md
@@ -455,11 +455,79 @@ The exported composition typing contracts are
 
 ## MAP estimation
 
-`search_map` performs bounded stochastic global initialization in unconstrained
-posterior-position coordinates. It evaluates the complete
-`PosteriorProblem.negative_log_density`, preserves the population and exact
-accounting, and never interprets that population as posterior samples. Local
+`search_map_candidates` performs deterministic screening over an explicitly declared
+finite set of unconstrained posterior positions. Candidate points must exactly match
+`PosteriorProblem.initial_position` in PyTree structure, trailing leaf shapes, and leaf
+dtypes. One `FiniteAxis` may hold complete correlated positions; multiple axes form a
+Cartesian product of independently chosen position blocks.
+
+!!! example
+    ```python
+    import jax.numpy as jnp
+    import phydrax as phx
+
+
+    parameter_space = phx.uq.ParameterSpace(
+        jnp.zeros((2,)),
+        log_prior=lambda _: jnp.zeros(()),
+    )
+    problem = phx.uq.PosteriorProblem(
+        parameter_space,
+        lambda value: -jnp.sum((value - jnp.asarray([1.2, 2.2])) ** 2),
+    )
+    candidates = phx.optim.FiniteProductSpace(
+        phx.optim.FiniteAxis(
+            jnp.asarray(
+                [
+                    [-2.0, -2.0],
+                    [1.0, 2.0],
+                    [3.0, 3.0],
+                ]
+            )
+        )
+    )
+
+    screened = phx.uq.search_map_candidates(
+        problem,
+        candidates,
+        search=phx.optim.FiniteExhaustiveSearch(batch_size=2),
+    )
+    if not screened.valid:
+        raise RuntimeError(screened.termination_reason)
+
+    # Optional continuous local refinement; a separate numerical claim.
+    local = phx.uq.find_map(problem, screened.position)
+    ```
+
+Each candidate is evaluated once with the complete
+`PosteriorProblem.negative_log_density`, including likelihood, prior, bijector
+Jacobian, and any parameter-space transformation. The selected constrained
+`parameters` are reconstructed only after the finite reduction. A valid result reports
+the exact finite minimum, flat and per-axis indices, deterministic axis paths,
+candidate signature, and exact attempted/valid/invalid counts. If every candidate is
+invalid or nonfinite, `valid=False`, `position=None`, `parameters=None`, indices are
+`-1`, and objective and log density are `NaN`; no arbitrary candidate is returned.
+
+Selection is nondifferentiable and the winning position is detached. Use the finite
+result as a deterministic coarse initializer only when a subsequent call to `find_map`
+is required. The finite guarantee does not extend to positions outside the catalog.
+`export_result` stores both valid and all-invalid candidate-search evidence as
+`map_candidate_search`, excluding the live `PosteriorProblem` and search object while
+retaining method, layout, signature, and count provenance.
+
+`search_map` remains the bounded stochastic differential-evolution initializer in
+unconstrained posterior-position coordinates. It preserves the population and exact
+accounting, but never interprets that population as posterior samples. Local
 stationarity remains a separate `find_map` phase.
+
+::: phydrax.uq.search_map_candidates
+
+---
+
+::: phydrax.uq.MAPCandidateSearchResult
+
+---
+
 
 ::: phydrax.uq.search_map
 

--- a/docs/cookbook/control.md
+++ b/docs/cookbook/control.md
@@ -234,7 +234,7 @@ SQP method with explicit Hessian and QP regularization, dense guard, defect audi
 failure statuses. Its nonlinear path constraints are still enforced only at the declared
 nodes; neither it nor `ControlProblem.evaluate` certifies feasibility between nodes.
 
-## B-spline controls and bounded global initialization
+## B-spline controls, finite catalogs, and bounded initialization
 
 Choose a piecewise-constant parameterization for discrete interval controls and direct
 local seeds, piecewise-linear controls for continuous nodal interpolation, or a B-spline
@@ -256,6 +256,29 @@ spline = phx.control.BSplineControlParameterization(
 lower = -2.0 * jnp.ones(spline.parameter_shape)
 upper = 2.0 * jnp.ones(spline.parameter_shape)
 initial = jnp.zeros(spline.parameter_shape)
+
+# Exact selection when the complete coefficient choices are known.
+catalog = phx.optim.FiniteProductSpace(
+    phx.optim.FiniteAxis(
+        jnp.stack(
+            (
+                initial,
+                0.5 * jnp.ones(spline.parameter_shape),
+                -0.5 * jnp.ones(spline.parameter_shape),
+            )
+        )
+    )
+)
+catalog_seed = phx.control.search_control_candidates(
+    problem,
+    spline,
+    catalog,
+    search=phx.optim.FiniteExhaustiveSearch(batch_size=2),
+)
+if not catalog_seed.valid:
+    raise RuntimeError(catalog_seed.termination_reason)
+
+# Differential evolution instead searches a bounded continuous coefficient box.
 
 search = phx.optim.DifferentialEvolutionSearch(
     16,
@@ -300,12 +323,18 @@ refined = spline.refine(
 local_from_global = phx.control.solve_ilqr(problem, global_seed.controls)
 ```
 
+`catalog_seed` certifies the exact minimum only among the three declared coefficient
+arrays. It records three search evaluations and one separate winner reconstruction;
+it does not retain three trajectories. Inspect its invalid count, selected flat index,
+candidate signature, and `total_control_evaluations`.
+
 Inspect `refined.transfer.method`, `condition_estimate`, and
 `projection_error_bound`; an L2 transfer is an approximation, while the nested,
-equal-degree refinement above is exact. The bounded search records its key, design
-signature, population, best-objective history, invalid count, termination reason, and all
-problem and approximation IDs. `population_converged` measures population dispersion.
-Neither it nor the best objective proves global optimality or basin coverage.
+equal-degree refinement above is exact. The bounded stochastic search records its key,
+design signature, population, best-objective history, invalid count, termination
+reason, and all problem and approximation IDs. `population_converged` measures
+population dispersion. Neither it nor the best objective proves global optimality or
+basin coverage.
 
 ## Failure and certification rules
 
@@ -320,5 +349,5 @@ Neither it nor the best objective proves global optimality or basin coverage.
 - Dense Lyapunov and Gramian routines default to `max_dimension=128`; dense QP-based
   routines default to `max_dense_dimension=512`. Use matrix-free actions or a different
   formulation rather than bypassing a guard accidentally.
-- Bounded differential evolution is an initializer or best-found finite search, not a
-  globally optimal control certificate.
+- Bounded differential evolution is a stochastic initializer or best-found bounded
+  search, not a globally optimal control certificate.

--- a/docs/guides_uncertainty.md
+++ b/docs/guides_uncertainty.md
@@ -1082,10 +1082,46 @@ domain-specific query arguments.
 
 ## MAP estimation
 
-### Bounded global initialization
+### Deterministic finite screening
 
-`search_map` minimizes `PosteriorProblem.negative_log_density(...)` over an explicit
-finite box when the posterior is multimodal, nonsmooth, or poorly served by one local
+Use `search_map_candidates` when prior scientific knowledge supplies a finite set of
+complete modes, phase/model cases, or low-dimensional coordinate choices:
+
+```python
+candidate_space = phx.optim.FiniteProductSpace(
+    phx.optim.FiniteAxis(
+        jnp.asarray(
+            [
+                [-2.0, -1.0],
+                [0.5, 1.5],
+                [2.0, 3.0],
+            ]
+        )
+    )
+)
+screened_mode = phx.uq.search_map_candidates(
+    posterior,
+    candidate_space,
+    search=phx.optim.FiniteExhaustiveSearch(batch_size=64),
+)
+```
+
+Candidate values are unconstrained posterior positions. A correlated axis chooses a
+complete position jointly; separate axes produce a Cartesian product. The adapter
+evaluates the full posterior objective once per candidate and returns deterministic
+first-index ties, exact invalid counts, product indices, and a content-sensitive
+candidate signature. It returns no position when every candidate is invalid. Its
+claim is exact only over the declared finite set, not over the surrounding continuous
+parameter space.
+
+Pass `screened_mode.position` explicitly to `find_map` for continuous local
+refinement. This second phase can improve the objective, but changes the numerical
+claim from exact finite selection to local stationarity.
+
+### Bounded stochastic initialization
+
+`search_map` minimizes `PosteriorProblem.negative_log_density(...)` over a bounded
+continuous box when the posterior is multimodal, nonsmooth, or poorly served by one local
 initialization. The box is defined in the `ParameterSpace`'s unconstrained position
 coordinates, not in physical parameter coordinates. Lower and upper bounds must be
 PyTrees matching `space.initial`; a scalar bound may broadcast only within its
@@ -1138,9 +1174,9 @@ mode = phx.uq.find_map(
 )
 ```
 
-`search_map` never runs L-BFGS or Laplace implicitly. This keeps the global
-population criterion, local gradient criterion, extra evaluations, and failure modes
-separate and observable.
+`search_map_candidates` and `search_map` never run L-BFGS or Laplace implicitly.
+This keeps finite selection or the global population criterion, the local gradient
+criterion, extra evaluations, and failure modes separate and observable.
 
 `MAPResult.compilation_seconds`, `execution_seconds`, and `mean_step_seconds`
 separate compiler cost from numerical optimization. Repeated problems reuse the
@@ -1615,7 +1651,10 @@ portable = phx.uq.read_result_archive(result_path)
 Both are ZIP containers with JSON metadata, individual NumPy array members,
 SHA-256 checksums, atomic replacement, and no pickle or Python object arrays.
 Portable archives export representable result arrays and explicitly list excluded
-live callables. `MAPSearchResult` archives retain the reconstructed best position,
+live callables. `MAPCandidateSearchResult` archives retain the selected position,
+parameters, objective, exact finite-set indices and counts, batching, method identity,
+and candidate signature; all-invalid archives retain the failure evidence without
+inventing a winner. `MAPSearchResult` archives retain the reconstructed best position,
 full final population, resolved bounds, deterministic key, convergence history,
 search configuration, design provenance, and exact evaluation accounting.
 `FlowNUTSResult` archives include frozen flow parameters, loss histories, local and
@@ -1967,21 +2006,23 @@ returning every exact failure rather than a generic warning.
 
 Phydrax currently recommends:
 
-1. NUTS for low-dimensional, effectively unimodal physical inverse problems.
-2. Flow-assisted NUTS for represented multimodality or nonlinear global geometry at
+1. Exact finite candidate screening for known low-dimensional mode catalogs, followed
+   by explicit local MAP refinement when continuous stationarity is required.
+2. NUTS for low-dimensional, effectively unimodal physical inverse problems.
+3. Flow-assisted NUTS for represented multimodality or nonlinear global geometry at
    moderate dimension; initialize chains across known modes and inspect exact global
    acceptance and ordinary rank diagnostics.
-3. Exact dense Laplace as the small-problem Gaussian reference.
-4. Whitened GGN, diagonal, or low-rank Laplax for selected larger subspaces.
-5. EKI for derivative-free physical or reduced-coordinate inverse problems,
+4. Exact dense Laplace as the small-problem Gaussian reference.
+5. Whitened GGN, diagonal, or low-rank Laplax for selected larger subspaces.
+6. EKI for derivative-free physical or reduced-coordinate inverse problems,
    benchmarked against NUTS or Laplace where feasible.
-6. Pathfinder for rapid local diagnostics, always benchmarked against NUTS.
-7. Tempered SMC for low-dimensional mode discovery and evidence estimation.
-8. Fixed-step SGLD, optionally with an exact-center control variate, for large
+7. Pathfinder for rapid local diagnostics, always benchmarked against NUTS.
+8. Tempered SMC for low-dimensional mode discovery and evidence estimation.
+9. Fixed-step SGLD, optionally with an exact-center control variate, for large
    uniformly factorized likelihoods after step-halving and exact-reference checks.
    Use SGNHT only when its momentum/thermostat dynamics improve measured mixing.
-9. Deep ensembles for independently trained neural-model epistemic variation.
-10. Exact GP discrepancy for moderate scalar data; explicit ICM/LMC for correlated
+10. Deep ensembles for independently trained neural-model epistemic variation.
+11. Exact GP discrepancy for moderate scalar data; explicit ICM/LMC for correlated
     heterotopic outputs; functional GP blocks for value/operator data; exact
     finite-feature factors when the covariance has declared finite rank; and FITC
     only when dense scaling fails a measured workload.

--- a/phydrax/control/__init__.py
+++ b/phydrax/control/__init__.py
@@ -4,6 +4,10 @@
 
 """Optimal-control problems, dynamics, parameterizations, and diagnostics."""
 
+from ._candidate_search import (
+    ControlCandidateSearchResult,
+    search_control_candidates,
+)
 from ._constraints import (
     evaluate_sampled_feasibility,
     PathConstraint,
@@ -179,6 +183,7 @@ __all__ = [
     "CONTROL_SUCCESS",
     "ControlSystemType",
     "CoefficientBounds",
+    "ControlCandidateSearchResult",
     "ControlProblem",
     "ControlResult",
     "ControlSearchResult",
@@ -263,6 +268,7 @@ __all__ = [
     "linearize_differential_dynamics",
     "linearize_discrete_dynamics",
     "search_control",
+    "search_control_candidates",
     "solve_continuous_are",
     "solve_continuous_lyapunov",
     "solve_continuous_lyapunov_krylov",

--- a/phydrax/control/_candidate_search.py
+++ b/phydrax/control/_candidate_search.py
@@ -1,0 +1,319 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from typing import Any
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jaxtyping import Array, ArrayLike
+
+from .._strict import StrictModule
+from ..optim import FiniteAxis, FiniteExhaustiveSearch, FiniteProductSpace
+from ..optim._finite import _exhaustive_minimum
+from ._global_search import _evaluate_control
+from ._parameterization import AbstractControlParameterization
+from ._problem import ControlProblem
+from ._trajectory import ControlResult, ControlTrajectory
+
+
+_CONTROL_CANDIDATE_METHOD_ID = "finite-exhaustive-control-candidate-search-v1"
+_DEFAULT_FINITE_SEARCH = FiniteExhaustiveSearch()
+
+
+class _ControlCandidateEvaluator(StrictModule):
+    problem: ControlProblem
+    parameterization: AbstractControlParameterization
+    solver_options: dict[str, Any]
+
+    def __init__(
+        self,
+        problem: ControlProblem,
+        parameterization: AbstractControlParameterization,
+        solver_options: dict[str, Any],
+        /,
+    ):
+        self.problem = problem
+        self.parameterization = parameterization
+        self.solver_options = solver_options
+
+    def __call__(self, coefficients: Array, /) -> tuple[Array, Array]:
+        result = _evaluate_control(
+            self.problem,
+            self.parameterization,
+            coefficients,
+            self.solver_options,
+        )
+        objective = jnp.sum(result.sampled_loss.total)
+        valid = (
+            jnp.all(result.successful)
+            & jnp.all(result.feasibility.feasible)
+            & jnp.isfinite(objective)
+        )
+        return objective, valid
+
+
+class ControlCandidateSearchResult(StrictModule):
+    """Exact finite control-catalog minimum and rollout evidence."""
+
+    problem: ControlProblem
+    parameterization: AbstractControlParameterization
+    evaluation: ControlResult | None
+    coefficients: Array | None
+    objective: Array
+    search: FiniteExhaustiveSearch
+    valid: bool = eqx.field(static=True)
+    termination_reason: str = eqx.field(static=True)
+    flat_index: int = eqx.field(static=True)
+    product_index: tuple[int, ...] = eqx.field(static=True)
+    axis_paths: tuple[str, ...] = eqx.field(static=True)
+    product_shape: tuple[int, ...] = eqx.field(static=True)
+    candidate_count: int = eqx.field(static=True)
+    objective_evaluations: int = eqx.field(static=True)
+    valid_evaluations: int = eqx.field(static=True)
+    invalid_candidates: int = eqx.field(static=True)
+    winner_evaluations: int = eqx.field(static=True)
+    effective_batch_size: int = eqx.field(static=True)
+    candidate_signature: str = eqx.field(static=True)
+    problem_id: str = eqx.field(static=True)
+    dynamics_id: str = eqx.field(static=True)
+    time_id: str = eqx.field(static=True)
+    control_id: str | None = eqx.field(static=True)
+    parameterization_id: str = eqx.field(static=True)
+    approximation_id: str = eqx.field(static=True)
+    result_id: str = eqx.field(static=True)
+    method_id: str = eqx.field(static=True)
+    control_shape: tuple[int, ...] = eqx.field(static=True)
+    case_shape: tuple[int, ...] = eqx.field(static=True)
+    parameter_shape: tuple[int, ...] = eqx.field(static=True)
+    coefficient_shape: tuple[int, ...] = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        problem: ControlProblem,
+        parameterization: AbstractControlParameterization,
+        evaluation: ControlResult | None,
+        coefficients: Array | None,
+        objective: ArrayLike,
+        search: FiniteExhaustiveSearch,
+        valid: bool,
+        flat_index: int,
+        product_index: tuple[int, ...],
+        axis_paths: tuple[str, ...],
+        product_shape: tuple[int, ...],
+        candidate_count: int,
+        objective_evaluations: int,
+        invalid_candidates: int,
+        winner_evaluations: int,
+        effective_batch_size: int,
+        candidate_signature: str,
+    ):
+        valid_ = bool(valid)
+        complete_winner = evaluation is not None and coefficients is not None
+        if valid_ != complete_winner:
+            raise ValueError(
+                "A valid control candidate result requires coefficients and evaluation."
+            )
+        evaluations = int(objective_evaluations)
+        invalid = int(invalid_candidates)
+        winner_count = int(winner_evaluations)
+        if evaluations != int(candidate_count):
+            raise ValueError(
+                "Control candidate evaluation count must equal candidate_count."
+            )
+        if invalid < 0 or invalid > evaluations:
+            raise ValueError("invalid_candidates must lie within the evaluation count.")
+        if winner_count != int(valid_):
+            raise ValueError("winner_evaluations must be one exactly when valid.")
+
+        if valid_:
+            if flat_index < 0 or any(index < 0 for index in product_index):
+                raise ValueError("Valid control candidate indices must be nonnegative.")
+            coefficients_ = jnp.asarray(coefficients)
+            objective_ = jnp.asarray(objective, dtype=float).reshape(())
+            termination_reason = "finite_minimum"
+            assert evaluation is not None
+            control_id = evaluation.trajectory.control_id
+        else:
+            if flat_index != -1 or any(index != -1 for index in product_index):
+                raise ValueError(
+                    "Invalid control candidate indices must use -1 sentinels."
+                )
+            coefficients_ = None
+            objective_ = jnp.asarray(jnp.nan, dtype=float)
+            termination_reason = "no_finite_candidates"
+            control_id = None
+
+        self.problem = problem
+        self.parameterization = parameterization
+        self.evaluation = evaluation
+        self.coefficients = coefficients_
+        self.objective = objective_
+        self.search = search
+        self.valid = valid_
+        self.termination_reason = termination_reason
+        self.flat_index = int(flat_index)
+        self.product_index = tuple(int(index) for index in product_index)
+        self.axis_paths = tuple(str(path) for path in axis_paths)
+        self.product_shape = tuple(int(size) for size in product_shape)
+        self.candidate_count = int(candidate_count)
+        self.objective_evaluations = evaluations
+        self.valid_evaluations = evaluations - invalid
+        self.invalid_candidates = invalid
+        self.winner_evaluations = winner_count
+        self.effective_batch_size = int(effective_batch_size)
+        self.candidate_signature = str(candidate_signature)
+        self.problem_id = problem.problem_id
+        self.dynamics_id = problem.dynamics.dynamics_id
+        self.time_id = problem.time_grid.time_id
+        self.control_id = control_id
+        self.parameterization_id = parameterization.parameterization_id
+        self.approximation_id = parameterization.approximation_id
+        self.result_id = (
+            f"control-candidate-search:{problem.problem_id}:"
+            f"{parameterization.parameterization_id}:{candidate_signature}"
+        )
+        self.method_id = _CONTROL_CANDIDATE_METHOD_ID
+        self.control_shape = parameterization.control_shape
+        self.case_shape = problem.case_shape
+        self.parameter_shape = parameterization.parameter_shape
+        self.coefficient_shape = problem.case_shape + parameterization.parameter_shape
+
+    @property
+    def total_control_evaluations(self) -> int:
+        """Return search evaluations plus full winner reconstruction."""
+        return self.objective_evaluations + self.winner_evaluations
+
+    @property
+    def successful(self) -> Array:
+        """Whether the selected candidate has a valid feasible rollout."""
+        if self.evaluation is None:
+            return jnp.asarray(False)
+        return (
+            jnp.all(self.evaluation.successful)
+            & jnp.all(self.evaluation.feasibility.feasible)
+            & jnp.isfinite(self.objective)
+        )
+
+    @property
+    def trajectory(self) -> ControlTrajectory:
+        """Return the selected trajectory or reject an all-invalid search."""
+        if self.evaluation is None:
+            raise RuntimeError("Control candidate search has no valid trajectory.")
+        return self.evaluation.trajectory
+
+    @property
+    def controls(self) -> Array:
+        """Return the selected sampled controls."""
+        return self.trajectory.controls
+
+
+def _validate_control_candidate_space(
+    problem: ControlProblem,
+    parameterization: AbstractControlParameterization,
+    candidates: FiniteProductSpace,
+    /,
+) -> None:
+    if parameterization.control_shape != problem.control_shape:
+        raise ValueError(
+            "Control parameterization control_shape does not match the problem."
+        )
+    candidate_spec = candidates.point_spec()
+    if not isinstance(candidate_spec, jax.ShapeDtypeStruct):
+        raise ValueError(
+            "Control candidate points must be one coefficient array; use one "
+            "correlated FiniteAxis catalog."
+        )
+    expected_shape = problem.case_shape + parameterization.parameter_shape
+    if tuple(candidate_spec.shape) != expected_shape:
+        raise ValueError(
+            f"Control candidate points must have coefficient shape {expected_shape}, "
+            f"got {candidate_spec.shape}."
+        )
+    if not np.issubdtype(np.dtype(candidate_spec.dtype), np.floating):
+        raise TypeError("Control candidate coefficients must be real floating-point.")
+
+    axis_blocks = jax.tree_util.tree_leaves(
+        candidates.axes,
+        is_leaf=lambda value: isinstance(value, FiniteAxis),
+    )
+    for axis in axis_blocks:
+        for values in jax.tree_util.tree_leaves(axis.values):
+            if not jnp.issubdtype(values.dtype, jnp.floating):
+                raise TypeError(
+                    "Control candidate coefficients must be real floating-point."
+                )
+            if bool(jnp.any(~jnp.isfinite(values))):
+                raise ValueError("Control candidate coefficients must be finite.")
+
+
+def search_control_candidates(
+    problem: ControlProblem,
+    parameterization: AbstractControlParameterization,
+    candidates: FiniteProductSpace,
+    /,
+    *,
+    search: FiniteExhaustiveSearch = _DEFAULT_FINITE_SEARCH,
+    **solver_options: Any,
+) -> ControlCandidateSearchResult:
+    """Find the exact feasible minimum over a declared control catalog."""
+    if not isinstance(problem, ControlProblem):
+        raise TypeError("problem must be a ControlProblem.")
+    if not isinstance(parameterization, AbstractControlParameterization):
+        raise TypeError(
+            "parameterization must implement AbstractControlParameterization."
+        )
+    if not isinstance(candidates, FiniteProductSpace):
+        raise TypeError("candidates must be a FiniteProductSpace.")
+    if not isinstance(search, FiniteExhaustiveSearch):
+        raise TypeError("search must be a FiniteExhaustiveSearch.")
+    _validate_control_candidate_space(problem, parameterization, candidates)
+
+    options = dict(solver_options)
+    evidence = _exhaustive_minimum(
+        _ControlCandidateEvaluator(problem, parameterization, options),
+        candidates,
+        search,
+    )
+    valid = bool(evidence.valid)
+    flat_index = int(evidence.flat_index) if valid else -1
+    product_index = (
+        tuple(int(index) for index in evidence.product_index)
+        if valid
+        else (-1,) * len(candidates.product_shape)
+    )
+    coefficients = jax.lax.stop_gradient(candidates.take(flat_index)) if valid else None
+    evaluation = (
+        _evaluate_control(problem, parameterization, coefficients, options)
+        if coefficients is not None
+        else None
+    )
+    signature = candidates.signature()
+
+    return ControlCandidateSearchResult(
+        problem=problem,
+        parameterization=parameterization,
+        evaluation=evaluation,
+        coefficients=coefficients,
+        objective=evidence.minimum,
+        search=search,
+        valid=valid,
+        flat_index=flat_index,
+        product_index=product_index,
+        axis_paths=candidates.axis_paths,
+        product_shape=candidates.product_shape,
+        candidate_count=candidates.size,
+        objective_evaluations=int(evidence.attempted_evaluations),
+        invalid_candidates=int(evidence.invalid_evaluations),
+        winner_evaluations=int(valid),
+        effective_batch_size=search.effective_batch_size(candidates.size),
+        candidate_signature=signature,
+    )
+
+
+__all__ = ["ControlCandidateSearchResult", "search_control_candidates"]

--- a/phydrax/optim/__init__.py
+++ b/phydrax/optim/__init__.py
@@ -6,6 +6,7 @@
 
 from .._model import KFACAffineBlock, KFACLayoutProvider
 from ._differential_evolution import DifferentialEvolutionSearch
+from ._finite import FiniteAxis, FiniteExhaustiveSearch, FiniteProductSpace
 from ._kfac._config import kfac
 from ._quadratic_program import (
     QP_INFEASIBLE,
@@ -33,6 +34,9 @@ from ._riemannian import (
 __all__ = [
     "ArmijoLineSearch",
     "DifferentialEvolutionSearch",
+    "FiniteAxis",
+    "FiniteExhaustiveSearch",
+    "FiniteProductSpace",
     "KFACAffineBlock",
     "KFACLayoutProvider",
     "ParameterGeometry",

--- a/phydrax/optim/_finite.py
+++ b/phydrax/optim/_finite.py
@@ -1,0 +1,476 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import math
+from collections.abc import Callable, Sequence
+from numbers import Integral
+from typing import Any
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax import core as jax_core
+from jaxtyping import Array, PyTree
+
+from .._fingerprint import array_tree_fingerprint, canonical_fingerprint
+from .._strict import StrictModule
+
+
+_FINITE_SPACE_VERSION = 1
+_FINITE_SEARCH_METHOD_ID = "finite-exhaustive-v1"
+
+
+def _is_finite_axis(value: Any, /) -> bool:
+    return isinstance(value, FiniteAxis)
+
+
+def _path_name(path: tuple[Any, ...], /) -> str:
+    return jax.tree_util.keystr(path) or "<root>"
+
+
+def _checked_integer_array(value: Any, name: str, /) -> Array:
+    array = jnp.asarray(value)
+    if jnp.issubdtype(array.dtype, jnp.bool_) or not jnp.issubdtype(
+        array.dtype, jnp.integer
+    ):
+        raise TypeError(f"{name} must contain integer indices.")
+    return array
+
+
+def _checked_index_bounds(
+    value: Array,
+    invalid: Array,
+    message: str,
+    /,
+) -> Array:
+    if isinstance(invalid, jax_core.Tracer):
+        return eqx.error_if(value, invalid, message)
+    if bool(invalid):
+        raise IndexError(message)
+    return value
+
+
+class FiniteAxis(StrictModule):
+    """One correlated finite axis with array-valued candidate payloads."""
+
+    values: PyTree[Array]
+    size: int = eqx.field(static=True)
+    tree_definition: Any = eqx.field(static=True)
+    paths: tuple[str, ...] = eqx.field(static=True)
+    payload_shapes: tuple[tuple[int, ...], ...] = eqx.field(static=True)
+    dtypes: tuple[str, ...] = eqx.field(static=True)
+
+    def __init__(self, values: PyTree[Any], /):
+        path_leaves, tree_definition = jax.tree_util.tree_flatten_with_path(values)
+        if not path_leaves:
+            raise ValueError("FiniteAxis requires at least one array leaf.")
+
+        arrays: list[Array] = []
+        paths: list[str] = []
+        payload_shapes: list[tuple[int, ...]] = []
+        dtypes: list[str] = []
+        axis_size: int | None = None
+        for path, raw in path_leaves:
+            if isinstance(raw, (str, bytes)):
+                raise TypeError("FiniteAxis leaves must be numerical or boolean arrays.")
+            array = jnp.asarray(raw)
+            if np.dtype(array.dtype).kind not in "biufc":
+                raise TypeError("FiniteAxis leaves must be numerical or boolean arrays.")
+            if array.ndim == 0:
+                raise ValueError(
+                    f"FiniteAxis leaf {_path_name(path)} must have a leading "
+                    "candidate dimension."
+                )
+            leading = int(array.shape[0])
+            if leading == 0:
+                raise ValueError("FiniteAxis candidate dimensions must be nonempty.")
+            if axis_size is None:
+                axis_size = leading
+            elif leading != axis_size:
+                raise ValueError(
+                    "Every FiniteAxis leaf must have the same leading candidate "
+                    f"dimension; {_path_name(path)} has {leading}, expected {axis_size}."
+                )
+            arrays.append(array)
+            paths.append(_path_name(path))
+            payload_shapes.append(tuple(int(size) for size in array.shape[1:]))
+            dtypes.append(str(array.dtype))
+
+        assert axis_size is not None
+        self.values = tree_definition.unflatten(arrays)
+        self.size = axis_size
+        self.tree_definition = tree_definition
+        self.paths = tuple(paths)
+        self.payload_shapes = tuple(payload_shapes)
+        self.dtypes = tuple(dtypes)
+
+    def point_spec(self, /) -> PyTree[jax.ShapeDtypeStruct]:
+        """Return the shape and dtype of one selected axis payload."""
+        leaves = tuple(
+            jax.ShapeDtypeStruct(shape, np.dtype(dtype))
+            for shape, dtype in zip(self.payload_shapes, self.dtypes, strict=True)
+        )
+        return self.tree_definition.unflatten(leaves)
+
+    def _take_unchecked(self, index: Array, /) -> PyTree[Array]:
+        return jax.tree_util.tree_map(
+            lambda values: values[index],
+            self.values,
+        )
+
+
+class FiniteProductSpace(StrictModule):
+    """Lazy Cartesian product of explicit correlated finite axes."""
+
+    axes: PyTree[FiniteAxis]
+    product_shape: tuple[int, ...] = eqx.field(static=True)
+    size: int = eqx.field(static=True)
+    axis_paths: tuple[str, ...] = eqx.field(static=True)
+    axis_tree_definition: Any = eqx.field(static=True)
+    point_tree_definition: Any = eqx.field(static=True)
+
+    def __init__(self, axes: PyTree[FiniteAxis], /):
+        path_axes, axis_tree_definition = jax.tree_util.tree_flatten_with_path(
+            axes,
+            is_leaf=_is_finite_axis,
+        )
+        if not path_axes:
+            raise ValueError("FiniteProductSpace requires at least one FiniteAxis.")
+        if any(not isinstance(axis, FiniteAxis) for _, axis in path_axes):
+            raise TypeError(
+                "Every FiniteProductSpace outer PyTree leaf must be a FiniteAxis."
+            )
+
+        axis_blocks = tuple(axis for _, axis in path_axes)
+        product_shape = tuple(axis.size for axis in axis_blocks)
+        size = math.prod(product_shape)
+        if size > np.iinfo(np.int64).max:
+            raise OverflowError(
+                "FiniteProductSpace cardinality exceeds signed 64-bit indexing."
+            )
+        point = axis_tree_definition.unflatten(
+            tuple(axis.point_spec() for axis in axis_blocks)
+        )
+
+        self.axes = axes
+        self.product_shape = product_shape
+        self.size = size
+        self.axis_paths = tuple(_path_name(path) for path, _ in path_axes)
+        self.axis_tree_definition = axis_tree_definition
+        self.point_tree_definition = jax.tree_util.tree_structure(point)
+
+    def _axis_blocks(self, /) -> tuple[FiniteAxis, ...]:
+        return tuple(jax.tree_util.tree_leaves(self.axes, is_leaf=_is_finite_axis))
+
+    def point_spec(self, /) -> PyTree[jax.ShapeDtypeStruct]:
+        """Return the shape and dtype PyTree of one product candidate."""
+        return self.axis_tree_definition.unflatten(
+            tuple(axis.point_spec() for axis in self._axis_blocks())
+        )
+
+    def signature(self, /) -> str:
+        """Return a content-sensitive identity for this finite candidate space."""
+        axes = []
+        for path, axis in zip(
+            self.axis_paths,
+            self._axis_blocks(),
+            strict=True,
+        ):
+            axes.append(
+                {
+                    "path": path,
+                    "size": axis.size,
+                    "treedef": str(axis.tree_definition),
+                    "values": array_tree_fingerprint(axis.values),
+                }
+            )
+        return canonical_fingerprint(
+            {
+                "kind": "finite-product-space",
+                "version": _FINITE_SPACE_VERSION,
+                "axis_treedef": str(self.axis_tree_definition),
+                "point_treedef": str(self.point_tree_definition),
+                "product_shape": list(self.product_shape),
+                "axes": axes,
+            }
+        )
+
+    def _unravel_unchecked(self, flat_index: Array, /) -> tuple[Array, ...]:
+        remaining = jnp.asarray(flat_index, dtype=jnp.int64)
+        reversed_indices: list[Array] = []
+        for axis_size in reversed(self.product_shape):
+            reversed_indices.append(jnp.mod(remaining, axis_size))
+            remaining = jnp.floor_divide(remaining, axis_size)
+        return tuple(reversed(reversed_indices))
+
+    def unravel_index(self, flat_index: Any, /) -> tuple[Array, ...]:
+        """Convert checked row-major flat indices to product-axis indices."""
+        raw = _checked_integer_array(flat_index, "flat_index")
+        checked = _checked_index_bounds(
+            raw,
+            jnp.any(raw < 0) | jnp.any(raw >= self.size),
+            "FiniteProductSpace flat index is out of range.",
+        )
+        return self._unravel_unchecked(checked.astype(jnp.int64))
+
+    def ravel_index(self, product_index: Sequence[Any], /) -> Array:
+        """Convert checked product-axis indices to row-major flat indices."""
+        if not isinstance(product_index, Sequence) or isinstance(
+            product_index, (str, bytes)
+        ):
+            raise TypeError("product_index must be a sequence of axis indices.")
+        if len(product_index) != len(self.product_shape):
+            raise ValueError(
+                "product_index length must equal the number of finite product axes."
+            )
+        raw_indices = tuple(
+            _checked_integer_array(index, f"product_index[{axis}]")
+            for axis, index in enumerate(product_index)
+        )
+        broadcast_shape = jnp.broadcast_shapes(*(index.shape for index in raw_indices))
+        flat = jnp.zeros(broadcast_shape, dtype=jnp.int64)
+        for axis, (raw, axis_size) in enumerate(
+            zip(raw_indices, self.product_shape, strict=True)
+        ):
+            raw = jnp.broadcast_to(raw, broadcast_shape)
+            checked = _checked_index_bounds(
+                raw,
+                jnp.any(raw < 0) | jnp.any(raw >= axis_size),
+                f"FiniteProductSpace product index for axis {axis} is out of range.",
+            ).astype(jnp.int64)
+            flat = flat * axis_size + checked
+        return flat
+
+    def _take_product_unchecked(
+        self,
+        product_index: tuple[Array, ...],
+        /,
+    ) -> PyTree[Array]:
+        selected = tuple(
+            axis._take_unchecked(index)
+            for axis, index in zip(
+                self._axis_blocks(),
+                product_index,
+                strict=True,
+            )
+        )
+        return self.axis_tree_definition.unflatten(selected)
+
+    def _take_unchecked(self, flat_index: Array, /) -> PyTree[Array]:
+        return self._take_product_unchecked(self._unravel_unchecked(flat_index))
+
+    def take(self, flat_index: Any, /) -> PyTree[Array]:
+        """Select one or more product candidates by checked flat index."""
+        raw = _checked_integer_array(flat_index, "flat_index")
+        checked = _checked_index_bounds(
+            raw,
+            jnp.any(raw < 0) | jnp.any(raw >= self.size),
+            "FiniteProductSpace flat index is out of range.",
+        )
+        return self._take_unchecked(checked.astype(jnp.int64))
+
+
+class FiniteExhaustiveSearch(StrictModule):
+    """Exact finite enumeration with bounded transient evaluation batches."""
+
+    batch_size: int | None = eqx.field(static=True)
+
+    def __init__(self, batch_size: int | None = None):
+        if batch_size is None:
+            self.batch_size = None
+            return
+        if isinstance(batch_size, bool) or not isinstance(batch_size, Integral):
+            raise TypeError("batch_size must be a positive integer or None.")
+        resolved = int(batch_size)
+        if resolved <= 0:
+            raise ValueError("batch_size must be positive.")
+        self.batch_size = resolved
+
+    @property
+    def method_id(self) -> str:
+        return _FINITE_SEARCH_METHOD_ID
+
+    def effective_batch_size(self, candidate_count: int, /) -> int:
+        count = int(candidate_count)
+        if count <= 0:
+            raise ValueError("candidate_count must be positive.")
+        requested = 1 if self.batch_size is None else self.batch_size
+        return min(requested, count)
+
+
+class _FiniteMinimumState(StrictModule):
+    minimum: Array
+    valid: Array
+    flat_index: Array
+    attempted_evaluations: Array
+    invalid_evaluations: Array
+
+
+class _FiniteMinimumEvidence(StrictModule):
+    minimum: Array
+    valid: Array
+    flat_index: Array
+    product_index: tuple[Array, ...]
+    attempted_evaluations: Array
+    invalid_evaluations: Array
+
+
+FiniteEvaluator = Callable[[PyTree[Array]], tuple[Array, Array]]
+
+
+def _merge_minimum(
+    left: _FiniteMinimumState,
+    right: _FiniteMinimumState,
+    /,
+) -> _FiniteMinimumState:
+    right_wins = right.valid & (
+        ~left.valid
+        | (right.minimum < left.minimum)
+        | ((right.minimum == left.minimum) & (right.flat_index < left.flat_index))
+    )
+    return _FiniteMinimumState(
+        minimum=jnp.where(right_wins, right.minimum, left.minimum),
+        valid=left.valid | right.valid,
+        flat_index=jnp.where(right_wins, right.flat_index, left.flat_index),
+        attempted_evaluations=(left.attempted_evaluations + right.attempted_evaluations),
+        invalid_evaluations=left.invalid_evaluations + right.invalid_evaluations,
+    )
+
+
+def _batch_minimum(
+    scores: Array,
+    declared_valid: Array,
+    flat_indices: Array,
+    /,
+) -> _FiniteMinimumState:
+    effective_valid = declared_valid & jnp.isfinite(scores)
+    safe_scores = jnp.where(effective_valid, scores, jnp.inf)
+    local_index = jnp.argmin(safe_scores, axis=0)
+    minimum = jnp.take_along_axis(
+        safe_scores,
+        local_index[None, ...],
+        axis=0,
+    )[0]
+    valid = jnp.any(effective_valid, axis=0)
+    flat_index = flat_indices[0] + local_index.astype(jnp.int64)
+    return _FiniteMinimumState(
+        minimum=minimum,
+        valid=valid,
+        flat_index=jnp.where(valid, flat_index, -1),
+        attempted_evaluations=jnp.asarray(scores.shape[0], dtype=jnp.int64),
+        invalid_evaluations=jnp.sum(~effective_valid, axis=0, dtype=jnp.int64),
+    )
+
+
+def _evaluate_finite_batch(
+    evaluator: FiniteEvaluator,
+    space: FiniteProductSpace,
+    flat_indices: Array,
+    /,
+) -> _FiniteMinimumState:
+    points = space._take_unchecked(flat_indices)
+    points = jax.tree_util.tree_map(jax.lax.stop_gradient, points)
+    scores, declared_valid = jax.vmap(evaluator)(points)
+    return _batch_minimum(scores, declared_valid, flat_indices)
+
+
+@eqx.filter_jit
+def _run_exhaustive_minimum(
+    evaluator: FiniteEvaluator,
+    space: FiniteProductSpace,
+    /,
+    *,
+    batch_size: int,
+    output_shape: tuple[int, ...],
+    output_dtype: str,
+) -> _FiniteMinimumEvidence:
+    state = _FiniteMinimumState(
+        minimum=jnp.full(output_shape, jnp.inf, dtype=np.dtype(output_dtype)),
+        valid=jnp.zeros(output_shape, dtype=bool),
+        flat_index=jnp.full(output_shape, -1, dtype=jnp.int64),
+        attempted_evaluations=jnp.asarray(0, dtype=jnp.int64),
+        invalid_evaluations=jnp.zeros(output_shape, dtype=jnp.int64),
+    )
+    full_batches, remainder = divmod(space.size, batch_size)
+
+    def body(batch_index, current):
+        start = jnp.asarray(batch_index, dtype=jnp.int64) * batch_size
+        indices = start + jnp.arange(batch_size, dtype=jnp.int64)
+        batch = _evaluate_finite_batch(evaluator, space, indices)
+        return _merge_minimum(current, batch)
+
+    state = jax.lax.fori_loop(0, full_batches, body, state)
+    if remainder:
+        start = full_batches * batch_size
+        indices = start + jnp.arange(remainder, dtype=jnp.int64)
+        state = _merge_minimum(
+            state,
+            _evaluate_finite_batch(evaluator, space, indices),
+        )
+
+    safe_flat_index = jnp.where(state.valid, state.flat_index, 0)
+    product_index = tuple(
+        jnp.where(state.valid, index, -1)
+        for index in space._unravel_unchecked(safe_flat_index)
+    )
+    return _FiniteMinimumEvidence(
+        minimum=jax.lax.stop_gradient(jnp.where(state.valid, state.minimum, jnp.nan)),
+        valid=jax.lax.stop_gradient(state.valid),
+        flat_index=jax.lax.stop_gradient(state.flat_index),
+        product_index=jax.tree_util.tree_map(
+            jax.lax.stop_gradient,
+            product_index,
+        ),
+        attempted_evaluations=state.attempted_evaluations,
+        invalid_evaluations=state.invalid_evaluations,
+    )
+
+
+def _exhaustive_minimum(
+    evaluator: FiniteEvaluator,
+    space: FiniteProductSpace,
+    search: FiniteExhaustiveSearch,
+    /,
+) -> _FiniteMinimumEvidence:
+    if not callable(evaluator):
+        raise TypeError("evaluator must be callable.")
+    if not isinstance(space, FiniteProductSpace):
+        raise TypeError("space must be a FiniteProductSpace.")
+    if not isinstance(search, FiniteExhaustiveSearch):
+        raise TypeError("search must be a FiniteExhaustiveSearch.")
+
+    output = eqx.filter_eval_shape(evaluator, space.point_spec())
+    if not isinstance(output, tuple) or len(output) != 2:
+        raise TypeError("Finite evaluators must return a (score, valid) tuple.")
+    score_spec, valid_spec = output
+    if not isinstance(score_spec, jax.ShapeDtypeStruct) or not isinstance(
+        valid_spec, jax.ShapeDtypeStruct
+    ):
+        raise TypeError("Finite evaluator scores and validity must be arrays.")
+    if not np.issubdtype(np.dtype(score_spec.dtype), np.floating):
+        raise TypeError("Finite evaluator scores must be real floating-point arrays.")
+    if np.dtype(valid_spec.dtype) != np.dtype(bool):
+        raise TypeError("Finite evaluator validity must be boolean.")
+    if score_spec.shape != valid_spec.shape:
+        raise ValueError("Finite evaluator score and validity shapes must match.")
+    if any(size == 0 for size in score_spec.shape):
+        raise ValueError("Finite evaluator output dimensions must be nonempty.")
+
+    return _run_exhaustive_minimum(
+        evaluator,
+        space,
+        batch_size=search.effective_batch_size(space.size),
+        output_shape=tuple(int(size) for size in score_spec.shape),
+        output_dtype=str(np.dtype(score_spec.dtype)),
+    )
+
+
+__all__ = [
+    "FiniteAxis",
+    "FiniteExhaustiveSearch",
+    "FiniteProductSpace",
+]

--- a/phydrax/uq/__init__.py
+++ b/phydrax/uq/__init__.py
@@ -301,6 +301,7 @@ from ._linearized import (
     propagate_linearized_map,
 )
 from ._map import find_map, MAPConvergenceError, MAPResult
+from ._map_candidate_search import MAPCandidateSearchResult, search_map_candidates
 from ._map_search import MAPSearchResult, search_map
 from ._martingale import (
     jump_compensator_diagnostics,
@@ -1072,10 +1073,12 @@ __all__ = [
     "FixedResidualLikelihood",
     "GaussianProcessMarginalLikelihood",
     "find_map",
+    "MAPCandidateSearchResult",
     "MAPConvergenceError",
     "MAPResult",
     "MAPSearchResult",
     "search_map",
+    "search_map_candidates",
     "FlowNUTSConfig",
     "FlowNUTSResult",
     "MCMCChainWarmup",

--- a/phydrax/uq/_map_candidate_search.py
+++ b/phydrax/uq/_map_candidate_search.py
@@ -1,0 +1,221 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jaxtyping import Array, ArrayLike, PyTree
+
+from .._strict import StrictModule
+from ..optim import FiniteAxis, FiniteExhaustiveSearch, FiniteProductSpace
+from ..optim._finite import _exhaustive_minimum
+from ._posterior import PosteriorProblem
+
+
+_MAP_CANDIDATE_METHOD_ID = "finite-exhaustive-map-candidate-search-v1"
+_DEFAULT_FINITE_SEARCH = FiniteExhaustiveSearch()
+
+
+class _MAPCandidateEvaluator(StrictModule):
+    problem: PosteriorProblem
+
+    def __init__(self, problem: PosteriorProblem, /):
+        self.problem = problem
+
+    def __call__(self, position: PyTree[Array], /) -> tuple[Array, Array]:
+        objective = self.problem.negative_log_density(position)
+        return objective, jnp.isfinite(objective)
+
+
+class MAPCandidateSearchResult(StrictModule):
+    """Exact finite-candidate posterior minimum and enumeration evidence."""
+
+    problem: PosteriorProblem
+    position: PyTree[Array] | None
+    parameters: PyTree[Array] | None
+    objective: Array
+    log_density: Array
+    search: FiniteExhaustiveSearch
+    valid: bool = eqx.field(static=True)
+    termination_reason: str = eqx.field(static=True)
+    flat_index: int = eqx.field(static=True)
+    product_index: tuple[int, ...] = eqx.field(static=True)
+    axis_paths: tuple[str, ...] = eqx.field(static=True)
+    product_shape: tuple[int, ...] = eqx.field(static=True)
+    candidate_count: int = eqx.field(static=True)
+    objective_evaluations: int = eqx.field(static=True)
+    valid_evaluations: int = eqx.field(static=True)
+    invalid_evaluations: int = eqx.field(static=True)
+    effective_batch_size: int = eqx.field(static=True)
+    candidate_signature: str = eqx.field(static=True)
+    method_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        problem: PosteriorProblem,
+        position: PyTree[Array] | None,
+        objective: ArrayLike,
+        search: FiniteExhaustiveSearch,
+        valid: bool,
+        flat_index: int,
+        product_index: tuple[int, ...],
+        axis_paths: tuple[str, ...],
+        product_shape: tuple[int, ...],
+        candidate_count: int,
+        objective_evaluations: int,
+        invalid_evaluations: int,
+        effective_batch_size: int,
+        candidate_signature: str,
+    ):
+        valid_ = bool(valid)
+        if valid_ != (position is not None):
+            raise ValueError("A valid MAP candidate result requires one position.")
+        evaluations = int(objective_evaluations)
+        invalid = int(invalid_evaluations)
+        if evaluations != int(candidate_count):
+            raise ValueError("MAP candidate evaluation count must equal candidate_count.")
+        if invalid < 0 or invalid > evaluations:
+            raise ValueError("invalid_evaluations must lie within the evaluation count.")
+        if valid_:
+            if flat_index < 0 or any(index < 0 for index in product_index):
+                raise ValueError("Valid MAP candidate indices must be nonnegative.")
+            position_ = jax.tree_util.tree_map(jnp.asarray, position)
+            parameters = problem.parameter_space.constrain(position_)
+            objective_ = jnp.asarray(objective, dtype=float).reshape(())
+            termination_reason = "finite_minimum"
+        else:
+            if flat_index != -1 or any(index != -1 for index in product_index):
+                raise ValueError("Invalid MAP candidate indices must use -1 sentinels.")
+            position_ = None
+            parameters = None
+            objective_ = jnp.asarray(jnp.nan, dtype=float)
+            termination_reason = "no_finite_candidates"
+
+        self.problem = problem
+        self.position = position_
+        self.parameters = parameters
+        self.objective = objective_
+        self.log_density = -objective_
+        self.search = search
+        self.valid = valid_
+        self.termination_reason = termination_reason
+        self.flat_index = int(flat_index)
+        self.product_index = tuple(int(index) for index in product_index)
+        self.axis_paths = tuple(str(path) for path in axis_paths)
+        self.product_shape = tuple(int(size) for size in product_shape)
+        self.candidate_count = int(candidate_count)
+        self.objective_evaluations = evaluations
+        self.valid_evaluations = evaluations - invalid
+        self.invalid_evaluations = invalid
+        self.effective_batch_size = int(effective_batch_size)
+        self.candidate_signature = str(candidate_signature)
+        self.method_id = _MAP_CANDIDATE_METHOD_ID
+
+
+def _validate_map_candidate_space(
+    problem: PosteriorProblem,
+    candidates: FiniteProductSpace,
+    /,
+) -> None:
+    candidate_spec = candidates.point_spec()
+    initial = problem.initial_position
+    candidate_structure = jax.tree_util.tree_structure(candidate_spec)
+    initial_structure = jax.tree_util.tree_structure(initial)
+    if candidate_structure != initial_structure:
+        raise ValueError(
+            "Finite candidate points must match the posterior initial-position "
+            "PyTree structure."
+        )
+
+    path_specs = jax.tree_util.tree_flatten_with_path(candidate_spec)[0]
+    initial_leaves = jax.tree_util.tree_leaves(initial)
+    for (path, spec), initial_leaf in zip(path_specs, initial_leaves, strict=True):
+        initial_array = jnp.asarray(initial_leaf)
+        expected_shape = tuple(int(size) for size in initial_array.shape)
+        if tuple(spec.shape) != expected_shape:
+            raise ValueError(
+                f"Finite candidate point leaf {jax.tree_util.keystr(path) or '<root>'} "
+                f"must have shape {expected_shape}, got {spec.shape}."
+            )
+        if np.dtype(spec.dtype) != np.dtype(initial_array.dtype):
+            raise TypeError(
+                f"Finite candidate point leaf {jax.tree_util.keystr(path) or '<root>'} "
+                f"must have dtype {initial_array.dtype}, got {spec.dtype}."
+            )
+
+    axis_blocks = jax.tree_util.tree_leaves(
+        candidates.axes,
+        is_leaf=lambda value: isinstance(value, FiniteAxis),
+    )
+    for axis_path, axis in zip(candidates.axis_paths, axis_blocks, strict=True):
+        for payload_path, values in jax.tree_util.tree_flatten_with_path(axis.values)[0]:
+            if not eqx.is_inexact_array(values):
+                raise TypeError(
+                    f"MAP candidate axis {axis_path} payload "
+                    f"{jax.tree_util.keystr(payload_path) or '<root>'} must be inexact."
+                )
+            if bool(jnp.any(~jnp.isfinite(values))):
+                raise ValueError("MAP candidate coordinates must be finite.")
+
+
+def search_map_candidates(
+    problem: PosteriorProblem,
+    candidates: FiniteProductSpace,
+    /,
+    *,
+    search: FiniteExhaustiveSearch = _DEFAULT_FINITE_SEARCH,
+) -> MAPCandidateSearchResult:
+    """Find the exact finite minimum of a posterior over declared positions."""
+    if not isinstance(problem, PosteriorProblem):
+        raise TypeError("problem must be a PosteriorProblem.")
+    if not isinstance(candidates, FiniteProductSpace):
+        raise TypeError("candidates must be a FiniteProductSpace.")
+    if not isinstance(search, FiniteExhaustiveSearch):
+        raise TypeError("search must be a FiniteExhaustiveSearch.")
+    _validate_map_candidate_space(problem, candidates)
+
+    evidence = _exhaustive_minimum(
+        _MAPCandidateEvaluator(problem),
+        candidates,
+        search,
+    )
+    valid = bool(evidence.valid)
+    flat_index = int(evidence.flat_index) if valid else -1
+    product_index = (
+        tuple(int(index) for index in evidence.product_index)
+        if valid
+        else (-1,) * len(candidates.product_shape)
+    )
+    position = (
+        jax.tree_util.tree_map(
+            jax.lax.stop_gradient,
+            candidates.take(flat_index),
+        )
+        if valid
+        else None
+    )
+
+    return MAPCandidateSearchResult(
+        problem=problem,
+        position=position,
+        objective=evidence.minimum,
+        search=search,
+        valid=valid,
+        flat_index=flat_index,
+        product_index=product_index,
+        axis_paths=candidates.axis_paths,
+        product_shape=candidates.product_shape,
+        candidate_count=candidates.size,
+        objective_evaluations=int(evidence.attempted_evaluations),
+        invalid_evaluations=int(evidence.invalid_evaluations),
+        effective_batch_size=search.effective_batch_size(candidates.size),
+        candidate_signature=candidates.signature(),
+    )
+
+
+__all__ = ["MAPCandidateSearchResult", "search_map_candidates"]

--- a/phydrax/uq/_result_export.py
+++ b/phydrax/uq/_result_export.py
@@ -36,6 +36,7 @@ from ._kalman import KalmanFilterResult, KalmanSmootherResult
 from ._laplace import LaplaceResult
 from ._laplax_backend import StructuredLaplaceResult
 from ._map import MAPResult
+from ._map_candidate_search import MAPCandidateSearchResult
 from ._map_search import MAPSearchResult
 from ._mcmc import MCMCResult
 from ._particle import (
@@ -872,6 +873,31 @@ def _adapt_result(result, arrays, fields, trees):
         for name in fields:
             metadata.pop(name, None)
         return "mcmc_convergence_report", metadata, ()
+
+    if isinstance(result, MAPCandidateSearchResult):
+        if result.position is not None:
+            _put_tree(trees, arrays, "position", result.position)
+        if result.parameters is not None:
+            _put_tree(trees, arrays, "parameters", result.parameters)
+        _put_field(fields, arrays, "objective", result.objective)
+        _put_field(fields, arrays, "log_density", result.log_density)
+        metadata = {
+            "valid": result.valid,
+            "termination_reason": result.termination_reason,
+            "flat_index": result.flat_index,
+            "product_index": result.product_index,
+            "axis_paths": result.axis_paths,
+            "product_shape": result.product_shape,
+            "candidate_count": result.candidate_count,
+            "objective_evaluations": result.objective_evaluations,
+            "valid_evaluations": result.valid_evaluations,
+            "invalid_evaluations": result.invalid_evaluations,
+            "effective_batch_size": result.effective_batch_size,
+            "candidate_signature": result.candidate_signature,
+            "method_id": result.method_id,
+            "search": {"batch_size": result.search.batch_size},
+        }
+        return "map_candidate_search", metadata, ("problem", "search")
 
     if isinstance(result, MAPSearchResult):
         _put_tree(trees, arrays, "position", result.position)

--- a/tests/unit/control/test_control_candidate_search.py
+++ b/tests/unit/control/test_control_candidate_search.py
@@ -1,0 +1,216 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import phydrax as phx
+from tests.unit.control.test_global_control_search import _quadratic_problem
+
+
+def _catalog(rows):
+    return phx.optim.FiniteProductSpace(
+        phx.optim.FiniteAxis(jnp.asarray(rows, dtype=float))
+    )
+
+
+def test_control_candidate_search_finds_exact_catalog_minimum_and_reconstructs():
+    problem, parameterization = _quadratic_problem()
+    candidates = _catalog(
+        [
+            [[-1.0], [-1.0]],
+            [[0.5], [0.5]],
+            [[1.0], [0.0]],
+        ]
+    )
+
+    result = phx.control.search_control_candidates(
+        problem,
+        parameterization,
+        candidates,
+        search=phx.optim.FiniteExhaustiveSearch(2),
+    )
+
+    assert isinstance(result, phx.control.ControlCandidateSearchResult)
+    assert result.valid
+    assert bool(result.successful)
+    assert result.termination_reason == "finite_minimum"
+    np.testing.assert_array_equal(result.coefficients, jnp.asarray([[0.5], [0.5]]))
+    assert result.objective == pytest.approx(0.0125)
+    assert result.flat_index == 1
+    assert result.product_index == (1,)
+    assert result.axis_paths == ("<root>",)
+    assert result.product_shape == (3,)
+    assert result.candidate_count == 3
+    assert result.objective_evaluations == 3
+    assert result.valid_evaluations == 3
+    assert result.invalid_candidates == 0
+    assert result.winner_evaluations == 1
+    assert result.total_control_evaluations == 4
+    assert result.effective_batch_size == 2
+    assert result.problem_id == problem.problem_id
+    assert result.dynamics_id == problem.dynamics.dynamics_id
+    assert result.time_id == problem.time_grid.time_id
+    assert result.control_id == parameterization.parameterization_id
+    assert result.parameterization_id == parameterization.parameterization_id
+    assert result.approximation_id == parameterization.approximation_id
+    assert result.method_id == "finite-exhaustive-control-candidate-search-v1"
+    assert result.candidate_signature == candidates.signature()
+    assert result.control_shape == (1,)
+    assert result.case_shape == ()
+    assert result.parameter_shape == (2, 1)
+    assert result.coefficient_shape == (2, 1)
+    assert result.trajectory is result.evaluation.trajectory
+    np.testing.assert_array_equal(result.controls, result.evaluation.trajectory.controls)
+
+
+def test_control_candidate_search_counts_infeasible_candidates_as_invalid():
+    base, parameterization = _quadratic_problem()
+    problem = phx.control.ControlProblem(
+        base.dynamics,
+        base.time_grid,
+        base.initial_state,
+        running_cost=base.running_cost,
+        terminal_cost=base.terminal_cost,
+        path_constraints=(lambda time, state, control, args: control[0] - 0.6,),
+        problem_id="constrained-candidate-search",
+    )
+    candidates = _catalog(
+        [
+            [[1.0], [1.0]],
+            [[0.5], [0.5]],
+            [[0.8], [0.0]],
+        ]
+    )
+
+    result = phx.control.search_control_candidates(problem, parameterization, candidates)
+
+    assert result.valid
+    assert result.flat_index == 1
+    assert result.invalid_candidates == 2
+    assert result.valid_evaluations == 1
+    assert result.objective_evaluations == 3
+    assert result.winner_evaluations == 1
+
+
+def test_control_candidate_search_has_explicit_all_invalid_result():
+    base, parameterization = _quadratic_problem()
+    problem = phx.control.ControlProblem(
+        base.dynamics,
+        base.time_grid,
+        base.initial_state,
+        running_cost=base.running_cost,
+        terminal_cost=base.terminal_cost,
+        path_constraints=(lambda time, state, control, args: jnp.asarray(1.0),),
+        problem_id="invalid-candidate-search",
+    )
+    candidates = _catalog(
+        [
+            [[0.0], [0.0]],
+            [[0.5], [0.5]],
+        ]
+    )
+
+    result = phx.control.search_control_candidates(
+        problem,
+        parameterization,
+        candidates,
+        search=phx.optim.FiniteExhaustiveSearch(8),
+    )
+
+    assert not result.valid
+    assert not bool(result.successful)
+    assert result.termination_reason == "no_finite_candidates"
+    assert result.coefficients is None
+    assert result.evaluation is None
+    assert jnp.isnan(result.objective)
+    assert result.flat_index == -1
+    assert result.product_index == (-1,)
+    assert result.objective_evaluations == 2
+    assert result.valid_evaluations == 0
+    assert result.invalid_candidates == 2
+    assert result.winner_evaluations == 0
+    assert result.total_control_evaluations == 2
+    assert result.control_id is None
+    with pytest.raises(RuntimeError, match="no valid trajectory"):
+        _ = result.trajectory
+    with pytest.raises(RuntimeError, match="no valid trajectory"):
+        _ = result.controls
+
+
+def test_control_candidate_search_preserves_case_and_coefficient_axes():
+    initial_state = jnp.asarray([[0.0], [0.5]])
+    problem, parameterization = _quadratic_problem(initial_state=initial_state)
+    candidates = _catalog(
+        [
+            [[[0.0], [0.0]], [[0.0], [0.0]]],
+            [[[0.5], [0.5]], [[0.25], [0.25]]],
+        ]
+    )
+
+    result = phx.control.search_control_candidates(problem, parameterization, candidates)
+
+    assert result.case_shape == (2,)
+    assert result.parameter_shape == (2, 1)
+    assert result.coefficient_shape == (2, 2, 1)
+    assert result.coefficients is not None
+    assert result.coefficients.shape == (2, 2, 1)
+    assert result.trajectory.states.shape == (2, 3, 1)
+    assert result.trajectory.controls.shape == (2, 2, 1)
+
+
+def test_control_candidate_search_has_stable_first_index_ties():
+    problem, parameterization = _quadratic_problem()
+    repeated = jnp.asarray([[0.5], [0.5]])
+    candidates = _catalog([repeated, repeated, [[1.0], [0.0]]])
+
+    result = phx.control.search_control_candidates(
+        problem,
+        parameterization,
+        candidates,
+        search=phx.optim.FiniteExhaustiveSearch(2),
+    )
+
+    assert result.flat_index == 0
+
+
+def test_control_candidate_space_rejects_ambiguous_or_invalid_coefficients():
+    problem, parameterization = _quadratic_problem()
+
+    wrong_shape = _catalog([[[0.0]], [[1.0]]])
+    with pytest.raises(ValueError, match="coefficient shape"):
+        phx.control.search_control_candidates(problem, parameterization, wrong_shape)
+
+    factored = phx.optim.FiniteProductSpace(
+        (
+            phx.optim.FiniteAxis(jnp.asarray([0.0, 1.0])),
+            phx.optim.FiniteAxis(jnp.asarray([0.0, 1.0])),
+        )
+    )
+    with pytest.raises(ValueError, match="one coefficient array"):
+        phx.control.search_control_candidates(problem, parameterization, factored)
+
+    integer = phx.optim.FiniteProductSpace(
+        phx.optim.FiniteAxis(jnp.zeros((2, 2, 1), dtype=jnp.int32))
+    )
+    with pytest.raises(TypeError, match="floating-point"):
+        phx.control.search_control_candidates(problem, parameterization, integer)
+
+    nonfinite = _catalog([[[0.0], [jnp.nan]]])
+    with pytest.raises(ValueError, match="finite"):
+        phx.control.search_control_candidates(problem, parameterization, nonfinite)
+
+    incompatible_parameterization = phx.control.PiecewiseConstantControlParameterization(
+        problem.time_grid,
+        (2,),
+        parameterization_id="wrong-control-shape",
+    )
+    incompatible_candidates = _catalog([jnp.zeros((2, 2))])
+    with pytest.raises(ValueError, match="control_shape"):
+        phx.control.search_control_candidates(
+            problem,
+            incompatible_parameterization,
+            incompatible_candidates,
+        )

--- a/tests/unit/optim/test_finite_search.py
+++ b/tests/unit/optim/test_finite_search.py
@@ -1,0 +1,245 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import phydrax as phx
+from phydrax.optim._finite import _exhaustive_minimum
+
+
+def test_finite_axis_validates_correlated_array_payloads():
+    axis = phx.optim.FiniteAxis(
+        {
+            "scalar": jnp.asarray([1.0, 2.0, 3.0]),
+            "vector": jnp.arange(6.0).reshape((3, 2)),
+        }
+    )
+
+    assert axis.size == 3
+    assert axis.payload_shapes == ((), (2,))
+    assert axis.point_spec()["scalar"].shape == ()
+    assert axis.point_spec()["vector"].shape == (2,)
+
+    with pytest.raises(ValueError, match="at least one"):
+        phx.optim.FiniteAxis(())
+    with pytest.raises(ValueError, match="leading candidate"):
+        phx.optim.FiniteAxis(jnp.asarray(1.0))
+    with pytest.raises(ValueError, match="nonempty"):
+        phx.optim.FiniteAxis(jnp.empty((0, 2)))
+    with pytest.raises(ValueError, match="same leading"):
+        phx.optim.FiniteAxis(
+            {
+                "left": jnp.ones((2,)),
+                "right": jnp.ones((3,)),
+            }
+        )
+    with pytest.raises(TypeError, match="numerical or boolean"):
+        phx.optim.FiniteAxis("abc")
+
+
+def test_finite_product_indexing_preserves_structure_and_never_clips():
+    space = phx.optim.FiniteProductSpace(
+        {
+            "x": phx.optim.FiniteAxis(jnp.asarray([10.0, 20.0])),
+            "pair": phx.optim.FiniteAxis(
+                {"vector": jnp.asarray([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])}
+            ),
+        }
+    )
+
+    assert space.product_shape == (3, 2)
+    assert space.size == 6
+    assert space.axis_paths == ("['pair']", "['x']")
+    np.testing.assert_array_equal(
+        space.ravel_index((jnp.asarray([0, 2]), jnp.asarray([0, 1]))),
+        jnp.asarray([0, 5]),
+    )
+    product_index = space.unravel_index(jnp.asarray([0, 5]))
+    np.testing.assert_array_equal(product_index[0], jnp.asarray([0, 2]))
+    np.testing.assert_array_equal(product_index[1], jnp.asarray([0, 1]))
+
+    selected = space.take(jnp.asarray([0, 5]))
+    np.testing.assert_array_equal(
+        selected["pair"]["vector"],
+        jnp.asarray([[1.0, 2.0], [5.0, 6.0]]),
+    )
+    np.testing.assert_array_equal(selected["x"], jnp.asarray([10.0, 20.0]))
+
+    with pytest.raises(IndexError, match="out of range"):
+        space.take(-1)
+    with pytest.raises(IndexError, match="out of range"):
+        space.take(space.size)
+    with pytest.raises(IndexError, match="axis 0"):
+        space.ravel_index((3, 0))
+    with pytest.raises(ValueError, match="length"):
+        space.ravel_index((0,))
+
+    compiled = jax.jit(lambda index: space.take(index))
+    selected_last = compiled(jnp.asarray(5))
+    np.testing.assert_array_equal(selected_last["x"], space.take(5)["x"])
+    np.testing.assert_array_equal(
+        selected_last["pair"]["vector"],
+        space.take(5)["pair"]["vector"],
+    )
+
+
+def test_finite_product_signature_covers_content_layout_and_dtype():
+    first = phx.optim.FiniteProductSpace(
+        (
+            phx.optim.FiniteAxis(jnp.asarray([0.0, 1.0])),
+            phx.optim.FiniteAxis(jnp.asarray([2.0, 3.0])),
+        )
+    )
+    replay = phx.optim.FiniteProductSpace(
+        (
+            phx.optim.FiniteAxis(jnp.asarray([0.0, 1.0])),
+            phx.optim.FiniteAxis(jnp.asarray([2.0, 3.0])),
+        )
+    )
+    changed = phx.optim.FiniteProductSpace(
+        (
+            phx.optim.FiniteAxis(jnp.asarray([0.0, 1.0])),
+            phx.optim.FiniteAxis(jnp.asarray([2.0, 4.0])),
+        )
+    )
+    regrouped = phx.optim.FiniteProductSpace(
+        phx.optim.FiniteAxis(
+            {
+                "left": jnp.asarray([0.0, 1.0]),
+                "right": jnp.asarray([2.0, 3.0]),
+            }
+        )
+    )
+
+    assert first.signature() == replay.signature()
+    assert first.signature() != changed.signature()
+    assert first.signature() != regrouped.signature()
+
+
+def test_finite_exhaustive_search_matches_dense_oracle_for_all_batch_layouts():
+    space = phx.optim.FiniteProductSpace(
+        (
+            phx.optim.FiniteAxis(jnp.asarray([-1.0, 1.0])),
+            phx.optim.FiniteAxis(jnp.asarray([0.0, 2.0, 4.0])),
+        )
+    )
+
+    def evaluator(point):
+        score = (point[0] - 1.0) ** 2 + (point[1] - 2.0) ** 2
+        return score, jnp.asarray(True)
+
+    for batch_size in (None, 1, 2, 4, 6, 20):
+        search = phx.optim.FiniteExhaustiveSearch(batch_size)
+        result = _exhaustive_minimum(evaluator, space, search)
+        assert result.minimum == pytest.approx(0.0)
+        assert int(result.flat_index) == 4
+        assert tuple(int(index) for index in result.product_index) == (1, 1)
+        assert int(result.attempted_evaluations) == 6
+        assert int(result.invalid_evaluations) == 0
+
+
+def test_finite_minimum_has_stable_ties_and_elementwise_indices():
+    scalar_space = phx.optim.FiniteProductSpace(
+        phx.optim.FiniteAxis(jnp.asarray([-2.0, -1.0, 1.0, 2.0]))
+    )
+    tied = _exhaustive_minimum(
+        lambda value: (jnp.abs(value), jnp.asarray(True)),
+        scalar_space,
+        phx.optim.FiniteExhaustiveSearch(3),
+    )
+    assert int(tied.flat_index) == 1
+
+    elementwise_space = phx.optim.FiniteProductSpace(
+        phx.optim.FiniteAxis(jnp.asarray([-1.0, 0.0, 2.0]))
+    )
+    elementwise = _exhaustive_minimum(
+        lambda value: (
+            jnp.stack((value**2, (value - 2.0) ** 2)),
+            jnp.ones((2,), dtype=bool),
+        ),
+        elementwise_space,
+        phx.optim.FiniteExhaustiveSearch(2),
+    )
+    np.testing.assert_array_equal(elementwise.minimum, jnp.zeros((2,)))
+    np.testing.assert_array_equal(elementwise.flat_index, jnp.asarray([1, 2]))
+    np.testing.assert_array_equal(
+        elementwise.product_index[0],
+        jnp.asarray([1, 2]),
+    )
+    np.testing.assert_array_equal(
+        elementwise.invalid_evaluations,
+        jnp.zeros((2,), dtype=jnp.int64),
+    )
+
+
+def test_finite_minimum_counts_declared_and_nonfinite_invalidity():
+    space = phx.optim.FiniteProductSpace(phx.optim.FiniteAxis(jnp.arange(5.0)))
+
+    def evaluator(value):
+        score = jnp.asarray([2.0, jnp.nan, -jnp.inf, 0.0, 1.0])[value.astype(int)]
+        declared_valid = value != 3.0
+        return score, declared_valid
+
+    result = _exhaustive_minimum(
+        evaluator,
+        space,
+        phx.optim.FiniteExhaustiveSearch(3),
+    )
+    assert result.minimum == pytest.approx(1.0)
+    assert int(result.flat_index) == 4
+    assert int(result.attempted_evaluations) == 5
+    assert int(result.invalid_evaluations) == 3
+
+    invalid = _exhaustive_minimum(
+        lambda value: (jnp.asarray(jnp.nan), jnp.asarray(value >= 0.0)),
+        space,
+        phx.optim.FiniteExhaustiveSearch(2),
+    )
+    assert not bool(invalid.valid)
+    assert jnp.isnan(invalid.minimum)
+    assert int(invalid.flat_index) == -1
+    assert int(invalid.product_index[0]) == -1
+    assert int(invalid.attempted_evaluations) == 5
+    assert int(invalid.invalid_evaluations) == 5
+
+
+def test_finite_search_configuration_and_evaluator_contract_are_strict():
+    assert phx.optim.FiniteExhaustiveSearch().effective_batch_size(5) == 1
+    assert phx.optim.FiniteExhaustiveSearch(batch_size=10).effective_batch_size(5) == 5
+    with pytest.raises(TypeError, match="positive integer"):
+        phx.optim.FiniteExhaustiveSearch(True)
+    with pytest.raises(TypeError, match="positive integer"):
+        phx.optim.FiniteExhaustiveSearch(1.5)
+    with pytest.raises(ValueError, match="positive"):
+        phx.optim.FiniteExhaustiveSearch(0)
+
+    space = phx.optim.FiniteProductSpace(phx.optim.FiniteAxis(jnp.asarray([0.0, 1.0])))
+    with pytest.raises(TypeError, match="floating-point"):
+        _exhaustive_minimum(
+            lambda value: (value.astype(int), jnp.asarray(True)),
+            space,
+            phx.optim.FiniteExhaustiveSearch(),
+        )
+    with pytest.raises(TypeError, match="boolean"):
+        _exhaustive_minimum(
+            lambda value: (value, jnp.asarray(1)),
+            space,
+            phx.optim.FiniteExhaustiveSearch(),
+        )
+    with pytest.raises(ValueError, match="shapes must match"):
+        _exhaustive_minimum(
+            lambda value: (jnp.stack((value, value)), jnp.asarray(True)),
+            space,
+            phx.optim.FiniteExhaustiveSearch(),
+        )
+
+
+def test_finite_space_cardinality_overflow_is_rejected():
+    huge = object.__new__(phx.optim.FiniteAxis)
+    object.__setattr__(huge, "size", 2**32)
+    with pytest.raises(OverflowError, match="64-bit"):
+        phx.optim.FiniteProductSpace((huge, huge))

--- a/tests/unit/uq/test_map_candidate_search.py
+++ b/tests/unit/uq/test_map_candidate_search.py
@@ -1,0 +1,185 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import phydrax as phx
+
+
+def _quadratic_problem(target=jnp.asarray([1.2, 2.2])):
+    space = phx.uq.ParameterSpace(
+        jnp.zeros((2,)),
+        log_prior=lambda _: jnp.zeros(()),
+    )
+    return phx.uq.PosteriorProblem(
+        space,
+        lambda value: -jnp.sum((value - target) ** 2),
+    )
+
+
+def test_map_candidate_search_finds_exact_correlated_catalog_minimum():
+    problem = _quadratic_problem()
+    candidates = phx.optim.FiniteProductSpace(
+        phx.optim.FiniteAxis(
+            jnp.asarray(
+                [
+                    [-1.0, -1.0],
+                    [1.0, 2.0],
+                    [1.0, 3.0],
+                    [3.0, 4.0],
+                ]
+            )
+        )
+    )
+
+    result = phx.uq.search_map_candidates(
+        problem,
+        candidates,
+        search=phx.optim.FiniteExhaustiveSearch(3),
+    )
+
+    assert isinstance(result, phx.uq.MAPCandidateSearchResult)
+    assert result.valid
+    assert result.termination_reason == "finite_minimum"
+    np.testing.assert_array_equal(result.position, jnp.asarray([1.0, 2.0]))
+    np.testing.assert_array_equal(result.parameters, result.position)
+    assert result.objective == pytest.approx(0.08)
+    assert result.log_density == pytest.approx(-0.08)
+    assert result.flat_index == 1
+    assert result.product_index == (1,)
+    assert result.axis_paths == ("<root>",)
+    assert result.product_shape == (4,)
+    assert result.candidate_count == 4
+    assert result.objective_evaluations == 4
+    assert result.valid_evaluations == 4
+    assert result.invalid_evaluations == 0
+    assert result.effective_batch_size == 3
+    assert result.method_id == "finite-exhaustive-map-candidate-search-v1"
+    assert result.candidate_signature == candidates.signature()
+
+    replay = phx.uq.search_map_candidates(problem, candidates)
+    assert replay.flat_index == result.flat_index
+    assert replay.candidate_signature == result.candidate_signature
+
+
+def test_map_candidate_space_can_factor_independent_structured_coordinates():
+    position = {"offset": jnp.asarray(0.0), "slope": jnp.zeros((2,))}
+    space = phx.uq.ParameterSpace(position, log_prior=lambda _: jnp.zeros(()))
+    problem = phx.uq.PosteriorProblem(
+        space,
+        lambda value: (
+            -(
+                (value["offset"] - 1.0) ** 2
+                + jnp.sum((value["slope"] - jnp.asarray([2.0, 3.0])) ** 2)
+            )
+        ),
+    )
+    candidates = phx.optim.FiniteProductSpace(
+        {
+            "offset": phx.optim.FiniteAxis(jnp.asarray([-1.0, 1.0])),
+            "slope": phx.optim.FiniteAxis(
+                jnp.asarray([[0.0, 0.0], [2.0, 3.0], [4.0, 5.0]])
+            ),
+        }
+    )
+
+    result = phx.uq.search_map_candidates(
+        problem,
+        candidates,
+        search=phx.optim.FiniteExhaustiveSearch(4),
+    )
+
+    assert result.product_shape == (2, 3)
+    assert result.axis_paths == ("['offset']", "['slope']")
+    assert result.flat_index == 4
+    assert result.product_index == (1, 1)
+    assert result.objective == pytest.approx(0.0)
+    assert result.position is not None
+    np.testing.assert_array_equal(result.position["offset"], 1.0)
+    np.testing.assert_array_equal(result.position["slope"], jnp.asarray([2.0, 3.0]))
+
+
+def test_map_candidate_search_reports_partial_and_complete_invalidity():
+    space = phx.uq.ParameterSpace(
+        jnp.asarray(0.0),
+        log_prior=lambda _: jnp.zeros(()),
+    )
+    partial_problem = phx.uq.PosteriorProblem(
+        space,
+        lambda value: jnp.where(value < 0.0, jnp.nan, -((value - 1.0) ** 2)),
+    )
+    candidates = phx.optim.FiniteProductSpace(
+        phx.optim.FiniteAxis(jnp.asarray([-1.0, 0.0, 1.0]))
+    )
+
+    partial = phx.uq.search_map_candidates(partial_problem, candidates)
+    assert partial.valid
+    assert partial.flat_index == 2
+    assert partial.invalid_evaluations == 1
+    assert partial.valid_evaluations == 2
+
+    invalid_problem = phx.uq.PosteriorProblem(
+        space,
+        lambda _: jnp.asarray(jnp.nan),
+    )
+    invalid = phx.uq.search_map_candidates(
+        invalid_problem,
+        candidates,
+        search=phx.optim.FiniteExhaustiveSearch(2),
+    )
+    assert not invalid.valid
+    assert invalid.termination_reason == "no_finite_candidates"
+    assert invalid.position is None
+    assert invalid.parameters is None
+    assert jnp.isnan(invalid.objective)
+    assert jnp.isnan(invalid.log_density)
+    assert invalid.flat_index == -1
+    assert invalid.product_index == (-1,)
+    assert invalid.objective_evaluations == 3
+    assert invalid.valid_evaluations == 0
+    assert invalid.invalid_evaluations == 3
+
+
+def test_map_candidate_search_rejects_incompatible_candidate_points():
+    problem = _quadratic_problem()
+
+    wrong_structure = phx.optim.FiniteProductSpace(
+        {"value": phx.optim.FiniteAxis(jnp.asarray([[1.0, 2.0]]))}
+    )
+    with pytest.raises(ValueError, match="PyTree structure"):
+        phx.uq.search_map_candidates(problem, wrong_structure)
+
+    wrong_shape = phx.optim.FiniteProductSpace(
+        phx.optim.FiniteAxis(jnp.asarray([[1.0, 2.0, 3.0]]))
+    )
+    with pytest.raises(ValueError, match="must have shape"):
+        phx.uq.search_map_candidates(problem, wrong_shape)
+
+    wrong_dtype = phx.optim.FiniteProductSpace(
+        phx.optim.FiniteAxis(jnp.asarray([[1, 2]], dtype=jnp.int32))
+    )
+    with pytest.raises(TypeError, match="dtype"):
+        phx.uq.search_map_candidates(problem, wrong_dtype)
+
+    nonfinite = phx.optim.FiniteProductSpace(
+        phx.optim.FiniteAxis(jnp.asarray([[1.0, jnp.nan]]))
+    )
+    with pytest.raises(ValueError, match="finite"):
+        phx.uq.search_map_candidates(problem, nonfinite)
+
+
+def test_finite_screen_can_seed_local_map_without_claiming_continuous_optimality():
+    problem = _quadratic_problem()
+    candidates = phx.optim.FiniteProductSpace(
+        phx.optim.FiniteAxis(jnp.asarray([[-2.0, -2.0], [1.0, 2.0], [3.0, 3.0]]))
+    )
+
+    screened = phx.uq.search_map_candidates(problem, candidates)
+    assert screened.position is not None
+    refined = phx.uq.find_map(problem, screened.position)
+
+    assert refined.objective < screened.objective
+    np.testing.assert_allclose(refined.position, jnp.asarray([1.2, 2.2]), atol=1e-7)

--- a/tests/unit/uq/test_result_export.py
+++ b/tests/unit/uq/test_result_export.py
@@ -171,6 +171,46 @@ def test_portable_result_archives_cover_declared_uq_result_types(tmp_path):
     ]
 
 
+def test_map_candidate_search_archives_preserve_valid_and_invalid_evidence(tmp_path):
+    problem = _problem()
+    candidates = phx.optim.FiniteProductSpace(
+        {
+            "offset": phx.optim.FiniteAxis(jnp.asarray([-1.0, 0.0, 1.0])),
+            "slope": phx.optim.FiniteAxis(jnp.asarray([[-1.0, -1.0], [-0.3, 0.8]])),
+        }
+    )
+    valid = phx.uq.search_map_candidates(
+        problem,
+        candidates,
+        search=phx.optim.FiniteExhaustiveSearch(4),
+    )
+    invalid_problem = phx.uq.PosteriorProblem(
+        problem.parameter_space,
+        lambda _: jnp.asarray(jnp.nan),
+    )
+    invalid = phx.uq.search_map_candidates(invalid_problem, candidates)
+
+    valid_archive = _assert_archive_matches_adapter(
+        valid,
+        tmp_path / "valid-map-candidate.phxuq",
+    )
+    invalid_archive = _assert_archive_matches_adapter(
+        invalid,
+        tmp_path / "invalid-map-candidate.phxuq",
+    )
+
+    assert valid_archive.kind == "map_candidate_search"
+    assert valid_archive.excluded == ("problem", "search")
+    assert set(valid_archive.trees) == {"position", "parameters"}
+    assert valid_archive.metadata["candidate_signature"] == candidates.signature()
+    assert valid_archive.metadata["search"] == {"batch_size": 4}
+    assert invalid_archive.kind == "map_candidate_search"
+    assert not invalid_archive.metadata["valid"]
+    assert invalid_archive.metadata["termination_reason"] == "no_finite_candidates"
+    assert not invalid_archive.trees
+    assert invalid_archive.excluded == ("problem", "search")
+
+
 def test_arviz_adapter_preserves_chain_draw_parameter_and_sampler_dimensions():
     problem = _problem()
     result = phx.uq.sample_nuts(

--- a/tools/finite_search_benchmarks.py
+++ b/tools/finite_search_benchmarks.py
@@ -1,0 +1,241 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+"""Benchmark factorized finite search against a bounded dense oracle."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+from time import perf_counter
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+import phydrax as phx
+from phydrax.optim._finite import _exhaustive_minimum
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--axes", type=int, default=3)
+    parser.add_argument("--axis-length", type=int, default=16)
+    parser.add_argument("--payload-size", type=int, default=1)
+    parser.add_argument("--objective-size", type=int, default=1)
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=64,
+        help="Candidate batch size; zero selects scalar streaming.",
+    )
+    parser.add_argument("--work", type=int, default=8)
+    parser.add_argument("--repeat", type=int, default=5)
+    parser.add_argument("--max-dense-bytes", type=int, default=512 * 1024 * 1024)
+    return parser
+
+
+def _validate_arguments(arguments: argparse.Namespace) -> None:
+    positive = (
+        "axes",
+        "axis_length",
+        "payload_size",
+        "objective_size",
+        "work",
+        "repeat",
+        "max_dense_bytes",
+    )
+    for name in positive:
+        if int(vars(arguments)[name]) <= 0:
+            raise ValueError(f"--{name.replace('_', '-')} must be positive.")
+    if arguments.batch_size < 0:
+        raise ValueError("--batch-size must be nonnegative.")
+
+
+def _candidate_space(
+    num_axes: int,
+    axis_length: int,
+    payload_size: int,
+) -> phx.optim.FiniteProductSpace:
+    axes = []
+    payload_offsets = jnp.arange(payload_size, dtype=float) / max(payload_size, 1)
+    for axis_index in range(num_axes):
+        coordinates = jnp.linspace(-1.0, 1.0, axis_length)
+        values = coordinates[:, None] + payload_offsets[None, :] + axis_index * 0.01
+        if payload_size == 1:
+            values = values[:, 0]
+        axes.append(phx.optim.FiniteAxis(values))
+    return phx.optim.FiniteProductSpace(tuple(axes))
+
+
+def _evaluator(objective_size: int, work: int):
+    def evaluate(point):
+        leaves = [jnp.ravel(value) for value in jax.tree_util.tree_leaves(point)]
+        state = jnp.concatenate(leaves)
+        score = jnp.sum((state - 0.125) ** 2)
+        for iteration in range(work):
+            scale = 0.001 * (iteration + 1)
+            score = score + scale * jnp.sum(jnp.sin(state + scale) ** 2)
+        if objective_size == 1:
+            return score, jnp.asarray(True)
+        values = score + jnp.arange(objective_size, dtype=score.dtype) * 1e-6
+        return values, jnp.ones((objective_size,), dtype=bool)
+
+    return evaluate
+
+
+def _compile_and_time(function, repeat: int):
+    started = perf_counter()
+    executable = jax.jit(function).lower().compile()
+    compilation_seconds = perf_counter() - started
+    output = jax.block_until_ready(executable())
+    samples = []
+    for _ in range(repeat):
+        started = perf_counter()
+        output = jax.block_until_ready(executable())
+        samples.append(perf_counter() - started)
+    return executable, output, compilation_seconds, samples
+
+
+def _memory_report(executable) -> dict[str, int]:
+    memory = executable.memory_analysis()
+    return {
+        "argument_bytes": int(memory.argument_size_in_bytes),
+        "output_bytes": int(memory.output_size_in_bytes),
+        "temporary_bytes": int(memory.temp_size_in_bytes),
+        "alias_bytes": int(memory.alias_size_in_bytes),
+        "generated_code_bytes": int(memory.generated_code_size_in_bytes),
+    }
+
+
+def _timing_report(samples: list[float], candidate_count: int) -> dict[str, float]:
+    values = np.asarray(samples, dtype=float)
+    median = float(np.median(values))
+    return {
+        "minimum_seconds": float(np.min(values)),
+        "median_seconds": median,
+        "maximum_seconds": float(np.max(values)),
+        "candidate_evaluations_per_second": float(candidate_count / median),
+    }
+
+
+def _json_value(value):
+    array = np.asarray(value)
+    return array.item() if array.shape == () else array.tolist()
+
+
+def run_benchmark(arguments: argparse.Namespace) -> dict[str, object]:
+    _validate_arguments(arguments)
+    space = _candidate_space(
+        arguments.axes,
+        arguments.axis_length,
+        arguments.payload_size,
+    )
+    evaluator = _evaluator(arguments.objective_size, arguments.work)
+    search = phx.optim.FiniteExhaustiveSearch(arguments.batch_size or None)
+    candidate_count = space.size
+    dtype_bytes = np.dtype(jnp.asarray(0.0).dtype).itemsize
+    candidate_storage_bytes = sum(
+        int(value.size * value.dtype.itemsize)
+        for axis in jax.tree_util.tree_leaves(
+            space.axes,
+            is_leaf=lambda value: isinstance(value, phx.optim.FiniteAxis),
+        )
+        for value in jax.tree_util.tree_leaves(axis.values)
+    )
+    dense_candidate_bytes = (
+        candidate_count * arguments.axes * arguments.payload_size * dtype_bytes
+    )
+    dense_objective_bytes = candidate_count * arguments.objective_size * dtype_bytes
+    estimated_dense_bytes = dense_candidate_bytes + dense_objective_bytes
+
+    def streaming_search():
+        evidence = _exhaustive_minimum(evaluator, space, search)
+        return evidence.minimum, evidence.flat_index
+
+    streaming_executable, streaming_output, streaming_compile, streaming_samples = (
+        _compile_and_time(streaming_search, arguments.repeat)
+    )
+    report: dict[str, object] = {
+        "backend": jax.default_backend(),
+        "device": str(jax.devices()[0]),
+        "host": platform.platform(),
+        "configuration": {
+            "axis_sizes": list(space.product_shape),
+            "axis_count": arguments.axes,
+            "payload_size": arguments.payload_size,
+            "objective_size": arguments.objective_size,
+            "candidate_count": candidate_count,
+            "requested_batch_size": arguments.batch_size or None,
+            "effective_batch_size": search.effective_batch_size(candidate_count),
+            "work": arguments.work,
+            "repeat": arguments.repeat,
+            "max_dense_bytes": arguments.max_dense_bytes,
+        },
+        "storage": {
+            "factorized_candidate_bytes": candidate_storage_bytes,
+            "estimated_dense_candidate_bytes": dense_candidate_bytes,
+            "estimated_dense_objective_bytes": dense_objective_bytes,
+            "estimated_dense_total_bytes": estimated_dense_bytes,
+        },
+        "streaming": {
+            "compilation_seconds": streaming_compile,
+            "timing": _timing_report(streaming_samples, candidate_count),
+            "compiler_memory": _memory_report(streaming_executable),
+            "minimum": _json_value(streaming_output[0]),
+            "flat_index": _json_value(streaming_output[1]),
+            "attempted_evaluations": candidate_count,
+        },
+    }
+
+    if estimated_dense_bytes > arguments.max_dense_bytes:
+        report["dense"] = {
+            "executed": False,
+            "reason": "estimated_dense_bytes_exceeds_limit",
+        }
+        return report
+
+    def dense_search():
+        points = space.take(jnp.arange(candidate_count, dtype=jnp.int64))
+        scores, valid = jax.vmap(evaluator)(points)
+        finite = valid & jnp.isfinite(scores)
+        masked = jnp.where(finite, scores, jnp.inf)
+        minimum = jnp.min(masked, axis=0)
+        flat_index = jnp.argmin(masked, axis=0).astype(jnp.int64)
+        return minimum, flat_index
+
+    dense_executable, dense_output, dense_compile, dense_samples = _compile_and_time(
+        dense_search,
+        arguments.repeat,
+    )
+    if not np.array_equal(
+        np.asarray(streaming_output[1]),
+        np.asarray(dense_output[1]),
+    ) or not np.allclose(
+        np.asarray(streaming_output[0]),
+        np.asarray(dense_output[0]),
+        rtol=1e-12,
+        atol=1e-12,
+    ):
+        raise RuntimeError("Streaming search disagrees with the dense oracle.")
+    report["dense"] = {
+        "executed": True,
+        "compilation_seconds": dense_compile,
+        "timing": _timing_report(dense_samples, candidate_count),
+        "compiler_memory": _memory_report(dense_executable),
+        "minimum": _json_value(dense_output[0]),
+        "flat_index": _json_value(dense_output[1]),
+        "attempted_evaluations": candidate_count,
+    }
+    return report
+
+
+def main() -> None:
+    arguments = _parser().parse_args()
+    print(json.dumps(run_benchmark(arguments), indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR adds a Phydrax-owned finite optimization substrate and two concrete domain adapters:

- deterministic finite-candidate MAP screening under `phydrax.uq`;
- exact finite control-catalog selection under `phydrax.control`.

The implementation keeps finite-set claims distinct from continuous global optimization. It enumerates every declared candidate exactly once, records explicit invalidity and index evidence, and does not materialize or retain the full Cartesian candidate landscape.

## Motivation

Several scientific workflows start from a small, explicit catalog rather than a continuous box: known posterior modes, phase/model cases, complete controller coefficients, or correlated template choices. Differential evolution can search a bounded continuous domain, but it cannot certify the exact minimum of a declared finite set or provide deterministic replay without a key.

This change introduces that narrower contract without expanding the optimization namespace into a generic discrete-optimization framework.

## Finite optimization substrate

### `FiniteAxis`

`FiniteAxis` stores one correlated array-backed catalog. Every array leaf has the same nonempty leading candidate dimension; trailing dimensions remain the payload of one candidate. This preserves coupled vectors, matrices, and structured PyTree values rather than accidentally taking a Cartesian product of their components.

### `FiniteProductSpace`

`FiniteProductSpace` combines one or more explicit axes into a lazy Cartesian product:

- candidate order follows deterministic JAX PyTree path order;
- the last product axis varies fastest;
- `ravel_index`, `unravel_index`, and `take` share the same checked row-major convention;
- negative and oversized indices are rejected rather than clipped;
- signed 64-bit cardinality overflow is rejected before execution;
- `signature()` covers paths, grouping, shapes, dtypes, and candidate bytes.

Only the axis arrays are stored. Cartesian candidate tensors are reconstructed on demand from flat indices.

### `FiniteExhaustiveSearch`

`FiniteExhaustiveSearch` configures scalar streaming or fixed-size batches. The private reduction kernel provides:

- exact-size remainder execution with no padding or repeated terminal candidates;
- associative finite-minimum evidence suitable for future shard-level merging;
- stable first-flat-index tie breaking within and across batches;
- separate attempted and invalid evaluation counts;
- elementwise minima for fixed-shape scalar, vector, or matrix objectives;
- explicit all-invalid sentinels;
- stopped gradients through discrete selection and reconstructed winners.

The default is scalar streaming. Positive batch sizes trade transient candidate/output memory for evaluator throughput.

## MAP candidate screening

`phydrax.uq.search_map_candidates` evaluates `PosteriorProblem.negative_log_density` over declared unconstrained posterior positions.

The adapter requires each reconstructed point to match `initial_position` exactly in PyTree structure, trailing leaf shapes, and dtypes. It retains:

- selected unconstrained position and constrained parameters;
- objective and log density without reevaluating the winner;
- flat and product indices;
- deterministic axis paths and product shape;
- exact attempted, valid, and invalid counts;
- effective batching, method identity, and candidate signature.

If every candidate is invalid or nonfinite, the result contains no position or parameters, uses `-1` index sentinels, and reports `NaN` objective/log density. Continuous local refinement remains an explicit follow-on call to `find_map`; the finite search does not imply stationarity outside the catalog.

Portable UQ export now supports the `map_candidate_search` archive kind. Live posterior/search objects are excluded while finite-space provenance, counts, selected arrays, and all-invalid evidence remain portable.

## Exact control catalogs

`phydrax.control.search_control_candidates` accepts a correlated catalog of complete coefficient arrays with shape `case_shape + parameterization.parameter_shape`.

Each candidate uses the existing control rollout, sampled-cost, and sampled-feasibility contracts. A candidate is selectable only when every case has a successful rollout, every declared sampled constraint is feasible, and the aggregate sampled objective is finite.

The search kernel retains objective, validity, and index evidence only. After selection, the adapter reconstructs the winning coefficients and performs one full winner evaluation to return the native `ControlResult` and trajectory. Search evaluations and winner reconstruction are accounted for separately. All-invalid catalogs do not fabricate coefficients, trajectories, controls, or control IDs.

## Public API

New optimization exports:

- `phydrax.optim.FiniteAxis`
- `phydrax.optim.FiniteProductSpace`
- `phydrax.optim.FiniteExhaustiveSearch`

New UQ exports:

- `phydrax.uq.search_map_candidates`
- `phydrax.uq.MAPCandidateSearchResult`

New control exports:

- `phydrax.control.search_control_candidates`
- `phydrax.control.ControlCandidateSearchResult`

Existing differential-evolution MAP and control APIs remain unchanged.

## Documentation and tooling

The optimization, UQ, control, export, cookbook, and top-level API documentation now distinguish:

- exact optimality over a declared finite set;
- bounded stochastic differential-evolution initialization;
- continuous local stationarity.

`tools/finite_search_benchmarks.py` compares factorized streaming against a memory-capped dense oracle and reports candidate cardinality, stored and estimated dense bytes, compilation/steady execution timing, compiler memory, exact evaluation counts, and selected value/index agreement.

## Explicit non-goals

This PR does not add top-k or Pareto reduction, adaptive splitting, branch-and-bound, mixed-integer programming, retained score landscapes, host progress callbacks, implicit local refinement, or multi-device sharding claims. Those surfaces remain deferred until a concrete Phydrax domain requires them.