### PR TITLE
feat: add operator-native moment calibration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@
 
 ### Added
 
+- `phydrax.weighting` exact and quadratically reconciled relative-entropy moment
+  calibration for dense, sparse, and matrix-free feature actions, with affine-rank
+  reduction, audited convergence/regularity evidence, warm starts, and implicit
+  target/prior derivatives. The mathematical formulation follows Barratt, Angeris,
+  and Boyd's *Optimal Representative Sample Weighting*; the public `cvxgrp/rsw`
+  and Apache-2.0 `andytimm/rswjax` packages are acknowledged as design
+  inspiration, while this implementation is independent and Phydrax-native.
+- Finite-measure calibration in `phydrax.integration`, shared calibration/coreset
+  lowering, and ordered transformation diagnostics that preserve physical mass,
+  masks, named axes, ancestry, support validity, execution keys, and provenance
+  while invalidating inapplicable inherited integration-error bounds.
+- Dense/sparse exact/soft calibration benchmarks with separate setup, first
+  compilation, steady-state, cold-nearby, and warm-nearby timing and numerical
+  evidence.
+- Newton--Krylov now passes its adaptive forcing tolerance into each inner linear
+  solve, so forcing policy changes actual Krylov work under eager and compiled
+  execution.
+
 - `phydrax.nonlinear` contracts for algebraic systems, Newton line-search and
   trust-region roots, nonlinear GMRES and preconditioning, fixed-point acceleration,
   full-approximation multigrid cycles, variational inequalities, semismooth

--- a/NOTICE
+++ b/NOTICE
@@ -47,3 +47,14 @@ Phydrax uses ASDEX as a compile-time global sparsity-detection and optimized-
 coloring dependency through its public Python API. ASDEX artifacts are
 normalized before Phydrax evaluates compressed derivatives through native JAX.
 See LICENSES/ASDEX-MIT.txt.
+
+Research and design acknowledgments
+
+The moment-calibration formulation follows Shane Barratt, Guillermo Angeris,
+and Stephen Boyd, “Optimal Representative Sample Weighting,” Statistics and
+Computing 31:19 (2021), and its public cvxgrp/rsw implementation.
+
+The absorption study also considered rswjax by Andrew Timm, licensed under the
+Apache License, Version 2.0. The Phydrax moment-calibration implementation is
+independent and does not include source code copied or translated from rsw or
+rswjax.

--- a/docs/all-of-phydrax.md
+++ b/docs/all-of-phydrax.md
@@ -193,6 +193,25 @@ execution does not support the parallel method. Discrete particle ancestry and
 resampling choices are nondifferentiable.
 
 
+### Moment calibration and target-aware finite measures
+
+`phydrax.weighting` computes the minimum-relative-entropy reweighting of a finite
+prior subject to exact feature expectations, or reconciles uncertain and
+unreachable expectations with a diagonal quadratic discrepancy. Dense,
+`SparseLinearMap`, and compatible matrix-free moment actions share one moment-space
+geometry path with explicit affine-rank, target-residual, regularity, optimizer, KL,
+effective-sample-size, support, and provenance evidence. Exact success means a
+finite regular relative-interior solution; boundary and inconsistent targets remain
+typed failures.
+
+`phydrax.integration.calibrate` applies that contract to a reusable realized
+measure while preserving physical mass, axes, masks, ancestry, support validity,
+and execution key. Calibration and coreset compression compose as an ordered
+transformation chain, allowing correction before support reduction without
+conflating feature preservation with a general integration-error bound. See
+[API → Moment weighting](api/weighting.md) and
+[Guides → Integrals and measures](guides_integrals.md#calibrate-a-reusable-finite-realization).
+
 ### Optimal transport: geometry between finite measures
 
 `phydrax.transport` lowers integration-native finite targets and explicit realizations
@@ -767,6 +786,7 @@ Below are the common SciML regimes expressed in Phydrax’s primitives.
 - `phydrax.conditions` for residual, moment, observation, and physical conditions.
 - `phydrax.terms` for penalty and specialized numerical/data terms.
 - `phydrax.integration` for targets, sources, and reductions.
+- `phydrax.weighting` for exact and quadratically reconciled moment calibration.
 - `phydrax.special` for JAX-native named special functions and integral primitives.
 - `phydrax.enforcement` for exact condition transforms.
 - `phydrax.operators` for PDE operators.

--- a/docs/api/integration.md
+++ b/docs/api/integration.md
@@ -50,8 +50,34 @@ measures, and composed space/time/stochastic reductions.
 ::: phydrax.integration.IntegrationRealization
 
 ---
+::: phydrax.integration.calibrate
+
+---
+
 
 ::: phydrax.integration.compress
+
+---
+
+
+## Measure calibration
+
+`calibrate` reweights an already materialized finite positive measure to exact or
+quadratically reconciled normalized feature expectations. It preserves physical
+mass and sample metadata, requires a successful core calibration, and appends
+ordered transformation evidence before downstream reduction.
+
+::: phydrax.integration.MeasureCalibrationDiagnostics
+
+---
+
+::: phydrax.integration.MeasureTransformationRecord
+
+---
+
+::: phydrax.integration.TransformedIntegrationDiagnostics
+
+---
 
 ## Measure compression
 
@@ -108,10 +134,6 @@ selection = phx.coresets.kernel_herd(
 ---
 
 ::: phydrax.integration.MeasureCompressionDiagnostics
-
----
-
-::: phydrax.integration.CompressedIntegrationDiagnostics
 
 ---
 

--- a/docs/api/phydrax.md
+++ b/docs/api/phydrax.md
@@ -10,6 +10,9 @@ Top-level package namespace. Most functionality lives in subpackages:
 - `phydrax.conditions`: residual, moment, observation, and physical condition declarations
 - `phydrax.terms`: penalty terms and specialized numerical/data terms
 - `phydrax.integration`: integration targets, sources, reductions, and realizations
+- `phydrax.weighting`: exact and quadratically reconciled relative-entropy
+  moment calibration with operator-native geometry, audited status, and implicit
+  derivatives
 - `phydrax.transport`: balanced finite-measure transport, Sinkhorn divergence,
   exact and sliced Wasserstein distances, and differentiable order operations
 - `phydrax.kernels`: composable positive-definite covariance functions shared by

--- a/docs/api/weighting.md
+++ b/docs/api/weighting.md
@@ -1,0 +1,131 @@
+# Moment weighting
+
+`phydrax.weighting` constructs normalized finite measures whose declared feature
+expectations match external targets. It is the target-aware complement to
+`phydrax.coresets`: calibration changes weights on an existing support; coreset
+methods subsequently reduce that support.
+
+For source points with prior probabilities `p`, feature matrix `F` with shape
+`(source_points, moment_count)`, and target moments `t`, exact calibration solves
+
+```text
+minimize    sum_i w_i log(w_i / p_i)
+subject to  w >= 0, sum(w) = 1, F.T @ w = t
+```
+
+`ExactMoments` certifies success only for a finite, regular relative-interior
+solution. An affine-inconsistent or boundary-only target returns a typed failure
+status; the solver never clips the target or reports a finite exponential tilt as
+an exact boundary solution.
+
+`QuadraticMoments(t, scale=s)` instead solves
+
+```text
+minimize  0.5 * sum_j ((F.T @ w - t)_j / s_j)^2
+          + sum_i w_i log(w_i / p_i)
+subject to w >= 0, sum(w) = 1
+```
+
+Every scale must be finite and strictly positive. This problem remains regular for
+finite targets outside the source moment hull and exposes the achieved moments and
+residual rather than pretending to attain an unreachable target.
+
+```python
+import jax.numpy as jnp
+import phydrax as phx
+
+points = jnp.linspace(-1.0, 1.0, 101)
+features = jnp.stack((points, points**2), axis=1)
+problem = phx.weighting.MomentCalibrationProblem(
+    features,
+    phx.weighting.ExactMoments(jnp.array([0.2, 0.45])),
+)
+result = phx.weighting.require_converged(
+    phx.weighting.calibrate_moments(problem)
+)
+weights = result.weights
+```
+
+A dense feature array is interpreted as `(source_points, moment_count)` and lowered
+to the operator `F.T`. `SparseLinearMap` and compatible one-dimensional
+`AbstractLinearOperator` implementations are accepted directly. Geometry is formed
+in moment space; neither path materializes a source-by-source matrix. Masks and
+negative-infinite prior log weights retain exactly zero mass.
+
+The solver removes constant and linearly redundant feature directions through an
+audited covariance eigenspectrum. Results retain affine rank and consistency,
+physical and scaled residuals, covariance regularity, optimizer evidence, KL
+divergence, effective sample size, active support, weight extrema, and provenance.
+Use `initial_dual=` to warm-start nearby targets.
+
+`implicit_calibrate_moments` returns only normalized weights and differentiates the
+regular stationarity equation rather than unrolling optimizer iterations. It raises
+for affine-inconsistent, boundary, singular, non-finite, or unconverged exact
+solutions. Gradients with respect to targets and finite prior logits are supported
+on a fixed support and fixed numerical rank; masks, rank changes, and active-set
+changes are not differentiable contracts.
+
+For a materialized integration measure, use `phydrax.integration.calibrate` instead.
+That adapter preserves physical mass, sample axes, masks, ancestry, support validity,
+execution key, and ordered transformation provenance. See
+[Integrals and measures](../guides_integrals.md#calibrate-a-reusable-finite-realization).
+
+## Problem and target contracts
+
+::: phydrax.weighting.MomentCalibrationProblem
+
+---
+
+::: phydrax.weighting.ExactMoments
+
+---
+
+::: phydrax.weighting.QuadraticMoments
+
+---
+
+::: phydrax.weighting.MomentCalibrationPolicy
+
+## Solvers
+
+::: phydrax.weighting.calibrate_moments
+
+---
+
+::: phydrax.weighting.implicit_calibrate_moments
+
+---
+
+::: phydrax.weighting.require_converged
+
+## Results and evidence
+
+::: phydrax.weighting.MomentCalibrationResult
+
+---
+
+::: phydrax.weighting.MomentCalibrationDiagnostics
+
+---
+
+::: phydrax.weighting.MomentCalibrationStatus
+
+---
+
+::: phydrax.weighting.MomentCalibrationProvenance
+
+---
+
+::: phydrax.weighting.moment_calibration_status_message
+
+## Method provenance
+
+The mathematical formulation follows Shane Barratt, Guillermo Angeris, and Stephen
+Boyd, [“Optimal Representative Sample
+Weighting”](https://stanford.edu/~boyd/papers/optimal_representative_sampling.html),
+*Statistics and Computing* 31:19 (2021). The public
+[`cvxgrp/rsw`](https://github.com/cvxgrp/rsw) implementation and Andrew Timm's
+Apache-2.0 [`rswjax`](https://github.com/andytimm/rswjax) package motivated this
+absorption study. The Phydrax implementation is independent: it does not import,
+copy, or translate either package and instead uses Phydrax-native operator,
+optimization, spectral, differentiation, diagnostics, and integration contracts.

--- a/docs/guides_integrals.md
+++ b/docs/guides_integrals.md
@@ -102,6 +102,49 @@ An integrand may itself be any nonempty PyTree of `DomainFunction`, callable, or
 array leaves. Reduction preserves that container structure and every leaf dtype in
 `estimate.value`; method diagnostics are returned with the same leaf structure.
 
+## Calibrate a reusable finite realization
+
+Calibration corrects a finite measure to externally known normalized feature
+expectations without discarding source points:
+
+```python
+samples = jnp.linspace(0.0, 1.0, 41)
+source = phx.integration.materialize(
+    phx.integration.weighted(
+        samples,
+        jnp.zeros((41,)),
+        normalized=False,
+        target_mass=jnp.asarray(7.0),
+    )
+)
+calibrated = phx.integration.calibrate(
+    source,
+    phx.weighting.ExactMoments(jnp.array([0.7])),
+    features=samples,
+)
+
+physical_first_moment = phx.integration.reduce(lambda x: x, calibrated)
+```
+
+The calibration target is always a normalized expectation: here it requests mean
+`0.7`. The transformed measure retains physical mass `7`, so reducing `x` returns
+`4.9`. `QuadraticMoments` provides soft reconciliation when targets are uncertain or
+outside the finite moment hull.
+
+Calibration accepts one-axis `PointIntegrationBatch` and `WeightedSampleBatch`
+realizations. A feature callable, array, named `coordax.Field`, or supported feature
+PyTree is canonicalized to `(source_points, moment_count)`. Sample values, named or
+positional sample axis, explicit mask, zero-prior support, ancestry, support validity,
+execution key, and source provenance remain attached. Strata, antithetic pairs,
+replicates, component unions, and multi-axis measures are rejected until their joint
+weight constraints can be preserved.
+
+Each calibration or compression appends a `MeasureTransformationRecord`.
+`TransformedIntegrationDiagnostics` retains that ordered history beside the
+downstream reduction diagnostics. Because reweighting invalidates the original
+quadrature or Monte Carlo error model, transformed reductions report
+`error_estimate=None` rather than a misleading inherited bound.
+
 ## Compress a reusable finite realization
 
 For several expensive integrands over the same finite positive measure, insert
@@ -126,12 +169,14 @@ moments, including mass through its internal constant feature. The result retain
 most one more active point than the supplied feature count. `KernelHerding(k)` instead
 selects `k` equally weighted points that greedily reduce a blockwise kernel MMD.
 
-Compression currently accepts a finite, one-axis `PointIntegrationBatch` or
-`WeightedSampleBatch`. It rejects signed weights and any stratum, antithetic pair,
-replicate, or component-union structure that cannot yet be preserved exactly. Source
-ancestry, target mass, named sample axes, masks, execution key, and provenance survive
-the reduction. `CompressedIntegrationDiagnostics` keeps selection evidence separate
-from downstream integration diagnostics.
+Compression accepts the same finite one-axis measure substrate as calibration. It
+rejects signed weights and any stratum, antithetic pair, replicate, or
+component-union structure that cannot yet be preserved exactly. Source ancestry,
+target mass, named sample axes, masks, execution key, and provenance survive the
+reduction. Its `MeasureTransformationRecord` contains
+`MeasureCompressionDiagnostics`; `TransformedIntegrationDiagnostics` keeps the
+complete ordered transformation chain separate from downstream integration
+diagnostics.
 
 Compression discrepancy is not reported as `IntegrationEstimate.error_estimate`:
 feature-moment residual and MMD are construction diagnostics, not general error bounds

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -134,6 +134,7 @@ nav:
         - External solver backends: "api/backends.md"
         - Sparse derivatives: "api/sparse_derivatives.md"
         - Integration: "api/integration.md"
+        - Moment weighting: "api/weighting.md"
         - Optimal transport:
             - Overview: "api/transport/index.md"
             - Ground costs: "api/transport/costs.md"

--- a/phydrax/__init__.py
+++ b/phydrax/__init__.py
@@ -11,8 +11,8 @@ jax.config.update("jax_enable_x64", True)
 from . import (
     backends,
     conditions,
-    control,
     continuation,
+    control,
     coresets,
     data_utils,
     domain,
@@ -39,6 +39,7 @@ from . import (
     terms,
     transport,
     uq,
+    weighting,
 )
 
 
@@ -74,4 +75,5 @@ __all__ = [
     "solver",
     "stochastic",
     "uq",
+    "weighting",
 ]

--- a/phydrax/_measure_weights.py
+++ b/phydrax/_measure_weights.py
@@ -18,6 +18,7 @@ def normalized_weights(
     rows_valid: Array | None = None,
 ) -> tuple[Array, Array, Array, Array]:
     """Normalize a masked finite log-weight vector without changing its shape."""
+
     if log_weights is None:
         values = jnp.zeros((count,), dtype=float)
     else:
@@ -48,6 +49,7 @@ def normalized_weights(
 
 def log_weights_from_normalized(weights: Array, mask: Array, /) -> Array:
     """Represent normalized nonnegative weights with inactive negative infinities."""
+
     values = jnp.asarray(weights, dtype=float)
     included = jnp.asarray(mask, dtype=bool)
     safe = jnp.where(included, values, 1.0)

--- a/phydrax/_numerics/_stable_reductions.py
+++ b/phydrax/_numerics/_stable_reductions.py
@@ -17,7 +17,9 @@ def log_normalize(
     keepdims: bool = False,
 ) -> tuple[Array, Array, Array]:
     """Normalize masked log weights independently over explicit sample axes."""
-    log_weights_ = jnp.asarray(log_weights, dtype=float)
+    log_weights_ = jnp.asarray(log_weights)
+    if not jnp.issubdtype(log_weights_.dtype, jnp.inexact):
+        log_weights_ = log_weights_.astype(float)
     raw_axes = (axes,) if isinstance(axes, int) else tuple(axes)
     if not raw_axes:
         raise ValueError("axes must contain at least one reduction axis.")
@@ -48,7 +50,7 @@ def log_normalize(
     safe_maximum = jnp.where(jnp.isfinite(maximum), maximum, 0.0)
     scaled = jnp.where(active, jnp.exp(log_weights_ - safe_maximum), 0.0)
     total = jnp.sum(scaled, axis=resolved_axes, keepdims=True)
-    safe_total = jnp.maximum(total, jnp.finfo(float).tiny)
+    safe_total = jnp.maximum(total, jnp.finfo(log_weights_.dtype).tiny)
     normalized = jnp.where(valid, scaled / safe_total, 0.0)
     log_sum = jnp.where(valid, safe_maximum + jnp.log(safe_total), -jnp.inf)
     if keepdims:

--- a/phydrax/coresets/_herding.py
+++ b/phydrax/coresets/_herding.py
@@ -14,10 +14,10 @@ from phydrax.kernels import (
     SquaredExponentialKernel,
 )
 
+from .._measure_weights import log_weights_from_normalized, normalized_weights
 from .._strict import StrictModule
 from ._kernel_reductions import _weighted_kernel_mean, _weighted_kernel_sum
 from ._types import CoresetSelection, KernelHerdingDiagnostics
-from ._weights import log_weights_from_normalized, normalized_weights
 
 
 class KernelHerding(StrictModule):

--- a/phydrax/coresets/_pivoted_cholesky.py
+++ b/phydrax/coresets/_pivoted_cholesky.py
@@ -16,9 +16,9 @@ from phydrax.kernels import (
 )
 
 from .._doc import DOC_KEY0
+from .._measure_weights import log_weights_from_normalized
 from .._strict import StrictModule
 from ._types import CoresetSelection, PivotedCholeskyDiagnostics
-from ._weights import log_weights_from_normalized
 
 
 class RandomizedPivotedCholesky(StrictModule):

--- a/phydrax/coresets/_recombination.py
+++ b/phydrax/coresets/_recombination.py
@@ -11,9 +11,9 @@ import jax
 import jax.numpy as jnp
 from jaxtyping import Array
 
+from .._measure_weights import log_weights_from_normalized, normalized_weights
 from .._strict import StrictModule
 from ._types import CoresetSelection, MomentRecombinationDiagnostics
-from ._weights import log_weights_from_normalized, normalized_weights
 
 
 class MomentRecombination(StrictModule):

--- a/phydrax/integration/__init__.py
+++ b/phydrax/integration/__init__.py
@@ -12,11 +12,8 @@ from ._batches import (
     SeparableIntegrationBatch,
     WeightedSampleBatch,
 )
-from ._compression import (
-    compress,
-    CompressedIntegrationDiagnostics,
-    MeasureCompressionDiagnostics,
-)
+from ._calibration import calibrate, MeasureCalibrationDiagnostics
+from ._compression import compress, MeasureCompressionDiagnostics
 from ._estimates import (
     AdaptivePartition,
     AdaptiveQuadratureDiagnostics,
@@ -135,6 +132,10 @@ from ._targets import (
     weighted,
     WeightedSampleTarget,
 )
+from ._transformations import (
+    MeasureTransformationRecord,
+    TransformedIntegrationDiagnostics,
+)
 
 
 __all__ = [
@@ -157,7 +158,6 @@ __all__ = [
     "CellQuadraturePlan",
     "CallerIntegration",
     "ClenshawCurtisRule",
-    "CompressedIntegrationDiagnostics",
     "ComponentTarget",
     "ControlVariateEstimator",
     "DensityTarget",
@@ -175,7 +175,9 @@ __all__ = [
     "IntegrationBatch",
     "IntegrationEstimate",
     "IntegrationPlan",
+    "MeasureCalibrationDiagnostics",
     "MeasureCompressionDiagnostics",
+    "MeasureTransformationRecord",
     "IntegrationProvenance",
     "IntegrationStatus",
     "IntegrationRealization",
@@ -226,10 +228,12 @@ __all__ = [
     "StratifiedDiagnostics",
     "StratifiedMonteCarloPlan",
     "TanhSinhRule",
+    "TransformedIntegrationDiagnostics",
     "WeightedSampleBatch",
     "WeightedSampleTarget",
     "adaptive",
     "caller",
+    "calibrate",
     "compress",
     "discrete",
     "density",

--- a/phydrax/integration/_api.py
+++ b/phydrax/integration/_api.py
@@ -69,19 +69,23 @@ from ._targets import (
     ProbabilityTarget,
     WeightedSampleTarget,
 )
+from ._transformations import (
+    MeasureTransformationRecord,
+    TransformedIntegrationDiagnostics,
+)
 
 
 _KEY_UNSET = object()
 
 
 class IntegrationRealization(StrictModule):
-    """A target, plan, reusable batch, execution key, and optional compression."""
+    """A target, plan, reusable batch, execution key, and transformation history."""
 
     target: Any
     plan: Any
     batch: Any
     key: Any
-    compression: Any | None = None
+    transformations: tuple[MeasureTransformationRecord, ...]
 
     def __init__(
         self,
@@ -89,38 +93,47 @@ class IntegrationRealization(StrictModule):
         plan: Any,
         batch: Any,
         key: Any,
-        compression: Any | None = None,
+        transformations: tuple[MeasureTransformationRecord, ...] = (),
         /,
     ):
         self.target = target
         self.plan = plan
         self.batch = batch
         self.key = key
-        self.compression = compression
+        records = tuple(transformations)
+        if any(not isinstance(item, MeasureTransformationRecord) for item in records):
+            raise TypeError(
+                "transformations must contain MeasureTransformationRecord values."
+            )
+        self.transformations = records
 
 
-def _attach_compression(
+def _attach_transformations(
     estimate: IntegrationEstimate,
     realization: IntegrationRealization,
     /,
 ) -> IntegrationEstimate:
-    if realization.compression is None:
+    if not realization.transformations:
         return estimate
-    from ._compression import CompressedIntegrationDiagnostics
     from ._estimates import IntegrationProvenance
 
+    final_kind = realization.transformations[-1].kind
+    method = {
+        "calibration": "calibrated",
+        "compression": "compressed",
+    }.get(final_kind, "transformed")
     return IntegrationEstimate(
         estimate.value,
         status=estimate.status,
         num_evaluations=estimate.num_evaluations,
         error_estimate=None,
         error_kind=None,
-        diagnostics=CompressedIntegrationDiagnostics(
-            realization.compression,
+        diagnostics=TransformedIntegrationDiagnostics(
+            realization.transformations,
             estimate.diagnostics,
         ),
         provenance=IntegrationProvenance(
-            "compressed",
+            method,
             estimate.provenance.target,
             estimate.provenance.realization,
         ),
@@ -369,7 +382,7 @@ def reduce(
         estimate = integrate_weighted_samples(
             integrand, target, realization.batch, key=key, kwargs=kwargs
         )
-        return _attach_compression(estimate, realization)
+        return _attach_transformations(estimate, realization)
     if isinstance(target, DiscreteMeasureTarget):
         return integrate_discrete_measure(
             integrand, target, realization.batch, key=key, kwargs=kwargs

--- a/phydrax/integration/_calibration.py
+++ b/phydrax/integration/_calibration.py
@@ -1,0 +1,98 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from typing import Any
+
+import equinox as eqx
+from jaxtyping import Array
+
+from .._strict import StrictModule
+from ..optim import AbstractScalarIterativeMethod, OptimizationTermination
+from ..weighting import (
+    calibrate_moments,
+    ExactMoments,
+    MomentCalibrationPolicy,
+    MomentCalibrationProblem,
+    MomentCalibrationResult,
+    QuadraticMoments,
+    require_converged,
+)
+from ._measure_transform import (
+    feature_matrix,
+    lower_finite_measure,
+    transformed_weighted_realization,
+)
+
+
+class MeasureCalibrationDiagnostics(StrictModule):
+    """Calibration evidence and source identity for one reweighted realization."""
+
+    calibration: MomentCalibrationResult
+    source_mass: Array
+    source_points: int = eqx.field(static=True)
+    feature_count: int = eqx.field(static=True)
+    source_provenance: str = eqx.field(static=True)
+
+
+def calibrate(
+    realization: Any,
+    target: ExactMoments | QuadraticMoments,
+    /,
+    *,
+    features: Any | None = None,
+    method: AbstractScalarIterativeMethod | None = None,
+    termination: OptimizationTermination | None = None,
+    policy: MomentCalibrationPolicy | None = None,
+    initial_dual: Array | None = None,
+):
+    """Calibrate one realized finite measure to normalized target expectations."""
+
+    if not isinstance(target, (ExactMoments, QuadraticMoments)):
+        raise TypeError("target must be ExactMoments or QuadraticMoments.")
+    measure = lower_finite_measure(realization)
+    raw_features = (
+        measure.samples
+        if features is None
+        else features(measure.samples)
+        if callable(features)
+        else features
+    )
+    feature_values = feature_matrix(raw_features, measure.axis, measure.count)
+    problem = MomentCalibrationProblem(
+        feature_values,
+        target,
+        prior_log_weights=measure.log_weights,
+        mask=measure.mask,
+    )
+    result = require_converged(
+        calibrate_moments(
+            problem,
+            method=method,
+            termination=termination,
+            policy=policy,
+            initial_dual=initial_dual,
+        )
+    )
+    diagnostics = MeasureCalibrationDiagnostics(
+        calibration=result,
+        source_mass=measure.physical_mass,
+        source_points=measure.count,
+        feature_count=int(feature_values.shape[1]),
+        source_provenance=measure.source_provenance,
+    )
+    target_kind = "exact" if isinstance(target, ExactMoments) else "quadratic"
+    provenance = f"calibrated:{target_kind}:{measure.source_provenance}"
+    return transformed_weighted_realization(
+        realization,
+        measure,
+        result.log_weights,
+        transformation_kind="calibration",
+        transformation_diagnostics=diagnostics,
+        provenance=provenance,
+    )
+
+
+__all__ = ["MeasureCalibrationDiagnostics", "calibrate"]

--- a/phydrax/integration/_compression.py
+++ b/phydrax/integration/_compression.py
@@ -5,14 +5,9 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any, cast
+from typing import Any
 
-import coordax as cx
 import equinox as eqx
-import jax
-import jax.numpy as jnp
-import jax.tree_util as jtu
-from jax import core as jax_core
 from jaxtyping import Array
 
 from phydrax.coresets import (
@@ -22,14 +17,12 @@ from phydrax.coresets import (
     moment_recombine,
     MomentRecombination,
 )
-from phydrax.domain import PointBatch
 
 from .._strict import StrictModule
-from ._batches import PointIntegrationBatch, WeightedSampleBatch
-from ._targets import (
-    DiscreteMeasureTarget,
-    ProbabilityTarget,
-    WeightedSampleTarget,
+from ._measure_transform import (
+    feature_matrix,
+    lower_finite_measure,
+    transformed_weighted_realization,
 )
 
 
@@ -45,142 +38,6 @@ class MeasureCompressionDiagnostics(StrictModule):
     source_points: int = eqx.field(static=True)
     feature_count: int = eqx.field(static=True)
     source_provenance: str = eqx.field(static=True)
-
-
-class CompressedIntegrationDiagnostics(StrictModule):
-    """Compression evidence paired with the downstream measure reduction."""
-
-    compression: MeasureCompressionDiagnostics
-    reduction: Any
-
-
-def _single_named_axis(batch: PointIntegrationBatch, /) -> tuple[str, int]:
-    if len(batch.axes) != 1:
-        raise ValueError("Compression currently requires exactly one integration axis.")
-    axis = batch.axes[0]
-    if batch.weights.dims != (axis,):
-        raise ValueError(
-            "Compression currently requires a one-dimensional point-weight field."
-        )
-    if batch.stratum_indices is not None:
-        raise ValueError(
-            "Stratified realizations must be compressed within strata, which is not "
-            "yet supported."
-        )
-    if "antithetic" in batch.provenance:
-        raise ValueError(
-            "Antithetic realizations cannot be compressed without preserving pairs."
-        )
-    return axis, int(batch.weights.shape[0])
-
-
-def _single_weighted_axis(
-    batch: WeightedSampleBatch,
-    /,
-) -> tuple[str | int, int]:
-    if len(batch.sample_axes) != 1:
-        raise ValueError("Compression currently requires exactly one sample axis.")
-    if batch.stratum_ids is not None:
-        raise ValueError(
-            "Weighted strata must be compressed independently, which is not yet supported."
-        )
-    if batch.pair_ids is not None:
-        raise ValueError(
-            "Paired samples cannot be compressed without preserving their pair blocks."
-        )
-    if batch.replicate_ids is not None:
-        raise ValueError(
-            "Replicated samples must be compressed independently by replicate."
-        )
-    axis = batch.sample_axes[0]
-    if isinstance(batch.log_weights, cx.Field):
-        if not isinstance(axis, str) or batch.log_weights.dims != (axis,):
-            raise ValueError(
-                "Named compression currently requires a one-dimensional log-weight field."
-            )
-        return axis, int(batch.log_weights.shape[0])
-    if not isinstance(axis, int) or batch.log_weights.ndim != 1 or axis != 0:
-        raise ValueError(
-            "Raw compression currently requires a leading one-dimensional sample axis."
-        )
-    return axis, int(batch.log_weights.shape[0])
-
-
-def _matrix_leaf(value: Any, axis: str | int, count: int, /) -> Array | None:
-    if isinstance(value, cx.Field):
-        if isinstance(axis, str):
-            if axis not in value.named_dims:
-                return None
-            position = value.dims.index(axis)
-        else:
-            if axis >= value.data.ndim:
-                return None
-            position = axis
-        data = jnp.moveaxis(jnp.asarray(value.data, dtype=float), position, 0)
-    elif isinstance(value, (jax.Array, jax_core.Tracer)):
-        data = jnp.asarray(value, dtype=float)
-        position = axis if isinstance(axis, int) else 0
-        if data.ndim == 0 or position >= data.ndim or data.shape[position] != count:
-            return None
-        data = jnp.moveaxis(data, position, 0)
-    else:
-        return None
-    if data.shape[0] != count:
-        raise ValueError("Sample fields disagree on the compression-axis size.")
-    return data.reshape((count, -1))
-
-
-def _feature_matrix(value: Any, axis: str | int, count: int, /) -> Array:
-    if isinstance(value, cx.Field):
-        leaves = (value,)
-    elif isinstance(value, (jax.Array, jax_core.Tracer)):
-        leaves = (value,)
-    else:
-        leaves = tuple(
-            jtu.tree_leaves(value, is_leaf=lambda leaf: isinstance(leaf, cx.Field))
-        )
-    matrices = tuple(
-        matrix
-        for leaf in leaves
-        if (matrix := _matrix_leaf(leaf, axis, count)) is not None
-    )
-    if not matrices:
-        raise ValueError("Could not derive finite-dimensional compression features.")
-    return jnp.concatenate(matrices, axis=1)
-
-
-def _take_samples(value: Any, axis: str | int, indices: Array, /) -> Any:
-    def take(leaf: Any) -> Any:
-        if isinstance(leaf, cx.Field):
-            if isinstance(axis, str):
-                if axis not in leaf.named_dims:
-                    return leaf
-                position = leaf.dims.index(axis)
-            else:
-                if axis >= leaf.data.ndim:
-                    return leaf
-                position = axis
-            return cx.Field(jnp.take(leaf.data, indices, axis=position), dims=leaf.dims)
-        if isinstance(leaf, (jax.Array, jax_core.Tracer)):
-            position = axis if isinstance(axis, int) else 0
-            if leaf.ndim == 0 or position >= leaf.ndim:
-                return leaf
-            return jnp.take(leaf, indices, axis=position)
-        return leaf
-
-    if isinstance(value, PointBatch):
-        points = jtu.tree_map(
-            take,
-            value.points,
-            is_leaf=lambda leaf: isinstance(leaf, cx.Field),
-        )
-        metadata = jtu.tree_map(
-            take,
-            value.metadata,
-            is_leaf=lambda leaf: isinstance(leaf, cx.Field),
-        )
-        return PointBatch(points, value.structure, metadata=metadata)
-    return jtu.tree_map(take, value, is_leaf=lambda leaf: isinstance(leaf, cx.Field))
 
 
 def _select(
@@ -208,77 +65,6 @@ def _select(
     raise TypeError("method must be MomentRecombination or KernelHerding.")
 
 
-def _point_source(
-    realization: Any,
-    batch: PointIntegrationBatch,
-    /,
-) -> tuple[Any, str, int, Array, Array | None, bool, Array]:
-    target = realization.target
-    if not isinstance(target, (DiscreteMeasureTarget, ProbabilityTarget)):
-        raise TypeError(
-            "Point-realization compression currently supports probability and "
-            "external discrete targets only."
-        )
-    axis, count = _single_named_axis(batch)
-    weights = jnp.asarray(batch.weights.data, dtype=float)
-    mask = None if batch.mask is None else jnp.asarray(batch.mask.data, dtype=bool)
-    included = jnp.ones((count,), dtype=bool) if mask is None else mask
-    if bool(jnp.any(included & (~jnp.isfinite(weights) | (weights < 0.0)))):
-        raise ValueError("Compression requires finite nonnegative source weights.")
-    active_weights = jnp.where(included & (weights > 0.0), weights, 0.0)
-    source_mass = jnp.sum(active_weights)
-    if not bool(jnp.isfinite(source_mass) & (source_mass > 0.0)):
-        raise ValueError("Compression requires positive source mass.")
-    log_weights = jnp.where(active_weights > 0.0, jnp.log(active_weights), -jnp.inf)
-    normalized = target.normalized
-    return batch.points, axis, count, log_weights, mask, normalized, source_mass
-
-
-def _weighted_source(
-    realization: Any,
-    batch: WeightedSampleBatch,
-    /,
-) -> tuple[Any, str | int, int, Array, Array | None, bool, Array]:
-    target = realization.target
-    if not isinstance(target, WeightedSampleTarget):
-        raise TypeError(
-            "Weighted compression currently supports externally materialized "
-            "WeightedSampleTarget realizations only."
-        )
-    axis, count = _single_weighted_axis(batch)
-    if isinstance(batch.log_weights, cx.Field):
-        log_weights = jnp.asarray(batch.log_weights.data, dtype=float)
-        mask = (
-            None if batch.mask is None else jnp.asarray(cast(cx.Field, batch.mask).data)
-        )
-    else:
-        log_weights = jnp.asarray(batch.log_weights, dtype=float)
-        mask = None if batch.mask is None else jnp.asarray(batch.mask, dtype=bool)
-    included = jnp.ones((count,), dtype=bool) if mask is None else mask
-    admissible = jnp.isfinite(log_weights) | jnp.isneginf(log_weights)
-    if bool(jnp.any(included & ~admissible)):
-        raise ValueError("Compression requires finite or negative-infinite log weights.")
-    finite = included & jnp.isfinite(log_weights)
-    if not bool(jnp.any(finite)):
-        raise ValueError("Compression requires positive source mass.")
-    log_mass = jax.scipy.special.logsumexp(jnp.where(finite, log_weights, -jnp.inf))
-    if target.normalized:
-        source_mass = jnp.asarray(1.0)
-    elif target.target_mass is not None:
-        source_mass = jnp.asarray(target.target_mass, dtype=float)
-    else:
-        source_mass = jnp.exp(log_mass)
-    return (
-        batch.samples,
-        axis,
-        count,
-        log_weights,
-        mask,
-        target.normalized,
-        source_mass,
-    )
-
-
 def compress(
     realization: Any,
     method: CompressionMethod,
@@ -287,123 +73,44 @@ def compress(
     features: FeatureMap | Any | None = None,
 ):
     """Compress a finite positive realization before evaluating its integrand."""
-    from ._api import IntegrationRealization
 
-    if not isinstance(realization, IntegrationRealization):
-        raise TypeError("compress expects an IntegrationRealization from materialize().")
-    if isinstance(realization.batch, tuple):
-        raise ValueError(
-            "Replicated or component-union realizations must be compressed per member."
-        )
-    if isinstance(realization.batch, PointIntegrationBatch):
-        source = _point_source(realization, realization.batch)
-        source_provenance = realization.batch.provenance
-    elif isinstance(realization.batch, WeightedSampleBatch):
-        source = _weighted_source(realization, realization.batch)
-        source_provenance = realization.batch.provenance
-    else:
-        raise TypeError(
-            "Compression requires a one-axis PointIntegrationBatch or "
-            "WeightedSampleBatch."
-        )
-    samples, axis, count, source_log_weights, source_mask, normalized, source_mass = (
-        source
-    )
-    support_valid = (
-        realization.batch.support_valid
-        if isinstance(realization.batch, WeightedSampleBatch)
-        else None
-    )
+    measure = lower_finite_measure(realization)
     raw_features = (
-        samples
+        measure.samples
         if features is None
-        else features(samples)
+        else features(measure.samples)
         if callable(features)
         else features
     )
-    feature_values = _feature_matrix(raw_features, axis, count)
+    feature_values = feature_matrix(raw_features, measure.axis, measure.count)
     selection = _select(
         feature_values,
         method,
-        log_weights=source_log_weights,
-        mask=source_mask,
+        log_weights=measure.log_weights,
+        mask=measure.mask,
     )
     if not bool(selection.diagnostics.valid):
         raise ValueError("Coreset selection failed for the supplied measure.")
-    selected_samples = _take_samples(samples, axis, selection.indices)
-    selected_source_ancestry = (
-        None
-        if not isinstance(realization.batch, WeightedSampleBatch)
-        or realization.batch.ancestry_ids is None
-        else _take_samples(
-            realization.batch.ancestry_ids,
-            axis,
-            selection.indices,
-        )
-    )
-    if isinstance(axis, str):
-        selected_log_weights: Array | cx.Field = cx.Field(
-            selection.log_weights,
-            dims=(axis,),
-        )
-        selected_mask: Array | cx.Field = cx.Field(selection.mask, dims=(axis,))
-        ancestry: Array | cx.Field = (
-            cx.Field(selection.indices, dims=(axis,))
-            if selected_source_ancestry is None
-            else cast(cx.Field, selected_source_ancestry)
-        )
-        sample_axes: int | str = axis
-    else:
-        selected_log_weights = selection.log_weights
-        selected_mask = selection.mask
-        ancestry = (
-            selection.indices
-            if selected_source_ancestry is None
-            else jnp.asarray(selected_source_ancestry, dtype=jnp.int32)
-        )
-        sample_axes = 0
-    target_mass = None if normalized else source_mass
-    compressed_target = WeightedSampleTarget(
-        selected_samples,
-        selected_log_weights,
-        normalized=normalized,
-        target_mass=target_mass,
-        independent=False,
-        ancestry=ancestry,
-        support_valid=support_valid,
-        mask=selected_mask,
-        sample_axes=sample_axes,
-        provenance=f"compressed:{selection.method}:{source_provenance}",
-    )
-    compressed_batch = WeightedSampleBatch(
-        compressed_target.samples,
-        compressed_target.log_weights,
-        mask=compressed_target.mask,
-        target_mass=compressed_target.target_mass,
-        ancestry_ids=compressed_target.ancestry,
-        support_valid=compressed_target.support_valid,
-        sample_axes=compressed_target.sample_axes,
-        independent=False,
-        provenance=compressed_target.provenance,
-    )
     diagnostics = MeasureCompressionDiagnostics(
         selection=selection.diagnostics,
-        source_mass=source_mass,
-        source_points=count,
+        source_mass=measure.physical_mass,
+        source_points=measure.count,
         feature_count=int(feature_values.shape[1]),
-        source_provenance=source_provenance,
+        source_provenance=measure.source_provenance,
     )
-    return IntegrationRealization(
-        compressed_target,
-        None,
-        compressed_batch,
-        realization.key,
-        diagnostics,
+    provenance = f"compressed:{selection.method}:{measure.source_provenance}"
+    return transformed_weighted_realization(
+        realization,
+        measure,
+        selection.log_weights,
+        transformation_kind="compression",
+        transformation_diagnostics=diagnostics,
+        provenance=provenance,
+        indices=selection.indices,
     )
 
 
 __all__ = [
-    "CompressedIntegrationDiagnostics",
     "CompressionMethod",
     "MeasureCompressionDiagnostics",
     "compress",

--- a/phydrax/integration/_measure_transform.py
+++ b/phydrax/integration/_measure_transform.py
@@ -1,0 +1,379 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import coordax as cx
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.tree_util as jtu
+from jax import core as jax_core
+from jaxtyping import Array
+
+from phydrax.domain import PointBatch
+
+from .._measure_weights import log_weights_from_normalized, normalized_weights
+from .._strict import StrictModule
+from ._batches import PointIntegrationBatch, WeightedSampleBatch
+from ._targets import DiscreteMeasureTarget, ProbabilityTarget, WeightedSampleTarget
+from ._transformations import MeasureTransformationRecord
+
+
+class FiniteMeasureRealization(StrictModule):
+    """Canonical one-axis finite positive measure for support transformations."""
+
+    samples: Any
+    log_weights: Array
+    mask: Array
+    physical_mass: Array
+    ancestry: Any
+    support_valid: Any
+    axis: str | int = eqx.field(static=True)
+    count: int = eqx.field(static=True)
+    normalized: bool = eqx.field(static=True)
+    source_provenance: str = eqx.field(static=True)
+
+
+def lower_finite_measure(realization: Any, /) -> FiniteMeasureRealization:
+    """Lower a supported realization to normalized probabilities and physical mass."""
+
+    if isinstance(realization.batch, tuple):
+        raise TypeError(
+            "Replicated or component-union realizations must be transformed per member."
+        )
+    if isinstance(realization.batch, PointIntegrationBatch):
+        return _lower_point_measure(realization, realization.batch)
+    if isinstance(realization.batch, WeightedSampleBatch):
+        return _lower_weighted_measure(realization, realization.batch)
+    raise TypeError(
+        "Finite-measure transformations require a one-axis PointIntegrationBatch "
+        "or WeightedSampleBatch."
+    )
+
+
+def feature_matrix(value: Any, axis: str | int, count: int, /) -> Array:
+    """Canonicalize array or named-field feature PyTrees to shape ``(count, m)``."""
+
+    if isinstance(value, (cx.Field, jax.Array, jax_core.Tracer)):
+        leaves = (value,)
+    else:
+        leaves = tuple(
+            jtu.tree_leaves(value, is_leaf=lambda leaf: isinstance(leaf, cx.Field))
+        )
+    matrices = tuple(
+        matrix
+        for leaf in leaves
+        if (matrix := _matrix_leaf(leaf, axis, count)) is not None
+    )
+    if not matrices:
+        raise ValueError("Could not derive finite-dimensional measure features.")
+    result = jnp.concatenate(matrices, axis=1)
+    if not bool(jnp.all(jnp.isfinite(result))):
+        raise ValueError("Measure features must be finite on every source point.")
+    return result
+
+
+def take_samples(value: Any, axis: str | int, indices: Array, /) -> Any:
+    """Take finite-measure sample leaves while preserving named structure."""
+
+    def take(leaf: Any) -> Any:
+        if isinstance(leaf, cx.Field):
+            if isinstance(axis, str):
+                if axis not in leaf.named_dims:
+                    return leaf
+                position = leaf.dims.index(axis)
+            else:
+                if axis >= leaf.data.ndim:
+                    return leaf
+                position = axis
+            return cx.Field(jnp.take(leaf.data, indices, axis=position), dims=leaf.dims)
+        if isinstance(leaf, (jax.Array, jax_core.Tracer)):
+            position = axis if isinstance(axis, int) else 0
+            if leaf.ndim == 0 or position >= leaf.ndim:
+                return leaf
+            return jnp.take(leaf, indices, axis=position)
+        return leaf
+
+    if isinstance(value, PointBatch):
+        points = jtu.tree_map(
+            take,
+            value.points,
+            is_leaf=lambda leaf: isinstance(leaf, cx.Field),
+        )
+        metadata = jtu.tree_map(
+            take,
+            value.metadata,
+            is_leaf=lambda leaf: isinstance(leaf, cx.Field),
+        )
+        return PointBatch(points, value.structure, metadata=metadata)
+    return jtu.tree_map(take, value, is_leaf=lambda leaf: isinstance(leaf, cx.Field))
+
+
+def transformed_weighted_realization(
+    realization: Any,
+    measure: FiniteMeasureRealization,
+    log_weights: Array,
+    /,
+    *,
+    transformation_kind: str,
+    transformation_diagnostics: Any,
+    provenance: str,
+    indices: Array | None = None,
+):
+    """Rebuild a weighted realization and append ordered transformation evidence."""
+
+    from ._api import IntegrationRealization
+
+    if not isinstance(realization, IntegrationRealization):
+        raise TypeError("realization must be an IntegrationRealization.")
+    log_weights_ = jnp.asarray(log_weights, dtype=measure.log_weights.dtype)
+    if log_weights_.shape != ((measure.count,) if indices is None else indices.shape):
+        raise ValueError("Transformed log weights disagree with the output support size.")
+    if indices is None:
+        samples = measure.samples
+        mask = measure.mask
+        ancestry = measure.ancestry
+        support_valid = measure.support_valid
+    else:
+        samples = take_samples(measure.samples, measure.axis, indices)
+        mask = jnp.take(measure.mask, indices)
+        ancestry = (
+            indices
+            if measure.ancestry is None
+            else take_samples(measure.ancestry, measure.axis, indices)
+        )
+        support_valid = measure.support_valid
+    if ancestry is None:
+        ancestry = jnp.arange(log_weights_.shape[0], dtype=jnp.int32)
+    if isinstance(measure.axis, str):
+        target_log_weights: Array | cx.Field = cx.Field(
+            log_weights_,
+            dims=(measure.axis,),
+        )
+        target_mask: Array | cx.Field = cx.Field(mask, dims=(measure.axis,))
+        if not isinstance(ancestry, cx.Field):
+            ancestry = cx.Field(jnp.asarray(ancestry), dims=(measure.axis,))
+        sample_axes: int | str = measure.axis
+    else:
+        target_log_weights = log_weights_
+        target_mask = mask
+        ancestry = jnp.asarray(ancestry, dtype=jnp.int32)
+        sample_axes = 0
+    target_mass = None if measure.normalized else measure.physical_mass
+    target = WeightedSampleTarget(
+        samples,
+        target_log_weights,
+        normalized=measure.normalized,
+        target_mass=target_mass,
+        independent=False,
+        ancestry=ancestry,
+        support_valid=support_valid,
+        mask=target_mask,
+        sample_axes=sample_axes,
+        provenance=provenance,
+    )
+    batch = WeightedSampleBatch(
+        target.samples,
+        target.log_weights,
+        mask=target.mask,
+        target_mass=target.target_mass,
+        ancestry_ids=target.ancestry,
+        support_valid=target.support_valid,
+        sample_axes=target.sample_axes,
+        independent=False,
+        provenance=target.provenance,
+    )
+    record = MeasureTransformationRecord(
+        transformation_kind,
+        transformation_diagnostics,
+        source_provenance=measure.source_provenance,
+        target_provenance=provenance,
+    )
+    return IntegrationRealization(
+        target,
+        None,
+        batch,
+        realization.key,
+        realization.transformations + (record,),
+    )
+
+
+def _single_named_axis(batch: PointIntegrationBatch, /) -> tuple[str, int]:
+    if len(batch.axes) != 1:
+        raise ValueError("Finite-measure transformations require exactly one axis.")
+    axis = batch.axes[0]
+    if batch.weights.dims != (axis,):
+        raise ValueError(
+            "Finite-measure transformations require one-dimensional point weights."
+        )
+    if batch.stratum_indices is not None:
+        raise ValueError("Stratified realizations must be transformed within strata.")
+    if "antithetic" in batch.provenance:
+        raise ValueError("Antithetic realizations must preserve their paired blocks.")
+    return axis, int(batch.weights.shape[0])
+
+
+def _single_weighted_axis(batch: WeightedSampleBatch, /) -> tuple[str | int, int]:
+    if len(batch.sample_axes) != 1:
+        raise ValueError("Finite-measure transformations require one sample axis.")
+    if batch.stratum_ids is not None:
+        raise ValueError("Weighted strata must be transformed independently.")
+    if batch.pair_ids is not None:
+        raise ValueError("Paired samples must be transformed in paired blocks.")
+    if batch.replicate_ids is not None:
+        raise ValueError("Replicated samples must be transformed independently.")
+    axis = batch.sample_axes[0]
+    if isinstance(batch.log_weights, cx.Field):
+        if not isinstance(axis, str) or batch.log_weights.dims != (axis,):
+            raise ValueError("Named transformations require one-dimensional log weights.")
+        return axis, int(batch.log_weights.shape[0])
+    if not isinstance(axis, int) or batch.log_weights.ndim != 1 or axis != 0:
+        raise ValueError("Raw transformations require a leading one-dimensional axis.")
+    return axis, int(batch.log_weights.shape[0])
+
+
+def _lower_point_measure(
+    realization: Any,
+    batch: PointIntegrationBatch,
+    /,
+) -> FiniteMeasureRealization:
+    target = realization.target
+    if not isinstance(target, (DiscreteMeasureTarget, ProbabilityTarget)):
+        raise TypeError(
+            "Point transformations currently support probability and external "
+            "discrete targets only."
+        )
+    axis, count = _single_named_axis(batch)
+    values = jnp.asarray(batch.weights.data, dtype=float)
+    mask = (
+        jnp.ones((count,), dtype=bool)
+        if batch.mask is None
+        else jnp.asarray(batch.mask.data, dtype=bool)
+    )
+    if bool(jnp.any(mask & (~jnp.isfinite(values) | (values < 0.0)))):
+        raise ValueError("Finite measures require finite nonnegative weights.")
+    positive = mask & (values > 0.0)
+    raw_log_weights = jnp.where(positive, jnp.log(values), -jnp.inf)
+    weights, active, valid, log_mass = normalized_weights(
+        count,
+        log_weights=raw_log_weights,
+        mask=mask,
+    )
+    if not bool(valid):
+        raise ValueError("Finite measures require positive source mass.")
+    normalized_log_weights = log_weights_from_normalized(weights, active)
+    normalized = target.normalized
+    physical_mass = (
+        jnp.asarray(1.0, dtype=weights.dtype)
+        if normalized
+        else jnp.asarray(batch.target_mass, dtype=weights.dtype)
+        if batch.target_mass is not None
+        else jnp.exp(log_mass)
+    )
+    return FiniteMeasureRealization(
+        samples=batch.points,
+        log_weights=normalized_log_weights,
+        mask=mask,
+        physical_mass=physical_mass,
+        ancestry=None,
+        support_valid=None,
+        axis=axis,
+        count=count,
+        normalized=normalized,
+        source_provenance=batch.provenance,
+    )
+
+
+def _lower_weighted_measure(
+    realization: Any,
+    batch: WeightedSampleBatch,
+    /,
+) -> FiniteMeasureRealization:
+    target = realization.target
+    if not isinstance(target, WeightedSampleTarget):
+        raise TypeError(
+            "Weighted transformations require an externally materialized "
+            "WeightedSampleTarget."
+        )
+    axis, count = _single_weighted_axis(batch)
+    if isinstance(batch.log_weights, cx.Field):
+        values = jnp.asarray(batch.log_weights.data, dtype=float)
+        mask = (
+            jnp.ones((count,), dtype=bool)
+            if batch.mask is None
+            else jnp.asarray(cast(cx.Field, batch.mask).data, dtype=bool)
+        )
+    else:
+        values = jnp.asarray(batch.log_weights, dtype=float)
+        mask = (
+            jnp.ones((count,), dtype=bool)
+            if batch.mask is None
+            else jnp.asarray(batch.mask, dtype=bool)
+        )
+    weights, active, valid, log_mass = normalized_weights(
+        count,
+        log_weights=values,
+        mask=mask,
+    )
+    if not bool(valid):
+        raise ValueError(
+            "Finite measures require finite or negative-infinite log weights and "
+            "positive source mass."
+        )
+    normalized_log_weights = log_weights_from_normalized(weights, active)
+    physical_mass = (
+        jnp.asarray(1.0, dtype=weights.dtype)
+        if target.normalized
+        else jnp.asarray(target.target_mass, dtype=weights.dtype)
+        if target.target_mass is not None
+        else jnp.exp(log_mass)
+    )
+    return FiniteMeasureRealization(
+        samples=batch.samples,
+        log_weights=normalized_log_weights,
+        mask=mask,
+        physical_mass=physical_mass,
+        ancestry=batch.ancestry_ids,
+        support_valid=batch.support_valid,
+        axis=axis,
+        count=count,
+        normalized=target.normalized,
+        source_provenance=batch.provenance,
+    )
+
+
+def _matrix_leaf(value: Any, axis: str | int, count: int, /) -> Array | None:
+    if isinstance(value, cx.Field):
+        if isinstance(axis, str):
+            if axis not in value.named_dims:
+                return None
+            position = value.dims.index(axis)
+        else:
+            if axis >= value.data.ndim:
+                return None
+            position = axis
+        data = jnp.moveaxis(jnp.asarray(value.data, dtype=float), position, 0)
+    elif isinstance(value, (jax.Array, jax_core.Tracer)):
+        data = jnp.asarray(value, dtype=float)
+        position = axis if isinstance(axis, int) else 0
+        if data.ndim == 0 or position >= data.ndim or data.shape[position] != count:
+            return None
+        data = jnp.moveaxis(data, position, 0)
+    else:
+        return None
+    if data.shape[0] != count:
+        raise ValueError("Sample fields disagree on the transformation-axis size.")
+    return data.reshape((count, -1))
+
+
+__all__ = [
+    "FiniteMeasureRealization",
+    "feature_matrix",
+    "lower_finite_measure",
+    "take_samples",
+    "transformed_weighted_realization",
+]

--- a/phydrax/integration/_transformations.py
+++ b/phydrax/integration/_transformations.py
@@ -1,0 +1,66 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from typing import Any
+
+import equinox as eqx
+
+from .._strict import StrictModule
+
+
+class MeasureTransformationRecord(StrictModule):
+    """Ordered evidence for one finite-measure transformation."""
+
+    diagnostics: Any
+    kind: str = eqx.field(static=True)
+    source_provenance: str = eqx.field(static=True)
+    target_provenance: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        kind: str,
+        diagnostics: Any,
+        /,
+        *,
+        source_provenance: str,
+        target_provenance: str,
+    ):
+        kind_ = str(kind)
+        source = str(source_provenance)
+        target = str(target_provenance)
+        if not kind_ or not source or not target:
+            raise ValueError("Transformation identities and provenance must be non-empty.")
+        self.kind = kind_
+        self.diagnostics = diagnostics
+        self.source_provenance = source
+        self.target_provenance = target
+
+
+class TransformedIntegrationDiagnostics(StrictModule):
+    """Ordered measure transformations paired with downstream reduction evidence."""
+
+    transformations: tuple[MeasureTransformationRecord, ...]
+    reduction: Any
+
+    def __init__(
+        self,
+        transformations: tuple[MeasureTransformationRecord, ...],
+        reduction: Any,
+        /,
+    ):
+        transformations_ = tuple(transformations)
+        if any(
+            not isinstance(item, MeasureTransformationRecord)
+            for item in transformations_
+        ):
+            raise TypeError(
+                "transformations must contain MeasureTransformationRecord values."
+            )
+        self.transformations = transformations_
+        self.reduction = reduction
+
+
+__all__ = ["MeasureTransformationRecord", "TransformedIntegrationDiagnostics"]

--- a/phydrax/operators/integral/_batch_ops.py
+++ b/phydrax/operators/integral/_batch_ops.py
@@ -58,7 +58,7 @@ def mean(
             target_or_realization.plan,
             target_or_realization.batch,
             target_or_realization.key,
-            target_or_realization.compression,
+            target_or_realization.transformations,
         )
         estimate = reduce_integration(integrand, realization, **kwargs)
     else:

--- a/phydrax/optim/_newton_krylov.py
+++ b/phydrax/optim/_newton_krylov.py
@@ -15,6 +15,7 @@ from jaxtyping import PyTree
 from .._linear_refresh import prepare_refresh_state
 from ..linalg import (
     FunctionLinearOperator,
+    LinearSolveControl,
     LinearSolvePolicy,
     LinearSolveStatus,
     LinearSystem,
@@ -246,6 +247,7 @@ class NewtonKrylov(AbstractScalarIterativeMethod):
             linear_result = solve_linear(
                 prepared,
                 _tree_negative(gradient),
+                control=LinearSolveControl(relative_tolerance=forcing),
             )
             proposed_direction = linear_result.value
             proposed_directional = _tree_inner(gradient, proposed_direction)

--- a/phydrax/terms/_residual.py
+++ b/phydrax/terms/_residual.py
@@ -153,6 +153,7 @@ def _apply_local_weight(
         realization.plan,
         weighted_batch,
         realization.key,
+        realization.transformations,
     )
 
 

--- a/phydrax/weighting/__init__.py
+++ b/phydrax/weighting/__init__.py
@@ -1,0 +1,39 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+"""Target-aware relative-entropy weighting of finite measures."""
+
+from ._problem import (
+    ExactMoments,
+    MomentCalibrationPolicy,
+    MomentCalibrationProblem,
+    MomentTarget,
+    QuadraticMoments,
+)
+from ._relative_entropy import calibrate_moments, implicit_calibrate_moments
+from ._results import (
+    moment_calibration_status_message,
+    MomentCalibrationDiagnostics,
+    MomentCalibrationProvenance,
+    MomentCalibrationResult,
+    MomentCalibrationStatus,
+    require_converged,
+)
+
+
+__all__ = [
+    "ExactMoments",
+    "MomentCalibrationDiagnostics",
+    "MomentCalibrationPolicy",
+    "MomentCalibrationProblem",
+    "MomentCalibrationProvenance",
+    "MomentCalibrationResult",
+    "MomentCalibrationStatus",
+    "MomentTarget",
+    "QuadraticMoments",
+    "calibrate_moments",
+    "implicit_calibrate_moments",
+    "moment_calibration_status_message",
+    "require_converged",
+]

--- a/phydrax/weighting/_geometry.py
+++ b/phydrax/weighting/_geometry.py
@@ -1,0 +1,321 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array
+
+from .._numerics import log_normalize
+from .._strict import StrictModule
+from ..linalg import DenseLinearOperator, OperatorProperties
+from ..linalg.eigen import (
+    Eigenproblem,
+    self_adjoint_spectrum,
+    SelfAdjointSpectrumStatus,
+)
+from ._problem import (
+    ExactMoments,
+    MomentCalibrationPolicy,
+    MomentCalibrationProblem,
+    QuadraticMoments,
+)
+
+
+class MomentGeometry(StrictModule):
+    """Fixed-capacity affine geometry and dual-coordinate preconditioner."""
+
+    prior_log_weights: Array
+    prior_weights: Array
+    active_support: Array
+    prior_moments: Array
+    covariance: Array
+    moment_scales: Array
+    transform: Array
+    retained_directions: Array
+    covariance_eigenvalues: Array
+    rank_cutoff: Array
+    affine_residual: Array
+    affine_residual_norm: Array
+    finite: Array
+    feature_values_finite: Array
+    spectrum_diagnostics: Any
+
+    @property
+    def numerical_affine_rank(self) -> Array:
+        return jnp.sum(self.retained_directions.astype(jnp.int32))
+
+
+def prepare_moment_geometry(
+    problem: MomentCalibrationProblem,
+    policy: MomentCalibrationPolicy,
+    /,
+) -> MomentGeometry:
+    """Prepare normalized prior geometry without materializing source Gram matrices."""
+
+    if not isinstance(problem, MomentCalibrationProblem):
+        raise TypeError("problem must be a MomentCalibrationProblem.")
+    if not isinstance(policy, MomentCalibrationPolicy):
+        raise TypeError("policy must be a MomentCalibrationPolicy.")
+    if problem.moment_count > policy.maximum_moments:
+        raise ValueError(
+            f"Moment count {problem.moment_count} exceeds the configured maximum "
+            f"{policy.maximum_moments}."
+        )
+
+    prior_weights, log_mass, prior_valid = log_normalize(
+        problem.prior_log_weights,
+        axes=0,
+        mask=problem.mask,
+    )
+    active = problem.mask & jnp.isfinite(problem.prior_log_weights)
+    normalized_log = jnp.where(
+        active,
+        problem.prior_log_weights - log_mass,
+        -jnp.inf,
+    )
+    prior_moments, covariance, feature_finite = _weighted_covariance(
+        problem,
+        prior_weights,
+    )
+    dtype = prior_weights.dtype
+    epsilon = jnp.finfo(dtype).eps
+    covariance = 0.5 * (covariance + jnp.swapaxes(covariance, -1, -2))
+    covariance_diagonal = jnp.maximum(jnp.diag(covariance), 0.0)
+    maximum_variance = jnp.maximum(jnp.max(covariance_diagonal), 1.0)
+    variance_floor = 64.0 * epsilon * maximum_variance
+    moment_scales = jnp.where(
+        covariance_diagonal > variance_floor,
+        jnp.sqrt(covariance_diagonal),
+        1.0,
+    )
+    standardized_covariance = covariance / (
+        moment_scales[:, None] * moment_scales[None, :]
+    )
+    covariance_spectrum = _spectrum(
+        standardized_covariance,
+        problem,
+        policy,
+        suffix="covariance",
+    )
+    covariance_eigenvalues = covariance_spectrum.eigenvalues
+    covariance_vectors = covariance_spectrum.eigenvectors
+    maximum_eigenvalue = jnp.maximum(
+        jnp.max(jnp.abs(covariance_eigenvalues)),
+        1.0,
+    )
+    relative_cutoff = (
+        64.0 * epsilon * problem.moment_count
+        if policy.rank.relative_cutoff is None
+        else policy.rank.relative_cutoff
+    )
+    rank_cutoff = jnp.asarray(relative_cutoff, dtype=dtype) * maximum_eigenvalue
+    retained = covariance_eigenvalues > rank_cutoff
+    target_delta = problem.target.values - prior_moments
+    standardized_delta = target_delta / moment_scales
+    retained_projection = covariance_vectors @ (
+        retained * (jnp.swapaxes(covariance_vectors, -1, -2) @ standardized_delta)
+    )
+    affine_residual = standardized_delta - retained_projection
+
+    if isinstance(problem.target, ExactMoments):
+        safe_eigenvalues = jnp.maximum(covariance_eigenvalues, rank_cutoff)
+        factors = jnp.where(retained, jax.lax.rsqrt(safe_eigenvalues), 0.0)
+        transform = (covariance_vectors * factors[None, :]) / moment_scales[:, None]
+        preconditioner_diagnostics = covariance_spectrum.diagnostics
+        preconditioner_finite = covariance_spectrum.diagnostics.finite
+    else:
+        assert isinstance(problem.target, QuadraticMoments)
+        base_hessian = covariance + jnp.diag(problem.target.scale**2)
+        base_diagonal = jnp.maximum(jnp.diag(base_hessian), 0.0)
+        base_scales = jnp.where(
+            base_diagonal > variance_floor,
+            jnp.sqrt(base_diagonal),
+            1.0,
+        )
+        standardized_base = base_hessian / (base_scales[:, None] * base_scales[None, :])
+        base_spectrum = _spectrum(
+            standardized_base,
+            problem,
+            policy,
+            suffix="soft-hessian",
+        )
+        safe_eigenvalues = jnp.maximum(base_spectrum.eigenvalues, rank_cutoff)
+        transform = (
+            base_spectrum.eigenvectors * jax.lax.rsqrt(safe_eigenvalues)[None, :]
+        ) / base_scales[:, None]
+        preconditioner_diagnostics = base_spectrum.diagnostics
+        preconditioner_finite = base_spectrum.diagnostics.finite
+
+    covariance_success = covariance_spectrum.status == int(
+        SelfAdjointSpectrumStatus.SUCCESS
+    )
+    materially_negative = jnp.min(covariance_eigenvalues) < -rank_cutoff
+    target_finite = jnp.all(jnp.isfinite(problem.target.values))
+    scale_valid = (
+        jnp.asarray(True)
+        if isinstance(problem.target, ExactMoments)
+        else jnp.all(jnp.isfinite(problem.target.scale) & (problem.target.scale > 0.0))
+    )
+    finite = (
+        prior_valid
+        & feature_finite
+        & target_finite
+        & scale_valid
+        & jnp.all(jnp.isfinite(prior_moments))
+        & jnp.all(jnp.isfinite(covariance))
+        & covariance_success
+        & preconditioner_finite
+        & (~materially_negative)
+    )
+    if policy.rank.require_full_rank:
+        finite = finite & jnp.all(retained)
+
+    return MomentGeometry(
+        prior_log_weights=normalized_log,
+        prior_weights=prior_weights,
+        active_support=jax.lax.stop_gradient(active),
+        prior_moments=prior_moments,
+        covariance=covariance,
+        moment_scales=moment_scales,
+        transform=jax.lax.stop_gradient(transform),
+        retained_directions=jax.lax.stop_gradient(retained),
+        covariance_eigenvalues=covariance_eigenvalues,
+        rank_cutoff=rank_cutoff,
+        affine_residual=affine_residual,
+        affine_residual_norm=jnp.linalg.norm(affine_residual),
+        finite=finite,
+        feature_values_finite=feature_finite,
+        spectrum_diagnostics=(
+            covariance_spectrum.diagnostics,
+            preconditioner_diagnostics,
+        ),
+    )
+
+
+def initial_coordinates(
+    geometry: MomentGeometry,
+    initial_dual: Array | None,
+    /,
+) -> Array:
+    """Map an optional physical dual warm start into prepared coordinates."""
+
+    if initial_dual is None:
+        return jnp.zeros_like(geometry.prior_moments)
+    dual = jnp.asarray(initial_dual, dtype=geometry.prior_weights.dtype)
+    if dual.shape != geometry.prior_moments.shape:
+        raise ValueError(f"initial_dual must have shape {geometry.prior_moments.shape}.")
+    coordinates = jnp.linalg.lstsq(geometry.transform, dual, rcond=None)[0]
+    return jnp.where(geometry.retained_directions, coordinates, 0.0)
+
+
+def physical_dual(geometry: MomentGeometry, coordinates: Array, /) -> Array:
+    return geometry.transform @ coordinates
+
+
+def log_weights_from_coordinates(
+    problem: MomentCalibrationProblem,
+    geometry: MomentGeometry,
+    coordinates: Array,
+    /,
+) -> Array:
+    dual = physical_dual(geometry, coordinates)
+    scores = problem.moment_map.transpose_mv(dual)
+    centered_scores = scores - jnp.vdot(geometry.prior_moments, dual).real
+    logits = jnp.where(
+        geometry.active_support,
+        geometry.prior_log_weights + centered_scores,
+        -jnp.inf,
+    )
+    _, log_normalizer, valid = log_normalize(logits, axes=0)
+    return jnp.where(
+        valid & geometry.active_support,
+        logits - log_normalizer,
+        -jnp.inf,
+    )
+
+
+def weights_from_coordinates(
+    problem: MomentCalibrationProblem,
+    geometry: MomentGeometry,
+    coordinates: Array,
+    /,
+) -> tuple[Array, Array]:
+    log_weights = log_weights_from_coordinates(problem, geometry, coordinates)
+    weights = jnp.where(jnp.isfinite(log_weights), jnp.exp(log_weights), 0.0)
+    return log_weights, weights
+
+
+def weighted_covariance(
+    problem: MomentCalibrationProblem,
+    weights: Array,
+    /,
+) -> tuple[Array, Array]:
+    moments, covariance, _ = _weighted_covariance(problem, weights)
+    return moments, covariance
+
+
+def _weighted_covariance(
+    problem: MomentCalibrationProblem,
+    weights: Array,
+    /,
+) -> tuple[Array, Array, Array]:
+    operator = problem.moment_map
+    if isinstance(operator, DenseLinearOperator):
+        matrix = operator.matrix
+        finite = jnp.all(jnp.isfinite(matrix))
+        safe_matrix = jnp.where(jnp.isfinite(matrix), matrix, 0.0)
+        moments = safe_matrix @ weights
+        second = (safe_matrix * weights[None, :]) @ jnp.swapaxes(safe_matrix, -1, -2)
+    else:
+        moments = operator.mv(weights)
+        identity = jnp.eye(problem.moment_count, dtype=weights.dtype)
+
+        def column(finite, basis):
+            row = operator.transpose_mv(basis)
+            row_finite = jnp.all(jnp.isfinite(row))
+            safe_row = jnp.where(jnp.isfinite(row), row, 0.0)
+            return finite & row_finite, operator.mv(weights * safe_row)
+
+        finite, columns = jax.lax.scan(column, jnp.asarray(True), identity)
+        second = jnp.swapaxes(columns, -1, -2)
+    covariance = second - moments[:, None] * moments[None, :]
+    return moments, covariance, finite
+
+
+def _spectrum(
+    matrix: Array,
+    problem: MomentCalibrationProblem,
+    policy: MomentCalibrationPolicy,
+    /,
+    *,
+    suffix: str,
+):
+    operator = DenseLinearOperator(
+        matrix,
+        properties=OperatorProperties(
+            self_adjoint=True,
+            evidence={"self_adjoint": "construction"},
+        ),
+        operator_id=f"moment-{suffix}:{problem.problem_id}",
+    )
+    eigenproblem = Eigenproblem(
+        operator,
+        problem_id=f"moment-{suffix}:{problem.problem_id}",
+    )
+    return self_adjoint_spectrum(eigenproblem, policy=policy.spectrum)
+
+
+__all__ = [
+    "MomentGeometry",
+    "initial_coordinates",
+    "log_weights_from_coordinates",
+    "physical_dual",
+    "prepare_moment_geometry",
+    "weighted_covariance",
+    "weights_from_coordinates",
+]

--- a/phydrax/weighting/_problem.py
+++ b/phydrax/weighting/_problem.py
@@ -1,0 +1,258 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from math import isfinite
+from typing import TypeAlias
+
+import equinox as eqx
+import jax.numpy as jnp
+import numpy as np
+from jax import core as jax_core
+from jaxtyping import Array, ArrayLike
+
+from .._fingerprint import canonical_fingerprint
+from .._strict import StrictModule
+from ..linalg import (
+    AbstractLinearOperator,
+    ArraySpace,
+    DenseLinearOperator,
+    RankPolicy,
+)
+from ..linalg.eigen import SelfAdjointSpectrumPolicy
+
+
+class ExactMoments(StrictModule):
+    """A vector of moments requested exactly on a regular interior branch."""
+
+    values: Array
+
+    def __init__(self, values: ArrayLike, /):
+        values_ = _moment_values(values)
+        self.values = values_
+
+
+class QuadraticMoments(StrictModule):
+    """Moment targets reconciled through a diagonal quadratic discrepancy."""
+
+    values: Array
+    scale: Array
+
+    def __init__(self, values: ArrayLike, /, *, scale: ArrayLike = 1.0):
+        values_ = _moment_values(values)
+        scale_ = jnp.asarray(scale, dtype=values_.dtype)
+        if jnp.broadcast_shapes(scale_.shape, values_.shape) != values_.shape:
+            raise ValueError(
+                "scale must be scalar or broadcast to the target moment shape."
+            )
+        self.values = values_
+        self.scale = jnp.broadcast_to(scale_, values_.shape)
+        invalid = jnp.any(~jnp.isfinite(self.scale) | (self.scale <= 0.0))
+        if isinstance(invalid, jax_core.Tracer):
+            self.scale = eqx.error_if(
+                self.scale,
+                invalid,
+                "Quadratic moment scales must be finite and strictly positive.",
+            )
+        elif bool(invalid):
+            raise ValueError(
+                "Quadratic moment scales must be finite and strictly positive."
+            )
+
+
+MomentTarget: TypeAlias = ExactMoments | QuadraticMoments
+
+
+class MomentCalibrationPolicy(StrictModule):
+    """Affine-rank, regularity, and bounded geometry policy for calibration."""
+
+    rank: RankPolicy
+    spectrum: SelfAdjointSpectrumPolicy
+    affine_absolute_tolerance: float = eqx.field(static=True)
+    affine_relative_tolerance: float = eqx.field(static=True)
+    regularity_relative_tolerance: float = eqx.field(static=True)
+    maximum_moments: int = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        rank: RankPolicy | None = None,
+        spectrum: SelfAdjointSpectrumPolicy | None = None,
+        affine_absolute_tolerance: float = 1e-10,
+        affine_relative_tolerance: float = 1e-8,
+        regularity_relative_tolerance: float = 1e-10,
+        maximum_moments: int = 512,
+    ):
+        rank_ = RankPolicy() if rank is None else rank
+        spectrum_ = SelfAdjointSpectrumPolicy() if spectrum is None else spectrum
+        if not isinstance(rank_, RankPolicy):
+            raise TypeError("rank must be a RankPolicy or None.")
+        if not isinstance(spectrum_, SelfAdjointSpectrumPolicy):
+            raise TypeError("spectrum must be a SelfAdjointSpectrumPolicy or None.")
+        tolerances = (
+            float(affine_absolute_tolerance),
+            float(affine_relative_tolerance),
+            float(regularity_relative_tolerance),
+        )
+        if any(not isfinite(value) or value < 0.0 for value in tolerances):
+            raise ValueError("Calibration tolerances must be finite and non-negative.")
+        maximum = int(maximum_moments)
+        if maximum < 1:
+            raise ValueError("maximum_moments must be positive.")
+        self.rank = rank_
+        self.spectrum = spectrum_
+        (
+            self.affine_absolute_tolerance,
+            self.affine_relative_tolerance,
+            self.regularity_relative_tolerance,
+        ) = tolerances
+        self.maximum_moments = maximum
+
+
+class MomentCalibrationProblem(StrictModule):
+    """A finite prior, linear moment map, and exact or soft target moments."""
+
+    moment_map: AbstractLinearOperator
+    target: MomentTarget
+    prior_log_weights: Array
+    mask: Array
+    source_points: int = eqx.field(static=True)
+    moment_count: int = eqx.field(static=True)
+    problem_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        features: ArrayLike | AbstractLinearOperator,
+        target: MomentTarget,
+        /,
+        *,
+        prior_log_weights: ArrayLike | None = None,
+        mask: ArrayLike | None = None,
+        problem_id: str | None = None,
+    ):
+        moment_map = _moment_operator(features)
+        if not isinstance(target, (ExactMoments, QuadraticMoments)):
+            raise TypeError("target must be ExactMoments or QuadraticMoments.")
+        source_points = int(moment_map.source.shape[0])
+        moment_count = int(moment_map.target.shape[0])
+        if target.values.shape != (moment_count,):
+            raise ValueError(
+                f"Target moments must have shape ({moment_count},); "
+                f"got {target.values.shape}."
+            )
+        dtype = moment_map.source.dtype
+        target_ = (
+            ExactMoments(target.values.astype(dtype))
+            if isinstance(target, ExactMoments)
+            else QuadraticMoments(
+                target.values.astype(dtype),
+                scale=target.scale.astype(dtype),
+            )
+        )
+        if prior_log_weights is None:
+            prior = jnp.zeros((source_points,), dtype=dtype)
+        else:
+            prior = jnp.asarray(prior_log_weights, dtype=dtype)
+            if prior.shape != (source_points,):
+                raise ValueError(f"prior_log_weights must have shape ({source_points},).")
+        if mask is None:
+            mask_ = jnp.ones((source_points,), dtype=bool)
+        else:
+            mask_ = jnp.asarray(mask, dtype=bool)
+            if mask_.shape != (source_points,):
+                raise ValueError(f"mask must have shape ({source_points},).")
+        self.moment_map = moment_map
+        self.target = target_
+        self.prior_log_weights = prior
+        self.mask = mask_
+        self.source_points = source_points
+        self.moment_count = moment_count
+        self.problem_id = (
+            canonical_fingerprint(
+                {
+                    "kind": "moment-calibration",
+                    "operator": moment_map.operator_id,
+                    "source_points": source_points,
+                    "moment_count": moment_count,
+                    "target": type(target_).__name__,
+                }
+            )
+            if problem_id is None
+            else str(problem_id)
+        )
+        if not self.problem_id:
+            raise ValueError("problem_id must be non-empty.")
+
+
+def _moment_values(values: ArrayLike, /) -> Array:
+    values_ = jnp.asarray(values)
+    if values_.ndim != 1 or values_.shape[0] == 0:
+        raise ValueError("Moment values must be a non-empty one-dimensional array.")
+    if jnp.issubdtype(values_.dtype, jnp.complexfloating):
+        raise TypeError("Moment values must be real.")
+    if not jnp.issubdtype(values_.dtype, jnp.inexact):
+        values_ = values_.astype(float)
+    invalid = ~jnp.all(jnp.isfinite(values_))
+    if isinstance(invalid, jax_core.Tracer):
+        values_ = eqx.error_if(
+            values_,
+            invalid,
+            "Moment target values must be finite.",
+        )
+    elif bool(invalid):
+        raise ValueError("Moment target values must be finite.")
+    return values_
+
+
+def _moment_operator(
+    features: ArrayLike | AbstractLinearOperator,
+    /,
+) -> AbstractLinearOperator:
+    if isinstance(features, AbstractLinearOperator):
+        operator = features
+    else:
+        values = jnp.asarray(features)
+        if values.ndim != 2 or any(size == 0 for size in values.shape):
+            raise ValueError(
+                "Dense features must have shape (source_points, moment_count)."
+            )
+        if jnp.issubdtype(values.dtype, jnp.complexfloating):
+            raise TypeError("Moment features must be real.")
+        if not jnp.issubdtype(values.dtype, jnp.inexact):
+            values = values.astype(float)
+        invalid = ~jnp.all(jnp.isfinite(values))
+        if isinstance(invalid, jax_core.Tracer):
+            values = eqx.error_if(
+                values,
+                invalid,
+                "Dense moment features must be finite.",
+            )
+        elif bool(invalid):
+            raise ValueError("Dense moment features must be finite.")
+        operator = DenseLinearOperator(jnp.swapaxes(values, 0, 1))
+    if not isinstance(operator.source, ArraySpace) or not isinstance(
+        operator.target, ArraySpace
+    ):
+        raise TypeError("Moment maps must act between ArraySpace values.")
+    if len(operator.source.shape) != 1 or len(operator.target.shape) != 1:
+        raise ValueError("Moment maps must act between one-dimensional arrays.")
+    if operator.batch_shape:
+        raise ValueError("Batched moment maps are not supported.")
+    if not operator.capabilities.transpose:
+        raise ValueError("Moment maps require a transpose action.")
+    if operator.source.dtype != operator.target.dtype:
+        raise TypeError("Moment-map source and target dtypes must match.")
+    if not np.issubdtype(operator.source.dtype, np.floating):
+        raise TypeError("Moment maps must have a real floating-point dtype.")
+    return operator
+
+
+__all__ = [
+    "ExactMoments",
+    "MomentCalibrationPolicy",
+    "MomentCalibrationProblem",
+    "MomentTarget",
+    "QuadraticMoments",
+]

--- a/phydrax/weighting/_relative_entropy.py
+++ b/phydrax/weighting/_relative_entropy.py
@@ -1,0 +1,403 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import equinox as eqx
+import jax.numpy as jnp
+import jax.scipy as jsp
+from jax import core as jax_core
+from jaxtyping import Array
+
+from .._numerics import weight_ess
+from ..linalg import DenseLinearOperator
+from ..optim import (
+    AbstractScalarIterativeMethod,
+    implicit_minimize,
+    minimize,
+    NewtonKrylov,
+    OptimizationStatus,
+    OptimizationTermination,
+)
+from ._geometry import (
+    initial_coordinates,
+    physical_dual,
+    prepare_moment_geometry,
+    weighted_covariance,
+    weights_from_coordinates,
+)
+from ._problem import (
+    ExactMoments,
+    MomentCalibrationPolicy,
+    MomentCalibrationProblem,
+    QuadraticMoments,
+)
+from ._results import (
+    MomentCalibrationDiagnostics,
+    MomentCalibrationProvenance,
+    MomentCalibrationResult,
+    MomentCalibrationStatus,
+)
+
+
+def calibrate_moments(
+    problem: MomentCalibrationProblem,
+    /,
+    *,
+    method: AbstractScalarIterativeMethod | None = None,
+    termination: OptimizationTermination | None = None,
+    policy: MomentCalibrationPolicy | None = None,
+    initial_dual: Array | None = None,
+) -> MomentCalibrationResult:
+    """Return an audited relative-entropy calibration of one finite prior."""
+
+    method_, termination_, policy_ = _resolve_configuration(
+        method,
+        termination,
+        policy,
+    )
+    geometry = _require_geometry(prepare_moment_geometry(problem, policy_))
+    initial = initial_coordinates(geometry, initial_dual)
+
+    def objective(coordinates, _):
+        return _dual_objective(problem, geometry, coordinates)
+
+    optimization = minimize(
+        objective,
+        initial,
+        method=method_,
+        termination=termination_,
+    )
+    return _result(
+        problem,
+        geometry,
+        optimization.parameters,
+        optimization.status,
+        optimization.diagnostics,
+        optimization.provenance,
+        termination_,
+        policy_,
+    )
+
+
+def implicit_calibrate_moments(
+    problem: MomentCalibrationProblem,
+    /,
+    *,
+    method: AbstractScalarIterativeMethod | None = None,
+    termination: OptimizationTermination | None = None,
+    policy: MomentCalibrationPolicy | None = None,
+    initial_dual: Array | None = None,
+) -> Array:
+    """Return calibrated weights with regular-stationarity implicit derivatives."""
+
+    method_, termination_, policy_ = _resolve_configuration(
+        method,
+        termination,
+        policy,
+    )
+    geometry = _require_geometry(prepare_moment_geometry(problem, policy_))
+    if isinstance(problem.target, ExactMoments):
+        affine_tolerance = _affine_tolerance(problem, geometry, policy_)
+        geometry = _error_if_geometry(
+            geometry,
+            geometry.affine_residual_norm > affine_tolerance,
+            "Implicit exact calibration requires an affine-consistent target.",
+        )
+    initial = initial_coordinates(geometry, initial_dual)
+
+    def objective(coordinates, _):
+        return _dual_objective(problem, geometry, coordinates)
+
+    coordinates = implicit_minimize(
+        objective,
+        initial,
+        method=method_,
+        termination=termination_,
+    )
+    _, weights = weights_from_coordinates(problem, geometry, coordinates)
+    achieved, final_covariance = weighted_covariance(problem, weights)
+    residual = achieved - problem.target.values
+    final_hessian = _coordinate_hessian(
+        problem,
+        geometry,
+        final_covariance,
+    )
+    eigenvalues = jnp.linalg.eigvalsh(final_hessian)
+    minimum_eigenvalue = jnp.min(eigenvalues)
+    maximum_eigenvalue = jnp.maximum(jnp.max(eigenvalues), 1.0)
+    regularity_threshold = (
+        jnp.maximum(
+            policy_.regularity_relative_tolerance,
+            jnp.sqrt(jnp.finfo(weights.dtype).eps),
+        )
+        * maximum_eigenvalue
+    )
+    scaled_residual = residual / geometry.moment_scales
+    residual_threshold = termination_.optimality_threshold(
+        jnp.linalg.norm(
+            (geometry.prior_moments - problem.target.values) / geometry.moment_scales
+        )
+    )
+    invalid = ~jnp.all(jnp.isfinite(weights))
+    if isinstance(problem.target, ExactMoments):
+        invalid = (
+            invalid
+            | (jnp.max(jnp.abs(scaled_residual)) > residual_threshold)
+            | (minimum_eigenvalue <= regularity_threshold)
+        )
+    return _error_if_array(
+        weights,
+        invalid,
+        "Implicit moment calibration requires a finite regular solution.",
+    )
+
+
+def _dual_objective(problem, geometry, coordinates):
+    dual = physical_dual(geometry, coordinates)
+    scores = problem.moment_map.transpose_mv(dual)
+    centered_scores = scores - jnp.vdot(geometry.prior_moments, dual).real
+    logits = jnp.where(
+        geometry.active_support,
+        geometry.prior_log_weights + centered_scores,
+        -jnp.inf,
+    )
+    target_delta = problem.target.values - geometry.prior_moments
+    value = jsp.special.logsumexp(logits) - jnp.vdot(target_delta, dual).real
+    if isinstance(problem.target, ExactMoments):
+        inactive = ~geometry.retained_directions
+        return value + 0.5 * jnp.sum(jnp.where(inactive, coordinates**2, 0.0))
+    assert isinstance(problem.target, QuadraticMoments)
+    return value + 0.5 * jnp.sum((problem.target.scale * dual) ** 2)
+
+
+def _result(
+    problem,
+    geometry,
+    coordinates,
+    optimizer_status,
+    optimization_diagnostics,
+    optimization_provenance,
+    termination,
+    policy,
+):
+    log_weights, weights = weights_from_coordinates(
+        problem,
+        geometry,
+        coordinates,
+    )
+    dual = physical_dual(geometry, coordinates)
+    achieved, final_covariance = weighted_covariance(problem, weights)
+    residual = achieved - problem.target.values
+    scaled_residual = residual / geometry.moment_scales
+    gradient = _dual_gradient(problem, geometry, coordinates, residual)
+    final_hessian = _coordinate_hessian(problem, geometry, final_covariance)
+    final_eigenvalues = jnp.linalg.eigvalsh(final_hessian)
+    minimum_final = jnp.min(final_eigenvalues)
+    maximum_final = jnp.max(final_eigenvalues)
+    condition = maximum_final / jnp.maximum(
+        minimum_final,
+        jnp.finfo(weights.dtype).tiny,
+    )
+    retained = geometry.retained_directions
+    minimum_prior = jnp.min(jnp.where(retained, geometry.covariance_eigenvalues, jnp.inf))
+    minimum_prior = jnp.where(
+        jnp.any(retained),
+        minimum_prior,
+        0.0,
+    )
+    maximum_prior = jnp.max(jnp.where(retained, geometry.covariance_eigenvalues, 0.0))
+    safe_log_weights = jnp.where(geometry.active_support, log_weights, 0.0)
+    safe_log_prior = jnp.where(
+        geometry.active_support,
+        geometry.prior_log_weights,
+        0.0,
+    )
+    relative_entropy = jnp.sum(weights * (safe_log_weights - safe_log_prior))
+    minimum_weight = jnp.min(jnp.where(geometry.active_support, weights, jnp.inf))
+    maximum_weight = jnp.max(jnp.where(geometry.active_support, weights, 0.0))
+    maximum_log_ratio = jnp.max(
+        jnp.where(
+            geometry.active_support,
+            safe_log_weights - safe_log_prior,
+            -jnp.inf,
+        )
+    )
+    normalization_residual = jnp.abs(jnp.sum(weights) - 1.0)
+    initial_residual_norm = jnp.linalg.norm(
+        (geometry.prior_moments - problem.target.values) / geometry.moment_scales
+    )
+    residual_threshold = termination.optimality_threshold(initial_residual_norm)
+    affine_tolerance = _affine_tolerance(problem, geometry, policy)
+    regularity_threshold = jnp.maximum(
+        policy.regularity_relative_tolerance,
+        jnp.sqrt(jnp.finfo(weights.dtype).eps),
+    ) * jnp.maximum(maximum_final, 1.0)
+    all_finite = (
+        jnp.all(jnp.isfinite(weights))
+        & jnp.all(jnp.isfinite(dual))
+        & jnp.all(jnp.isfinite(achieved))
+        & jnp.all(jnp.isfinite(gradient))
+        & jnp.isfinite(relative_entropy)
+        & jnp.isfinite(minimum_final)
+        & jnp.isfinite(maximum_final)
+    )
+    optimizer_success = optimizer_status == int(OptimizationStatus.SUCCESS)
+    status = jnp.asarray(int(MomentCalibrationStatus.SUCCESS), dtype=jnp.int32)
+    status = jnp.where(
+        ~optimizer_success,
+        int(MomentCalibrationStatus.OPTIMIZATION_FAILED),
+        status,
+    )
+    if isinstance(problem.target, ExactMoments):
+        status = jnp.where(
+            minimum_final <= regularity_threshold,
+            int(MomentCalibrationStatus.REGULARITY_NOT_CERTIFIED),
+            status,
+        )
+        status = jnp.where(
+            jnp.max(jnp.abs(scaled_residual)) > residual_threshold,
+            int(MomentCalibrationStatus.TARGET_RESIDUAL_NOT_MET),
+            status,
+        )
+        status = jnp.where(
+            geometry.affine_residual_norm > affine_tolerance,
+            int(MomentCalibrationStatus.AFFINE_TARGET_INCONSISTENT),
+            status,
+        )
+    status = jnp.where(
+        ~all_finite,
+        int(MomentCalibrationStatus.NONFINITE_RESULT),
+        status,
+    ).astype(jnp.int32)
+    diagnostics = MomentCalibrationDiagnostics(
+        optimizer_status=jnp.asarray(optimizer_status, dtype=jnp.int32),
+        optimization=optimization_diagnostics,
+        prior_moments=geometry.prior_moments,
+        target_residual=residual,
+        scaled_target_residual=scaled_residual,
+        maximum_absolute_residual=jnp.max(jnp.abs(residual)),
+        maximum_scaled_residual=jnp.max(jnp.abs(scaled_residual)),
+        affine_residual_norm=geometry.affine_residual_norm,
+        numerical_affine_rank=geometry.numerical_affine_rank,
+        rank_cutoff=geometry.rank_cutoff,
+        minimum_prior_eigenvalue=minimum_prior,
+        maximum_prior_eigenvalue=maximum_prior,
+        minimum_final_eigenvalue=minimum_final,
+        final_condition_estimate=condition,
+        dual_gradient_norm=jnp.linalg.norm(gradient),
+        dual_norm=jnp.linalg.norm(dual),
+        relative_entropy=relative_entropy,
+        effective_sample_size=weight_ess(weights),
+        active_support=jnp.sum(geometry.active_support.astype(jnp.int32)),
+        minimum_active_weight=minimum_weight,
+        maximum_active_weight=maximum_weight,
+        maximum_log_weight_ratio=maximum_log_ratio,
+        normalization_residual=normalization_residual,
+        geometry_finite=geometry.finite,
+        spectrum=geometry.spectrum_diagnostics,
+    )
+    provenance = MomentCalibrationProvenance(
+        problem_id=problem.problem_id,
+        operator_id=problem.moment_map.operator_id,
+        target_kind=(
+            "exact" if isinstance(problem.target, ExactMoments) else "quadratic"
+        ),
+        source_points=problem.source_points,
+        moment_count=problem.moment_count,
+        execution=(
+            "dense" if isinstance(problem.moment_map, DenseLinearOperator) else "operator"
+        ),
+        differentiation="explicit",
+        optimizer=optimization_provenance,
+    )
+    return MomentCalibrationResult(
+        problem=problem,
+        log_weights=log_weights,
+        dual_variables=dual,
+        achieved_moments=achieved,
+        status=status,
+        diagnostics=diagnostics,
+        provenance=provenance,
+    )
+
+
+def _dual_gradient(problem, geometry, coordinates, residual):
+    gradient = jnp.swapaxes(geometry.transform, -1, -2) @ residual
+    if isinstance(problem.target, ExactMoments):
+        return gradient + jnp.where(
+            geometry.retained_directions,
+            0.0,
+            coordinates,
+        )
+    assert isinstance(problem.target, QuadraticMoments)
+    dual = physical_dual(geometry, coordinates)
+    return gradient + jnp.swapaxes(geometry.transform, -1, -2) @ (
+        problem.target.scale**2 * dual
+    )
+
+
+def _coordinate_hessian(problem, geometry, covariance):
+    physical_hessian = covariance
+    if isinstance(problem.target, QuadraticMoments):
+        physical_hessian = physical_hessian + jnp.diag(problem.target.scale**2)
+    transformed = (
+        jnp.swapaxes(geometry.transform, -1, -2) @ physical_hessian @ geometry.transform
+    )
+    if isinstance(problem.target, ExactMoments):
+        transformed = transformed + jnp.diag(
+            (~geometry.retained_directions).astype(transformed.dtype)
+        )
+    return 0.5 * (transformed + jnp.swapaxes(transformed, -1, -2))
+
+
+def _affine_tolerance(problem, geometry, policy):
+    scale = jnp.maximum(
+        jnp.linalg.norm(
+            (problem.target.values - geometry.prior_moments) / geometry.moment_scales
+        ),
+        1.0,
+    )
+    return policy.affine_absolute_tolerance + policy.affine_relative_tolerance * scale
+
+
+def _resolve_configuration(method, termination, policy):
+    method_ = NewtonKrylov() if method is None else method
+    termination_ = OptimizationTermination() if termination is None else termination
+    policy_ = MomentCalibrationPolicy() if policy is None else policy
+    if not isinstance(method_, AbstractScalarIterativeMethod):
+        raise TypeError("method must be an AbstractScalarIterativeMethod or None.")
+    if not isinstance(termination_, OptimizationTermination):
+        raise TypeError("termination must be an OptimizationTermination or None.")
+    if not isinstance(policy_, MomentCalibrationPolicy):
+        raise TypeError("policy must be a MomentCalibrationPolicy or None.")
+    return method_, termination_, policy_
+
+
+def _require_geometry(geometry):
+    return _error_if_geometry(
+        geometry,
+        ~geometry.finite,
+        "Moment calibration inputs or affine geometry are invalid.",
+    )
+
+
+def _error_if_geometry(geometry, predicate, message):
+    if not isinstance(predicate, jax_core.Tracer):
+        if bool(predicate):
+            raise ValueError(message)
+        return geometry
+    checked = eqx.error_if(geometry.transform, predicate, message)
+    return eqx.tree_at(lambda item: item.transform, geometry, checked)
+
+
+def _error_if_array(value, predicate, message):
+    if not isinstance(predicate, jax_core.Tracer):
+        if bool(predicate):
+            raise eqx.EquinoxRuntimeError(message)
+        return value
+    return eqx.error_if(value, predicate, message)
+
+
+__all__ = ["calibrate_moments", "implicit_calibrate_moments"]

--- a/phydrax/weighting/_results.py
+++ b/phydrax/weighting/_results.py
@@ -1,0 +1,161 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from enum import IntEnum
+from typing import Any
+
+import equinox as eqx
+import jax.numpy as jnp
+from jax import core as jax_core
+from jaxtyping import Array
+
+from .._strict import StrictModule
+from ..optim import OptimizationDiagnostics, OptimizationProvenance
+from ._problem import MomentCalibrationProblem
+
+
+class MomentCalibrationStatus(IntEnum):
+    """Terminal statuses for finite-measure moment calibration."""
+
+    SUCCESS = 0
+    AFFINE_TARGET_INCONSISTENT = 1
+    TARGET_RESIDUAL_NOT_MET = 2
+    REGULARITY_NOT_CERTIFIED = 3
+    OPTIMIZATION_FAILED = 4
+    NONFINITE_RESULT = 5
+
+
+_STATUS_MESSAGES = {
+    MomentCalibrationStatus.SUCCESS: "success",
+    MomentCalibrationStatus.AFFINE_TARGET_INCONSISTENT: (
+        "target is inconsistent with the active feature affine hull"
+    ),
+    MomentCalibrationStatus.TARGET_RESIDUAL_NOT_MET: (
+        "exact target residual exceeds tolerance"
+    ),
+    MomentCalibrationStatus.REGULARITY_NOT_CERTIFIED: (
+        "finite exact-dual regularity was not certified"
+    ),
+    MomentCalibrationStatus.OPTIMIZATION_FAILED: "underlying optimization failed",
+    MomentCalibrationStatus.NONFINITE_RESULT: "calibration produced non-finite values",
+}
+
+
+def moment_calibration_status_message(
+    status: int | MomentCalibrationStatus,
+    /,
+) -> str:
+    """Return a stable human-readable calibration status message."""
+
+    return _STATUS_MESSAGES[MomentCalibrationStatus(int(status))]
+
+
+class MomentCalibrationDiagnostics(StrictModule):
+    """Moment, regularity, concentration, and optimizer evidence."""
+
+    optimizer_status: Array
+    optimization: OptimizationDiagnostics
+    prior_moments: Array
+    target_residual: Array
+    scaled_target_residual: Array
+    maximum_absolute_residual: Array
+    maximum_scaled_residual: Array
+    affine_residual_norm: Array
+    numerical_affine_rank: Array
+    rank_cutoff: Array
+    minimum_prior_eigenvalue: Array
+    maximum_prior_eigenvalue: Array
+    minimum_final_eigenvalue: Array
+    final_condition_estimate: Array
+    dual_gradient_norm: Array
+    dual_norm: Array
+    relative_entropy: Array
+    effective_sample_size: Array
+    active_support: Array
+    minimum_active_weight: Array
+    maximum_active_weight: Array
+    maximum_log_weight_ratio: Array
+    normalization_residual: Array
+    geometry_finite: Array
+    spectrum: Any
+
+
+class MomentCalibrationProvenance(StrictModule):
+    """Static numerical identity for one moment-calibration solve."""
+
+    problem_id: str = eqx.field(static=True)
+    operator_id: str = eqx.field(static=True)
+    target_kind: str = eqx.field(static=True)
+    source_points: int = eqx.field(static=True)
+    moment_count: int = eqx.field(static=True)
+    execution: str = eqx.field(static=True)
+    differentiation: str = eqx.field(static=True)
+    optimizer: OptimizationProvenance
+
+
+class MomentCalibrationResult(StrictModule):
+    """Calibrated normalized weights with explicit numerical evidence."""
+
+    problem: MomentCalibrationProblem
+    log_weights: Array
+    dual_variables: Array
+    achieved_moments: Array
+    status: Array
+    diagnostics: MomentCalibrationDiagnostics
+    provenance: MomentCalibrationProvenance
+
+    @property
+    def weights(self) -> Array:
+        """Return normalized nonnegative weights with inactive support at zero."""
+
+        return jnp.where(
+            jnp.isfinite(self.log_weights),
+            jnp.exp(self.log_weights),
+            0.0,
+        )
+
+    @property
+    def converged(self) -> Array:
+        """Whether all calibration success criteria were satisfied."""
+
+        return self.status == int(MomentCalibrationStatus.SUCCESS)
+
+    @property
+    def successful(self) -> Array:
+        """Alias for the terminal calibration success predicate."""
+
+        return self.converged
+
+
+def require_converged(result: MomentCalibrationResult, /) -> MomentCalibrationResult:
+    """Raise unless calibration succeeded, including under JAX transforms."""
+
+    if not isinstance(result, MomentCalibrationResult):
+        raise TypeError("result must be a MomentCalibrationResult.")
+    failed = jnp.logical_not(result.converged)
+    if not isinstance(failed, jax_core.Tracer):
+        if bool(failed):
+            raise eqx.EquinoxRuntimeError(
+                "Moment calibration did not converge: "
+                f"{moment_calibration_status_message(result.status)}."
+            )
+        return result
+    checked = eqx.error_if(
+        result.log_weights,
+        failed,
+        "Moment calibration did not converge.",
+    )
+    return eqx.tree_at(lambda item: item.log_weights, result, checked)
+
+
+__all__ = [
+    "MomentCalibrationDiagnostics",
+    "MomentCalibrationProvenance",
+    "MomentCalibrationResult",
+    "MomentCalibrationStatus",
+    "moment_calibration_status_message",
+    "require_converged",
+]

--- a/tests/unit/integration/test_calibration.py
+++ b/tests/unit/integration/test_calibration.py
@@ -1,0 +1,226 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from typing import Any
+
+import coordax as cx
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import pytest
+
+import phydrax as phx
+
+
+TERMINATION = phx.optim.OptimizationTermination(
+    absolute_optimality=1e-8,
+    relative_optimality=0.0,
+    maximum_steps=100,
+)
+
+
+def _array(value):
+    return value.data if isinstance(value, cx.Field) else value
+
+
+def test_named_calibration_preserves_mass_support_ancestry_and_provenance():
+    axis = "sample"
+    coordinates = jnp.linspace(0.0, 1.0, 21)
+    samples = cx.Field(coordinates, dims=(axis,))
+    log_weights = cx.Field(jnp.linspace(-1.0, 1.0, 21), dims=(axis,))
+    mask = cx.Field(jnp.arange(21) != 7, dims=(axis,))
+    ancestry = cx.Field(jnp.arange(100, 121, dtype=jnp.int32), dims=(axis,))
+    features = cx.Field(coordinates[:, None], dims=(axis, "moment"))
+    target = phx.integration.weighted(
+        samples,
+        log_weights,
+        normalized=False,
+        target_mass=jnp.asarray(5.0),
+        mask=mask,
+        ancestry=ancestry,
+        support_valid=jnp.asarray(True),
+        sample_axes=axis,
+        provenance="observed-ensemble",
+    )
+    source = phx.integration.materialize(target)
+
+    calibrated = phx.integration.calibrate(
+        source,
+        phx.weighting.ExactMoments(jnp.array([0.6])),
+        features=features,
+        termination=TERMINATION,
+    )
+    estimate = phx.integration.reduce(lambda value: value, calibrated)
+
+    assert jnp.isclose(calibrated.target.target_mass, 5.0)
+    assert jnp.allclose(calibrated.batch.samples.data, coordinates)
+    assert jnp.array_equal(calibrated.batch.mask.data, mask.data)
+    assert calibrated.batch.log_weights.data[7] == -jnp.inf
+    assert jnp.array_equal(calibrated.batch.ancestry_ids.data, ancestry.data)
+    assert jnp.array_equal(calibrated.batch.support_valid, jnp.asarray(True))
+    assert jnp.allclose(estimate.value.data, 3.0, atol=1e-8)
+    assert estimate.error_estimate is None
+    assert estimate.provenance.method == "calibrated"
+    assert isinstance(
+        estimate.diagnostics,
+        phx.integration.TransformedIntegrationDiagnostics,
+    )
+    assert tuple(record.kind for record in calibrated.transformations) == ("calibration",)
+    diagnostics = calibrated.transformations[0].diagnostics
+    assert isinstance(diagnostics, phx.integration.MeasureCalibrationDiagnostics)
+    assert diagnostics.calibration.successful
+    assert jnp.allclose(
+        diagnostics.calibration.achieved_moments,
+        jnp.array([0.6]),
+        atol=1e-8,
+    )
+    assert diagnostics.source_provenance == "observed-ensemble"
+
+
+def test_raw_callable_features_calibrate_normalized_expectations():
+    samples = jnp.linspace(-1.0, 1.0, 31)
+    source = phx.integration.materialize(
+        phx.integration.weighted(
+            samples,
+            -0.5 * samples**2,
+            normalized=True,
+        )
+    )
+
+    calibrated = phx.integration.calibrate(
+        source,
+        phx.weighting.ExactMoments(jnp.array([0.2, 0.5])),
+        features=lambda values: jnp.stack((values, values**2), axis=1),
+        termination=TERMINATION,
+    )
+    first = phx.integration.reduce(lambda values: values, calibrated)
+    second = phx.integration.reduce(lambda values: values**2, calibrated)
+
+    assert calibrated.target.target_mass is None
+    assert jnp.allclose(_array(first.value), 0.2, atol=1e-8)
+    assert jnp.allclose(_array(second.value), 0.5, atol=1e-8)
+
+
+def test_calibration_then_recombination_preserves_calibrated_moments_and_history():
+    samples = jnp.linspace(-1.0, 1.0, 65)
+    features = jnp.stack((samples, samples**2), axis=1)
+    source = phx.integration.materialize(
+        phx.integration.weighted(
+            samples,
+            jnp.zeros_like(samples),
+            normalized=False,
+            target_mass=jnp.asarray(4.0),
+            ancestry=jnp.arange(1000, 1065, dtype=jnp.int32),
+        )
+    )
+    calibrated = phx.integration.calibrate(
+        source,
+        phx.weighting.ExactMoments(jnp.array([0.25, 0.45])),
+        features=features,
+        termination=TERMINATION,
+    )
+
+    compressed = phx.integration.compress(
+        calibrated,
+        phx.coresets.MomentRecombination(),
+        features=features,
+    )
+    first = phx.integration.reduce(lambda values: values, compressed)
+    second = phx.integration.reduce(lambda values: values**2, compressed)
+
+    assert compressed.batch.num_samples <= 3
+    assert jnp.isclose(compressed.target.target_mass, 4.0)
+    assert jnp.allclose(_array(first.value), 1.0, atol=1e-8)
+    assert jnp.allclose(_array(second.value), 1.8, atol=1e-8)
+    assert tuple(record.kind for record in compressed.transformations) == (
+        "calibration",
+        "compression",
+    )
+    assert first.provenance.method == "compressed"
+    assert tuple(record.kind for record in first.diagnostics.transformations) == (
+        "calibration",
+        "compression",
+    )
+
+
+def test_recombination_then_calibration_uses_the_compressed_prior_and_order():
+    samples = jnp.linspace(0.0, 1.0, 41)
+    source = phx.integration.materialize(
+        phx.integration.weighted(samples, jnp.zeros_like(samples))
+    )
+    compressed = phx.integration.compress(
+        source,
+        phx.coresets.MomentRecombination(),
+        features=jnp.stack((samples, samples**2), axis=1),
+    )
+    compressed_samples = jnp.asarray(compressed.batch.samples)
+    compressed_logits = jnp.asarray(compressed.batch.log_weights)
+    expected_weights = jax.nn.softmax(compressed_logits + 0.7 * compressed_samples)
+    target_moment = jnp.sum(expected_weights * compressed_samples)
+
+    calibrated = phx.integration.calibrate(
+        compressed,
+        phx.weighting.ExactMoments(jnp.reshape(target_moment, (1,))),
+        features=compressed_samples,
+        termination=TERMINATION,
+    )
+    estimate = phx.integration.reduce(lambda values: values, calibrated)
+
+    assert calibrated.batch.num_samples == compressed.batch.num_samples
+    assert jnp.allclose(_array(estimate.value), target_moment, atol=1e-8)
+    assert tuple(record.kind for record in calibrated.transformations) == (
+        "compression",
+        "calibration",
+    )
+    assert estimate.provenance.method == "calibrated"
+
+
+def test_soft_calibration_returns_a_finite_measure_for_unreachable_targets():
+    samples = jnp.array([0.0, 1.0, 2.0])
+    source = phx.integration.materialize(
+        phx.integration.weighted(samples, jnp.log(jnp.array([0.2, 0.5, 0.3])))
+    )
+
+    calibrated = phx.integration.calibrate(
+        source,
+        phx.weighting.QuadraticMoments(jnp.array([-3.0]), scale=0.5),
+        features=samples,
+        termination=TERMINATION,
+    )
+    result = calibrated.transformations[0].diagnostics.calibration
+
+    assert result.successful
+    assert jnp.all(jnp.isfinite(result.weights))
+    assert 0.0 <= result.achieved_moments[0] <= 2.0
+    assert jnp.isclose(jnp.sum(result.weights), 1.0)
+
+
+def test_calibration_rejects_unpreserved_grouping_and_failed_exact_targets():
+    samples = jnp.linspace(0.0, 1.0, 12)
+    identifiers = jnp.arange(12, dtype=jnp.int32) // 2
+    for identifier in ("stratum_ids", "pair_ids", "replicate_ids"):
+        grouping: dict[str, Any] = {identifier: identifiers}
+        grouped = phx.integration.materialize(
+            phx.integration.weighted(
+                samples,
+                jnp.zeros_like(samples),
+                **grouping,
+            )
+        )
+        with pytest.raises(ValueError, match="transformed"):
+            phx.integration.calibrate(
+                grouped,
+                phx.weighting.ExactMoments(jnp.array([0.5])),
+                features=samples,
+            )
+
+    source = phx.integration.materialize(
+        phx.integration.weighted(samples, jnp.zeros_like(samples))
+    )
+    with pytest.raises(eqx.EquinoxRuntimeError, match="did not converge"):
+        phx.integration.calibrate(
+            source,
+            phx.weighting.ExactMoments(jnp.array([2.0])),
+            features=samples,
+        )

--- a/tests/unit/integration/test_compression.py
+++ b/tests/unit/integration/test_compression.py
@@ -54,7 +54,12 @@ def test_moment_compression_is_reusable_and_preserves_named_ancestry():
     assert compressed_estimate.provenance.method == "compressed"
     assert isinstance(
         compressed_estimate.diagnostics,
-        phx.integration.CompressedIntegrationDiagnostics,
+        phx.integration.TransformedIntegrationDiagnostics,
+    )
+    assert compressed_estimate.diagnostics.transformations[0].kind == "compression"
+    assert isinstance(
+        compressed_estimate.diagnostics.transformations[0].diagnostics,
+        phx.integration.MeasureCompressionDiagnostics,
     )
 
 
@@ -156,7 +161,7 @@ def test_compression_rejects_unpreserved_sample_grouping(identifier):
         **grouping,
     )
 
-    with pytest.raises(ValueError, match="compressed"):
+    with pytest.raises(ValueError, match="transformed"):
         phx.integration.compress(
             phx.integration.materialize(target),
             phx.coresets.MomentRecombination(),

--- a/tests/unit/optim/test_iterative_optimization.py
+++ b/tests/unit/optim/test_iterative_optimization.py
@@ -157,6 +157,50 @@ def test_newton_krylov_uses_descent_fallback_for_indefinite_hessian():
     assert result.provenance.method == "newton-krylov"
 
 
+def test_newton_krylov_forcing_controls_inner_accuracy_under_jit():
+    diagonal = jnp.logspace(0.0, 6.0, 24)
+
+    def objective(value, _):
+        return 0.5 * jnp.sum(diagonal * value**2)
+
+    termination = _termination(steps=1, tolerance=0.0)
+    initial = jnp.ones((24,))
+    loose_method = phx.optim.NewtonKrylov(
+        minimum_forcing=0.5,
+        maximum_forcing=0.5,
+    )
+    tight_method = phx.optim.NewtonKrylov(
+        minimum_forcing=1e-8,
+        maximum_forcing=1e-8,
+    )
+
+    def solve(method):
+        return phx.optim.minimize(
+            objective,
+            initial,
+            method=method,
+            termination=termination,
+        )
+
+    loose = solve(loose_method)
+    tight = solve(tight_method)
+    compiled_loose = eqx.filter_jit(lambda: solve(loose_method))()
+    compiled_tight = eqx.filter_jit(lambda: solve(tight_method))()
+
+    assert int(loose.diagnostics.linear_iterations) < int(
+        tight.diagnostics.linear_iterations
+    )
+    assert float(tight.diagnostics.final_optimality_norm) < float(
+        loose.diagnostics.final_optimality_norm
+    )
+    assert int(compiled_loose.diagnostics.linear_iterations) == int(
+        loose.diagnostics.linear_iterations
+    )
+    assert int(compiled_tight.diagnostics.linear_iterations) == int(
+        tight.diagnostics.linear_iterations
+    )
+
+
 def test_nonfinite_initial_parameters_return_typed_status():
     result = phx.optim.minimize(
         lambda value, _: jnp.sum(value**2),

--- a/tests/unit/weighting/test_relative_entropy.py
+++ b/tests/unit/weighting/test_relative_entropy.py
@@ -1,0 +1,412 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import pytest
+
+import phydrax as phx
+
+
+TIGHT_TERMINATION = phx.optim.OptimizationTermination(
+    absolute_optimality=1e-10,
+    relative_optimality=0.0,
+    maximum_steps=100,
+)
+
+
+def _problem(features, target, prior, *, mask=None):
+    return phx.weighting.MomentCalibrationProblem(
+        features,
+        target,
+        prior_log_weights=jnp.log(prior),
+        mask=mask,
+    )
+
+
+def test_binary_exact_calibration_has_analytic_weights_dual_and_kl():
+    features = jnp.array([[0.0], [1.0]])
+    prior = jnp.array([0.25, 0.75])
+    problem = _problem(
+        features,
+        phx.weighting.ExactMoments(jnp.array([0.5])),
+        prior,
+    )
+
+    result = phx.weighting.calibrate_moments(
+        problem,
+        termination=TIGHT_TERMINATION,
+    )
+
+    assert result.successful
+    assert jnp.allclose(result.weights, jnp.array([0.5, 0.5]), atol=1e-10)
+    assert jnp.allclose(result.achieved_moments, jnp.array([0.5]), atol=1e-10)
+    assert jnp.allclose(result.dual_variables, -jnp.log(3.0), atol=1e-9)
+    expected_kl = 0.5 * jnp.log(0.5 / 0.25) + 0.5 * jnp.log(0.5 / 0.75)
+    assert jnp.allclose(result.diagnostics.relative_entropy, expected_kl, atol=1e-10)
+    assert int(result.diagnostics.numerical_affine_rank) == 1
+    assert result.diagnostics.maximum_scaled_residual < 1e-9
+
+
+def test_prior_solution_mask_and_extreme_logits_remain_exact_and_finite():
+    features = jnp.array([[0.0], [1.0], [2.0], [3.0]])
+    mask = jnp.array([True, True, False, True])
+    logits = jnp.array([1000.0, 999.0, -jnp.inf, 998.0])
+    prior = jax.nn.softmax(jnp.array([0.0, -1.0, -2.0]))
+    target = jnp.array([prior @ jnp.array([0.0, 1.0, 3.0])])
+    problem = phx.weighting.MomentCalibrationProblem(
+        features,
+        phx.weighting.ExactMoments(target),
+        prior_log_weights=logits,
+        mask=mask,
+    )
+
+    result = phx.weighting.calibrate_moments(
+        problem,
+        termination=TIGHT_TERMINATION,
+    )
+
+    assert result.successful
+    assert jnp.all(jnp.isfinite(result.weights))
+    assert result.weights[2] == 0.0
+    assert result.log_weights[2] == -jnp.inf
+    assert jnp.allclose(result.dual_variables, 0.0, atol=1e-9)
+    assert jnp.allclose(result.diagnostics.relative_entropy, 0.0, atol=1e-11)
+    assert jnp.isclose(jnp.sum(result.weights), 1.0)
+
+
+def test_exact_calibration_recovers_known_exponential_tilt_and_is_permutation_invariant():
+    features = jnp.array(
+        [
+            [-1.0, 1.0],
+            [-0.2, 0.04],
+            [0.4, 0.16],
+            [1.3, 1.69],
+            [2.0, 4.0],
+        ]
+    )
+    prior = jnp.array([0.1, 0.2, 0.25, 0.3, 0.15])
+    known_dual = jnp.array([0.45, -0.2])
+    expected = jax.nn.softmax(jnp.log(prior) + features @ known_dual)
+    target = features.T @ expected
+    problem = _problem(features, phx.weighting.ExactMoments(target), prior)
+
+    result = phx.weighting.calibrate_moments(
+        problem,
+        termination=TIGHT_TERMINATION,
+    )
+    permutation = jnp.array([3, 0, 4, 1, 2])
+    permuted = _problem(
+        features[permutation],
+        phx.weighting.ExactMoments(target),
+        prior[permutation],
+    )
+    permuted_result = phx.weighting.calibrate_moments(
+        permuted,
+        termination=TIGHT_TERMINATION,
+    )
+
+    assert result.successful
+    assert permuted_result.successful
+    assert jnp.allclose(result.weights, expected, atol=2e-9)
+    assert jnp.allclose(result.dual_variables, known_dual, atol=2e-8)
+    assert jnp.allclose(
+        permuted_result.weights,
+        result.weights[permutation],
+        atol=2e-9,
+    )
+
+
+def test_redundant_and_constant_moments_are_rank_reduced_without_changing_solution():
+    x = jnp.linspace(-1.0, 1.0, 9)
+    features = jnp.stack((x, 2.0 * x, jnp.ones_like(x)), axis=1)
+    prior = jnp.ones((9,)) / 9.0
+    target = jnp.array([0.25, 0.5, 1.0])
+    problem = _problem(features, phx.weighting.ExactMoments(target), prior)
+
+    result = phx.weighting.calibrate_moments(
+        problem,
+        termination=TIGHT_TERMINATION,
+    )
+
+    assert result.successful
+    assert int(result.diagnostics.numerical_affine_rank) == 1
+    assert result.diagnostics.affine_residual_norm < 1e-10
+    assert jnp.allclose(result.achieved_moments, target, atol=1e-9)
+    assert result.diagnostics.minimum_final_eigenvalue > 0.0
+
+
+def test_affine_inconsistency_and_boundary_targets_never_report_success():
+    x = jnp.array([0.0, 1.0, 2.0])
+    features = jnp.stack((x, 2.0 * x, jnp.ones_like(x)), axis=1)
+    prior = jnp.ones((3,)) / 3.0
+    inconsistent = _problem(
+        features,
+        phx.weighting.ExactMoments(jnp.array([0.5, 1.2, 1.0])),
+        prior,
+    )
+    boundary = _problem(
+        x[:, None],
+        phx.weighting.ExactMoments(jnp.array([0.0])),
+        prior,
+    )
+
+    inconsistent_result = phx.weighting.calibrate_moments(inconsistent)
+    boundary_result = phx.weighting.calibrate_moments(
+        boundary,
+        termination=phx.optim.OptimizationTermination(
+            absolute_optimality=1e-10,
+            relative_optimality=0.0,
+            maximum_steps=150,
+        ),
+    )
+
+    assert inconsistent_result.status == int(
+        phx.weighting.MomentCalibrationStatus.AFFINE_TARGET_INCONSISTENT
+    )
+    assert not inconsistent_result.successful
+    assert not boundary_result.successful
+    assert boundary_result.status in (
+        int(phx.weighting.MomentCalibrationStatus.REGULARITY_NOT_CERTIFIED),
+        int(phx.weighting.MomentCalibrationStatus.TARGET_RESIDUAL_NOT_MET),
+        int(phx.weighting.MomentCalibrationStatus.OPTIMIZATION_FAILED),
+    )
+
+
+def test_quadratic_calibration_recovers_known_soft_stationary_point():
+    features = jnp.array([[-1.0, 0.5], [0.0, -0.2], [0.7, 0.4], [1.5, 1.2]])
+    prior = jnp.array([0.15, 0.25, 0.4, 0.2])
+    scale = jnp.array([0.3, 0.5])
+    known_dual = jnp.array([0.4, -0.25])
+    expected = jax.nn.softmax(jnp.log(prior) + features @ known_dual)
+    achieved = features.T @ expected
+    target = achieved + scale**2 * known_dual
+    problem = _problem(
+        features,
+        phx.weighting.QuadraticMoments(target, scale=scale),
+        prior,
+    )
+
+    result = phx.weighting.calibrate_moments(
+        problem,
+        termination=TIGHT_TERMINATION,
+    )
+
+    assert result.successful
+    assert jnp.allclose(result.weights, expected, atol=2e-9)
+    assert jnp.allclose(result.dual_variables, known_dual, atol=2e-8)
+    assert result.diagnostics.dual_gradient_norm < 1e-8
+
+
+def test_quadratic_scale_controls_target_fit_and_prior_shrinkage():
+    features = jnp.array([[0.0], [1.0], [2.0]])
+    prior = jnp.array([0.2, 0.5, 0.3])
+
+    def solve(scale):
+        problem = _problem(
+            features,
+            phx.weighting.QuadraticMoments(jnp.array([-1.0]), scale=scale),
+            prior,
+        )
+        return phx.weighting.calibrate_moments(
+            problem,
+            termination=TIGHT_TERMINATION,
+        )
+
+    tight = solve(0.1)
+    loose = solve(2.0)
+
+    assert tight.successful and loose.successful
+    assert jnp.abs(tight.achieved_moments[0] + 1.0) < jnp.abs(
+        loose.achieved_moments[0] + 1.0
+    )
+    assert tight.diagnostics.relative_entropy > loose.diagnostics.relative_entropy
+    assert jnp.linalg.norm(loose.weights - prior) < jnp.linalg.norm(tight.weights - prior)
+
+
+def test_dense_sparse_and_function_operator_calibrations_agree():
+    features = jnp.array([[1.0, 0.0], [0.0, 1.0], [1.0, 2.0], [2.0, 1.0]])
+    prior = jnp.array([0.1, 0.2, 0.3, 0.4])
+    target = jnp.array([1.1, 1.05])
+    source_indices = jnp.tile(jnp.arange(4, dtype=jnp.int32), 2)
+    target_indices = jnp.repeat(jnp.arange(2, dtype=jnp.int32), 4)
+    relation = phx.sparse.EdgeRelation(
+        source_indices,
+        target_indices,
+        source_size=4,
+        target_size=2,
+    )
+    sparse_map = phx.sparse.SparseLinearMap(relation, features.T.reshape((-1,)))
+    source_space = phx.linalg.ArraySpace((4,), dtype=features.dtype)
+    target_space = phx.linalg.ArraySpace((2,), dtype=features.dtype)
+    function_map = phx.linalg.FunctionLinearOperator(
+        lambda weights: features.T @ weights,
+        source=source_space,
+        target=target_space,
+        transpose_action=lambda dual: features @ dual,
+    )
+    operator_termination = phx.optim.OptimizationTermination(
+        absolute_optimality=1e-8,
+        relative_optimality=0.0,
+        maximum_steps=100,
+    )
+
+    dense_result = phx.weighting.calibrate_moments(
+        _problem(features, phx.weighting.ExactMoments(target), prior),
+        termination=operator_termination,
+    )
+    sparse_result = phx.weighting.calibrate_moments(
+        phx.weighting.MomentCalibrationProblem(
+            sparse_map,
+            phx.weighting.ExactMoments(target),
+            prior_log_weights=jnp.log(prior),
+        ),
+        termination=operator_termination,
+    )
+    function_result = phx.weighting.calibrate_moments(
+        phx.weighting.MomentCalibrationProblem(
+            function_map,
+            phx.weighting.ExactMoments(target),
+            prior_log_weights=jnp.log(prior),
+        ),
+        termination=operator_termination,
+    )
+
+    assert dense_result.successful
+    assert sparse_result.successful
+    assert function_result.successful
+    assert jnp.allclose(sparse_result.weights, dense_result.weights, atol=2e-9)
+    assert jnp.allclose(function_result.weights, dense_result.weights, atol=2e-9)
+    assert sparse_result.provenance.execution == "operator"
+    assert function_result.provenance.execution == "operator"
+
+
+def test_calibration_is_filter_jittable_and_warm_start_reuses_dual():
+    x = jnp.linspace(-2.0, 2.0, 31)
+    features = jnp.stack((x, x**2), axis=1)
+    prior = jax.nn.softmax(-0.3 * x**2)
+    first_problem = _problem(
+        features,
+        phx.weighting.ExactMoments(jnp.array([0.15, 0.9])),
+        prior,
+    )
+    nearby_problem = _problem(
+        features,
+        phx.weighting.ExactMoments(jnp.array([0.16, 0.91])),
+        prior,
+    )
+    compiled = eqx.filter_jit(
+        lambda problem: phx.weighting.calibrate_moments(
+            problem,
+            termination=TIGHT_TERMINATION,
+        )
+    )
+
+    first = compiled(first_problem)
+    eager_nearby = phx.weighting.calibrate_moments(
+        nearby_problem,
+        termination=TIGHT_TERMINATION,
+    )
+    warm_nearby = phx.weighting.calibrate_moments(
+        nearby_problem,
+        termination=TIGHT_TERMINATION,
+        initial_dual=first.dual_variables,
+    )
+    compiled_nearby = compiled(nearby_problem)
+
+    assert first.successful and eager_nearby.successful and warm_nearby.successful
+    assert compiled_nearby.successful
+    assert jnp.allclose(compiled_nearby.weights, eager_nearby.weights, atol=1e-9)
+    assert warm_nearby.diagnostics.optimization.iterations <= (
+        eager_nearby.diagnostics.optimization.iterations
+    )
+
+
+def test_implicit_exact_derivatives_match_analytic_and_finite_difference_results():
+    features = jnp.array([[0.0], [1.0]])
+    prior_logits = jnp.log(jnp.array([0.25, 0.75]))
+
+    def solve_target(target):
+        problem = phx.weighting.MomentCalibrationProblem(
+            features,
+            phx.weighting.ExactMoments(jnp.reshape(target, (1,))),
+            prior_log_weights=prior_logits,
+        )
+        return phx.weighting.implicit_calibrate_moments(
+            problem,
+            termination=TIGHT_TERMINATION,
+        )
+
+    forward = jax.jacfwd(solve_target)(jnp.array(0.5))
+    reverse = jax.jacrev(solve_target)(jnp.array(0.5))
+
+    assert jnp.allclose(forward, jnp.array([-1.0, 1.0]), atol=1e-8)
+    assert jnp.allclose(reverse, forward, atol=1e-8)
+
+    three_features = jnp.array([[0.0], [1.0], [2.0]])
+    direction = jnp.array([0.3, -0.2, 0.1])
+
+    def solve_prior(logits):
+        problem = phx.weighting.MomentCalibrationProblem(
+            three_features,
+            phx.weighting.ExactMoments(jnp.array([0.8])),
+            prior_log_weights=logits,
+        )
+        return phx.weighting.implicit_calibrate_moments(
+            problem,
+            termination=phx.optim.OptimizationTermination(
+                absolute_optimality=1e-8,
+                relative_optimality=0.0,
+                maximum_steps=100,
+            ),
+        )
+
+    logits = jnp.log(jnp.array([0.2, 0.5, 0.3]))
+    _, tangent = jax.jvp(solve_prior, (logits,), (direction,))
+    step = 2e-5
+    finite_difference = (
+        solve_prior(logits + step * direction) - solve_prior(logits - step * direction)
+    ) / (2.0 * step)
+    assert jnp.allclose(tangent, finite_difference, atol=2e-6, rtol=2e-5)
+
+
+def test_problem_validation_precision_and_convergence_guard_contracts():
+    with pytest.raises(ValueError, match="Target moments"):
+        phx.weighting.MomentCalibrationProblem(
+            jnp.ones((3, 2)),
+            phx.weighting.ExactMoments(jnp.ones((3,))),
+        )
+    with pytest.raises(ValueError, match="finite"):
+        phx.weighting.MomentCalibrationProblem(
+            jnp.array([[0.0], [jnp.nan]]),
+            phx.weighting.ExactMoments(jnp.array([0.0])),
+        )
+    with pytest.raises(ValueError, match="strictly positive"):
+        phx.weighting.QuadraticMoments(jnp.array([0.0]), scale=0.0)
+
+    for dtype in (jnp.float32, jnp.float64):
+        features = jnp.array([[0.0], [1.0]], dtype=dtype)
+        problem = phx.weighting.MomentCalibrationProblem(
+            features,
+            phx.weighting.ExactMoments(jnp.array([0.5], dtype=dtype)),
+        )
+        result = phx.weighting.calibrate_moments(
+            problem,
+            termination=TIGHT_TERMINATION,
+        )
+        assert result.weights.dtype == dtype
+        assert result.dual_variables.dtype == dtype
+
+    failed_problem = _problem(
+        jnp.array([[0.0], [1.0]]),
+        phx.weighting.ExactMoments(jnp.array([2.0])),
+        jnp.array([0.5, 0.5]),
+    )
+    failed = phx.weighting.calibrate_moments(failed_problem)
+    with pytest.raises(eqx.EquinoxRuntimeError, match="did not converge"):
+        phx.weighting.require_converged(failed)
+    compiled_guard = eqx.filter_jit(phx.weighting.require_converged)
+    with pytest.raises(Exception, match="did not converge"):
+        jax.block_until_ready(compiled_guard(failed).weights)

--- a/tools/weighting_benchmarks.py
+++ b/tools/weighting_benchmarks.py
@@ -1,0 +1,224 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+
+import phydrax as phx
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Benchmark dense and sparse relative-entropy moment calibration."
+    )
+    parser.add_argument("--sizes", type=int, nargs="+", default=(1_000, 10_000))
+    parser.add_argument("--moments", type=int, nargs="+", default=(4, 16, 64))
+    parser.add_argument(
+        "--execution",
+        choices=("dense", "sparse", "both"),
+        default="both",
+    )
+    parser.add_argument(
+        "--target-kind",
+        choices=("exact", "quadratic", "both"),
+        default="both",
+    )
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--smoke", action="store_true")
+    return parser
+
+
+def _dense_operator(size: int, moments: int, seed: int):
+    key = jr.fold_in(jr.key(seed), size * 10_000 + moments)
+    return jr.normal(key, (size, moments)) / jnp.sqrt(float(moments))
+
+
+def _sparse_operator(size: int, moments: int):
+    source_indices = jnp.arange(size, dtype=jnp.int32)
+    target_indices = source_indices % moments
+    relation = phx.sparse.EdgeRelation(
+        source_indices,
+        target_indices,
+        source_size=size,
+        target_size=moments,
+    )
+    return phx.sparse.SparseLinearMap(
+        relation,
+        jnp.ones((size,), dtype=float),
+    )
+
+
+def _problem(size: int, moments: int, execution: str, target_kind: str, seed: int):
+    moment_map = (
+        _dense_operator(size, moments, seed)
+        if execution == "dense"
+        else _sparse_operator(size, moments)
+    )
+    prior_logits = -0.1 * jnp.sin(jnp.arange(size, dtype=float) * 0.017)
+    known_dual = 0.15 * jnp.cos(jnp.arange(moments, dtype=float) * 0.31)
+    known_weights = jax.nn.softmax(
+        prior_logits + moment_map.transpose_mv(known_dual)
+        if not isinstance(moment_map, jax.Array)
+        else prior_logits + moment_map @ known_dual
+    )
+    achieved = (
+        moment_map.mv(known_weights)
+        if not isinstance(moment_map, jax.Array)
+        else moment_map.T @ known_weights
+    )
+    if target_kind == "exact":
+        target = phx.weighting.ExactMoments(achieved)
+    else:
+        scale = jnp.full((moments,), 0.2)
+        target = phx.weighting.QuadraticMoments(
+            achieved + scale**2 * known_dual,
+            scale=scale,
+        )
+    return phx.weighting.MomentCalibrationProblem(
+        moment_map,
+        target,
+        prior_log_weights=prior_logits,
+    )
+
+
+def _nearby_problem(problem, target_kind: str):
+    perturbation = 0.002 * jnp.cos(
+        jnp.arange(problem.moment_count, dtype=problem.target.values.dtype) * 0.23
+    )
+    if target_kind == "exact":
+        nearby_dual = 0.152 * jnp.cos(
+            jnp.arange(
+                problem.moment_count,
+                dtype=problem.target.values.dtype,
+            )
+            * 0.31
+        )
+        nearby_weights = jax.nn.softmax(
+            problem.prior_log_weights + problem.moment_map.transpose_mv(nearby_dual)
+        )
+        target = phx.weighting.ExactMoments(problem.moment_map.mv(nearby_weights))
+    else:
+        target = phx.weighting.QuadraticMoments(
+            problem.target.values + perturbation,
+            scale=problem.target.scale,
+        )
+    return phx.weighting.MomentCalibrationProblem(
+        problem.moment_map,
+        target,
+        prior_log_weights=problem.prior_log_weights,
+        mask=problem.mask,
+    )
+
+
+def _bytes(tree) -> int:
+    return sum(
+        int(leaf.size * leaf.dtype.itemsize)
+        for leaf in jax.tree.leaves(tree)
+        if isinstance(leaf, jax.Array)
+    )
+
+
+def _record(size, moments, execution, target_kind, repeats, seed):
+    setup_started = time.perf_counter()
+    problem = _problem(size, moments, execution, target_kind, seed)
+    nearby = _nearby_problem(problem, target_kind)
+    setup_ms = 1e3 * (time.perf_counter() - setup_started)
+    termination = phx.optim.OptimizationTermination(
+        absolute_optimality=1e-7,
+        relative_optimality=0.0,
+        maximum_steps=100,
+    )
+    method = phx.optim.NewtonKrylov()
+    compiled = eqx.filter_jit(
+        lambda candidate, initial: phx.weighting.calibrate_moments(
+            candidate,
+            method=method,
+            termination=termination,
+            initial_dual=initial,
+        )
+    )
+    initial = jnp.zeros((moments,), dtype=problem.target.values.dtype)
+
+    started = time.perf_counter()
+    result = compiled(problem, initial)
+    jax.block_until_ready(result.log_weights)
+    compile_first_ms = 1e3 * (time.perf_counter() - started)
+
+    started = time.perf_counter()
+    for _ in range(repeats):
+        result = compiled(problem, initial)
+        jax.block_until_ready(result.log_weights)
+    steady_ms = 1e3 * (time.perf_counter() - started) / repeats
+
+    started = time.perf_counter()
+    cold_nearby = compiled(nearby, initial)
+    jax.block_until_ready(cold_nearby.log_weights)
+    cold_nearby_ms = 1e3 * (time.perf_counter() - started)
+
+    started = time.perf_counter()
+    warm_nearby = compiled(nearby, result.dual_variables)
+    jax.block_until_ready(warm_nearby.log_weights)
+    warm_nearby_ms = 1e3 * (time.perf_counter() - started)
+
+    diagnostics = result.diagnostics
+    return {
+        "source_points": size,
+        "moment_count": moments,
+        "execution": execution,
+        "target_kind": target_kind,
+        "setup_ms": setup_ms,
+        "compile_first_ms": compile_first_ms,
+        "steady_ms": steady_ms,
+        "cold_nearby_ms": cold_nearby_ms,
+        "warm_nearby_ms": warm_nearby_ms,
+        "iterations": int(diagnostics.optimization.iterations),
+        "cold_nearby_iterations": int(cold_nearby.diagnostics.optimization.iterations),
+        "warm_nearby_iterations": int(warm_nearby.diagnostics.optimization.iterations),
+        "linear_iterations": int(diagnostics.optimization.linear_iterations),
+        "status": int(result.status),
+        "optimizer_status": int(diagnostics.optimizer_status),
+        "affine_rank": int(diagnostics.numerical_affine_rank),
+        "active_support": int(diagnostics.active_support),
+        "maximum_scaled_residual": float(diagnostics.maximum_scaled_residual),
+        "relative_entropy": float(diagnostics.relative_entropy),
+        "effective_sample_size": float(diagnostics.effective_sample_size),
+        "problem_bytes": _bytes(problem),
+        "result_bytes": _bytes(result),
+    }
+
+
+def main() -> None:
+    arguments = _parser().parse_args()
+    sizes = (128,) if arguments.smoke else tuple(arguments.sizes)
+    moments = (4,) if arguments.smoke else tuple(arguments.moments)
+    repeats = 1 if arguments.smoke else int(arguments.repeats)
+    executions = (
+        ("dense", "sparse") if arguments.execution == "both" else (arguments.execution,)
+    )
+    target_kinds = (
+        ("exact", "quadratic")
+        if arguments.target_kind == "both"
+        else (arguments.target_kind,)
+    )
+    records = [
+        _record(size, count, execution, target_kind, repeats, arguments.seed)
+        for size in sizes
+        for count in moments
+        for execution in executions
+        for target_kind in target_kinds
+    ]
+    print(json.dumps({"records": records}, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a Phydrax-native moment-calibration subsystem for constructing normalized finite measures whose declared feature expectations match external targets.

This change:

- introduces exact and quadratically reconciled relative-entropy calibration under `phydrax.weighting`;
- supports dense, sparse, and compatible matrix-free moment operators through one canonical geometry path;
- exposes audited convergence, affine-rank, regularity, support, and provenance evidence;
- provides implicit target/prior derivatives for successful regular solutions;
- integrates calibration with reusable finite `IntegrationRealization` values;
- composes calibration and coreset compression through ordered transformation records;
- centralizes finite-measure weight normalization shared by calibration and coreset methods; and
- fixes Newton–Krylov adaptive forcing so the selected forcing tolerance controls each inner linear solve.

## Motivation

Phydrax already supports finite weighted measures and support-reducing coreset methods, but it did not provide the complementary operation: changing weights on an existing support to satisfy externally known feature expectations.

Moment calibration is useful for simulation-ensemble correction, scientific covariance balancing, posterior or particle reweighting, experiment-design correction, and survey-style representative weighting. Treating this as a standalone numerical capability avoids coupling generic finite-vector optimization to integration metadata while still allowing integration realizations to consume the calibrated weights.

The dependency direction is intentionally one-way:

`phydrax.integration` → `phydrax.weighting` → `phydrax.optim` / `phydrax.linalg`

`phydrax.weighting` returns normalized probabilities and numerical evidence. The integration adapter remains responsible for physical mass, axes, masks, ancestry, support validity, execution keys, and transformation provenance.

## Public API

The new `phydrax.weighting` namespace exports:

- `ExactMoments`
- `QuadraticMoments`
- `MomentCalibrationProblem`
- `MomentCalibrationPolicy`
- `MomentCalibrationStatus`
- `MomentCalibrationDiagnostics`
- `MomentCalibrationProvenance`
- `MomentCalibrationResult`
- `calibrate_moments`
- `implicit_calibrate_moments`
- `require_converged`

The integration namespace additionally exports:

- `calibrate`
- `MeasureCalibrationDiagnostics`
- `MeasureTransformationRecord`
- `TransformedIntegrationDiagnostics`

## Mathematical contract

Given normalized prior probabilities `p`, a moment action `A`, and target moments `t`, exact calibration computes the minimum-relative-entropy measure satisfying nonnegativity, unit mass, and `A w = t`.

`QuadraticMoments` replaces the hard moment constraint with a declared diagonal quadratic discrepancy. This provides a finite, regular solution for uncertain or unreachable targets while retaining the same prior-relative-entropy geometry.

Core semantics:

- calibration always operates on normalized probabilities;
- moment targets are normalized expectations, independent of downstream physical measure mass;
- masked and zero-prior entries remain exactly zero;
- active prior support must contain at least one finite positive entry;
- all active feature and target values must be finite;
- exact boundary targets are not reported as regular finite-dual successes;
- affine inconsistency, target mismatch, optimizer failure, and uncertified regularity remain distinct typed outcomes.

## Numerical architecture

### Shared moment geometry

`phydrax.weighting._geometry` prepares one fixed-shape moment-space representation for dense, sparse, and matrix-free inputs:

- normalized prior moments and weighted feature covariance;
- full self-adjoint covariance spectrum through `phydrax.linalg.eigen`;
- policy-controlled affine-rank reduction;
- a fixed-capacity retained basis and mask suitable for compiled execution;
- a certificate for target components outside the retained affine span;
- canonical primal weights, physical duals, achieved moments, covariance, and warm-start coordinates.

The implementation works in moment coordinates and does not materialize an `n × n` source-space matrix.

### Exact and soft dual objectives

The exact branch uses a stabilized log-partition dual. Gradient and Hessian actions are the achieved-moment residual and weighted covariance action, respectively.

The quadratic branch adds the declared diagonal target discrepancy directly in the dual. Both branches use the existing `phydrax.optim.minimize` / `implicit_minimize` lifecycle rather than introducing a second optimizer stack.

### Audited completion

A successful result requires more than an optimizer success code. Finalization independently recomputes:

- finite normalized weights and dual variables;
- achieved moments and physical/scaled target residuals;
- primal and dual normalization evidence;
- final covariance spectrum and retained regularity;
- KL divergence to the prior;
- effective sample size;
- active support size and weight extrema;
- maximum log-weight-to-prior expansion;
- optimizer diagnostics and provenance.

The resulting status distinguishes success from nonfinite output, affine inconsistency, unmet target residuals, uncertified regularity, and optimizer failure.

## Differentiation contract

`implicit_calibrate_moments` differentiates the successful stationary calibration map through the existing implicit optimizer machinery.

The contract supports derivatives with respect to target moments and prior log-weights for regular exact and quadratic problems. Invalid, boundary, singular, or failed solves follow the existing JAX-compatible error path rather than returning fabricated derivatives.

## Integration and coreset composition

`phydrax.integration.calibrate` lowers a supported finite realization to normalized probabilities, invokes the weighting subsystem, and rebuilds a weighted realization while preserving:

- physical target mass and normalized/unnormalized semantics;
- named or positional sample axes;
- masks and zero-support entries;
- ancestry and support-validity metadata;
- execution keys and source provenance.

Calibration and compression now append `MeasureTransformationRecord` values to an ordered history. Downstream reductions expose this history through `TransformedIntegrationDiagnostics`, keeping transformation evidence separate from method-specific reduction diagnostics.

Because arbitrary reweighting invalidates inherited quadrature and Monte Carlo error models, transformed reductions explicitly return no generic integration-error estimate.

Compression now uses the same finite-measure lowering and rebuilding path as calibration. This removes duplicated weight/mask/axis handling while preserving existing moment recombination and kernel herding semantics.

## Optimizer correction

Newton–Krylov previously computed an adaptive Eisenstat–Walker-style forcing value but did not pass it to `solve_linear`. Inner solves therefore always used the method default tolerance.

The Newton step now supplies `LinearSolveControl(relative_tolerance=forcing)`, making loose and tight forcing policies change actual Krylov work under eager and compiled execution without changing the surrounding optimizer lifecycle.

## Benchmark tooling

Adds `tools/weighting_benchmarks.py` with analytically controlled dense and sparse exact/soft cases. The harness records setup, first compilation, steady-state execution, cold-nearby and warm-nearby execution, iteration counts, residuals, KL/ESS evidence, effective support, and memory estimates without depending on an external weighting package.

## Documentation and attribution

- adds the Moment Weighting API guide and navigation entry;
- documents finite-realization calibration and ordered calibration/compression provenance;
- updates the integration and top-level API references;
- records the feature in the changelog; and
- acknowledges Barratt, Angeris, and Boyd's representative-sample-weighting formulation, `cvxgrp/rsw`, and Andrew Timm's Apache-2.0 `rswjax` package in `NOTICE`.

The implementation is independent and does not copy or translate source code from either reference package.

## Deliberate scope boundaries

This PR does not add hard interval moments, arbitrary full soft covariance, equal-weight subset selection, grouped/stratified reweighting, or a special boundary-target solver. Unsupported structures and nonregular exact targets fail explicitly rather than silently changing their mathematical meaning.

## Review guide

Suggested review order:

1. `phydrax/weighting/_problem.py` and `_results.py` — public contracts and status semantics.
2. `phydrax/weighting/_geometry.py` — affine reduction and operator normalization.
3. `phydrax/weighting/_relative_entropy.py` — dual objectives, final audit, and differentiation entry points.
4. `phydrax/integration/_measure_transform.py`, `_transformations.py`, and `_calibration.py` — reusable finite-measure composition.
5. `phydrax/integration/_compression.py` — migration to shared lowering.
6. `phydrax/optim/_newton_krylov.py` — adaptive forcing correction.
7. Public exports, documentation, benchmark harness, and attribution.