### PR TITLE
feat: add native differentiable DAE solving

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ dist/
 site/
 _gitignore/
 benchmarks/*
+!benchmarks/dae_benchmark_artifact.json
 !benchmarks/advanced_solvers/
 !benchmarks/advanced_solvers/**
 benchmarks/advanced_solvers/**/__pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@
   trust-region roots, nonlinear GMRES and preconditioning, fixed-point acceleration,
   full-approximation multigrid cycles, variational inequalities, semismooth
   complementarity solves, and implicit root derivatives with explicit failure status.
+- Native regular index-one differential-algebraic systems with explicit structural
+  roles and scales, consistent initialization contracts, prepared fixed-grid BDF1/BDF2
+  integration, implicit JVP/VJP differentiation, status-rich trajectory evidence,
+  semidiscrete implicit PDE compilation, and canonical identification adapters.
 - Reusable nonlinear Newton preparation/refresh/solve lifecycles, adaptive
   Eisenstat--Walker forcing, explicit Jacobian refresh policies, hard aggregate
   inner-linear work budgets, and physical-root certification for transformed

--- a/benchmarks/dae_benchmark_artifact.json
+++ b/benchmarks/dae_benchmark_artifact.json
@@ -1,0 +1,666 @@
+{
+  "cases": [
+    {
+      "certificates": {
+        "constraint": {
+          "applicable": false,
+          "maximum_absolute_residual": 0.0,
+          "passed": true,
+          "reference": null,
+          "tolerance": 0.0
+        },
+        "gradient": {
+          "absolute_error": 7.892720522539864e-06,
+          "absolute_tolerance": 1e-08,
+          "objective": 0.3679172379932296,
+          "passed": true,
+          "reference": "closed-form terminal derivative",
+          "reference_value": -0.3678794411714423,
+          "relative_error": 2.1454638773525897e-05,
+          "relative_tolerance": 0.005,
+          "symmetric_finite_difference_step": null,
+          "value": -0.36787154845091974
+        },
+        "residual": {
+          "independent_maximum_scaled_rms": 5.329070518200751e-15,
+          "passed": true,
+          "reported_maximum_constraint_rms": 0.0,
+          "reported_maximum_scaled_rms": 5.329070518200751e-15,
+          "threshold": 1e-10
+        },
+        "trajectory": {
+          "passed": true,
+          "reference": "closed-form exponential trajectory",
+          "relative_error": 0.0001514899086565386,
+          "tolerance": 0.001220703125
+        }
+      },
+      "finite_outputs": true,
+      "grid_points": 65,
+      "initialization_status": "success",
+      "metadata": {
+        "class": "linear ODE in implicit residual form"
+      },
+      "name": "scalar-linear",
+      "passed": true,
+      "plan_id": "dae-plan:b4221293b467c9211abba4e857a3779f198affca3282cf7609f8a0e721c34878",
+      "prepared_id": "prepared-dae:23aa994c3ac2aa459a23119a676633f6e6eea32a48a4547241caec02b360f2c4",
+      "problem_id": "benchmark:dae:scalar-linear",
+      "solver_evidence": {
+        "approximation_id": "fixed-grid-bdf2",
+        "differentiation_mode": "fixed-grid-discrete-implicit",
+        "grid_origin": "user",
+        "initialization_linear_iterations": 1,
+        "initialization_linear_plan_id": "1f970e40ce2d90d09fe5477ff5fd5254c843e6004a7a35b3b5a0069000e0e2bb",
+        "initialization_nonlinear_iterations": 1,
+        "integration_method": "bdf2",
+        "maximum_stage_nonlinear_iterations": 1,
+        "nonlinear_method_id": "newton-krylov-line-search",
+        "stage_linear_plan_id": "000165acc060ebaa4adcf69086688f76a8ec2d5cb1d9ab0ed62e1c83638a4ad1",
+        "stage_linear_template_reused": true,
+        "total_globalization_rejections": 0,
+        "total_jacobian_preparations": 64,
+        "total_linear_iterations": 64,
+        "total_linear_solves": 64,
+        "total_numeric_refreshes": 128,
+        "total_residual_evaluations": 128,
+        "total_setup_refreshes": 0,
+        "total_stage_nonlinear_iterations": 64
+      },
+      "state_shape": [
+        1
+      ],
+      "status_histogram": {
+        "success": 65
+      },
+      "storage": {
+        "prepared_array_bytes": 1388,
+        "scope": "logical array payloads; excludes allocator pools and compiled executables",
+        "solution_array_bytes": 7354,
+        "state_rate_trajectory_bytes": 520,
+        "state_trajectory_bytes": 520
+      },
+      "successful": true,
+      "system_id": "benchmark:dae:scalar-linear",
+      "time_id": "benchmark:dae:scalar-linear:64",
+      "timing": {
+        "forward": {
+          "compilation_ms": 918.8577089225873,
+          "first_execution_ms": 3.3269590931013227,
+          "lowering_ms": 1019.9316660873592,
+          "steady_samples_ms": [
+            1.1805000249296427,
+            1.051833969540894,
+            5.293167079798877
+          ],
+          "steady_summary": {
+            "maximum_ms": 5.293167079798877,
+            "mean_ms": 2.5085003580898046,
+            "median_ms": 1.1805000249296427,
+            "minimum_ms": 1.051833969540894,
+            "standard_deviation_ms": 1.9697572272910164
+          },
+          "warmup_execution_ms": 1.1884999694302678
+        },
+        "model_setup_ms": 311.23350001871586,
+        "solver_preparation_ms": 1069.1465409472585,
+        "unit": "milliseconds",
+        "value_and_grad": {
+          "compilation_ms": 988.6261250358075,
+          "first_execution_ms": 2.4387910962104797,
+          "lowering_ms": 1469.0083750756457,
+          "steady_samples_ms": [
+            1.415375038050115,
+            1.2851669453084469,
+            1.4091669581830502
+          ],
+          "steady_summary": {
+            "maximum_ms": 1.415375038050115,
+            "mean_ms": 1.3699029805138707,
+            "median_ms": 1.4091669581830502,
+            "minimum_ms": 1.2851669453084469,
+            "standard_deviation_ms": 0.05997100305236459
+          },
+          "warmup_execution_ms": 1.5670419670641422
+        }
+      }
+    },
+    {
+      "certificates": {
+        "constraint": {
+          "applicable": false,
+          "maximum_absolute_residual": 0.0,
+          "passed": true,
+          "reference": null,
+          "tolerance": 0.0
+        },
+        "gradient": {
+          "absolute_error": 2.7347316342019035e-05,
+          "absolute_tolerance": 1e-08,
+          "objective": 0.7288604561611397,
+          "passed": true,
+          "reference": "closed-form terminal derivative",
+          "reference_value": -0.605173494792745,
+          "relative_error": 4.5189216939160114e-05,
+          "relative_tolerance": 0.008,
+          "symmetric_finite_difference_step": null,
+          "value": -0.605200842109087
+        },
+        "residual": {
+          "independent_maximum_scaled_rms": 2.2083463457661466e-14,
+          "passed": true,
+          "reported_maximum_constraint_rms": 0.0,
+          "reported_maximum_scaled_rms": 2.219509580091501e-14,
+          "threshold": 1e-10
+        },
+        "trajectory": {
+          "passed": true,
+          "reference": "closed-form diagonal mass-matrix trajectory",
+          "relative_error": 0.00012735845754956347,
+          "tolerance": 0.0029296875
+        }
+      },
+      "finite_outputs": true,
+      "grid_points": 65,
+      "initialization_status": "success",
+      "metadata": {
+        "class": "diagonal nonsingular mass matrix",
+        "state_size": 4
+      },
+      "name": "vector-linear-mass",
+      "passed": true,
+      "plan_id": "dae-plan:32a65503da451cc1de1989984fb1152c7976c7cc035dc6937c21bd01f3610b4d",
+      "prepared_id": "prepared-dae:e0621f8d36ff76eed50ecc6d4d51a548a87dcdd6ca7709b42de5eda7e2b2e9a1",
+      "problem_id": "benchmark:dae:vector-linear",
+      "solver_evidence": {
+        "approximation_id": "fixed-grid-bdf2",
+        "differentiation_mode": "fixed-grid-discrete-implicit",
+        "grid_origin": "user",
+        "initialization_linear_iterations": 12,
+        "initialization_linear_plan_id": "83f3e905207122cb9e69fb892df240603242fbb0606e2591a87fcf960eb0cae5",
+        "initialization_nonlinear_iterations": 5,
+        "integration_method": "bdf2",
+        "maximum_stage_nonlinear_iterations": 5,
+        "nonlinear_method_id": "newton-krylov-line-search",
+        "stage_linear_plan_id": "2230b6ce63413ed27e732db86c7f11d60dbeda44796d24e550db11cefa8bcda7",
+        "stage_linear_template_reused": true,
+        "total_globalization_rejections": 0,
+        "total_jacobian_preparations": 284,
+        "total_linear_iterations": 660,
+        "total_linear_solves": 284,
+        "total_numeric_refreshes": 348,
+        "total_residual_evaluations": 568,
+        "total_setup_refreshes": 0,
+        "total_stage_nonlinear_iterations": 284
+      },
+      "state_shape": [
+        4
+      ],
+      "status_histogram": {
+        "success": 65
+      },
+      "storage": {
+        "prepared_array_bytes": 3364,
+        "scope": "logical array payloads; excludes allocator pools and compiled executables",
+        "solution_array_bytes": 10822,
+        "state_rate_trajectory_bytes": 2080,
+        "state_trajectory_bytes": 2080
+      },
+      "successful": true,
+      "system_id": "benchmark:dae:vector-linear",
+      "time_id": "benchmark:dae:vector-linear:64",
+      "timing": {
+        "forward": {
+          "compilation_ms": 1307.0802909787744,
+          "first_execution_ms": 6.838332978077233,
+          "lowering_ms": 1790.8019580645487,
+          "steady_samples_ms": [
+            6.478124996647239,
+            6.358165992423892,
+            5.436082952655852
+          ],
+          "steady_summary": {
+            "maximum_ms": 6.478124996647239,
+            "mean_ms": 6.090791313908994,
+            "median_ms": 6.358165992423892,
+            "minimum_ms": 5.436082952655852,
+            "standard_deviation_ms": 0.46553182447221625
+          },
+          "warmup_execution_ms": 6.58312498126179
+        },
+        "model_setup_ms": 260.8509580604732,
+        "solver_preparation_ms": 679.6434170100838,
+        "unit": "milliseconds",
+        "value_and_grad": {
+          "compilation_ms": 891.2262499798089,
+          "first_execution_ms": 7.393875042907894,
+          "lowering_ms": 1504.6122079947963,
+          "steady_samples_ms": [
+            5.459500011056662,
+            5.762208020314574,
+            5.2088749362155795
+          ],
+          "steady_summary": {
+            "maximum_ms": 5.762208020314574,
+            "mean_ms": 5.476860989195605,
+            "median_ms": 5.459500011056662,
+            "minimum_ms": 5.2088749362155795,
+            "standard_deviation_ms": 0.22623060235238138
+          },
+          "warmup_execution_ms": 5.561875062994659
+        }
+      }
+    },
+    {
+      "certificates": {
+        "constraint": {
+          "applicable": true,
+          "maximum_absolute_residual": 1.4688472660395746e-09,
+          "passed": true,
+          "reference": "species conservation y1 + y2 + y3 = 1",
+          "tolerance": 2e-09
+        },
+        "gradient": {
+          "absolute_error": 5.870828259299521e-11,
+          "absolute_tolerance": 1e-08,
+          "objective": 0.00036286663930489737,
+          "passed": true,
+          "reference": "symmetric finite difference of the discrete BDF solve",
+          "reference_value": 0.00039859088500577905,
+          "relative_error": 1.4728957635883724e-07,
+          "relative_tolerance": 0.0005,
+          "symmetric_finite_difference_step": 0.0001,
+          "value": 0.00039859082629749645
+        },
+        "residual": {
+          "independent_maximum_scaled_rms": 9.267752617061107e-10,
+          "passed": true,
+          "reported_maximum_constraint_rms": 1.4688472660395746e-09,
+          "reported_maximum_scaled_rms": 9.26775305869672e-10,
+          "threshold": 1e-09
+        },
+        "trajectory": {
+          "passed": true,
+          "reference": "high-accuracy Robertson terminal state at t=0.01",
+          "relative_error": 2.737727755337788e-10,
+          "tolerance": 5e-07
+        }
+      },
+      "finite_outputs": true,
+      "grid_points": 65,
+      "initialization_status": "success",
+      "metadata": {
+        "class": "stiff semi-explicit chemical kinetics DAE",
+        "reference_time": 0.01
+      },
+      "name": "robertson-semi-explicit",
+      "passed": true,
+      "plan_id": "dae-plan:4cdc93d192abcd696cb865fbdd5616b0aef1793ea53c8a772a620e36a385f27c",
+      "prepared_id": "prepared-dae:e434e1a0df6d210028c11163497a4052e9b5fc79eabe5585f6b59960b9331711",
+      "problem_id": "benchmark:dae:robertson",
+      "solver_evidence": {
+        "approximation_id": "fixed-grid-bdf2",
+        "differentiation_mode": "fixed-grid-discrete-implicit",
+        "grid_origin": "user",
+        "initialization_linear_iterations": 5,
+        "initialization_linear_plan_id": "809a6fc1f8548cf1beb1cf9b388ba68ecbfdde4649b8841dd8a7573b3cb1ee6b",
+        "initialization_nonlinear_iterations": 2,
+        "integration_method": "bdf2",
+        "maximum_stage_nonlinear_iterations": 5,
+        "nonlinear_method_id": "newton-krylov-line-search",
+        "stage_linear_plan_id": "b3d0a448836d8fef8e8a43b7d4ba39818de2155adc4637fa5e01f282305d5914",
+        "stage_linear_template_reused": true,
+        "total_globalization_rejections": 0,
+        "total_jacobian_preparations": 194,
+        "total_linear_iterations": 279,
+        "total_linear_solves": 194,
+        "total_numeric_refreshes": 258,
+        "total_residual_evaluations": 388,
+        "total_setup_refreshes": 0,
+        "total_stage_nonlinear_iterations": 194
+      },
+      "state_shape": [
+        3
+      ],
+      "status_histogram": {
+        "success": 65
+      },
+      "storage": {
+        "prepared_array_bytes": 2500,
+        "scope": "logical array payloads; excludes allocator pools and compiled executables",
+        "solution_array_bytes": 9666,
+        "state_rate_trajectory_bytes": 1560,
+        "state_trajectory_bytes": 1560
+      },
+      "successful": true,
+      "system_id": "benchmark:dae:robertson",
+      "time_id": "benchmark:dae:robertson:64",
+      "timing": {
+        "forward": {
+          "compilation_ms": 848.2803329825401,
+          "first_execution_ms": 4.463541088625789,
+          "lowering_ms": 889.8662090068683,
+          "steady_samples_ms": [
+            3.6460410337895155,
+            3.346291952766478,
+            3.329874947667122
+          ],
+          "steady_summary": {
+            "maximum_ms": 3.6460410337895155,
+            "mean_ms": 3.440735978074372,
+            "median_ms": 3.346291952766478,
+            "minimum_ms": 3.329874947667122,
+            "standard_deviation_ms": 0.14532722603549267
+          },
+          "warmup_execution_ms": 3.275875002145767
+        },
+        "model_setup_ms": 255.72066707536578,
+        "solver_preparation_ms": 919.1410840721801,
+        "unit": "milliseconds",
+        "value_and_grad": {
+          "compilation_ms": 1171.6599579667673,
+          "first_execution_ms": 5.8695420157164335,
+          "lowering_ms": 1321.72583299689,
+          "steady_samples_ms": [
+            4.029167001135647,
+            3.6297080805525184,
+            3.42645903583616
+          ],
+          "steady_summary": {
+            "maximum_ms": 4.029167001135647,
+            "mean_ms": 3.6951113725081086,
+            "median_ms": 3.6297080805525184,
+            "minimum_ms": 3.42645903583616,
+            "standard_deviation_ms": 0.250362957600671
+          },
+          "warmup_execution_ms": 3.758958075195551
+        }
+      }
+    },
+    {
+      "certificates": {
+        "constraint": {
+          "applicable": true,
+          "maximum_absolute_residual": 1.1102230246251565e-16,
+          "passed": true,
+          "reference": "Kirchhoff branch-current constraint",
+          "tolerance": 1e-10
+        },
+        "gradient": {
+          "absolute_error": 0.000444994403097608,
+          "absolute_tolerance": 1e-08,
+          "objective": 0.46076539275266093,
+          "passed": true,
+          "reference": "closed-form matrix-exponential terminal derivative",
+          "reference_value": -0.029284697545086946,
+          "relative_error": 0.015195458392988052,
+          "relative_tolerance": 0.01708984375,
+          "symmetric_finite_difference_step": null,
+          "value": -0.029729691948184554
+        },
+        "residual": {
+          "independent_maximum_scaled_rms": 1.302153897377236e-15,
+          "passed": true,
+          "reported_maximum_constraint_rms": 1.304539585185078e-16,
+          "reported_maximum_scaled_rms": 1.263840837864162e-15,
+          "threshold": 1e-10
+        },
+        "trajectory": {
+          "passed": true,
+          "reference": "closed-form reduced linear circuit trajectory",
+          "relative_error": 0.0005430072629132259,
+          "tolerance": 0.003662109375
+        }
+      },
+      "finite_outputs": true,
+      "grid_points": 65,
+      "initialization_status": "success",
+      "metadata": {
+        "class": "linear circuit with singular mass matrix"
+      },
+      "name": "singular-mass-circuit",
+      "passed": true,
+      "plan_id": "dae-plan:44df07358fc7e70bdd4c21c5e2a4a1eec21bb2a3b23446f550b95ec8e2148b57",
+      "prepared_id": "prepared-dae:7b1a5c4f474b6d19ab372b104914bde9374727ab5b1b98ed53cc85f2ad7b9261",
+      "problem_id": "benchmark:dae:rlc-circuit",
+      "solver_evidence": {
+        "approximation_id": "fixed-grid-bdf2",
+        "differentiation_mode": "fixed-grid-discrete-implicit",
+        "grid_origin": "user",
+        "initialization_linear_iterations": 3,
+        "initialization_linear_plan_id": "d539a3f9c6b270aaf3780a88a3ffc3af584f7ddf8268beb886605a75cb5e7d9f",
+        "initialization_nonlinear_iterations": 1,
+        "integration_method": "bdf2",
+        "maximum_stage_nonlinear_iterations": 4,
+        "nonlinear_method_id": "newton-krylov-line-search",
+        "stage_linear_plan_id": "b79ccf5b2c67dd0c11aa3ac951e4c72059362ed2481dba703c9eae34dbe80ff0",
+        "stage_linear_template_reused": true,
+        "total_globalization_rejections": 0,
+        "total_jacobian_preparations": 197,
+        "total_linear_iterations": 350,
+        "total_linear_solves": 197,
+        "total_numeric_refreshes": 261,
+        "total_residual_evaluations": 394,
+        "total_setup_refreshes": 0,
+        "total_stage_nonlinear_iterations": 197
+      },
+      "state_shape": [
+        3
+      ],
+      "status_histogram": {
+        "success": 65
+      },
+      "storage": {
+        "prepared_array_bytes": 2372,
+        "scope": "logical array payloads; excludes allocator pools and compiled executables",
+        "solution_array_bytes": 9666,
+        "state_rate_trajectory_bytes": 1560,
+        "state_trajectory_bytes": 1560
+      },
+      "successful": true,
+      "system_id": "benchmark:dae:rlc-circuit",
+      "time_id": "benchmark:dae:circuit:64",
+      "timing": {
+        "forward": {
+          "compilation_ms": 767.9441249929368,
+          "first_execution_ms": 4.322791937738657,
+          "lowering_ms": 969.1103328950703,
+          "steady_samples_ms": [
+            3.2980829710140824,
+            3.3544580219313502,
+            2.9472920577973127
+          ],
+          "steady_summary": {
+            "maximum_ms": 3.3544580219313502,
+            "mean_ms": 3.199944350247582,
+            "median_ms": 3.2980829710140824,
+            "minimum_ms": 2.9472920577973127,
+            "standard_deviation_ms": 0.18012851384823994
+          },
+          "warmup_execution_ms": 3.5054159816354513
+        },
+        "model_setup_ms": 1.1214999249204993,
+        "solver_preparation_ms": 147.8009580168873,
+        "unit": "milliseconds",
+        "value_and_grad": {
+          "compilation_ms": 1288.94624998793,
+          "first_execution_ms": 4.759750096127391,
+          "lowering_ms": 1218.842834001407,
+          "steady_samples_ms": [
+            3.3340409863740206,
+            3.536083037033677,
+            3.2433330779895186
+          ],
+          "steady_summary": {
+            "maximum_ms": 3.536083037033677,
+            "mean_ms": 3.3711523671324053,
+            "median_ms": 3.3340409863740206,
+            "minimum_ms": 3.2433330779895186,
+            "standard_deviation_ms": 0.12236169217102352
+          },
+          "warmup_execution_ms": 3.566083963960409
+        }
+      }
+    },
+    {
+      "certificates": {
+        "constraint": {
+          "applicable": true,
+          "maximum_absolute_residual": 1.4988010832439613e-13,
+          "passed": true,
+          "reference": "pointwise equilibrium = u**2",
+          "tolerance": 1e-09
+        },
+        "gradient": {
+          "absolute_error": 1.047817047961086e-05,
+          "absolute_tolerance": 1e-08,
+          "objective": 0.9612909703517638,
+          "passed": true,
+          "reference": "exact semidiscrete Fourier-mode terminal derivative",
+          "reference_value": -0.7590047144465168,
+          "relative_error": 1.380514544926348e-05,
+          "relative_tolerance": 0.008,
+          "symmetric_finite_difference_step": null,
+          "value": -0.7589942362760372
+        },
+        "residual": {
+          "independent_maximum_scaled_rms": 9.63919255708994e-11,
+          "passed": true,
+          "reported_maximum_constraint_rms": 8.859690320426835e-14,
+          "reported_maximum_scaled_rms": 9.639192363256746e-11,
+          "threshold": 1e-10
+        },
+        "trajectory": {
+          "passed": true,
+          "reference": "exact semidiscrete Fourier-mode trajectory",
+          "relative_error": 4.185524877337754e-07,
+          "tolerance": 0.003662109375
+        }
+      },
+      "finite_outputs": true,
+      "grid_points": 65,
+      "initialization_status": "success",
+      "metadata": {
+        "class": "semidiscrete PDE DAE",
+        "regularity_verified": false,
+        "spatial_points": 16,
+        "structural_assumption": "regular-index-1-required-unverified"
+      },
+      "name": "constrained-reaction-diffusion",
+      "passed": true,
+      "plan_id": "dae-plan:5c4f4a955fd3d3097d5b6921cf935975e5a35eae8dd92d147b91f96f06f8be61",
+      "prepared_id": "prepared-dae:4230c2ad14f048f18ed422522f226bb4f34513fa52e6dae61f5e08c26f35453a",
+      "problem_id": "benchmark:dae:reaction-diffusion",
+      "solver_evidence": {
+        "approximation_id": "fixed-grid-bdf2",
+        "differentiation_mode": "fixed-grid-discrete-implicit",
+        "grid_origin": "user",
+        "initialization_linear_iterations": 20,
+        "initialization_linear_plan_id": "754569fe48a35f3c71b67dedd2f2cd1bdc1291b7d000e435c1c3fa8f08349f79",
+        "initialization_nonlinear_iterations": 2,
+        "integration_method": "bdf2",
+        "maximum_stage_nonlinear_iterations": 3,
+        "nonlinear_method_id": "newton-krylov-line-search",
+        "stage_linear_plan_id": "4f0b404871e79f3d925debf5ddac2f03f153133488321d00d9cce6cf5f15d888",
+        "stage_linear_template_reused": true,
+        "total_globalization_rejections": 0,
+        "total_jacobian_preparations": 150,
+        "total_linear_iterations": 214,
+        "total_linear_solves": 150,
+        "total_numeric_refreshes": 214,
+        "total_residual_evaluations": 300,
+        "total_setup_refreshes": 0,
+        "total_stage_nonlinear_iterations": 150
+      },
+      "state_shape": [
+        16,
+        2
+      ],
+      "status_histogram": {
+        "success": 65
+      },
+      "storage": {
+        "prepared_array_bytes": 20948,
+        "scope": "logical array payloads; excludes allocator pools and compiled executables",
+        "solution_array_bytes": 43190,
+        "state_rate_trajectory_bytes": 16640,
+        "state_trajectory_bytes": 16640
+      },
+      "successful": true,
+      "system_id": "semidiscrete-dae:4cb78bf40cbdb83c14a3921bc216c98e5a96394a3ccd4337dba79fc084b82209",
+      "time_id": "benchmark:dae:reaction-diffusion:64:16",
+      "timing": {
+        "forward": {
+          "compilation_ms": 1935.6195000000298,
+          "first_execution_ms": 9.800542029552162,
+          "lowering_ms": 2465.6709589762613,
+          "steady_samples_ms": [
+            11.21220807544887,
+            8.725833962671459,
+            6.154583999887109
+          ],
+          "steady_summary": {
+            "maximum_ms": 11.21220807544887,
+            "mean_ms": 8.697542012669146,
+            "median_ms": 8.725833962671459,
+            "minimum_ms": 6.154583999887109,
+            "standard_deviation_ms": 2.064863296242101
+          },
+          "warmup_execution_ms": 5.446417024359107
+        },
+        "model_setup_ms": 442.8431249689311,
+        "solver_preparation_ms": 1722.867124946788,
+        "unit": "milliseconds",
+        "value_and_grad": {
+          "compilation_ms": 1378.9532500086352,
+          "first_execution_ms": 8.999874931760132,
+          "lowering_ms": 2537.327624973841,
+          "steady_samples_ms": [
+            5.833875038661063,
+            5.485999980010092,
+            5.156999919563532
+          ],
+          "steady_summary": {
+            "maximum_ms": 5.833875038661063,
+            "mean_ms": 5.492291646078229,
+            "median_ms": 5.485999980010092,
+            "minimum_ms": 5.156999919563532,
+            "standard_deviation_ms": 0.27636892071982194
+          },
+          "warmup_execution_ms": 5.95074996817857
+        }
+      }
+    }
+  ],
+  "configuration": {
+    "effective": {
+      "repeats": 3,
+      "smoke": false,
+      "spatial_points": 16,
+      "steps": 64
+    },
+    "requested": {
+      "repeats": 3,
+      "spatial_points": 16,
+      "steps": 64
+    }
+  },
+  "environment": {
+    "backend": "cpu",
+    "device_kind": "cpu",
+    "jax_version": "0.9.2",
+    "machine": "arm64",
+    "python_version": "3.12.8",
+    "system": "Darwin",
+    "system_release": "24.6.0",
+    "x64_enabled": true
+  },
+  "passed": true,
+  "protocol": {
+    "gradient": "discrete implicit value-and-grad compared with an independent closed-form or symmetric finite-difference reference",
+    "memory": "logical result payload only; no cumulative allocator counters",
+    "synchronization": "every measured JAX execution blocks all array leaves",
+    "timing": "model setup, solver preparation, lowering, compilation, first execution, warmup, and synchronized steady executions are separate"
+  },
+  "schema_version": "phydrax-dae-benchmark-v2"
+}

--- a/docs/all-of-phydrax.md
+++ b/docs/all-of-phydrax.md
@@ -235,6 +235,11 @@ keep physical-time and map-iteration normalization distinct. Solver, control,
 stochastic, memory/delay, rough, and canonical evolution outputs enter the same
 `TrajectoryData` contract through explicit adapters without losing masks, reset
 boundaries, case/realization axes, or provenance.
+`DifferentialAlgebraicSystem` adds a state-shaped implicit residual with declared
+differential/algebraic component roles and independent state, rate, and residual
+scales. Its prepared fixed-grid BDF solver preserves native nonlinear diagnostics,
+implicit derivatives, and trajectory rate-validity masks without introducing a
+second identification representation.
 Array models bind into `ContinuousSystem` as explicit trainable PyTree children.
 Structured Port-Hamiltonian fields provide state-dependent energy,
 interconnection, dissipation, control, and forcing components while preserving
@@ -575,6 +580,13 @@ Below are the common SciML regimes expressed in Phydrax’s primitives.
   Diffrax backend. Stochastic collocation provides a separate deterministic
   quadrature path for finite-dimensional random inputs.
   See [API → Solver → Differential equations](api/solver/differential.md).
+- **Differential-algebraic equations**: declare a state-shaped residual
+  `F(t, y, ydot, args) = 0`, component roles, scales, and an explicit consistency
+  contract. Native prepared BDF1/BDF2 solves support fixed-grid JIT, JVP, VJP, and
+  batching; failed initialization or stages remain explicit status evidence.
+  Semidiscrete PDE IR can compile directly to the same residual contract when every
+  equation has a bijective field target and supported direct temporal incidence.
+  See [API → Solver → Differential-algebraic equations](api/solver/differential_algebraic.md).
 - **System identification and equation discovery**: normalize canonical
   evolution, differential/delay/memory/rough, controlled, or stochastic output
   as `TrajectoryData`; preserve sample/transition masks and reset boundaries;

--- a/docs/api/dynamics.md
+++ b/docs/api/dynamics.md
@@ -114,8 +114,9 @@ mask.
 The four adapters preserve the source contract:
 
 - `trajectory_data_from_evolution` retains canonical evolution node and segment status;
-- `trajectory_data_from_differential_solution` retains deterministic or ensemble solver
-  sample axes, including delay and structured differential solutions;
+- `trajectory_data_from_differential_solution` retains deterministic, DAE, or ensemble
+  solver sample axes, including DAE state rates and their componentwise validity,
+  delay solutions, and structured differential solutions;
 - `trajectory_data_from_control` attaches source-aligned controls and their layout;
 - `trajectory_data_from_stochastic` retains case and realization axes.
 
@@ -420,10 +421,11 @@ convergence claim is hidden behind this evaluation call.
 
 ## Interoperability and hard boundaries
 
-- **Structured and delay systems:** differential, delay, rough, memory, hybrid, and
-  semidiscrete solver results enter through `trajectory_data_from_differential_solution`.
-  Their solver meaning stays in the source ID and masks. A delay history is not inferred
-  from a flat state vector.
+- **Structured, DAE, and delay systems:** differential, DAE, delay, rough, memory,
+  hybrid, and semidiscrete solver results enter through
+  `trajectory_data_from_differential_solution`. Their solver meaning stays in the
+  source ID and masks. DAE rates retain their own validity, and a delay history is not
+  inferred from a flat state vector.
 - **Controlled dynamics:** `trajectory_data_from_control` attaches controls with
   transition alignment. Controlled DMD and controlled SINDy then use the same
   `InputLayout`; autonomous fitting never silently drops supplied controls.

--- a/docs/api/nonlinear.md
+++ b/docs/api/nonlinear.md
@@ -165,10 +165,23 @@ result; final success requires the complementarity certificate as well.
 
 ## Implicit root differentiation
 
-`implicit_root` differentiates the mathematical solution map through the accepted
-root using a fresh linearized solve. It does not differentiate through iteration
-history. Singular or incompatible derivative systems fail according to the supplied
-linear policy instead of returning an unverified gradient.
+`implicit_root_result` runs the native nonlinear solve exactly once and returns a
+`NonlinearResult` whose state, residual, and auxiliary output are evaluated at the
+same accepted root. The state and user auxiliary leaves carry implicit JVP/VJP rules;
+status, iteration counts, work diagnostics, provenance, and transformation evidence
+remain nondifferentiable solver evidence. The explicit result therefore supports
+differentiable downstream observables without discarding failure information.
+
+`implicit_root` is the strict convenience form. It returns only the accepted state and
+raises when the native solve is unsuccessful. It does not hide or repair failure; use
+`implicit_root_result` when status-valued control flow or diagnostics are required.
+
+Both entry points differentiate the mathematical root map through a fresh linearized
+solve, not through nonlinear iteration history. They accept either an ordinary
+problem/state/method contract or a `PreparedNonlinearSolve`, so a caller can retain one
+symbolic linear template while refreshing runtime parameters. Singular or
+incompatible derivative systems fail according to the supplied linear policy instead
+of returning an unverified gradient.
 
 ## API reference
 
@@ -255,5 +268,9 @@ linear policy instead of returning an unverified gradient.
 ::: phydrax.nonlinear.NonlinearTransformationEvidence
 
 ---
+::: phydrax.nonlinear.implicit_root_result
+
+---
+
 
 ::: phydrax.nonlinear.implicit_root

--- a/docs/api/solver/differential.md
+++ b/docs/api/solver/differential.md
@@ -5,6 +5,11 @@ The differential backend integrates finite-dimensional initial-value problems th
 `FunctionalSolver` minimizes a physics/data functional, while `solve_diffrax` numerically
 integrates a supplied drift and optional named stochastic terms.
 
+Implicit residuals `F(t, y, ydot, args) = 0` use the separate native
+[differential-algebraic solver](differential_algebraic.md). That path owns consistent
+initialization and fixed-grid BDF differentiation rather than encoding a singular
+mass matrix as an explicit Diffrax vector field.
+
 ## Problem, Wiener terms, and realization contract
 
 `DifferentialProblem` represents

--- a/docs/api/solver/differential_algebraic.md
+++ b/docs/api/solver/differential_algebraic.md
@@ -1,0 +1,290 @@
+# Differential-algebraic equation integration
+
+`phydrax.solver` integrates regular finite-dimensional implicit systems of the form
+
+\[
+F(t, y, \dot y, a) = 0
+\]
+
+on a declared `TimeGrid`. The implementation is native Phydrax: consistency and every
+BDF stage use the prepared nonlinear and linear-solve lifecycles from
+`phydrax.nonlinear` and `phydrax.linalg`. It does not route through Optimistix or
+Diffrax.
+
+This path deliberately covers fixed-grid, regular index-one problems. It does not
+infer a differentiation index, reduce a higher-index system, adapt the step size, or
+handle events. Those capabilities require separate structural and trajectory
+contracts rather than hidden heuristics in the integrator.
+
+## System and structure
+
+`DifferentialAlgebraicSystem` owns only the state-shaped residual and its invariant
+metadata. Initialization and integration policy belong to the problem and solver.
+`DAEStructure` declares differential/algebraic roles for variables and equations along
+one component axis. For an unstructured state, use one role with
+`component_axis=None`.
+
+The residual, state, and state rate must all have `state_shape`. `state_scale`,
+`state_rate_scale`, and `residual_scale` are independent positive, finite, real arrays
+broadcast to that shape:
+
+- state and state-rate scales define the coordinate weights used by consistency and
+  BDF nonlinear solves;
+- residual scale defines the equation weights used by convergence checks;
+- none of the scales changes the raw value returned by `system(...)`.
+
+Nontrivial state geometry is rejected by the fixed-grid BDF backend. The current BDF
+formula combines ambient Euclidean states and therefore cannot honestly preserve a
+manifold-valued state.
+
+```python
+import jax
+import jax.numpy as jnp
+import phydrax as phx
+
+
+def residual(time, state, state_rate, decay):
+    del time
+    differential = state_rate[0] + decay * state[0]
+    constraint = state[1] - state[0] ** 2
+    return jnp.stack((differential, constraint))
+
+
+system = phx.dynamics.DifferentialAlgebraicSystem(
+    residual,
+    state_shape=(2,),
+    structure=phx.dynamics.DAEStructure(
+        ("differential", "algebraic"),
+    ),
+    state_scale=jnp.asarray((1.0, 1.0)),
+    state_rate_scale=jnp.asarray((1.0, 1.0)),
+    residual_scale=jnp.asarray((1.0, 1.0)),
+    system_id="decay-with-constraint",
+)
+```
+
+`DifferentialAlgebraicSystem.from_mass_matrix` is a convenience constructor for
+`M(t, y, a) @ ydot - f(t, y, a) = 0`. The caller still supplies the structural roles;
+a singular mass matrix alone does not prove index-one regularity.
+
+## Consistent initialization
+
+`DifferentialAlgebraicProblem` stores guesses for both `y(0)` and `ydot(0)` and an
+explicit `DAEInitializationSpec`. The default is `index_one()`:
+
+- fix differential state components;
+- solve algebraic state components;
+- solve differential rate components;
+- fix algebraic rate components while marking those rates semantically unavailable.
+
+The other modes are explicit:
+
+- `fixed_rate_state()` fixes the entire supplied state and solves the entire rate;
+- `check_only()` changes nothing and only checks the supplied pair;
+- `from_masks(fixed_state, fixed_rate)` defines custom fixed/free scalar masks.
+
+A custom contract must expose exactly one free state-or-rate scalar per residual
+scalar. Masks operate on flattened scalar coordinates after structural broadcasting;
+they do not silently choose a least-squares initialization.
+
+```python
+problem = phx.solver.DifferentialAlgebraicProblem(
+    system,
+    jnp.asarray((1.0, 0.0)),
+    initial_state_rate=jnp.zeros(2),
+    args=jnp.asarray(0.5),
+    initialization=phx.solver.DAEInitializationSpec.index_one(),
+    problem_id="decay-with-constraint-ivp",
+)
+
+initialization = phx.solver.initialize_dae(problem, 0.0)
+assert bool(initialization.valid)
+```
+
+`DAEInitializationResult` returns the consistent state and rate, their corrections,
+fixed masks, componentwise rate validity, scaled residual threshold and norms, native
+nonlinear status and diagnostics, and a stable initialization ID. A check-only result
+has no nonlinear solve. Failed consistency is reported as evidence; the solver does
+not replace a failed pair with the original guess.
+
+## Fixed-grid BDF lifecycle
+
+`DAESolvePolicy` selects `"bdf1"` or variable-step `"bdf2"`, native
+`NewtonKrylov` or `NewtonTrustRegion` methods for initialization and stages,
+termination contracts, a maximum adjacent-step ratio, and failure behavior.
+
+BDF2 uses BDF1 for its first accepted step. Later stages use the exact coefficients
+for the two adjacent grid intervals. A BDF2 grid whose adjacent interval ratio exceeds
+`max_step_ratio` is rejected during planning; it is not silently downgraded. Every
+accepted state is followed by an independent residual certification against the
+configured nonlinear threshold.
+
+Planning, preparation, and execution are separate:
+
+1. `plan_dae` validates the grid, method, state contract, and static identities.
+2. `prepare_dae` prepares reusable symbolic nonlinear/linear templates for the
+   consistency problem and every BDF stage.
+3. `solve_dae(prepared, ...)` solves consistency for the runtime state, rate, and
+   model arguments, then refreshes numeric stage and Jacobian data while preserving
+   both template identities.
+
+```python
+grid = phx.dynamics.TimeGrid(
+    jnp.linspace(0.0, 1.0, 21),
+    time_id="training-grid",
+)
+policy = phx.solver.DAESolvePolicy(
+    integration_method="bdf2",
+    nonlinear_method=phx.nonlinear.NewtonKrylov(),
+    nonlinear_termination=phx.nonlinear.NonlinearTermination(
+        absolute_residual=1e-9,
+        relative_residual=0.0,
+        maximum_steps=20,
+    ),
+)
+prepared = phx.solver.prepare_dae(problem, grid, policy=policy)
+solution = phx.solver.solve_dae(prepared)
+```
+
+The prepared path supports JIT, JVP, VJP, and `vmap`. Each successful stage state has
+implicit derivatives obtained from that stage's residual Jacobian; nonlinear
+iteration history and diagnostics are nondifferentiable evidence. Dependencies on
+previous accepted states are chained through the outer fixed-length scan. Grid times
+are stop-gradient values: derivatives are for the declared discrete fixed-grid map,
+not for a parameter-dependent time controller.
+
+```python
+def terminal_state(decay):
+    solved = phx.solver.solve_dae(prepared, args=decay)
+    return solved.states[-1, 0]
+
+terminal_gradient = jax.jit(jax.grad(terminal_state))(jnp.asarray(0.5))
+```
+
+`DifferentialAlgebraicSolution` stores states, reconstructed BDF state rates, node and
+step validity, orders, step sizes, residual and constraint norms, per-stage native
+nonlinear statuses and work counts, initialization evidence, plan/method/linear-plan
+provenance, and the original time identity. If initialization or one stage fails,
+later nodes are `NOT_RUN`; no explicit fallback state is fabricated. Use
+`failure="error"` when a non-successful solution must raise at the call boundary.
+
+## Semidiscrete implicit PDE residuals
+
+`compile_semidiscrete_dae` lowers validated `PDEProblemIR` into a
+`CompiledSpatialResidual` and `DifferentialAlgebraicSystem`. It shares field layout,
+coordinate, boundary-lift, parameter-binding, and expression validation with
+`compile_semidiscrete_pde`, but retains temporal derivatives in the implicit
+residual.
+
+The required `equation_targets` mapping is a bijection from every equation name to
+every field name. It determines residual component order and prevents positional
+matching from silently changing the model. A differential target must contain exactly
+one direct first temporal derivative of its target field. Algebraic targets contain
+none. Temporal derivatives nested inside nonlinear or composite expressions are
+rejected rather than approximated.
+
+`SemidiscreteDAEStructuralReport` records targets, component roles, derivative counts,
+and the explicit assumption `regular-index-1-required-unverified`. This is incidence
+evidence, not a numerical rank certificate or an index claim. The compiled object's
+`rate_jacobian` materializes the dense derivative of the residual with respect to the
+state rate for diagnostics; the solver itself retains matrix-free native derivative
+policies unless configured otherwise.
+
+```python
+compiled = phx.equations.compile_semidiscrete_dae(
+    pde_problem,
+    spatial_discretization,
+    equation_targets={"momentum": "velocity", "constraint": "pressure"},
+    parameter_values={"viscosity": 0.01},
+)
+dae_problem = phx.solver.DifferentialAlgebraicProblem(
+    compiled.system,
+    compiled.layout.pack(initial_fields),
+    args=runtime_parameters,
+)
+```
+
+Only semidiscrete states whose time derivative is representable by the PDE IR are
+accepted. Unsupported temporal structure and a non-bijective residual layout fail at
+compilation rather than becoming an invalid numerical solve.
+
+## Trajectory interoperability
+
+`phydrax.dynamics.identification.trajectory_data_from_differential_solution` accepts a
+`DifferentialAlgebraicSolution`. It uses accepted BDF state rates as trajectory
+derivatives, preserves componentwise rate validity, derives transition validity from
+adjacent node validity, and retains the DAE plan in the source ID. The initialization
+node is not labeled derivative-valid when the chosen consistency contract did not
+determine all algebraic rates.
+
+## API reference
+
+::: phydrax.dynamics.DAEStructure
+
+---
+
+::: phydrax.dynamics.DifferentialAlgebraicSystem
+
+---
+
+::: phydrax.solver.DAEInitializationSpec
+
+---
+
+::: phydrax.solver.DAEInitializationResult
+
+---
+
+::: phydrax.solver.DAEInitializationStatus
+
+---
+
+::: phydrax.solver.DAESolvePolicy
+
+---
+
+::: phydrax.solver.DAESolvePlan
+
+---
+
+::: phydrax.solver.PreparedDAESolve
+
+---
+
+::: phydrax.solver.DifferentialAlgebraicProblem
+
+---
+
+::: phydrax.solver.DifferentialAlgebraicSolution
+
+---
+
+::: phydrax.solver.DAEStatus
+
+---
+
+::: phydrax.solver.initialize_dae
+
+---
+
+::: phydrax.solver.plan_dae
+
+---
+
+::: phydrax.solver.prepare_dae
+
+---
+
+::: phydrax.solver.solve_dae
+
+---
+
+::: phydrax.equations.SemidiscreteDAEStructuralReport
+
+---
+
+::: phydrax.equations.CompiledSpatialResidual
+
+---
+
+::: phydrax.equations.compile_semidiscrete_dae

--- a/docs/api/solver/index.md
+++ b/docs/api/solver/index.md
@@ -1,9 +1,10 @@
 # Solver
 
 Phydrax has two separate solver paths: functional minimization over physics/data
-terms and direct finite-dimensional ODE/SDE, differentiable controlled,
-probabilistic ODE, Lyapunov, finite-activity jump, hybrid jump-differential, or
-semidiscrete SPDE integration.
+terms and direct finite-dimensional integration. Direct solvers cover explicit
+ODE/SDE, differential-algebraic, differentiable controlled, probabilistic ODE,
+Lyapunov, finite-activity jump, hybrid jump-differential, and semidiscrete spatial
+systems.
 
 For a conceptual overview (loss evaluation, exact enforcement, training loop behavior), see
 [Guides → Solvers and training](../../guides_solver.md).
@@ -12,6 +13,9 @@ For a conceptual overview (loss evaluation, exact enforcement, training loop beh
   differentiable CDE and neural-CDE training, probabilistic ODE filtering,
   finite-time Lyapunov spectra, finite-activity jump and hybrid trajectories,
   finite-rank semidiscrete SPDEs, and process ensembles.
+- [Differential-algebraic equation integration](differential_algebraic.md) defines
+  consistent initialization, prepared fixed-grid BDF1/BDF2, discrete implicit
+  differentiation, and implicit semidiscrete PDE residuals.
 - [Delay and functional differential equations](delay.md) defines causal method-of-steps,
   stochastic/geometric/rough/jump histories, functional/distributed/state-dependent/
   neutral delays, bounded and infinite memory, convolution, Caputo integration, and
@@ -31,6 +35,8 @@ For a conceptual overview (loss evaluation, exact enforcement, training loop beh
     - `phydrax.optim.kfac(...)` accepts quadratic `ResidualPenalty` terms and freezes
       each active term realization across its gradient, curvature update, and line search.
     - Use `DifferentialProblem` plus `solve_diffrax` for numerical ODE/SDE trajectories.
+    - Use `DifferentialAlgebraicProblem`, a `TimeGrid`, and `solve_dae` for regular
+      fixed-grid index-one residuals `F(t, y, ydot, args) = 0`.
     - Use `AbstractDifferentiableDrivingPath` plus `solve_diffrax_cde` for smooth
       first-level controls; rough controls and their second level belong to
       `solve_rough_differential`.

--- a/docs/cookbook/inverse_and_data.md
+++ b/docs/cookbook/inverse_and_data.md
@@ -133,3 +133,9 @@ operator. Everything is still “minimize functionals over domains”.
   `phx.enforcement.EnforcementSpec` (see the Poisson recipe).
 - For sensor tracks over time, construct their paired coordinates with
   `component.points(...)` and use a fixed `ObservationPenalty` source.
+- When the forward model is an implicit index-one system rather than a learned
+  residual field, use `DifferentialAlgebraicProblem` with a prepared fixed-grid
+  `solve_dae`. Runtime parameter PyTrees and consistent initial values remain
+  differentiable through the accepted BDF stages; solver status and work diagnostics
+  remain explicit. See
+  [Differential-algebraic equation integration](../api/solver/differential_algebraic.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -242,6 +242,7 @@ nav:
         - Solver:
             - Overview: "api/solver/index.md"
             - Differential equations: "api/solver/differential.md"
+            - Differential-algebraic equations: "api/solver/differential_algebraic.md"
             - Delay and functional differential equations: "api/solver/delay.md"
             - Functional solver: "api/solver/functional_solver.md"
             - Exact enforcement: "api/solver/enforcement.md"

--- a/phydrax/dynamics/__init__.py
+++ b/phydrax/dynamics/__init__.py
@@ -5,6 +5,12 @@
 """Dynamical-system, pathwise-evolution, analysis, and identification contracts."""
 
 from . import analysis, identification
+from ._differential_algebraic import (
+    DAERole,
+    DAEStructure,
+    DifferentialAlgebraicResidual,
+    DifferentialAlgebraicSystem,
+)
 from ._evolution import (
     AbstractDifferentiableEvolution,
     AbstractEvolution,
@@ -54,6 +60,10 @@ __all__ = [
     "CaseAxisRole",
     "ContinuousModelVectorField",
     "ContinuousSystem",
+    "DAERole",
+    "DAEStructure",
+    "DifferentialAlgebraicResidual",
+    "DifferentialAlgebraicSystem",
     "DiscreteEvolution",
     "DiscreteSystem",
     "EVOLUTION_BACKEND_FAILED",

--- a/phydrax/dynamics/_differential_algebraic.py
+++ b/phydrax/dynamics/_differential_algebraic.py
@@ -1,0 +1,345 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from math import prod
+from typing import Any, Literal, TypeAlias
+
+import equinox as eqx
+import jax.numpy as jnp
+from jaxtyping import Array, ArrayLike
+
+from .._strict import StrictModule
+from ..metrix import AbstractStateGeometry, EuclideanStateGeometry
+
+
+DAERole: TypeAlias = Literal["differential", "algebraic"]
+DifferentialAlgebraicResidual: TypeAlias = Callable[[Array, Array, Array, Any], ArrayLike]
+
+
+def _identifier(value: str, owner: str, /) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{owner} must be a non-empty string.")
+    return value
+
+
+def _shape(value: Sequence[int], owner: str, /) -> tuple[int, ...]:
+    shape = tuple(int(size) for size in value)
+    if not shape or any(size <= 0 for size in shape):
+        raise ValueError(f"{owner} dimensions must be positive.")
+    return shape
+
+
+def _roles(value: Sequence[DAERole], owner: str, /) -> tuple[DAERole, ...]:
+    roles = tuple(value)
+    if not roles:
+        raise ValueError(f"{owner} must not be empty.")
+    if any(role not in ("differential", "algebraic") for role in roles):
+        raise ValueError(f"{owner} entries must be 'differential' or 'algebraic'.")
+    return roles
+
+
+def _inexact(value: ArrayLike, /) -> Array:
+    array = jnp.asarray(value)
+    return array if jnp.issubdtype(array.dtype, jnp.inexact) else array.astype(float)
+
+
+def _positive_scale(
+    value: ArrayLike | None, shape: tuple[int, ...], owner: str, /
+) -> Array:
+    scale = jnp.ones(shape) if value is None else _inexact(value)
+    scale = jnp.broadcast_to(scale, shape)
+    if jnp.issubdtype(scale.dtype, jnp.complexfloating):
+        raise TypeError(f"{owner} must be real-valued.")
+    return eqx.error_if(
+        scale,
+        jnp.any(~jnp.isfinite(scale)) | jnp.any(scale <= 0.0),
+        f"{owner} must be finite and positive.",
+    )
+
+
+class DAEStructure(StrictModule):
+    """Differential/algebraic roles broadcast along one state component axis."""
+
+    variable_roles: tuple[DAERole, ...] = eqx.field(static=True)
+    equation_roles: tuple[DAERole, ...] = eqx.field(static=True)
+    component_axis: int | None = eqx.field(static=True)
+
+    def __init__(
+        self,
+        variable_roles: Sequence[DAERole],
+        /,
+        *,
+        equation_roles: Sequence[DAERole] | None = None,
+        component_axis: int | None = -1,
+    ):
+        variables = _roles(variable_roles, "variable_roles")
+        equations = (
+            variables
+            if equation_roles is None
+            else _roles(equation_roles, "equation_roles")
+        )
+        if len(equations) != len(variables):
+            raise ValueError("Variable and equation role counts must match.")
+        if variables.count("differential") != equations.count("differential"):
+            raise ValueError(
+                "Differential variable and equation component counts must match."
+            )
+        self.variable_roles = variables
+        self.equation_roles = equations
+        self.component_axis = None if component_axis is None else int(component_axis)
+
+    def resolved_axis(self, state_shape: Sequence[int], /) -> int | None:
+        shape = tuple(int(size) for size in state_shape)
+        if self.component_axis is None:
+            if len(self.variable_roles) != 1:
+                raise ValueError(
+                    "DAE component_axis=None requires one role applied to the full state."
+                )
+            return None
+        rank = len(shape)
+        axis = (
+            self.component_axis + rank if self.component_axis < 0 else self.component_axis
+        )
+        if axis < 0 or axis >= rank:
+            raise ValueError(
+                f"DAE component_axis {self.component_axis} is invalid for shape {shape}."
+            )
+        if shape[axis] != len(self.variable_roles):
+            raise ValueError(
+                "DAE role count must match the selected component axis: "
+                f"got {len(self.variable_roles)} roles for axis size {shape[axis]}."
+            )
+        return axis
+
+    def _mask(
+        self,
+        state_shape: Sequence[int],
+        roles: tuple[DAERole, ...],
+        selected: DAERole,
+        /,
+    ) -> Array:
+        shape = tuple(int(size) for size in state_shape)
+        axis = self.resolved_axis(shape)
+        if axis is None:
+            return jnp.full(shape, roles[0] == selected, dtype=bool)
+        component_mask = jnp.asarray(
+            tuple(role == selected for role in roles),
+            dtype=bool,
+        )
+        broadcast_shape = [1] * len(shape)
+        broadcast_shape[axis] = len(roles)
+        return jnp.broadcast_to(component_mask.reshape(tuple(broadcast_shape)), shape)
+
+    def differential_variable_mask(self, state_shape: Sequence[int], /) -> Array:
+        return self._mask(state_shape, self.variable_roles, "differential")
+
+    def algebraic_variable_mask(self, state_shape: Sequence[int], /) -> Array:
+        return self._mask(state_shape, self.variable_roles, "algebraic")
+
+    def differential_equation_mask(self, state_shape: Sequence[int], /) -> Array:
+        return self._mask(state_shape, self.equation_roles, "differential")
+
+    def algebraic_equation_mask(self, state_shape: Sequence[int], /) -> Array:
+        return self._mask(state_shape, self.equation_roles, "algebraic")
+
+
+class DifferentialAlgebraicSystem(StrictModule):
+    """State-shaped implicit residual independent of initialization and integration."""
+
+    residual: DifferentialAlgebraicResidual
+    structure: DAEStructure
+    state_scale: Array
+    state_rate_scale: Array
+    residual_scale: Array
+    state_geometry: AbstractStateGeometry
+    state_shape: tuple[int, ...] = eqx.field(static=True)
+    system_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        residual: DifferentialAlgebraicResidual,
+        /,
+        *,
+        state_shape: Sequence[int],
+        structure: DAEStructure,
+        state_scale: ArrayLike | None = None,
+        state_rate_scale: ArrayLike | None = None,
+        residual_scale: ArrayLike | None = None,
+        state_geometry: AbstractStateGeometry | None = None,
+        system_id: str,
+    ):
+        if not callable(residual):
+            raise TypeError("DifferentialAlgebraicSystem residual must be callable.")
+        if not isinstance(structure, DAEStructure):
+            raise TypeError("structure must be a DAEStructure.")
+        shape = _shape(state_shape, "DifferentialAlgebraicSystem state_shape")
+        structure.resolved_axis(shape)
+        geometry = EuclideanStateGeometry() if state_geometry is None else state_geometry
+        if not isinstance(geometry, AbstractStateGeometry):
+            raise TypeError("state_geometry must be an AbstractStateGeometry or None.")
+        if not geometry.trivial:
+            raise ValueError(
+                "DifferentialAlgebraicSystem currently requires Euclidean state "
+                "geometry; manifold BDF needs independent local tangent coordinates."
+            )
+        resolved_state_scale = _positive_scale(state_scale, shape, "state_scale")
+        resolved_rate_scale = (
+            resolved_state_scale
+            if state_rate_scale is None
+            else _positive_scale(state_rate_scale, shape, "state_rate_scale")
+        )
+        self.residual = residual
+        self.structure = structure
+        self.state_scale = resolved_state_scale
+        self.state_rate_scale = resolved_rate_scale
+        self.residual_scale = _positive_scale(
+            residual_scale,
+            shape,
+            "residual_scale",
+        )
+        self.state_geometry = geometry
+        self.state_shape = shape
+        self.system_id = _identifier(
+            system_id,
+            "DifferentialAlgebraicSystem system_id",
+        )
+
+    @property
+    def state_size(self) -> int:
+        return prod(self.state_shape)
+
+    def evaluate(
+        self,
+        time: ArrayLike,
+        state: ArrayLike,
+        state_rate: ArrayLike,
+        args: Any = None,
+        /,
+    ) -> Array:
+        time_array = jnp.asarray(time)
+        if time_array.shape != () or jnp.issubdtype(
+            time_array.dtype,
+            jnp.complexfloating,
+        ):
+            raise ValueError("DAE residual time must be one real scalar.")
+        state_array = _inexact(state)
+        rate_array = _inexact(state_rate)
+        if state_array.shape != self.state_shape:
+            raise ValueError(
+                f"state must have shape {self.state_shape}; got {state_array.shape}."
+            )
+        if rate_array.shape != self.state_shape:
+            raise ValueError(
+                f"state_rate must have shape {self.state_shape}; got {rate_array.shape}."
+            )
+        if state_array.dtype != rate_array.dtype:
+            raise TypeError("state and state_rate must have the same dtype.")
+        value = _inexact(self.residual(time_array, state_array, rate_array, args))
+        if value.shape != self.state_shape:
+            raise ValueError(
+                "DifferentialAlgebraicSystem residual returned shape "
+                f"{value.shape}; expected {self.state_shape}."
+            )
+        return value
+
+    def scaled_residual(
+        self,
+        time: ArrayLike,
+        state: ArrayLike,
+        state_rate: ArrayLike,
+        args: Any = None,
+        /,
+    ) -> Array:
+        residual = self.evaluate(time, state, state_rate, args)
+        return residual / self.residual_scale.astype(residual.dtype)
+
+    def __call__(
+        self,
+        time: ArrayLike,
+        state: ArrayLike,
+        state_rate: ArrayLike,
+        args: Any = None,
+        /,
+    ) -> Array:
+        return self.evaluate(time, state, state_rate, args)
+
+    @classmethod
+    def from_mass_matrix(
+        cls,
+        mass_matrix: Any,
+        vector_field: Callable[[Array, Array, Any], ArrayLike],
+        /,
+        *,
+        state_shape: Sequence[int],
+        structure: DAEStructure,
+        state_scale: ArrayLike | None = None,
+        state_rate_scale: ArrayLike | None = None,
+        residual_scale: ArrayLike | None = None,
+        state_geometry: AbstractStateGeometry | None = None,
+        system_id: str,
+    ) -> "DifferentialAlgebraicSystem":
+        """Construct ``M(t, state, args) @ state_rate - f(t, state, args) = 0``."""
+        from ..linalg import AbstractLinearOperator
+
+        if not callable(vector_field):
+            raise TypeError("vector_field must be callable.")
+        shape = _shape(state_shape, "Mass-matrix DAE state_shape")
+        size = prod(shape)
+        constant_operator = isinstance(mass_matrix, AbstractLinearOperator)
+        dynamic_mass = callable(mass_matrix) and not constant_operator
+        constant_array = None
+        if not dynamic_mass and not constant_operator:
+            constant_array = _inexact(mass_matrix)
+            if constant_array.shape != (size, size):
+                raise ValueError(
+                    f"mass_matrix must have shape {(size, size)}; "
+                    f"got {constant_array.shape}."
+                )
+
+        def residual(time, state, state_rate, args):
+            resolved_mass = (
+                mass_matrix(time, state, args) if dynamic_mass else mass_matrix
+            )
+            if isinstance(resolved_mass, AbstractLinearOperator):
+                mass_rate = resolved_mass.mv(state_rate)
+            else:
+                matrix = (
+                    constant_array
+                    if constant_array is not None
+                    else _inexact(resolved_mass)
+                )
+                if matrix.shape != (size, size):
+                    raise ValueError(
+                        f"Dynamic mass matrix must have shape {(size, size)}; "
+                        f"got {matrix.shape}."
+                    )
+                mass_rate = (matrix @ state_rate.reshape((size,))).reshape(shape)
+            drift = _inexact(vector_field(time, state, args))
+            if drift.shape != shape:
+                raise ValueError(
+                    f"vector_field must return shape {shape}; got {drift.shape}."
+                )
+            return mass_rate - drift
+
+        return cls(
+            residual,
+            state_shape=shape,
+            structure=structure,
+            state_scale=state_scale,
+            state_rate_scale=state_rate_scale,
+            residual_scale=residual_scale,
+            state_geometry=state_geometry,
+            system_id=system_id,
+        )
+
+
+__all__ = [
+    "DAERole",
+    "DAEStructure",
+    "DifferentialAlgebraicResidual",
+    "DifferentialAlgebraicSystem",
+]

--- a/phydrax/dynamics/identification/_adapters.py
+++ b/phydrax/dynamics/identification/_adapters.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from ...control import ControlTrajectory
     from ...solver import (
         ControlledDifferentialSolution,
+        DifferentialAlgebraicSolution,
         DifferentialSolution,
         MemoryEquationSolution,
         RoughDifferentialSolution,
@@ -105,7 +106,8 @@ def trajectory_data_from_control(
 
 def trajectory_data_from_differential_solution(
     solution: (
-        DifferentialSolution
+        DifferentialAlgebraicSolution
+        | DifferentialSolution
         | MemoryEquationSolution
         | RoughDifferentialSolution
         | ControlledDifferentialSolution
@@ -115,18 +117,20 @@ def trajectory_data_from_differential_solution(
     state_layout: StateLayout | None = None,
     sample_axes: tuple[str, ...] | None = None,
     sample_axis_roles: tuple[CaseAxisRole, ...] | None = None,
-    coordinate_id: str = "time",
+    coordinate_id: str | None = None,
     source_id: str | None = None,
 ) -> TrajectoryData:
-    """Convert differential, delay/memory, rough, or controlled solver output."""
+    """Convert differential solver output, retaining native DAE state rates."""
     from ...solver import (
         ControlledDifferentialSolution,
+        DifferentialAlgebraicSolution,
         DifferentialSolution,
         MemoryEquationSolution,
         RoughDifferentialSolution,
     )
 
     supported = (
+        DifferentialAlgebraicSolution,
         DifferentialSolution,
         MemoryEquationSolution,
         RoughDifferentialSolution,
@@ -134,10 +138,29 @@ def trajectory_data_from_differential_solution(
     )
     if not isinstance(solution, supported):
         raise TypeError(
-            "solution must be differential, delay/memory, rough, or controlled "
-            "differential solver output."
+            "solution must be DAE, differential, delay/memory, rough, or "
+            "controlled differential solver output."
         )
-    if isinstance(solution, ControlledDifferentialSolution):
+    derivatives = None
+    derivative_valid = None
+    if isinstance(solution, DifferentialAlgebraicSolution):
+        states = solution.states
+        times = solution.times
+        valid = solution.valid
+        sample_shape = solution.sample_shape
+        state_shape = solution.state_shape
+        geometry_id = None
+        derivatives = solution.state_rates
+        state_rank = len(solution.state_shape)
+        state_axes = tuple(
+            range(solution.rate_valid.ndim - state_rank, solution.rate_valid.ndim)
+        )
+        derivative_valid = jnp.all(solution.rate_valid, axis=state_axes)
+        default_coordinate_id = solution.time_id
+        default_source_id = (
+            f"dae:{solution.problem_id}:{solution.integration_method}:{solution.plan_id}"
+        )
+    elif isinstance(solution, ControlledDifferentialSolution):
         base = solution.differential_solution
         states = base.states
         times = base.times
@@ -149,6 +172,7 @@ def trajectory_data_from_differential_solution(
             f"controlled-differential:{solution.problem_id}:{solution.path_id}:"
             f"{base.solver_id}:{base.resolved_method}"
         )
+        default_coordinate_id = "time"
     elif isinstance(solution, DifferentialSolution):
         states = solution.states
         times = solution.times
@@ -159,6 +183,7 @@ def trajectory_data_from_differential_solution(
         default_source_id = (
             f"differential:{solution.solver_id}:{solution.resolved_method}"
         )
+        default_coordinate_id = "time"
     elif isinstance(solution, MemoryEquationSolution):
         states = solution.states
         times = solution.times
@@ -167,6 +192,7 @@ def trajectory_data_from_differential_solution(
         state_shape = solution.state_shape
         geometry_id = None
         default_source_id = f"memory:{solution.solver_id}:{solution.resolved_method}"
+        default_coordinate_id = "time"
     else:
         states = solution.states
         times = solution.times
@@ -175,6 +201,7 @@ def trajectory_data_from_differential_solution(
         state_shape = solution.state_shape
         geometry_id = solution.state_geometry_id
         default_source_id = f"rough:{solution.solver.solver_name}"
+        default_coordinate_id = "time"
     default_layout = StateLayout(state_shape)
     if state_layout is None:
         if geometry_id is not None and geometry_id != default_layout.geometry.geometry_id:
@@ -211,9 +238,11 @@ def trajectory_data_from_differential_solution(
         state_layout=resolved_state,
         sample_valid=valid,
         transition_valid=transitions,
+        derivatives=derivatives,
+        derivative_valid=derivative_valid,
         case_axes=axes,
         case_axis_roles=roles,
-        coordinate_id=coordinate_id,
+        coordinate_id=(default_coordinate_id if coordinate_id is None else coordinate_id),
         source_id=default_source_id if source_id is None else source_id,
     )
 

--- a/phydrax/equations/__init__.py
+++ b/phydrax/equations/__init__.py
@@ -42,10 +42,13 @@ from ._randomized_compile import (
 )
 from ._semidiscrete import (
     BoundaryLift,
+    compile_semidiscrete_dae,
     compile_semidiscrete_pde,
     CompiledSpatialDynamics,
+    CompiledSpatialResidual,
     ResolvedSemidiscreteMethod,
     SemidiscreteCompilationMethod,
+    SemidiscreteDAEStructuralReport,
     SemidiscreteFieldLayout,
 )
 from ._serialize import (
@@ -74,10 +77,12 @@ __all__ = [
     "CompiledPDEEquation",
     "CompiledPDEProblem",
     "CompiledSpatialDynamics",
+    "CompiledSpatialResidual",
     "CompiledRandomizedPDETerm",
     "DifferentialBackend",
     "ResolvedSemidiscreteMethod",
     "SemidiscreteCompilationMethod",
+    "SemidiscreteDAEStructuralReport",
     "SemidiscreteFieldLayout",
     "IntegralCompiler",
     "PDECondition",
@@ -103,6 +108,7 @@ __all__ = [
     "compile_pde_residual_term",
     "compile_pde_randomized_term",
     "compile_pde_problem",
+    "compile_semidiscrete_dae",
     "compile_semidiscrete_pde",
     "infer_expression_type",
     "make_pde_operator",

--- a/phydrax/equations/_semidiscrete.py
+++ b/phydrax/equations/_semidiscrete.py
@@ -15,6 +15,7 @@ import numpy as np
 from jaxtyping import Array, ArrayLike
 
 from .._strict import StrictModule
+from ..dynamics import DAERole, DAEStructure, DifferentialAlgebraicSystem
 from ..linalg import (
     ArraySpace,
     DiagonalPairing,
@@ -836,6 +837,8 @@ class _SemidiscreteEvaluator(StrictModule):
         args: Any,
         fields: Mapping[str, Array],
         /,
+        *,
+        rate_fields: Mapping[str, Array] | None = None,
     ) -> Any:
         if (
             node.op == "divergence"
@@ -851,6 +854,7 @@ class _SemidiscreteEvaluator(StrictModule):
                 time,
                 args,
                 fields,
+                rate_fields=rate_fields,
             )
         if node.op == "constant":
             assert node.value is not None
@@ -864,8 +868,29 @@ class _SemidiscreteEvaluator(StrictModule):
         if node.op == "coordinate":
             assert node.symbol is not None
             return self._coordinate(node.symbol, time)
+        if node.op == "derivative" and node.coordinate == self.time_coordinate:
+            field_name = _temporal_field(node, self.time_coordinate)
+            if field_name is None:
+                raise ValueError(
+                    "Semidiscrete DAE residuals support only direct first temporal "
+                    "derivatives of fields."
+                )
+            if rate_fields is None:
+                raise ValueError(
+                    "Temporal derivatives may only appear in implicit DAE residuals."
+                )
+            return rate_fields[field_name]
 
-        values = tuple(self._evaluate(arg, time, args, fields) for arg in node.args)
+        values = tuple(
+            self._evaluate(
+                argument,
+                time,
+                args,
+                fields,
+                rate_fields=rate_fields,
+            )
+            for argument in node.args
+        )
         if node.op == "add":
             result = values[0]
             for value in values[1:]:
@@ -1156,7 +1181,7 @@ class _SemidiscreteEvaluator(StrictModule):
         if compatible:
             return jnp.broadcast_to(result, expected)
         raise ValueError(
-            f"Evolution RHS for field {name!r} must have shape {expected}; "
+            f"Semidiscrete value for field {name!r} must have shape {expected}; "
             f"got {result.shape}."
         )
 
@@ -1169,6 +1194,74 @@ class _SemidiscreteEvaluator(StrictModule):
                 f"got {value.shape}."
             )
         return self.layout.pack(self._physical_fields(time_array, value, args))
+
+    def physical_state_rate(
+        self,
+        time: ArrayLike,
+        state_rate: ArrayLike,
+        args: Any,
+        /,
+    ) -> Array:
+        time_array = jnp.asarray(time)
+        value = jnp.asarray(state_rate)
+        if tuple(value.shape) != self.layout.state_shape:
+            raise ValueError(
+                f"Semidiscrete state rate must have shape {self.layout.state_shape}; "
+                f"got {value.shape}."
+            )
+        fields = self.layout.unpack(value)
+        for lift in self.boundary_lifts:
+            derivative = lift.derivative(time_array, args)
+            expected = self.layout.field_shape(lift.field_name)
+            if tuple(derivative.shape) != expected:
+                raise ValueError(
+                    f"Boundary lift derivative {lift.lift_id!r} has shape "
+                    f"{derivative.shape}; expected {expected}."
+                )
+            fields[lift.field_name] = fields[lift.field_name] + derivative
+        return self.layout.pack(fields)
+
+    def residual(
+        self,
+        time: ArrayLike,
+        state: ArrayLike,
+        state_rate: ArrayLike,
+        args: Any,
+        /,
+    ) -> Array:
+        time_array = jnp.asarray(time)
+        value = jnp.asarray(state)
+        rate = jnp.asarray(state_rate)
+        if tuple(value.shape) != self.layout.state_shape:
+            raise ValueError(
+                f"Semidiscrete state must have shape {self.layout.state_shape}; "
+                f"got {value.shape}."
+            )
+        if tuple(rate.shape) != self.layout.state_shape:
+            raise ValueError(
+                f"Semidiscrete state rate must have shape {self.layout.state_shape}; "
+                f"got {rate.shape}."
+            )
+        fields = self._physical_fields(time_array, value, args)
+        rate_fields = self.layout.unpack(self.physical_state_rate(time_array, rate, args))
+        residuals = {
+            name: self._coerce_field_value(
+                name,
+                self._evaluate(
+                    expression,
+                    time_array,
+                    args,
+                    fields,
+                    rate_fields=rate_fields,
+                ),
+            )
+            for name, expression in zip(
+                self.layout.field_names,
+                self.rhs_expressions,
+                strict=True,
+            )
+        }
+        return self.layout.pack(residuals)
 
     def __call__(self, time: Array, state: Array, args: Any) -> Array:
         value = jnp.asarray(state)
@@ -1288,6 +1381,162 @@ class CompiledSpatialDynamics(StrictModule):
         return self.drift(jnp.asarray(time), state, args)
 
 
+class SemidiscreteDAEStructuralReport(StrictModule):
+    """Temporal-incidence evidence without an inferred index or regularity claim."""
+
+    field_names: tuple[str, ...] = eqx.field(static=True)
+    equation_names: tuple[str, ...] = eqx.field(static=True)
+    equation_targets: tuple[tuple[str, str], ...] = eqx.field(static=True)
+    variable_roles: tuple[DAERole, ...] = eqx.field(static=True)
+    equation_roles: tuple[DAERole, ...] = eqx.field(static=True)
+    temporal_derivative_counts: tuple[int, ...] = eqx.field(static=True)
+    regularity_verified: bool = eqx.field(static=True)
+    index_assumption: str = eqx.field(static=True)
+    report_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        field_names: Sequence[str],
+        equation_names: Sequence[str],
+        equation_targets: Sequence[tuple[str, str]],
+        variable_roles: Sequence[DAERole],
+        equation_roles: Sequence[DAERole],
+        temporal_derivative_counts: Sequence[int],
+    ):
+        fields = tuple(str(name) for name in field_names)
+        equations = tuple(str(name) for name in equation_names)
+        targets = tuple(
+            (str(equation), str(field)) for equation, field in equation_targets
+        )
+        variables = tuple(variable_roles)
+        residual_roles = tuple(equation_roles)
+        counts = tuple(int(count) for count in temporal_derivative_counts)
+        if not fields or not variables:
+            raise ValueError("Semidiscrete DAE structural evidence must not be empty.")
+        if not (
+            len(fields) == len(equations) == len(targets) == len(counts)
+            and len(variables) == len(residual_roles)
+        ):
+            raise ValueError("Semidiscrete DAE structural evidence entries must align.")
+        self.field_names = fields
+        self.equation_names = equations
+        self.equation_targets = targets
+        self.variable_roles = variables
+        self.equation_roles = residual_roles
+        self.temporal_derivative_counts = counts
+        self.regularity_verified = False
+        self.index_assumption = "regular-index-1-required-unverified"
+        self.report_id = _stable_id(
+            "semidiscrete-dae-structure-v2",
+            repr((fields, equations, targets, variables, residual_roles, counts)),
+        )
+
+
+class _CompiledSpatialResidualFunction(StrictModule):
+    evaluator: _SemidiscreteEvaluator
+
+    def __call__(
+        self,
+        time: Array,
+        state: Array,
+        state_rate: Array,
+        args: Any,
+    ) -> Array:
+        return self.evaluator.residual(time, state, state_rate, args)
+
+
+class CompiledSpatialResidual(StrictModule):
+    """Implicit semidiscrete PDE residual and explicit DAE structure."""
+
+    residual: _CompiledSpatialResidualFunction
+    system: DifferentialAlgebraicSystem
+    layout: SemidiscreteFieldLayout
+    spatial_discretization: Any
+    structure: DAEStructure
+    structural_report: SemidiscreteDAEStructuralReport
+    boundary_lifts: tuple[BoundaryLift, ...]
+    _evaluator: _SemidiscreteEvaluator
+    compilation_id: str = eqx.field(static=True)
+    source_hash: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        residual: _CompiledSpatialResidualFunction,
+        system: DifferentialAlgebraicSystem,
+        layout: SemidiscreteFieldLayout,
+        spatial_discretization: Any,
+        evaluator: _SemidiscreteEvaluator,
+        /,
+        *,
+        structure: DAEStructure,
+        structural_report: SemidiscreteDAEStructuralReport,
+        boundary_lifts: Sequence[BoundaryLift],
+        compilation_id: str,
+        source_hash: str,
+    ):
+        self.residual = residual
+        self.system = system
+        self.layout = layout
+        self.spatial_discretization = spatial_discretization
+        self.structure = structure
+        self.structural_report = structural_report
+        self.boundary_lifts = tuple(boundary_lifts)
+        self._evaluator = evaluator
+        self.compilation_id = str(compilation_id)
+        self.source_hash = str(source_hash)
+
+    @property
+    def state_shape(self) -> tuple[int, ...]:
+        return self.layout.state_shape
+
+    def physical_state(
+        self,
+        time: ArrayLike,
+        state: ArrayLike,
+        args: Any = None,
+    ) -> Array:
+        return self._evaluator.physical_state(jnp.asarray(time), state, args)
+
+    def physical_state_rate(
+        self,
+        time: ArrayLike,
+        state_rate: ArrayLike,
+        args: Any = None,
+    ) -> Array:
+        return self._evaluator.physical_state_rate(
+            jnp.asarray(time),
+            state_rate,
+            args,
+        )
+
+    def rate_jacobian(
+        self,
+        time: ArrayLike,
+        state: ArrayLike,
+        state_rate: ArrayLike,
+        args: Any = None,
+    ) -> Array:
+        """Materialize the dense local derivative ∂F/∂state_rate."""
+        time_array = jnp.asarray(time)
+        state_array = jnp.asarray(state)
+        rate_array = jnp.asarray(state_rate)
+        jacobian = jax.jacfwd(
+            lambda rate: self.residual(time_array, state_array, rate, args)
+        )(rate_array)
+        size = int(np.prod(self.layout.state_shape))
+        return jacobian.reshape((size, size))
+
+    def __call__(
+        self,
+        time: ArrayLike,
+        state: Array,
+        state_rate: Array,
+        args: Any,
+    ) -> Array:
+        return self.residual(jnp.asarray(time), state, state_rate, args)
+
+
 def _signed_additive_terms(
     expression: PDEExpression,
     sign: float = 1.0,
@@ -1381,6 +1630,87 @@ def _expression_nodes(expression: PDEExpression, /) -> tuple[PDEExpression, ...]
     return (expression,) + tuple(
         node for argument in expression.args for node in _expression_nodes(argument)
     )
+
+
+def _dae_residual_layout(
+    problem: PDEProblemIR,
+    layout: SemidiscreteFieldLayout,
+    time_coordinate: str,
+    equation_targets: Mapping[str, str],
+    /,
+) -> tuple[
+    tuple[PDEExpression, ...],
+    DAEStructure,
+    SemidiscreteDAEStructuralReport,
+]:
+    targets = {str(name): str(field) for name, field in equation_targets.items()}
+    equation_names = {equation.name for equation in problem.equations}
+    field_names = set(layout.field_names)
+    if set(targets) != equation_names:
+        missing = sorted(equation_names - set(targets))
+        extra = sorted(set(targets) - equation_names)
+        raise ValueError(
+            "equation_targets must name every PDE equation exactly once; "
+            f"missing={missing}, extra={extra}."
+        )
+    if set(targets.values()) != field_names or len(set(targets.values())) != len(targets):
+        raise ValueError(
+            "equation_targets must map equations bijectively onto all PDE fields."
+        )
+    equation_by_name = {equation.name: equation for equation in problem.equations}
+    target_to_equation = {field: name for name, field in targets.items()}
+    residuals: list[PDEExpression] = []
+    ordered_equations: list[str] = []
+    ordered_targets: list[tuple[str, str]] = []
+    variable_roles: list[DAERole] = []
+    equation_roles: list[DAERole] = []
+    derivative_counts: list[int] = []
+    for field_name, components in zip(
+        layout.field_names,
+        layout.component_counts,
+        strict=True,
+    ):
+        equation_name = target_to_equation[field_name]
+        equation = equation_by_name[equation_name]
+        temporal_nodes = tuple(
+            node
+            for node in _expression_nodes(equation.residual)
+            if node.op == "derivative" and node.coordinate == time_coordinate
+        )
+        temporal_fields = tuple(
+            _temporal_field(node, time_coordinate) for node in temporal_nodes
+        )
+        if any(name is None for name in temporal_fields):
+            raise ValueError(
+                f"PDE equation {equation_name!r} contains an unsupported temporal "
+                "derivative; only direct first derivatives of fields are accepted."
+            )
+        if any(name != field_name for name in temporal_fields):
+            raise ValueError(
+                f"PDE equation {equation_name!r} targets field {field_name!r} but "
+                f"contains temporal derivatives of {temporal_fields}."
+            )
+        role: DAERole = "differential" if temporal_fields else "algebraic"
+        residuals.append(equation.residual)
+        ordered_equations.append(equation_name)
+        ordered_targets.append((equation_name, field_name))
+        variable_roles.extend((role,) * components)
+        equation_roles.extend((role,) * components)
+        derivative_counts.append(len(temporal_fields))
+    structure = DAEStructure(
+        variable_roles,
+        equation_roles=equation_roles,
+        component_axis=None if layout.squeezed else -1,
+    )
+    report = SemidiscreteDAEStructuralReport(
+        field_names=layout.field_names,
+        equation_names=ordered_equations,
+        equation_targets=ordered_targets,
+        variable_roles=variable_roles,
+        equation_roles=equation_roles,
+        temporal_derivative_counts=derivative_counts,
+    )
+    return tuple(residuals), structure, report
 
 
 def _evolution_rhs(
@@ -1855,36 +2185,31 @@ def _spectral_representation(
     )
 
 
-def compile_semidiscrete_pde(
+def _semidiscrete_setup(
     problem: PDEProblemIR,
     discretization: Any,
+    boundary_lifts: Sequence[BoundaryLift],
     /,
-    *,
-    parameter_values: Mapping[str, Any] | None = None,
-    boundary_lifts: Sequence[BoundaryLift] = (),
-    method: SemidiscreteCompilationMethod = "auto",
-) -> CompiledSpatialDynamics:
-    """Compile validated PDE IR into state-shaped method-of-lines dynamics."""
-    from ..solver._semilinear_drift import SemilinearDrift
-    from ..solver._spatial import (
-        AbstractSpatialDiscretization,
-        SpectralSpatialDiscretization,
-    )
+) -> tuple[
+    str,
+    tuple[str, ...],
+    tuple[BoundaryLift, ...],
+    tuple[tuple[str, tuple[int, ...]], ...],
+    SemidiscreteFieldLayout,
+]:
+    from ..solver._spatial import AbstractSpatialDiscretization
 
     if not isinstance(problem, PDEProblemIR):
         raise TypeError("problem must be a PDEProblemIR.")
     if not isinstance(discretization, AbstractSpatialDiscretization):
         raise TypeError("discretization must be an AbstractSpatialDiscretization.")
-    if method not in ("auto", "direct", "semilinear"):
-        raise ValueError("method must be 'auto', 'direct', or 'semilinear'.")
     validate_pde_ir(problem)
-
     time_coordinates = tuple(
         coordinate for coordinate in problem.coordinates if coordinate.kind == "time"
     )
     if len(time_coordinates) != 1 or time_coordinates[0].size != 1:
         raise ValueError(
-            "Semidiscrete PDE compilation requires exactly one scalar time coordinate."
+            "Semidiscrete compilation requires exactly one scalar time coordinate."
         )
     time_coordinate = time_coordinates[0].name
     spatial_coordinates = tuple(
@@ -1896,7 +2221,7 @@ def compile_semidiscrete_pde(
     for field in problem.fields:
         if time_coordinate not in field.coordinates:
             raise ValueError(
-                f"Evolution field {field.name!r} must depend on time coordinate "
+                f"Semidiscrete field {field.name!r} must depend on time coordinate "
                 f"{time_coordinate!r}."
             )
         field_spatial_coordinates = tuple(
@@ -1906,11 +2231,10 @@ def compile_semidiscrete_pde(
         )
         if field_spatial_coordinates != spatial_coordinates:
             raise ValueError(
-                "All evolution fields must use the same complete spatial coordinate "
-                f"layout {spatial_coordinates}; field {field.name!r} uses "
-                f"{field_spatial_coordinates}."
+                "All semidiscrete fields must use the same complete spatial "
+                f"coordinate layout {spatial_coordinates}; field {field.name!r} "
+                f"uses {field_spatial_coordinates}."
             )
-
     lifts = tuple(boundary_lifts)
     if any(not isinstance(lift, BoundaryLift) for lift in lifts):
         raise TypeError("boundary_lifts must contain BoundaryLift objects.")
@@ -1922,7 +2246,6 @@ def compile_semidiscrete_pde(
         raise ValueError(
             f"Boundary lifts reference unknown fields {sorted(unknown_lifts)}."
         )
-
     coordinate_axes = _coordinate_axis_map(problem, discretization)
     _validate_boundary_conditions(
         problem,
@@ -1930,49 +2253,25 @@ def compile_semidiscrete_pde(
         coordinate_axes,
         lifts,
     )
-    rhs_expressions = _evolution_rhs(problem, time_coordinate)
-    regions_by_name = {region.name: region for region in problem.regions}
-    unsupported_integrals = tuple(
-        region_name
-        for expression in rhs_expressions
-        for region_name in _integral_regions(expression)
-        if (
-            regions_by_name[region_name].kind != "interior"
-            or regions_by_name[region_name].component is not None
-            or len(set(regions_by_name[region_name].coordinates))
-            != len(regions_by_name[region_name].coordinates)
-            or any(
-                coordinate not in spatial_coordinate_set
-                for coordinate in regions_by_name[region_name].coordinates
-            )
-        )
+    return (
+        time_coordinate,
+        spatial_coordinates,
+        lifts,
+        coordinate_axes,
+        SemidiscreteFieldLayout(problem.fields, discretization.state_shape),
     )
-    if unsupported_integrals:
-        raise ValueError(
-            "Semidiscrete volume quadrature only supports unpartitioned interior "
-            f"spatial regions with unique coordinates; got {unsupported_integrals}."
-        )
-    if isinstance(discretization, SpectralSpatialDiscretization):
-        if lifts:
-            raise ValueError(
-                "SpectralSpatialDiscretization cannot apply coordinate-space "
-                "BoundaryLift objects without a coordinate frame."
-            )
-        framed_expressions = rhs_expressions + tuple(
-            expression
-            for condition in problem.conditions
-            for expression in (condition.expression, condition.target)
-        )
-        if any(
-            _requires_coordinate_frame(expression, spatial_coordinate_set)
-            for expression in framed_expressions
-        ):
-            raise ValueError(
-                "SpectralSpatialDiscretization has no coordinate frame for "
-                "coordinate, derivative, gradient, divergence, or curl nodes."
-            )
-    layout = SemidiscreteFieldLayout(problem.fields, discretization.state_shape)
 
+
+def _parameter_defaults(
+    problem: PDEProblemIR,
+    layout: SemidiscreteFieldLayout,
+    parameter_values: Mapping[str, Any] | None,
+    /,
+) -> tuple[
+    tuple[Any | None, ...],
+    dict[str, Any],
+    tuple[tuple[str, str], ...],
+]:
     supplied = {} if parameter_values is None else dict(parameter_values)
     parameter_names = {parameter.name for parameter in problem.parameters}
     unknown_parameters = set(supplied) - parameter_names
@@ -2014,35 +2313,81 @@ def compile_semidiscrete_pde(
         defaults.append(normalized)
         if normalized is not None:
             defaults_by_name[parameter.name] = normalized
-    lift_bindings = tuple(sorted((lift.field_name, lift.lift_id) for lift in lifts))
     parameter_bindings = tuple(
         (parameter.name, _value_fingerprint(value))
         for parameter, value in zip(problem.parameters, defaults, strict=True)
     )
-    binding_id = _stable_id(
-        "semidiscrete-bindings-v1",
-        problem.canonical_hash,
-        discretization.discretization_id,
-        layout.layout_id,
-        repr(lift_bindings),
-        repr(parameter_bindings),
+    return tuple(defaults), defaults_by_name, parameter_bindings
+
+
+def _validate_semidiscrete_expressions(
+    problem: PDEProblemIR,
+    discretization: Any,
+    evaluator: _SemidiscreteEvaluator,
+    expressions: Sequence[PDEExpression],
+    spatial_coordinates: set[str],
+    lifts: Sequence[BoundaryLift],
+    /,
+    *,
+    allow_temporal_derivatives: bool,
+) -> None:
+    from ..solver._spatial import (
+        SpectralSpatialDiscretization,
+        TensorGridDiscretization,
     )
 
-    evaluator = _SemidiscreteEvaluator(
-        problem,
-        rhs_expressions,
-        layout,
-        discretization,
-        lifts,
-        defaults,
-        coordinate_axes,
-        time_coordinate,
-        _region_axis_map(problem, coordinate_axes),
+    expression_values = tuple(expressions)
+    regions_by_name = {region.name: region for region in problem.regions}
+    unsupported_integrals = tuple(
+        region_name
+        for expression in expression_values
+        for region_name in _integral_regions(expression)
+        if (
+            regions_by_name[region_name].kind != "interior"
+            or regions_by_name[region_name].component is not None
+            or len(set(regions_by_name[region_name].coordinates))
+            != len(regions_by_name[region_name].coordinates)
+            or any(
+                coordinate not in spatial_coordinates
+                for coordinate in regions_by_name[region_name].coordinates
+            )
+        )
     )
-    from ..solver._spatial import TensorGridDiscretization
-
-    for expression in rhs_expressions:
+    if unsupported_integrals:
+        raise ValueError(
+            "Semidiscrete volume quadrature only supports unpartitioned interior "
+            f"spatial regions with unique coordinates; got {unsupported_integrals}."
+        )
+    if isinstance(discretization, SpectralSpatialDiscretization):
+        if lifts:
+            raise ValueError(
+                "SpectralSpatialDiscretization cannot apply coordinate-space "
+                "BoundaryLift objects without a coordinate frame."
+            )
+        framed_expressions = expression_values + tuple(
+            expression
+            for condition in problem.conditions
+            for expression in (condition.expression, condition.target)
+        )
+        if any(
+            _requires_coordinate_frame(expression, spatial_coordinates)
+            for expression in framed_expressions
+        ):
+            raise ValueError(
+                "SpectralSpatialDiscretization has no coordinate frame for "
+                "coordinate, derivative, gradient, divergence, or curl nodes."
+            )
+    for expression in expression_values:
         for node in _expression_nodes(expression):
+            if node.op == "derivative" and node.coordinate == evaluator.time_coordinate:
+                if (
+                    allow_temporal_derivatives
+                    and _temporal_field(node, evaluator.time_coordinate) is not None
+                ):
+                    continue
+                raise ValueError(
+                    "Only direct first field derivatives may use the time coordinate."
+                )
             if node.op not in (
                 "derivative",
                 "gradient",
@@ -2051,6 +2396,10 @@ def compile_semidiscrete_pde(
                 "laplacian",
             ):
                 continue
+            if node.coordinate == evaluator.time_coordinate:
+                raise ValueError(
+                    "Only direct first field derivatives may use the time coordinate."
+                )
             if (
                 node.op in ("divergence", "curl")
                 and infer_expression_type(node.args[0], problem).is_scalar
@@ -2082,10 +2431,67 @@ def compile_semidiscrete_pde(
                 parity[axis] == 2 for parity in parities for axis in axes
             ):
                 raise ValueError(
-                    "Cannot infer sine/cosine extension parity for a "
-                    "differentiated composite expression; rewrite it into "
-                    "boundary-compatible terms."
+                    "Cannot infer sine/cosine extension parity for a differentiated "
+                    "composite expression; rewrite it into boundary-compatible terms."
                 )
+
+
+def compile_semidiscrete_pde(
+    problem: PDEProblemIR,
+    discretization: Any,
+    /,
+    *,
+    parameter_values: Mapping[str, Any] | None = None,
+    boundary_lifts: Sequence[BoundaryLift] = (),
+    method: SemidiscreteCompilationMethod = "auto",
+) -> CompiledSpatialDynamics:
+    """Compile validated PDE IR into state-shaped method-of-lines dynamics."""
+    from ..solver._semilinear_drift import SemilinearDrift
+
+    if method not in ("auto", "direct", "semilinear"):
+        raise ValueError("method must be 'auto', 'direct', or 'semilinear'.")
+    (
+        time_coordinate,
+        spatial_coordinates,
+        lifts,
+        coordinate_axes,
+        layout,
+    ) = _semidiscrete_setup(problem, discretization, boundary_lifts)
+    rhs_expressions = _evolution_rhs(problem, time_coordinate)
+    defaults, defaults_by_name, parameter_bindings = _parameter_defaults(
+        problem,
+        layout,
+        parameter_values,
+    )
+    lift_bindings = tuple(sorted((lift.field_name, lift.lift_id) for lift in lifts))
+    binding_id = _stable_id(
+        "semidiscrete-bindings-v1",
+        problem.canonical_hash,
+        discretization.discretization_id,
+        layout.layout_id,
+        repr(lift_bindings),
+        repr(parameter_bindings),
+    )
+    evaluator = _SemidiscreteEvaluator(
+        problem,
+        rhs_expressions,
+        layout,
+        discretization,
+        lifts,
+        defaults,
+        coordinate_axes,
+        time_coordinate,
+        _region_axis_map(problem, coordinate_axes),
+    )
+    _validate_semidiscrete_expressions(
+        problem,
+        discretization,
+        evaluator,
+        rhs_expressions,
+        set(spatial_coordinates),
+        lifts,
+        allow_temporal_derivatives=False,
+    )
 
     full_spatial_axes = tuple(range(len(discretization.state_shape)))
     full_spatial_coordinates = {
@@ -2217,11 +2623,112 @@ def compile_semidiscrete_pde(
     )
 
 
+def compile_semidiscrete_dae(
+    problem: PDEProblemIR,
+    discretization: Any,
+    /,
+    *,
+    equation_targets: Mapping[str, str],
+    parameter_values: Mapping[str, Any] | None = None,
+    boundary_lifts: Sequence[BoundaryLift] = (),
+    state_scale: ArrayLike | None = None,
+    state_rate_scale: ArrayLike | None = None,
+    residual_scale: ArrayLike | None = None,
+    system_id: str | None = None,
+) -> CompiledSpatialResidual:
+    """Compile PDE IR into an implicit residual without claiming index regularity."""
+    if not isinstance(equation_targets, Mapping):
+        raise TypeError("equation_targets must be a mapping from equations to fields.")
+    (
+        time_coordinate,
+        spatial_coordinates,
+        lifts,
+        coordinate_axes,
+        layout,
+    ) = _semidiscrete_setup(problem, discretization, boundary_lifts)
+    residual_expressions, structure, structural_report = _dae_residual_layout(
+        problem,
+        layout,
+        time_coordinate,
+        equation_targets,
+    )
+    defaults, _, parameter_bindings = _parameter_defaults(
+        problem,
+        layout,
+        parameter_values,
+    )
+    lift_bindings = tuple(sorted((lift.field_name, lift.lift_id) for lift in lifts))
+    binding_id = _stable_id(
+        "semidiscrete-dae-bindings-v2",
+        problem.canonical_hash,
+        discretization.discretization_id,
+        layout.layout_id,
+        structural_report.report_id,
+        repr(lift_bindings),
+        repr(parameter_bindings),
+    )
+    evaluator = _SemidiscreteEvaluator(
+        problem,
+        residual_expressions,
+        layout,
+        discretization,
+        lifts,
+        defaults,
+        coordinate_axes,
+        time_coordinate,
+        _region_axis_map(problem, coordinate_axes),
+    )
+    _validate_semidiscrete_expressions(
+        problem,
+        discretization,
+        evaluator,
+        residual_expressions,
+        set(spatial_coordinates),
+        lifts,
+        allow_temporal_derivatives=True,
+    )
+    compilation_id = _stable_id(
+        "semidiscrete-dae-compiler-v2",
+        binding_id,
+        _value_fingerprint(state_scale),
+        _value_fingerprint(state_rate_scale),
+        _value_fingerprint(residual_scale),
+    )
+    residual = _CompiledSpatialResidualFunction(evaluator)
+    resolved_system_id = (
+        f"semidiscrete-dae:{compilation_id}" if system_id is None else system_id
+    )
+    system = DifferentialAlgebraicSystem(
+        residual,
+        state_shape=layout.state_shape,
+        structure=structure,
+        state_scale=state_scale,
+        state_rate_scale=state_rate_scale,
+        residual_scale=residual_scale,
+        system_id=resolved_system_id,
+    )
+    return CompiledSpatialResidual(
+        residual,
+        system,
+        layout,
+        discretization,
+        evaluator,
+        structure=structure,
+        structural_report=structural_report,
+        boundary_lifts=lifts,
+        compilation_id=compilation_id,
+        source_hash=problem.canonical_hash,
+    )
+
+
 __all__ = [
     "BoundaryLift",
     "CompiledSpatialDynamics",
+    "CompiledSpatialResidual",
     "ResolvedSemidiscreteMethod",
     "SemidiscreteCompilationMethod",
+    "SemidiscreteDAEStructuralReport",
     "SemidiscreteFieldLayout",
+    "compile_semidiscrete_dae",
     "compile_semidiscrete_pde",
 ]

--- a/phydrax/nonlinear/__init__.py
+++ b/phydrax/nonlinear/__init__.py
@@ -16,7 +16,7 @@ from ._fas import (
     FASResult,
 )
 from ._fixed_point import AndersonAcceleration, FixedPointIteration, PicardIteration
-from ._implicit import implicit_root
+from ._implicit import implicit_root, implicit_root_result
 from ._linearization import (
     JacobianMode,
     JacobianPolicy,
@@ -127,6 +127,7 @@ __all__ = [
     "complementarity_certificate",
     "fas_cycle",
     "implicit_root",
+    "implicit_root_result",
     "left_precondition",
     "nonlinear_status_message",
     "prepare_jacobian",

--- a/phydrax/nonlinear/_implicit.py
+++ b/phydrax/nonlinear/_implicit.py
@@ -11,8 +11,8 @@ import jax
 import jax.numpy as jnp
 from jaxtyping import Array, PyTree
 
-from .._tree_math import validate_inexact_tree
 from ..linalg import (
+    AbstractVectorSpace,
     FGMRES,
     FunctionLinearOperator,
     GMRES,
@@ -24,25 +24,66 @@ from ..linalg import (
 )
 from ..linalg._runtime import _callable_gmres_for_policy
 from ._newton import NewtonKrylov, NewtonTrustRegion
+from ._prepared import PreparedNonlinearSolve, solve_prepared_nonlinear
 from ._types import (
     AbstractNonlinearMethod,
+    NonlinearDiagnostics,
+    NonlinearResult,
     NonlinearStatus,
     NonlinearSystemProblem,
     NonlinearTermination,
 )
 
 
-def _checked_root_coordinates(
-    result,
-    space: PyTreeSpace,
+_DEFAULT_ARGS = object()
+
+
+def _diagnostic_counts(
+    diagnostics: NonlinearDiagnostics,
     /,
-) -> Array:
+) -> tuple[Array, ...]:
+    return (
+        diagnostics.iterations,
+        diagnostics.residual_evaluations,
+        diagnostics.jvp_evaluations,
+        diagnostics.vjp_evaluations,
+        diagnostics.jacobian_preparations,
+        diagnostics.linear_solves,
+        diagnostics.linear_iterations,
+        diagnostics.accepted_steps,
+        diagnostics.rejected_steps,
+        diagnostics.domain_failures,
+        diagnostics.nonfinite_trials,
+        diagnostics.acceleration_restarts,
+        diagnostics.setup_refreshes,
+        diagnostics.numeric_refreshes,
+    )
+
+
+def _cast_diagnostic_counts(
+    diagnostics: NonlinearDiagnostics,
+    dtype,
+    /,
+) -> NonlinearDiagnostics:
+    return eqx.tree_at(
+        _diagnostic_counts,
+        diagnostics,
+        tuple(value.astype(dtype) for value in _diagnostic_counts(diagnostics)),
+    )
+
+
+def _checked_root_state(
+    result: NonlinearResult,
+    space: AbstractVectorSpace,
+    /,
+) -> PyTree[Array]:
     coordinates = space.flatten(result.state)
-    return eqx.error_if(
+    coordinates = eqx.error_if(
         coordinates,
         result.status != int(NonlinearStatus.SUCCESS),
         "Implicit nonlinear root solve failed; inspect an explicit root result first.",
     )
+    return space.unflatten(coordinates)
 
 
 def _checked_tangent_solve(
@@ -84,27 +125,52 @@ def _checked_tangent_solve(
     )
 
 
-def implicit_root(
-    problem: NonlinearSystemProblem,
-    initial_state: PyTree[Any],
+def implicit_root_result(
+    problem_or_prepared: NonlinearSystemProblem | PreparedNonlinearSolve,
+    initial_state: PyTree[Any] | None = None,
     /,
     *,
     method: AbstractNonlinearMethod | None = None,
     termination: NonlinearTermination | None = None,
     linear_policy: LinearSolvePolicy | None = None,
-    args: Any = None,
-) -> PyTree[Array]:
-    """Return a root with forward- and reverse-mode implicit derivatives.
+    args: Any = _DEFAULT_ARGS,
+) -> NonlinearResult:
+    """Return one nonlinear result whose root has implicit derivatives.
 
-    Differentiation follows the residual arguments captured by ``args``; the initial
-    guess is treated only as a globalization input. The derivative solve must converge
-    successfully, so singular or unresolved Jacobians fail rather than returning a
-    misleading tangent.
+    The primal nonlinear solve runs once. Its status and diagnostics are retained as
+    nondifferentiable evidence, while state, residual, and auxiliary values are
+    evaluated at the implicitly differentiated root. A failed solve remains a failed
+    result; implicit derivatives are meaningful only when ``successful`` is true.
     """
-    if not isinstance(problem, NonlinearSystemProblem):
-        raise TypeError("problem must be a NonlinearSystemProblem.")
-    method_ = NewtonKrylov() if method is None else method
-    termination_ = NonlinearTermination() if termination is None else termination
+    if isinstance(problem_or_prepared, PreparedNonlinearSolve):
+        if initial_state is not None or method is not None or termination is not None:
+            raise ValueError(
+                "initial_state, method, and termination must be omitted for a "
+                "prepared implicit root."
+            )
+        if args is not _DEFAULT_ARGS:
+            raise ValueError("args must be omitted for a prepared implicit root.")
+        prepared = problem_or_prepared
+        problem = prepared.problem
+        initial = prepared.state
+        method_ = prepared.method
+        termination_ = prepared.termination
+        runtime_args = prepared.args
+    elif isinstance(problem_or_prepared, NonlinearSystemProblem):
+        if initial_state is None:
+            raise ValueError("initial_state is required for an unprepared implicit root.")
+        prepared = None
+        problem = problem_or_prepared
+        initial = problem.validate_state(initial_state)
+        method_ = NewtonKrylov() if method is None else method
+        termination_ = NonlinearTermination() if termination is None else termination
+        runtime_args = None if args is _DEFAULT_ARGS else args
+    else:
+        raise TypeError(
+            "problem_or_prepared must be a NonlinearSystemProblem or "
+            "PreparedNonlinearSolve."
+        )
+
     if not isinstance(method_, AbstractNonlinearMethod):
         raise TypeError("method must be AbstractNonlinearMethod or None.")
     if not isinstance(termination_, NonlinearTermination):
@@ -120,26 +186,41 @@ def implicit_root(
     if not isinstance(derivative_policy, LinearSolvePolicy):
         raise TypeError("linear_policy must be LinearSolvePolicy or None.")
 
-    initial = validate_inexact_tree(initial_state, name="initial implicit root state")
-    source = PyTreeSpace(initial)
-    initial_residual = problem.residual(initial, args)
-    target = PyTreeSpace(initial_residual)
+    initial_residual = problem.residual(initial, runtime_args)
+    source = PyTreeSpace(initial) if problem.state_space is None else problem.state_space
+    target = (
+        PyTreeSpace(initial_residual)
+        if problem.residual_space is None
+        else problem.residual_space
+    )
     if source.size != target.size:
         raise ValueError("Implicit root differentiation requires a square Jacobian.")
     initial_coordinates = source.flatten(initial)
 
     def coordinate_residual(coordinates):
         state = source.unflatten(coordinates)
-        return target.flatten(problem.residual(state, args))
+        return target.flatten(problem.residual(state, runtime_args))
 
     def primal_solve(_, coordinates):
-        result = method_.solve(
-            problem,
-            source.unflatten(coordinates),
-            termination=termination_,
-            args=args,
+        if prepared is None:
+            result = method_.solve(
+                problem,
+                source.unflatten(coordinates),
+                termination=termination_,
+                args=runtime_args,
+            )
+        else:
+            result = solve_prepared_nonlinear(prepared)
+        if result.transformation_evidence is not None:
+            raise ValueError(
+                "Implicit root results do not support transformed nonlinear evidence."
+            )
+        evidence = (
+            result.status.astype(coordinates.dtype),
+            _cast_diagnostic_counts(result.diagnostics, coordinates.dtype),
+            result.provenance,
         )
-        return _checked_root_coordinates(result, source)
+        return source.flatten(result.state), evidence
 
     def tangent_solve(linearized, right_hand_side):
         return jax.lax.custom_linear_solve(
@@ -153,13 +234,48 @@ def implicit_root(
             ),
         )
 
-    coordinates = jax.lax.custom_root(
+    coordinates, evidence = jax.lax.custom_root(
         coordinate_residual,
         initial_coordinates,
         solve=primal_solve,
         tangent_solve=tangent_solve,
+        has_aux=True,
     )
-    return source.unflatten(coordinates)
+    status, diagnostics, provenance = evidence
+    state = source.unflatten(coordinates)
+    residual, auxiliary = problem.evaluate(state, runtime_args)
+    return NonlinearResult(
+        state=state,
+        residual=residual,
+        auxiliary=auxiliary,
+        status=status,
+        diagnostics=_cast_diagnostic_counts(diagnostics, jnp.int32),
+        provenance=provenance,
+    )
 
 
-__all__ = ["implicit_root"]
+def implicit_root(
+    problem: NonlinearSystemProblem,
+    initial_state: PyTree[Any],
+    /,
+    *,
+    method: AbstractNonlinearMethod | None = None,
+    termination: NonlinearTermination | None = None,
+    linear_policy: LinearSolvePolicy | None = None,
+    args: Any = None,
+) -> PyTree[Array]:
+    """Return a successful root with forward- and reverse-mode implicit derivatives."""
+    result = implicit_root_result(
+        problem,
+        initial_state,
+        method=method,
+        termination=termination,
+        linear_policy=linear_policy,
+        args=args,
+    )
+    state = problem.validate_state(result.state)
+    source = PyTreeSpace(state) if problem.state_space is None else problem.state_space
+    return _checked_root_state(result, source)
+
+
+__all__ = ["implicit_root", "implicit_root_result"]

--- a/phydrax/nonlinear/_newton.py
+++ b/phydrax/nonlinear/_newton.py
@@ -905,13 +905,22 @@ def _eager_initial_status(
     termination: NonlinearTermination,
     /,
 ) -> Array | None:
-    if isinstance(state.status, jax_core.Tracer):
+    if any(
+        isinstance(value, jax_core.Tracer)
+        for value in (
+            state.status,
+            state.residual_norm,
+            state.initial_residual_norm,
+        )
+    ):
         return None
     if int(state.status) != int(NonlinearStatus.ITERATING):
         return state.status
     converged = state.residual_norm <= termination.residual_threshold(
         state.initial_residual_norm
     )
+    if isinstance(converged, jax_core.Tracer):
+        return None
     if bool(converged):
         return jnp.asarray(int(NonlinearStatus.SUCCESS), dtype=jnp.int32)
     return None

--- a/phydrax/solver/__init__.py
+++ b/phydrax/solver/__init__.py
@@ -81,6 +81,12 @@ from ._coupled import (
     CoupledValidity,
     solve_coupled_hierarchy,
 )
+from ._dae_initialization import (
+    DAEInitializationMode,
+    DAEInitializationResult,
+    DAEInitializationSpec,
+    DAEInitializationStatus,
+)
 from ._deep_bsde import DeepBSDEResult, solve_deep_bsde
 from ._deep_picard import (
     DeepPicardDiagnostics,
@@ -137,6 +143,20 @@ from ._differential import (
     DifferentialVectorField,
     NoiseStructure,
     WienerTerm,
+)
+from ._differential_algebraic import (
+    DAEFailureMode,
+    DAEIntegrationMethod,
+    DAESolvePlan,
+    DAESolvePolicy,
+    DAEStatus,
+    DifferentialAlgebraicProblem,
+    DifferentialAlgebraicSolution,
+    initialize_dae,
+    plan_dae,
+    prepare_dae,
+    PreparedDAESolve,
+    solve_dae,
 )
 from ._diffrax_backend import solve_diffrax, solve_diffrax_ensemble
 from ._diffrax_cde import ControlledDifferentialSolution, solve_diffrax_cde
@@ -383,6 +403,22 @@ __all__ = [
     "DifferentialInterpretation",
     "DifferentialProblem",
     "DifferentialSolution",
+    "DAEFailureMode",
+    "DAEIntegrationMethod",
+    "DAESolvePlan",
+    "DAESolvePolicy",
+    "DAEStatus",
+    "DAEInitializationMode",
+    "DAEInitializationResult",
+    "DAEInitializationSpec",
+    "DAEInitializationStatus",
+    "DifferentialAlgebraicProblem",
+    "DifferentialAlgebraicSolution",
+    "initialize_dae",
+    "plan_dae",
+    "prepare_dae",
+    "PreparedDAESolve",
+    "solve_dae",
     "DiffraxEvolution",
     "DifferentialVectorField",
     "FixedBSplineDrivingPath",

--- a/phydrax/solver/_dae_initialization.py
+++ b/phydrax/solver/_dae_initialization.py
@@ -1,0 +1,639 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import hashlib
+from enum import IntEnum
+from math import prod
+from typing import Any, Literal, TypeAlias
+
+import equinox as eqx
+import jax.numpy as jnp
+import numpy as np
+from jaxtyping import Array, ArrayLike
+
+from .._strict import StrictModule
+from ..dynamics import DifferentialAlgebraicSystem
+from ..linalg import ArraySpace, DiagonalPairing
+from ..nonlinear import (
+    AbstractNonlinearMethod,
+    implicit_root_result,
+    NonlinearResult,
+    NonlinearStatus,
+    NonlinearSystemProblem,
+    NonlinearTermination,
+    prepare_nonlinear,
+    PreparedNonlinearSolve,
+    refresh_nonlinear,
+)
+
+
+DAEInitializationMode: TypeAlias = Literal[
+    "index-one",
+    "fixed-rate",
+    "check",
+    "custom",
+]
+
+
+class DAEInitializationStatus(IntEnum):
+    SUCCESS = 0
+    RESIDUAL_TOO_LARGE = 1
+    NONLINEAR_FAILED = 2
+    NONFINITE = 3
+
+
+def _mask_tuple(value: ArrayLike, owner: str, /) -> tuple[bool, ...]:
+    array = np.asarray(value)
+    if array.dtype.kind != "b":
+        raise TypeError(f"{owner} must have Boolean dtype.")
+    if array.size == 0:
+        raise ValueError(f"{owner} must not be empty.")
+    return tuple(bool(item) for item in array.reshape((-1,)))
+
+
+def _spec_id(
+    mode: DAEInitializationMode,
+    fixed_state: tuple[bool, ...] | None,
+    fixed_rate: tuple[bool, ...] | None,
+    /,
+) -> str:
+    digest = hashlib.sha256()
+    digest.update(repr((mode, fixed_state, fixed_rate)).encode("utf-8"))
+    return f"dae-initialization:{digest.hexdigest()}"
+
+
+class DAEInitializationSpec(StrictModule):
+    """Free/fixed state and state-rate contract for one consistency solve."""
+
+    mode: DAEInitializationMode = eqx.field(static=True)
+    fixed_state: tuple[bool, ...] | None = eqx.field(static=True)
+    fixed_rate: tuple[bool, ...] | None = eqx.field(static=True)
+    initialization_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        mode: DAEInitializationMode = "index-one",
+        /,
+        *,
+        fixed_state: ArrayLike | None = None,
+        fixed_rate: ArrayLike | None = None,
+    ):
+        if mode not in ("index-one", "fixed-rate", "check", "custom"):
+            raise ValueError("Unknown DAE initialization mode.")
+        if mode == "custom":
+            if fixed_state is None or fixed_rate is None:
+                raise ValueError("Custom initialization requires both fixed masks.")
+            state_mask = _mask_tuple(fixed_state, "fixed_state")
+            rate_mask = _mask_tuple(fixed_rate, "fixed_rate")
+            if len(state_mask) != len(rate_mask):
+                raise ValueError("Custom fixed-state and fixed-rate masks must match.")
+        else:
+            if fixed_state is not None or fixed_rate is not None:
+                raise ValueError(
+                    "fixed_state and fixed_rate are only accepted in custom mode."
+                )
+            state_mask = None
+            rate_mask = None
+        self.mode = mode
+        self.fixed_state = state_mask
+        self.fixed_rate = rate_mask
+        self.initialization_id = _spec_id(mode, state_mask, rate_mask)
+
+    @classmethod
+    def index_one(cls) -> "DAEInitializationSpec":
+        return cls("index-one")
+
+    @classmethod
+    def fixed_rate_state(cls) -> "DAEInitializationSpec":
+        return cls("fixed-rate")
+
+    @classmethod
+    def check_only(cls) -> "DAEInitializationSpec":
+        return cls("check")
+
+    @classmethod
+    def from_masks(
+        cls,
+        fixed_state: ArrayLike,
+        fixed_rate: ArrayLike,
+        /,
+    ) -> "DAEInitializationSpec":
+        return cls("custom", fixed_state=fixed_state, fixed_rate=fixed_rate)
+
+
+class DAEInitializationResult(StrictModule):
+    """Consistent state/rate pair with native nonlinear and constraint evidence."""
+
+    state: Array
+    state_rate: Array
+    state_correction: Array
+    rate_correction: Array
+    fixed_state_mask: Array
+    fixed_rate_mask: Array
+    rate_valid: Array
+    residual_norm: Array
+    residual_threshold: Array
+    differential_residual_norm: Array
+    constraint_norm: Array
+    valid: Array
+    status: Array
+    nonlinear_result: NonlinearResult | None
+    initialization_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        state: Array,
+        state_rate: Array,
+        state_correction: Array,
+        rate_correction: Array,
+        fixed_state_mask: Array,
+        fixed_rate_mask: Array,
+        rate_valid: Array,
+        residual_norm: Array,
+        residual_threshold: Array,
+        differential_residual_norm: Array,
+        constraint_norm: Array,
+        valid: Array,
+        status: Array,
+        nonlinear_result: NonlinearResult | None,
+        initialization_id: str,
+    ):
+        if nonlinear_result is not None and not isinstance(
+            nonlinear_result, NonlinearResult
+        ):
+            raise TypeError("nonlinear_result must be a NonlinearResult or None.")
+        self.state = jnp.asarray(state)
+        self.state_rate = jnp.asarray(state_rate)
+        self.state_correction = jnp.asarray(state_correction)
+        self.rate_correction = jnp.asarray(rate_correction)
+        self.fixed_state_mask = jnp.asarray(fixed_state_mask, dtype=bool)
+        self.fixed_rate_mask = jnp.asarray(fixed_rate_mask, dtype=bool)
+        self.rate_valid = jnp.asarray(rate_valid, dtype=bool)
+        self.residual_norm = jnp.asarray(residual_norm)
+        self.residual_threshold = jnp.asarray(residual_threshold)
+        self.differential_residual_norm = jnp.asarray(differential_residual_norm)
+        self.constraint_norm = jnp.asarray(constraint_norm)
+        self.valid = jnp.asarray(valid, dtype=bool)
+        self.status = jnp.asarray(status, dtype=jnp.int32)
+        self.nonlinear_result = nonlinear_result
+        self.initialization_id = str(initialization_id)
+
+    @property
+    def nonlinear_iterations(self) -> Array:
+        if self.nonlinear_result is None:
+            return jnp.asarray(0, dtype=jnp.int32)
+        return self.nonlinear_result.diagnostics.iterations
+
+    @property
+    def linear_iterations(self) -> Array:
+        if self.nonlinear_result is None:
+            return jnp.asarray(0, dtype=jnp.int32)
+        return self.nonlinear_result.diagnostics.linear_iterations
+
+
+class _DAEInitializationArguments(StrictModule):
+    time: Array
+    state_guess: Array
+    rate_guess: Array
+    model_args: Any
+
+
+class _DAEInitializationResidual(StrictModule):
+    system: DifferentialAlgebraicSystem
+    state_indices: Array
+    rate_indices: Array
+    state_unknown_count: int = eqx.field(static=True)
+
+    def __call__(
+        self,
+        unknown: Array,
+        arguments: _DAEInitializationArguments,
+        /,
+    ) -> Array:
+        flat_state = (
+            arguments.state_guess.reshape((-1,))
+            .at[self.state_indices]
+            .set(unknown[: self.state_unknown_count])
+        )
+        flat_rate = (
+            arguments.rate_guess.reshape((-1,))
+            .at[self.rate_indices]
+            .set(unknown[self.state_unknown_count :])
+        )
+        state = flat_state.reshape(self.system.state_shape)
+        state_rate = flat_rate.reshape(self.system.state_shape)
+        return self.system.scaled_residual(
+            arguments.time,
+            state,
+            state_rate,
+            arguments.model_args,
+        ).reshape(unknown.shape)
+
+
+class _PreparedDAEInitialization(StrictModule):
+    system: DifferentialAlgebraicSystem
+    spec: DAEInitializationSpec
+    fixed_state_mask: Array
+    fixed_rate_mask: Array
+    state_indices: Array
+    rate_indices: Array
+    nonlinear_problem: NonlinearSystemProblem | None
+    nonlinear_solve: PreparedNonlinearSolve | None
+    state_unknown_count: int = eqx.field(static=True)
+    preparation_id: str = eqx.field(static=True)
+
+
+def _role_mask(
+    system: DifferentialAlgebraicSystem,
+    roles: tuple[str, ...],
+    selected: str,
+    /,
+) -> np.ndarray:
+    axis = system.structure.resolved_axis(system.state_shape)
+    if axis is None:
+        return np.full(system.state_shape, roles[0] == selected, dtype=bool)
+    component = np.asarray(tuple(role == selected for role in roles), dtype=bool)
+    reshape = [1] * len(system.state_shape)
+    reshape[axis] = component.size
+    return np.broadcast_to(component.reshape(tuple(reshape)), system.state_shape)
+
+
+def _fixed_masks(
+    system: DifferentialAlgebraicSystem,
+    spec: DAEInitializationSpec,
+    /,
+) -> tuple[np.ndarray, np.ndarray]:
+    if spec.mode == "index-one":
+        fixed_state = _role_mask(
+            system,
+            system.structure.variable_roles,
+            "differential",
+        )
+        fixed_rate = _role_mask(
+            system,
+            system.structure.variable_roles,
+            "algebraic",
+        )
+    elif spec.mode == "fixed-rate":
+        fixed_state = np.zeros(system.state_shape, dtype=bool)
+        fixed_rate = np.ones(system.state_shape, dtype=bool)
+    elif spec.mode == "check":
+        fixed_state = np.ones(system.state_shape, dtype=bool)
+        fixed_rate = np.ones(system.state_shape, dtype=bool)
+    else:
+        assert spec.fixed_state is not None and spec.fixed_rate is not None
+        if len(spec.fixed_state) != system.state_size:
+            raise ValueError(
+                "Custom DAE initialization masks must contain exactly "
+                f"{system.state_size} entries."
+            )
+        fixed_state = np.asarray(spec.fixed_state, dtype=bool).reshape(system.state_shape)
+        fixed_rate = np.asarray(spec.fixed_rate, dtype=bool).reshape(system.state_shape)
+    if spec.mode != "check":
+        free_count = int(np.count_nonzero(~fixed_state) + np.count_nonzero(~fixed_rate))
+        if free_count != system.state_size:
+            raise ValueError(
+                "A square DAE consistency solve requires exactly one free state/rate "
+                f"unknown per residual scalar; got {free_count} free values and "
+                f"{system.state_size} residuals."
+            )
+    return fixed_state, fixed_rate
+
+
+def _inexact(value: ArrayLike, /) -> Array:
+    array = jnp.asarray(value)
+    return array if jnp.issubdtype(array.dtype, jnp.inexact) else array.astype(float)
+
+
+def _validated_guesses(
+    system: DifferentialAlgebraicSystem,
+    state: ArrayLike,
+    state_rate: ArrayLike,
+    /,
+) -> tuple[Array, Array]:
+    state_array = _inexact(state)
+    rate_array = _inexact(state_rate)
+    if state_array.shape != system.state_shape or rate_array.shape != system.state_shape:
+        raise ValueError(
+            f"Initial state and rate must both have shape {system.state_shape}."
+        )
+    if state_array.dtype != rate_array.dtype:
+        raise TypeError("Initial state and rate must have the same dtype.")
+    state_array = eqx.error_if(
+        state_array,
+        jnp.any(~jnp.isfinite(state_array)) | jnp.any(~jnp.isfinite(rate_array)),
+        "DAE initial state and rate must be finite.",
+    )
+    state_array = eqx.error_if(
+        state_array,
+        ~jnp.asarray(system.state_geometry.contains(state_array), dtype=bool),
+        "DAE initial state is outside its state geometry.",
+    )
+    return state_array, rate_array
+
+
+def _scaled_space(
+    shape: tuple[int, ...],
+    dtype: Any,
+    scale: Array,
+    /,
+    *,
+    space_id: str,
+) -> ArraySpace:
+    count = prod(shape)
+    weights = 1.0 / (count * jnp.square(scale.astype(dtype)))
+    return ArraySpace(
+        shape,
+        dtype=dtype,
+        pairing=DiagonalPairing(weights, pairing_id=f"{space_id}:pairing"),
+        space_id=space_id,
+    )
+
+
+def _masked_rms(values: Array, mask: Array, /) -> Array:
+    count = jnp.sum(mask)
+    squared = jnp.where(mask, jnp.square(jnp.abs(values)), 0.0)
+    return jnp.sqrt(jnp.sum(squared) / jnp.maximum(count, 1))
+
+
+def _unknown_guess(
+    state: Array,
+    state_rate: Array,
+    state_indices: Array,
+    rate_indices: Array,
+    /,
+) -> Array:
+    return jnp.concatenate(
+        (
+            state.reshape((-1,))[state_indices],
+            state_rate.reshape((-1,))[rate_indices],
+        )
+    )
+
+
+def _prepare_dae_initialization(
+    system: DifferentialAlgebraicSystem,
+    initial_state: ArrayLike,
+    initial_state_rate: ArrayLike,
+    time: ArrayLike,
+    /,
+    *,
+    args: Any,
+    spec: DAEInitializationSpec,
+    method: AbstractNonlinearMethod,
+    termination: NonlinearTermination,
+) -> _PreparedDAEInitialization:
+    if not isinstance(system, DifferentialAlgebraicSystem):
+        raise TypeError("system must be a DifferentialAlgebraicSystem.")
+    if not isinstance(spec, DAEInitializationSpec):
+        raise TypeError("spec must be a DAEInitializationSpec.")
+    state, state_rate = _validated_guesses(system, initial_state, initial_state_rate)
+    fixed_state_host, fixed_rate_host = _fixed_masks(system, spec)
+    fixed_state = jnp.asarray(fixed_state_host, dtype=bool)
+    fixed_rate = jnp.asarray(fixed_rate_host, dtype=bool)
+    state_indices = jnp.asarray(np.flatnonzero(~fixed_state_host), dtype=jnp.int32)
+    rate_indices = jnp.asarray(np.flatnonzero(~fixed_rate_host), dtype=jnp.int32)
+    state_unknown_count = int(state_indices.size)
+
+    if spec.mode == "check":
+        nonlinear_problem = None
+        nonlinear_solve = None
+        linear_plan_id = "check-only"
+    else:
+        residual_function = _DAEInitializationResidual(
+            system,
+            state_indices,
+            rate_indices,
+            state_unknown_count,
+        )
+        unknown = _unknown_guess(
+            state,
+            state_rate,
+            state_indices,
+            rate_indices,
+        )
+        flat_state_scale = system.state_scale.astype(state.dtype).reshape((-1,))
+        flat_rate_scale = system.state_rate_scale.astype(state.dtype).reshape((-1,))
+        unknown_scale = jnp.concatenate(
+            (
+                flat_state_scale[state_indices],
+                flat_rate_scale[rate_indices],
+            )
+        )
+        state_space = _scaled_space(
+            unknown.shape,
+            unknown.dtype,
+            unknown_scale,
+            space_id=f"{system.system_id}:{spec.initialization_id}:unknowns",
+        )
+        residual_space = _scaled_space(
+            unknown.shape,
+            unknown.dtype,
+            jnp.ones_like(unknown_scale),
+            space_id=f"{system.system_id}:{spec.initialization_id}:residuals",
+        )
+        nonlinear_problem = NonlinearSystemProblem(
+            residual_function,
+            state_space=state_space,
+            residual_space=residual_space,
+            problem_id=f"{system.system_id}:{spec.initialization_id}:root",
+        )
+        arguments = _DAEInitializationArguments(
+            jnp.asarray(time),
+            state,
+            state_rate,
+            args,
+        )
+        nonlinear_solve = prepare_nonlinear(
+            nonlinear_problem,
+            unknown,
+            method=method,
+            termination=termination,
+            args=arguments,
+        )
+        linear_plan_id = nonlinear_solve.linear_plan_id
+
+    digest = hashlib.sha256()
+    digest.update(
+        repr(
+            (
+                system.system_id,
+                spec.initialization_id,
+                method.method_id,
+                linear_plan_id,
+            )
+        ).encode("utf-8")
+    )
+    return _PreparedDAEInitialization(
+        system,
+        spec,
+        fixed_state,
+        fixed_rate,
+        state_indices,
+        rate_indices,
+        nonlinear_problem,
+        nonlinear_solve,
+        state_unknown_count,
+        f"prepared-dae-initialization:{digest.hexdigest()}",
+    )
+
+
+def _unpack_unknown(
+    prepared: _PreparedDAEInitialization,
+    unknown: Array,
+    state_guess: Array,
+    rate_guess: Array,
+    /,
+) -> tuple[Array, Array]:
+    state_flat = (
+        state_guess.reshape((-1,))
+        .at[prepared.state_indices]
+        .set(unknown[: prepared.state_unknown_count])
+    )
+    rate_flat = (
+        rate_guess.reshape((-1,))
+        .at[prepared.rate_indices]
+        .set(unknown[prepared.state_unknown_count :])
+    )
+    return (
+        state_flat.reshape(prepared.system.state_shape),
+        rate_flat.reshape(prepared.system.state_shape),
+    )
+
+
+def _initialize_dae(
+    prepared: _PreparedDAEInitialization,
+    initial_state: ArrayLike,
+    initial_state_rate: ArrayLike,
+    time: ArrayLike,
+    /,
+    *,
+    args: Any,
+    termination: NonlinearTermination,
+) -> DAEInitializationResult:
+    if not isinstance(prepared, _PreparedDAEInitialization):
+        raise TypeError("prepared must be prepared DAE initialization data.")
+    state_guess, rate_guess = _validated_guesses(
+        prepared.system,
+        initial_state,
+        initial_state_rate,
+    )
+    arguments = _DAEInitializationArguments(
+        jnp.asarray(time),
+        state_guess,
+        rate_guess,
+        args,
+    )
+
+    if prepared.spec.mode == "check":
+        state = state_guess
+        state_rate = rate_guess
+        nonlinear_result = None
+        nonlinear_success = jnp.asarray(True)
+        initial_residual_norm = _masked_rms(
+            prepared.system.scaled_residual(
+                arguments.time,
+                state,
+                state_rate,
+                args,
+            ),
+            jnp.ones(prepared.system.state_shape, dtype=bool),
+        )
+    else:
+        assert prepared.nonlinear_problem is not None
+        assert prepared.nonlinear_solve is not None
+        unknown = _unknown_guess(
+            state_guess,
+            rate_guess,
+            prepared.state_indices,
+            prepared.rate_indices,
+        )
+        refreshed = refresh_nonlinear(
+            prepared.nonlinear_solve,
+            prepared.nonlinear_problem,
+            unknown,
+            args=arguments,
+        )
+        nonlinear_result = implicit_root_result(refreshed)
+        state, state_rate = _unpack_unknown(
+            prepared,
+            nonlinear_result.state,
+            state_guess,
+            rate_guess,
+        )
+        nonlinear_success = nonlinear_result.status == int(NonlinearStatus.SUCCESS)
+        initial_residual_norm = nonlinear_result.diagnostics.initial_residual_norm
+
+    scaled_residual = prepared.system.scaled_residual(
+        arguments.time,
+        state,
+        state_rate,
+        args,
+    )
+    differential_equations = prepared.system.structure.differential_equation_mask(
+        prepared.system.state_shape
+    )
+    algebraic_equations = prepared.system.structure.algebraic_equation_mask(
+        prepared.system.state_shape
+    )
+    residual_norm = _masked_rms(
+        scaled_residual,
+        jnp.ones(prepared.system.state_shape, dtype=bool),
+    )
+    residual_threshold = termination.residual_threshold(initial_residual_norm)
+    differential_norm = _masked_rms(scaled_residual, differential_equations)
+    constraint_norm = _masked_rms(scaled_residual, algebraic_equations)
+    finite = (
+        jnp.all(jnp.isfinite(state))
+        & jnp.all(jnp.isfinite(state_rate))
+        & jnp.isfinite(residual_norm)
+    )
+    residual_accepted = residual_norm <= residual_threshold
+    valid = nonlinear_success & finite & residual_accepted
+    status = jnp.where(
+        ~finite,
+        int(DAEInitializationStatus.NONFINITE),
+        jnp.where(
+            ~nonlinear_success,
+            int(DAEInitializationStatus.NONLINEAR_FAILED),
+            jnp.where(
+                ~residual_accepted,
+                int(DAEInitializationStatus.RESIDUAL_TOO_LARGE),
+                int(DAEInitializationStatus.SUCCESS),
+            ),
+        ),
+    ).astype(jnp.int32)
+    rate_valid = (
+        prepared.system.structure.differential_variable_mask(prepared.system.state_shape)
+        if prepared.spec.mode == "index-one"
+        else jnp.ones(prepared.system.state_shape, dtype=bool)
+    )
+    return DAEInitializationResult(
+        state=state,
+        state_rate=state_rate,
+        state_correction=state - state_guess,
+        rate_correction=state_rate - rate_guess,
+        fixed_state_mask=prepared.fixed_state_mask,
+        fixed_rate_mask=prepared.fixed_rate_mask,
+        rate_valid=rate_valid & valid,
+        residual_norm=residual_norm,
+        residual_threshold=residual_threshold,
+        differential_residual_norm=differential_norm,
+        constraint_norm=constraint_norm,
+        valid=valid,
+        status=status,
+        nonlinear_result=nonlinear_result,
+        initialization_id=prepared.spec.initialization_id,
+    )
+
+
+__all__ = [
+    "DAEInitializationMode",
+    "DAEInitializationResult",
+    "DAEInitializationSpec",
+    "DAEInitializationStatus",
+]

--- a/phydrax/solver/_differential_algebraic.py
+++ b/phydrax/solver/_differential_algebraic.py
@@ -1,0 +1,1092 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import hashlib
+import math
+from enum import IntEnum
+from typing import Any, Literal, TypeAlias
+
+import equinox as eqx
+import jax.lax as lax
+import jax.numpy as jnp
+import numpy as np
+from jaxtyping import Array, ArrayLike
+
+from .._strict import StrictModule
+from ..dynamics import DifferentialAlgebraicSystem, TimeGrid
+from ..nonlinear import (
+    AbstractNonlinearMethod,
+    implicit_root_result,
+    NewtonKrylov,
+    NewtonTrustRegion,
+    NonlinearStatus,
+    NonlinearSystemProblem,
+    NonlinearTermination,
+    prepare_nonlinear,
+    PreparedNonlinearSolve,
+    refresh_nonlinear,
+)
+from ._dae_initialization import (
+    _initialize_dae,
+    _masked_rms,
+    _prepare_dae_initialization,
+    _PreparedDAEInitialization,
+    _scaled_space,
+    DAEInitializationResult,
+    DAEInitializationSpec,
+)
+from ._solution_validation import validate_solution_arrays
+
+
+DAEIntegrationMethod: TypeAlias = Literal["bdf1", "bdf2"]
+DAEFailureMode: TypeAlias = Literal["status", "error"]
+_DEFAULT_ARGS = object()
+
+
+class DAEStatus(IntEnum):
+    SUCCESS = 0
+    INITIALIZATION_FAILED = 1
+    NONLINEAR_FAILED = 2
+    LINEAR_FAILED = 3
+    NONFINITE = 4
+    RESIDUAL_TOO_LARGE = 5
+    NOT_RUN = 6
+
+
+def _identifier(value: str | None, payload: object, prefix: str, /) -> str:
+    if value is not None:
+        if not isinstance(value, str) or not value:
+            raise ValueError(f"{prefix} identifier must be a non-empty string or None.")
+        return value
+    digest = hashlib.sha256(repr(payload).encode("utf-8")).hexdigest()
+    return f"{prefix}:{digest}"
+
+
+def _inexact(value: ArrayLike, /) -> Array:
+    array = jnp.asarray(value)
+    return array if jnp.issubdtype(array.dtype, jnp.inexact) else array.astype(float)
+
+
+def _method_identity(method: NewtonKrylov | NewtonTrustRegion, /) -> tuple[str, ...]:
+    globalization = (
+        method.line_search if isinstance(method, NewtonKrylov) else method.trust_region
+    )
+    return (
+        method.method_id,
+        method.jacobian_policy.policy_id,
+        repr(method.linear_policy),
+        repr(method.forcing_policy),
+        repr(method.jacobian_refresh),
+        repr(globalization),
+    )
+
+
+def _termination_identity(termination: NonlinearTermination, /) -> tuple[Any, ...]:
+    return (
+        termination.absolute_residual,
+        termination.relative_residual,
+        termination.absolute_step,
+        termination.relative_step,
+        termination.maximum_steps,
+        termination.maximum_evaluations,
+        termination.maximum_linear_iterations,
+        termination.divergence_factor,
+    )
+
+
+class DAESolvePolicy(StrictModule):
+    """Fixed-grid BDF integration and native nonlinear solve policy."""
+
+    nonlinear_method: NewtonKrylov | NewtonTrustRegion
+    nonlinear_termination: NonlinearTermination
+    initialization_method: NewtonKrylov | NewtonTrustRegion
+    initialization_termination: NonlinearTermination
+    integration_method: DAEIntegrationMethod = eqx.field(static=True)
+    max_step_ratio: float = eqx.field(static=True)
+    failure: DAEFailureMode = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        integration_method: DAEIntegrationMethod = "bdf2",
+        nonlinear_method: AbstractNonlinearMethod | None = None,
+        nonlinear_termination: NonlinearTermination | None = None,
+        initialization_method: AbstractNonlinearMethod | None = None,
+        initialization_termination: NonlinearTermination | None = None,
+        max_step_ratio: float = 2.0,
+        failure: DAEFailureMode = "status",
+    ):
+        if integration_method not in ("bdf1", "bdf2"):
+            raise ValueError("integration_method must be 'bdf1' or 'bdf2'.")
+        stage_method = NewtonKrylov() if nonlinear_method is None else nonlinear_method
+        initial_method = (
+            NewtonKrylov() if initialization_method is None else initialization_method
+        )
+        if not isinstance(stage_method, (NewtonKrylov, NewtonTrustRegion)):
+            raise TypeError(
+                "nonlinear_method must be NewtonKrylov, NewtonTrustRegion, or None."
+            )
+        if not isinstance(initial_method, (NewtonKrylov, NewtonTrustRegion)):
+            raise TypeError(
+                "initialization_method must be NewtonKrylov, NewtonTrustRegion, or None."
+            )
+        stage_termination = (
+            NonlinearTermination(
+                absolute_residual=1e-8,
+                relative_residual=0.0,
+                maximum_steps=12,
+            )
+            if nonlinear_termination is None
+            else nonlinear_termination
+        )
+        initial_termination = (
+            NonlinearTermination(
+                absolute_residual=1e-8,
+                relative_residual=0.0,
+                maximum_steps=32,
+            )
+            if initialization_termination is None
+            else initialization_termination
+        )
+        if not isinstance(stage_termination, NonlinearTermination):
+            raise TypeError(
+                "nonlinear_termination must be a NonlinearTermination or None."
+            )
+        if not isinstance(initial_termination, NonlinearTermination):
+            raise TypeError(
+                "initialization_termination must be a NonlinearTermination or None."
+            )
+        ratio = float(max_step_ratio)
+        if not math.isfinite(ratio) or ratio < 1.0:
+            raise ValueError("max_step_ratio must be finite and at least one.")
+        if failure not in ("status", "error"):
+            raise ValueError("failure must be 'status' or 'error'.")
+        self.nonlinear_method = stage_method
+        self.nonlinear_termination = stage_termination
+        self.initialization_method = initial_method
+        self.initialization_termination = initial_termination
+        self.integration_method = integration_method
+        self.max_step_ratio = ratio
+        self.failure = failure
+
+
+class DifferentialAlgebraicProblem(StrictModule):
+    """Implicit initial-value problem with an explicit consistency contract."""
+
+    system: DifferentialAlgebraicSystem
+    initial_state: Array
+    initial_state_rate: Array
+    args: Any
+    initialization: DAEInitializationSpec
+    problem_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        system: DifferentialAlgebraicSystem,
+        initial_state: ArrayLike,
+        /,
+        *,
+        initial_state_rate: ArrayLike | None = None,
+        args: Any = None,
+        initialization: DAEInitializationSpec | None = None,
+        problem_id: str | None = None,
+    ):
+        if not isinstance(system, DifferentialAlgebraicSystem):
+            raise TypeError("system must be a DifferentialAlgebraicSystem.")
+        state = _inexact(initial_state)
+        state_rate = (
+            jnp.zeros_like(state)
+            if initial_state_rate is None
+            else _inexact(initial_state_rate)
+        )
+        if state.shape != system.state_shape or state_rate.shape != system.state_shape:
+            raise ValueError(
+                f"Initial state and rate must both have shape {system.state_shape}."
+            )
+        if state.dtype != state_rate.dtype:
+            raise TypeError("Initial state and rate must have the same dtype.")
+        state = eqx.error_if(
+            state,
+            jnp.any(~jnp.isfinite(state)) | jnp.any(~jnp.isfinite(state_rate)),
+            "DAE initial state and rate must be finite.",
+        )
+        state = eqx.error_if(
+            state,
+            ~jnp.asarray(system.state_geometry.contains(state), dtype=bool),
+            "DAE initial state is outside its state geometry.",
+        )
+        initial_spec = (
+            DAEInitializationSpec.index_one()
+            if initialization is None
+            else initialization
+        )
+        if not isinstance(initial_spec, DAEInitializationSpec):
+            raise TypeError("initialization must be a DAEInitializationSpec or None.")
+        self.system = system
+        self.initial_state = state
+        self.initial_state_rate = state_rate
+        self.args = args
+        self.initialization = initial_spec
+        self.problem_id = _identifier(
+            problem_id,
+            (
+                system.system_id,
+                system.state_shape,
+                np.dtype(state.dtype).str,
+                initial_spec.initialization_id,
+            ),
+            "dae-problem",
+        )
+
+
+class DAESolvePlan(StrictModule):
+    """Validated fixed-grid DAE integration policy and structural identity."""
+
+    policy: DAESolvePolicy
+    system_id: str = eqx.field(static=True)
+    problem_id: str = eqx.field(static=True)
+    time_id: str = eqx.field(static=True)
+    state_shape: tuple[int, ...] = eqx.field(static=True)
+    state_dtype: str = eqx.field(static=True)
+    num_steps: int = eqx.field(static=True)
+    plan_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        problem: DifferentialAlgebraicProblem,
+        time_grid: TimeGrid,
+        policy: DAESolvePolicy,
+        /,
+    ):
+        if not isinstance(problem, DifferentialAlgebraicProblem):
+            raise TypeError("problem must be a DifferentialAlgebraicProblem.")
+        if not isinstance(time_grid, TimeGrid):
+            raise TypeError("time_grid must be a TimeGrid.")
+        if not isinstance(policy, DAESolvePolicy):
+            raise TypeError("policy must be a DAESolvePolicy.")
+        durations = np.asarray(time_grid.durations, dtype=float)
+        if policy.integration_method == "bdf2" and durations.size > 1:
+            ratios = durations[1:] / durations[:-1]
+            if np.any(ratios > policy.max_step_ratio) or np.any(
+                ratios < 1.0 / policy.max_step_ratio
+            ):
+                raise ValueError(
+                    "BDF2 adjacent step ratios exceed the declared max_step_ratio."
+                )
+        self.policy = policy
+        self.system_id = problem.system.system_id
+        self.problem_id = problem.problem_id
+        self.time_id = time_grid.time_id
+        self.state_shape = problem.system.state_shape
+        self.state_dtype = np.dtype(problem.initial_state.dtype).str
+        self.num_steps = time_grid.num_steps
+        self.plan_id = _identifier(
+            None,
+            (
+                self.system_id,
+                self.problem_id,
+                self.time_id,
+                self.state_shape,
+                self.state_dtype,
+                policy.integration_method,
+                policy.max_step_ratio,
+                _method_identity(policy.nonlinear_method),
+                _termination_identity(policy.nonlinear_termination),
+                _method_identity(policy.initialization_method),
+                _termination_identity(policy.initialization_termination),
+            ),
+            "dae-plan",
+        )
+
+
+def _bdf_rate(
+    state: Array,
+    previous: Array,
+    previous_previous: Array,
+    step_size: Array,
+    previous_step_size: Array,
+    order: Array,
+    /,
+) -> Array:
+    def first_order(_):
+        return (state - previous) / step_size
+
+    def second_order(_):
+        ratio = step_size / previous_step_size
+        return (
+            ((1.0 + 2.0 * ratio) / (1.0 + ratio)) * state
+            - (1.0 + ratio) * previous
+            + (ratio * ratio / (1.0 + ratio)) * previous_previous
+        ) / step_size
+
+    return lax.cond(order == 1, first_order, second_order, operand=None)
+
+
+def _predict(
+    previous: Array,
+    previous_previous: Array,
+    previous_rate: Array,
+    step_size: Array,
+    previous_step_size: Array,
+    order: Array,
+    /,
+) -> Array:
+    return lax.cond(
+        order == 1,
+        lambda _: previous + step_size * previous_rate,
+        lambda _: (
+            previous + (step_size / previous_step_size) * (previous - previous_previous)
+        ),
+        operand=None,
+    )
+
+
+class _DAEStageArguments(StrictModule):
+    time: Array
+    previous: Array
+    previous_previous: Array
+    step_size: Array
+    previous_step_size: Array
+    order: Array
+    model_args: Any
+
+
+class _DAEStageResidual(StrictModule):
+    system: DifferentialAlgebraicSystem
+
+    def __call__(self, state: Array, arguments: _DAEStageArguments, /) -> Array:
+        state_rate = _bdf_rate(
+            state,
+            arguments.previous,
+            arguments.previous_previous,
+            arguments.step_size,
+            arguments.previous_step_size,
+            arguments.order,
+        )
+        return self.system.scaled_residual(
+            arguments.time,
+            state,
+            state_rate,
+            arguments.model_args,
+        )
+
+
+def _stage_arguments(
+    *,
+    time: Array,
+    previous: Array,
+    previous_previous: Array,
+    step_size: Array,
+    previous_step_size: Array,
+    order: Array,
+    model_args: Any,
+) -> _DAEStageArguments:
+    return _DAEStageArguments(
+        time,
+        previous,
+        previous_previous,
+        step_size,
+        previous_step_size,
+        order,
+        model_args,
+    )
+
+
+class PreparedDAESolve(StrictModule):
+    """DAE problem, grid, consistency root, and reusable BDF-stage root."""
+
+    problem: DifferentialAlgebraicProblem
+    time_grid: TimeGrid
+    plan: DAESolvePlan
+    initialization: _PreparedDAEInitialization
+    stage_problem: NonlinearSystemProblem
+    stage_solve: PreparedNonlinearSolve
+    prepared_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        problem: DifferentialAlgebraicProblem,
+        time_grid: TimeGrid,
+        plan: DAESolvePlan,
+        initialization: _PreparedDAEInitialization,
+        stage_problem: NonlinearSystemProblem,
+        stage_solve: PreparedNonlinearSolve,
+        /,
+    ):
+        if (
+            plan.problem_id != problem.problem_id
+            or plan.system_id != problem.system.system_id
+        ):
+            raise ValueError("DAE plan and problem identities must match.")
+        if plan.time_id != time_grid.time_id or plan.num_steps != time_grid.num_steps:
+            raise ValueError("DAE plan and TimeGrid identities must match.")
+        self.problem = problem
+        self.time_grid = time_grid
+        self.plan = plan
+        self.initialization = initialization
+        self.stage_problem = stage_problem
+        self.stage_solve = stage_solve
+        self.prepared_id = _identifier(
+            None,
+            (
+                plan.plan_id,
+                initialization.preparation_id,
+                stage_solve.linear_template_id,
+            ),
+            "prepared-dae",
+        )
+
+    @property
+    def stage_linear_plan_id(self) -> str:
+        return self.stage_solve.linear_plan_id
+
+    @property
+    def initialization_linear_plan_id(self) -> str:
+        nonlinear_solve = self.initialization.nonlinear_solve
+        return "" if nonlinear_solve is None else nonlinear_solve.linear_plan_id
+
+
+class DifferentialAlgebraicSolution(StrictModule):
+    """Fixed-grid DAE trajectory with node, step, and nonlinear evidence."""
+
+    times: Array
+    states: Array
+    state_rates: Array
+    valid: Array
+    rate_valid: Array
+    status: Array
+    residual_norm: Array
+    residual_threshold: Array
+    differential_residual_norm: Array
+    constraint_norm: Array
+    step_sizes: Array
+    orders: Array
+    nonlinear_status: Array
+    nonlinear_status_valid: Array
+    nonlinear_iterations: Array
+    residual_evaluations: Array
+    jacobian_preparations: Array
+    linear_solves: Array
+    linear_iterations: Array
+    globalization_rejections: Array
+    setup_refreshes: Array
+    numeric_refreshes: Array
+    initialization: DAEInitializationResult
+    sample_shape: tuple[int, ...] = eqx.field(static=True)
+    state_shape: tuple[int, ...] = eqx.field(static=True)
+    problem_id: str = eqx.field(static=True)
+    system_id: str = eqx.field(static=True)
+    time_id: str = eqx.field(static=True)
+    plan_id: str = eqx.field(static=True)
+    prepared_id: str = eqx.field(static=True)
+    nonlinear_method_id: str = eqx.field(static=True)
+    stage_linear_plan_id: str = eqx.field(static=True)
+    initialization_linear_plan_id: str = eqx.field(static=True)
+    integration_method: DAEIntegrationMethod = eqx.field(static=True)
+    differentiation_mode: str = eqx.field(static=True)
+    grid_origin: str = eqx.field(static=True)
+    approximation_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        times: Array,
+        states: Array,
+        state_rates: Array,
+        valid: Array,
+        rate_valid: Array,
+        status: Array,
+        residual_norm: Array,
+        residual_threshold: Array,
+        differential_residual_norm: Array,
+        constraint_norm: Array,
+        step_sizes: Array,
+        orders: Array,
+        nonlinear_status: Array,
+        nonlinear_status_valid: Array,
+        nonlinear_iterations: Array,
+        residual_evaluations: Array,
+        jacobian_preparations: Array,
+        linear_solves: Array,
+        linear_iterations: Array,
+        globalization_rejections: Array,
+        setup_refreshes: Array,
+        numeric_refreshes: Array,
+        initialization: DAEInitializationResult,
+        problem_id: str,
+        system_id: str,
+        time_id: str,
+        plan_id: str,
+        prepared_id: str,
+        nonlinear_method_id: str,
+        stage_linear_plan_id: str,
+        initialization_linear_plan_id: str,
+        integration_method: DAEIntegrationMethod,
+    ):
+        validated = validate_solution_arrays(
+            times,
+            states,
+            valid,
+            sample_shape=(),
+            state_shape=tuple(state_rates.shape[1:]),
+            time_layout="shared",
+            owner="DifferentialAlgebraicSolution",
+        )
+        if state_rates.shape != validated.states.shape:
+            raise ValueError("DAE state_rates must have the same shape as states.")
+        if rate_valid.shape != validated.states.shape:
+            raise ValueError("DAE rate_valid must have the same shape as states.")
+        node_shape = (int(validated.times.size),)
+        for values, name in (
+            (status, "status"),
+            (residual_norm, "residual_norm"),
+            (residual_threshold, "residual_threshold"),
+            (differential_residual_norm, "differential_residual_norm"),
+            (constraint_norm, "constraint_norm"),
+        ):
+            if jnp.asarray(values).shape != node_shape:
+                raise ValueError(f"DAE {name} must have shape {node_shape}.")
+        step_shape = (int(validated.times.size) - 1,)
+        step_values = (
+            (step_sizes, "step_sizes"),
+            (orders, "orders"),
+            (nonlinear_status, "nonlinear_status"),
+            (nonlinear_status_valid, "nonlinear_status_valid"),
+            (nonlinear_iterations, "nonlinear_iterations"),
+            (residual_evaluations, "residual_evaluations"),
+            (jacobian_preparations, "jacobian_preparations"),
+            (linear_solves, "linear_solves"),
+            (linear_iterations, "linear_iterations"),
+            (globalization_rejections, "globalization_rejections"),
+            (setup_refreshes, "setup_refreshes"),
+            (numeric_refreshes, "numeric_refreshes"),
+        )
+        for values, name in step_values:
+            if jnp.asarray(values).shape != step_shape:
+                raise ValueError(f"DAE {name} must have shape {step_shape}.")
+        self.times = validated.times
+        self.states = validated.states
+        self.state_rates = jnp.asarray(state_rates)
+        self.valid = validated.valid
+        self.rate_valid = jnp.asarray(rate_valid, dtype=bool)
+        self.status = jnp.asarray(status, dtype=jnp.int32)
+        self.residual_norm = jnp.asarray(residual_norm)
+        self.residual_threshold = jnp.asarray(residual_threshold)
+        self.differential_residual_norm = jnp.asarray(differential_residual_norm)
+        self.constraint_norm = jnp.asarray(constraint_norm)
+        self.step_sizes = jnp.asarray(step_sizes)
+        self.orders = jnp.asarray(orders, dtype=jnp.int32)
+        self.nonlinear_status = jnp.asarray(nonlinear_status, dtype=jnp.int32)
+        self.nonlinear_status_valid = jnp.asarray(nonlinear_status_valid, dtype=bool)
+        self.nonlinear_iterations = jnp.asarray(nonlinear_iterations, dtype=jnp.int32)
+        self.residual_evaluations = jnp.asarray(residual_evaluations, dtype=jnp.int32)
+        self.jacobian_preparations = jnp.asarray(
+            jacobian_preparations,
+            dtype=jnp.int32,
+        )
+        self.linear_solves = jnp.asarray(linear_solves, dtype=jnp.int32)
+        self.linear_iterations = jnp.asarray(linear_iterations, dtype=jnp.int32)
+        self.globalization_rejections = jnp.asarray(
+            globalization_rejections,
+            dtype=jnp.int32,
+        )
+        self.setup_refreshes = jnp.asarray(setup_refreshes, dtype=jnp.int32)
+        self.numeric_refreshes = jnp.asarray(numeric_refreshes, dtype=jnp.int32)
+        self.initialization = initialization
+        self.sample_shape = validated.sample_shape
+        self.state_shape = validated.state_shape
+        self.problem_id = str(problem_id)
+        self.system_id = str(system_id)
+        self.time_id = str(time_id)
+        self.plan_id = str(plan_id)
+        self.prepared_id = str(prepared_id)
+        self.nonlinear_method_id = str(nonlinear_method_id)
+        self.stage_linear_plan_id = str(stage_linear_plan_id)
+        self.initialization_linear_plan_id = str(initialization_linear_plan_id)
+        self.integration_method = integration_method
+        self.differentiation_mode = "fixed-grid-discrete-implicit"
+        self.grid_origin = "user"
+        self.approximation_id = f"fixed-grid-{integration_method}"
+
+    @property
+    def successful(self) -> Array:
+        return jnp.all(self.valid)
+
+
+def plan_dae(
+    problem: DifferentialAlgebraicProblem,
+    time_grid: TimeGrid,
+    /,
+    *,
+    policy: DAESolvePolicy | None = None,
+) -> DAESolvePlan:
+    resolved_policy = DAESolvePolicy() if policy is None else policy
+    return DAESolvePlan(problem, time_grid, resolved_policy)
+
+
+def prepare_dae(
+    problem: DifferentialAlgebraicProblem,
+    time_grid: TimeGrid,
+    /,
+    *,
+    policy: DAESolvePolicy | DAESolvePlan | None = None,
+) -> PreparedDAESolve:
+    if isinstance(policy, DAESolvePlan):
+        plan = policy
+    else:
+        plan = plan_dae(problem, time_grid, policy=policy)
+    if plan.problem_id != problem.problem_id:
+        raise ValueError("A supplied DAE plan must match the problem.")
+    resolved_policy = plan.policy
+    initialization = _prepare_dae_initialization(
+        problem.system,
+        problem.initial_state,
+        problem.initial_state_rate,
+        time_grid.times[0],
+        args=problem.args,
+        spec=problem.initialization,
+        method=resolved_policy.initialization_method,
+        termination=resolved_policy.initialization_termination,
+    )
+    step_size = time_grid.durations[0]
+    order = jnp.asarray(1, dtype=jnp.int32)
+    predictor = _predict(
+        problem.initial_state,
+        problem.initial_state,
+        problem.initial_state_rate,
+        step_size,
+        step_size,
+        order,
+    )
+    stage_arguments = _stage_arguments(
+        time=time_grid.times[1],
+        previous=problem.initial_state,
+        previous_previous=problem.initial_state,
+        step_size=step_size,
+        previous_step_size=step_size,
+        order=order,
+        model_args=problem.args,
+    )
+    state_space = _scaled_space(
+        problem.system.state_shape,
+        problem.initial_state.dtype,
+        problem.system.state_scale,
+        space_id=f"{problem.system.system_id}:bdf-state",
+    )
+    residual_space = _scaled_space(
+        problem.system.state_shape,
+        problem.initial_state.dtype,
+        jnp.ones_like(problem.system.residual_scale),
+        space_id=f"{problem.system.system_id}:bdf-residual",
+    )
+    stage_problem = NonlinearSystemProblem(
+        _DAEStageResidual(problem.system),
+        state_space=state_space,
+        residual_space=residual_space,
+        problem_id=f"{problem.system.system_id}:bdf-stage-root",
+    )
+    stage_solve = prepare_nonlinear(
+        stage_problem,
+        predictor,
+        method=resolved_policy.nonlinear_method,
+        termination=resolved_policy.nonlinear_termination,
+        args=stage_arguments,
+    )
+    return PreparedDAESolve(
+        problem,
+        time_grid,
+        plan,
+        initialization,
+        stage_problem,
+        stage_solve,
+    )
+
+
+def initialize_dae(
+    problem: DifferentialAlgebraicProblem,
+    time: ArrayLike,
+    /,
+    *,
+    policy: DAESolvePolicy | None = None,
+    args: Any = _DEFAULT_ARGS,
+    initial_state: ArrayLike | None = None,
+    initial_state_rate: ArrayLike | None = None,
+) -> DAEInitializationResult:
+    if not isinstance(problem, DifferentialAlgebraicProblem):
+        raise TypeError("problem must be a DifferentialAlgebraicProblem.")
+    resolved_policy = DAESolvePolicy() if policy is None else policy
+    if not isinstance(resolved_policy, DAESolvePolicy):
+        raise TypeError("policy must be a DAESolvePolicy or None.")
+    runtime_args = problem.args if args is _DEFAULT_ARGS else args
+    state = problem.initial_state if initial_state is None else initial_state
+    state_rate = (
+        problem.initial_state_rate if initial_state_rate is None else initial_state_rate
+    )
+    prepared = _prepare_dae_initialization(
+        problem.system,
+        state,
+        state_rate,
+        time,
+        args=runtime_args,
+        spec=problem.initialization,
+        method=resolved_policy.initialization_method,
+        termination=resolved_policy.initialization_termination,
+    )
+    return _initialize_dae(
+        prepared,
+        state,
+        state_rate,
+        time,
+        args=runtime_args,
+        termination=resolved_policy.initialization_termination,
+    )
+
+
+def _linear_failure(status: Array, /) -> Array:
+    return (
+        (status == int(NonlinearStatus.LINEAR_SOLVE_FAILED))
+        | (status == int(NonlinearStatus.SINGULAR_JACOBIAN))
+        | (status == int(NonlinearStatus.MAXIMUM_LINEAR_ITERATIONS_REACHED))
+    )
+
+
+def _solve_prepared(
+    prepared: PreparedDAESolve,
+    /,
+    *,
+    args: Any,
+    initial_state: ArrayLike | None,
+    initial_state_rate: ArrayLike | None,
+) -> DifferentialAlgebraicSolution:
+    problem = prepared.problem
+    system = problem.system
+    policy = prepared.plan.policy
+    times = lax.stop_gradient(prepared.time_grid.times)
+    state_guess = problem.initial_state if initial_state is None else initial_state
+    rate_guess = (
+        problem.initial_state_rate if initial_state_rate is None else initial_state_rate
+    )
+    initialization = _initialize_dae(
+        prepared.initialization,
+        state_guess,
+        rate_guess,
+        times[0],
+        args=args,
+        termination=policy.initialization_termination,
+    )
+    differential_equations = system.structure.differential_equation_mask(
+        system.state_shape
+    )
+    algebraic_equations = system.structure.algebraic_equation_mask(system.state_shape)
+    indices = jnp.arange(prepared.time_grid.num_steps, dtype=jnp.int32)
+    step_sizes = jnp.diff(times)
+
+    def scan_step(carry, inputs):
+        (
+            previous,
+            previous_previous,
+            previous_rate,
+            previous_step,
+            prior_valid,
+        ) = carry
+        index, target_time, step_size = inputs
+        order = (
+            jnp.asarray(1, dtype=jnp.int32)
+            if policy.integration_method == "bdf1"
+            else jnp.where(index == 0, 1, 2).astype(jnp.int32)
+        )
+        predictor = _predict(
+            previous,
+            previous_previous,
+            previous_rate,
+            step_size,
+            previous_step,
+            order,
+        )
+
+        def solve_step(_):
+            arguments = _stage_arguments(
+                time=target_time,
+                previous=previous,
+                previous_previous=previous_previous,
+                step_size=step_size,
+                previous_step_size=previous_step,
+                order=order,
+                model_args=args,
+            )
+            refreshed = refresh_nonlinear(
+                prepared.stage_solve,
+                prepared.stage_problem,
+                predictor,
+                args=arguments,
+            )
+            nonlinear_result = implicit_root_result(refreshed)
+            state = jnp.asarray(nonlinear_result.state)
+            state_rate = _bdf_rate(
+                state,
+                previous,
+                previous_previous,
+                step_size,
+                previous_step,
+                order,
+            )
+            scaled = system.scaled_residual(
+                target_time,
+                state,
+                state_rate,
+                args,
+            )
+            residual_norm = _masked_rms(
+                scaled,
+                jnp.ones(system.state_shape, dtype=bool),
+            )
+            differential_norm = _masked_rms(scaled, differential_equations)
+            constraint_norm = _masked_rms(scaled, algebraic_equations)
+            residual_threshold = policy.nonlinear_termination.residual_threshold(
+                nonlinear_result.diagnostics.initial_residual_norm
+            )
+            nonlinear_status = nonlinear_result.status
+            nonlinear_success = nonlinear_status == int(NonlinearStatus.SUCCESS)
+            finite = (
+                jnp.all(jnp.isfinite(state))
+                & jnp.all(jnp.isfinite(state_rate))
+                & jnp.isfinite(residual_norm)
+            )
+            residual_accepted = residual_norm <= residual_threshold
+            valid = nonlinear_success & finite & residual_accepted
+            status = jnp.where(
+                ~finite,
+                int(DAEStatus.NONFINITE),
+                jnp.where(
+                    _linear_failure(nonlinear_status),
+                    int(DAEStatus.LINEAR_FAILED),
+                    jnp.where(
+                        ~nonlinear_success,
+                        int(DAEStatus.NONLINEAR_FAILED),
+                        jnp.where(
+                            ~residual_accepted,
+                            int(DAEStatus.RESIDUAL_TOO_LARGE),
+                            int(DAEStatus.SUCCESS),
+                        ),
+                    ),
+                ),
+            ).astype(jnp.int32)
+            diagnostics = nonlinear_result.diagnostics
+            return (
+                state,
+                state_rate,
+                valid,
+                status,
+                residual_norm,
+                residual_threshold,
+                differential_norm,
+                constraint_norm,
+                nonlinear_status,
+                jnp.asarray(True),
+                diagnostics.iterations,
+                diagnostics.residual_evaluations,
+                diagnostics.jacobian_preparations,
+                diagnostics.linear_solves,
+                diagnostics.linear_iterations,
+                diagnostics.rejected_steps,
+                diagnostics.setup_refreshes,
+                diagnostics.numeric_refreshes,
+            )
+
+        def skip_step(_):
+            nan_state = jnp.full_like(previous, jnp.nan)
+            zero = jnp.asarray(0, dtype=jnp.int32)
+            infinity = jnp.asarray(jnp.inf, dtype=previous.real.dtype)
+            return (
+                nan_state,
+                nan_state,
+                jnp.asarray(False),
+                jnp.asarray(int(DAEStatus.NOT_RUN), dtype=jnp.int32),
+                infinity,
+                infinity,
+                infinity,
+                infinity,
+                zero,
+                jnp.asarray(False),
+                zero,
+                zero,
+                zero,
+                zero,
+                zero,
+                zero,
+                zero,
+                zero,
+            )
+
+        output = lax.cond(prior_valid, solve_step, skip_step, operand=None)
+        state, state_rate, valid, *_ = output
+        next_carry = (
+            state,
+            previous,
+            state_rate,
+            step_size,
+            valid,
+        )
+        return next_carry, output
+
+    initial_step = step_sizes[0]
+    initial_carry = (
+        initialization.state,
+        initialization.state,
+        initialization.state_rate,
+        initial_step,
+        initialization.valid,
+    )
+    _, outputs = lax.scan(
+        scan_step,
+        initial_carry,
+        (indices, times[1:], step_sizes),
+    )
+    (
+        step_states,
+        step_rates,
+        step_valid,
+        step_status,
+        step_residual_norm,
+        step_residual_threshold,
+        step_differential_norm,
+        step_constraint_norm,
+        nonlinear_status,
+        nonlinear_status_valid,
+        nonlinear_iterations,
+        residual_evaluations,
+        jacobian_preparations,
+        linear_solves,
+        linear_iterations,
+        globalization_rejections,
+        setup_refreshes,
+        numeric_refreshes,
+    ) = outputs
+    initial_status = jnp.where(
+        initialization.valid,
+        int(DAEStatus.SUCCESS),
+        int(DAEStatus.INITIALIZATION_FAILED),
+    ).astype(jnp.int32)
+    states = jnp.concatenate((initialization.state[None, ...], step_states), axis=0)
+    state_rates = jnp.concatenate(
+        (initialization.state_rate[None, ...], step_rates),
+        axis=0,
+    )
+    valid = jnp.concatenate((initialization.valid[None], step_valid), axis=0)
+    status = jnp.concatenate((initial_status[None], step_status), axis=0)
+    residual_norm = jnp.concatenate(
+        (initialization.residual_norm[None], step_residual_norm),
+        axis=0,
+    )
+    residual_threshold = jnp.concatenate(
+        (initialization.residual_threshold[None], step_residual_threshold),
+        axis=0,
+    )
+    differential_norm = jnp.concatenate(
+        (
+            initialization.differential_residual_norm[None],
+            step_differential_norm,
+        ),
+        axis=0,
+    )
+    constraint_norm = jnp.concatenate(
+        (initialization.constraint_norm[None], step_constraint_norm),
+        axis=0,
+    )
+    step_rate_valid = jnp.broadcast_to(
+        step_valid.reshape((-1,) + (1,) * len(system.state_shape)),
+        step_rates.shape,
+    )
+    rate_valid = jnp.concatenate(
+        (initialization.rate_valid[None, ...], step_rate_valid),
+        axis=0,
+    )
+    if policy.failure == "error":
+        states = eqx.error_if(states, jnp.any(~valid), "DAE solve failed.")
+    return DifferentialAlgebraicSolution(
+        times=times,
+        states=states,
+        state_rates=state_rates,
+        valid=valid,
+        rate_valid=rate_valid,
+        status=status,
+        residual_norm=residual_norm,
+        residual_threshold=residual_threshold,
+        differential_residual_norm=differential_norm,
+        constraint_norm=constraint_norm,
+        step_sizes=step_sizes,
+        orders=(
+            jnp.ones_like(indices)
+            if policy.integration_method == "bdf1"
+            else jnp.where(indices == 0, 1, 2).astype(jnp.int32)
+        ),
+        nonlinear_status=nonlinear_status,
+        nonlinear_status_valid=nonlinear_status_valid,
+        nonlinear_iterations=nonlinear_iterations,
+        residual_evaluations=residual_evaluations,
+        jacobian_preparations=jacobian_preparations,
+        linear_solves=linear_solves,
+        linear_iterations=linear_iterations,
+        globalization_rejections=globalization_rejections,
+        setup_refreshes=setup_refreshes,
+        numeric_refreshes=numeric_refreshes,
+        initialization=initialization,
+        problem_id=problem.problem_id,
+        system_id=system.system_id,
+        time_id=prepared.time_grid.time_id,
+        plan_id=prepared.plan.plan_id,
+        prepared_id=prepared.prepared_id,
+        nonlinear_method_id=policy.nonlinear_method.method_id,
+        stage_linear_plan_id=prepared.stage_linear_plan_id,
+        initialization_linear_plan_id=prepared.initialization_linear_plan_id,
+        integration_method=policy.integration_method,
+    )
+
+
+def solve_dae(
+    problem_or_prepared: DifferentialAlgebraicProblem | PreparedDAESolve,
+    time_grid: TimeGrid | None = None,
+    /,
+    *,
+    policy: DAESolvePolicy | None = None,
+    args: Any = _DEFAULT_ARGS,
+    initial_state: ArrayLike | None = None,
+    initial_state_rate: ArrayLike | None = None,
+) -> DifferentialAlgebraicSolution:
+    """Solve one regular index-1 DAE on every node of a fixed ``TimeGrid``."""
+    if isinstance(problem_or_prepared, PreparedDAESolve):
+        if time_grid is not None or policy is not None:
+            raise ValueError("time_grid and policy must be omitted for a prepared solve.")
+        prepared = problem_or_prepared
+    elif isinstance(problem_or_prepared, DifferentialAlgebraicProblem):
+        if time_grid is None:
+            raise ValueError("time_grid is required for an unprepared DAE problem.")
+        prepared = prepare_dae(problem_or_prepared, time_grid, policy=policy)
+    else:
+        raise TypeError("Expected a DifferentialAlgebraicProblem or PreparedDAESolve.")
+    runtime_args = prepared.problem.args if args is _DEFAULT_ARGS else args
+    return _solve_prepared(
+        prepared,
+        args=runtime_args,
+        initial_state=initial_state,
+        initial_state_rate=initial_state_rate,
+    )
+
+
+__all__ = [
+    "DAEFailureMode",
+    "DAEIntegrationMethod",
+    "DAESolvePlan",
+    "DAESolvePolicy",
+    "DAEStatus",
+    "DifferentialAlgebraicProblem",
+    "DifferentialAlgebraicSolution",
+    "PreparedDAESolve",
+    "initialize_dae",
+    "plan_dae",
+    "prepare_dae",
+    "solve_dae",
+]

--- a/tests/unit/nonlinear/test_implicit_result.py
+++ b/tests/unit/nonlinear/test_implicit_result.py
@@ -1,0 +1,119 @@
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import pytest
+
+import phydrax.nonlinear as nl
+
+
+def _termination(*, maximum_steps=20):
+    return nl.NonlinearTermination(
+        absolute_residual=1e-11,
+        relative_residual=0.0,
+        absolute_step=0.0,
+        relative_step=0.0,
+        maximum_steps=maximum_steps,
+    )
+
+
+def test_implicit_root_result_retains_native_evidence_and_analytic_derivatives():
+    problem = nl.NonlinearSystemProblem(
+        lambda state, target: state**2 - target,
+        problem_id="implicit-square",
+    )
+
+    def root(target):
+        result = nl.implicit_root_result(
+            problem,
+            jnp.asarray([1.0, 1.0]),
+            termination=_termination(),
+            args=target,
+        )
+        return result.state
+
+    target = jnp.asarray([1.0, 4.0])
+    value, tangent = jax.jvp(root, (target,), (jnp.ones_like(target),))
+    gradient = jax.grad(lambda argument: jnp.sum(root(argument)))(target)
+    result = nl.implicit_root_result(
+        problem,
+        jnp.asarray([1.0, 1.0]),
+        termination=_termination(),
+        args=target,
+    )
+
+    assert result.successful
+    assert result.provenance.problem_id == "implicit-square"
+    assert result.diagnostics.iterations > 0
+    assert jnp.allclose(value, jnp.asarray([1.0, 2.0]), rtol=1e-9, atol=1e-11)
+    assert jnp.allclose(tangent, jnp.asarray([0.5, 0.25]), rtol=1e-8, atol=1e-10)
+    assert jnp.allclose(gradient, tangent, rtol=1e-8, atol=1e-10)
+
+
+def test_implicit_root_result_recomputes_differentiable_auxiliary_at_root():
+    problem = nl.NonlinearSystemProblem(
+        lambda state, target: (state**2 - target, target * state),
+        has_aux=True,
+        problem_id="implicit-auxiliary",
+    )
+
+    def observable(target):
+        result = nl.implicit_root_result(
+            problem,
+            jnp.asarray(1.0),
+            termination=_termination(),
+            args=target,
+        )
+        return result.auxiliary
+
+    value, gradient = jax.value_and_grad(observable)(jnp.asarray(4.0))
+
+    assert jnp.allclose(value, 8.0, rtol=1e-9, atol=1e-11)
+    assert jnp.allclose(gradient, 3.0, rtol=1e-8, atol=1e-10)
+
+
+def test_prepared_implicit_root_refresh_preserves_symbolic_linear_identity():
+    problem = nl.NonlinearSystemProblem(
+        lambda state, target: state**2 - target,
+        problem_id="prepared-implicit-square",
+    )
+    prepared = nl.prepare_nonlinear(
+        problem,
+        jnp.asarray([1.0, 1.0]),
+        termination=_termination(),
+        args=jnp.asarray([1.0, 1.0]),
+    )
+    refreshed = nl.refresh_nonlinear(
+        prepared,
+        problem,
+        jnp.asarray([2.0, 3.0]),
+        args=jnp.asarray([4.0, 9.0]),
+    )
+    result = nl.implicit_root_result(refreshed)
+
+    assert result.successful
+    assert jnp.allclose(result.state, jnp.asarray([2.0, 3.0]), atol=1e-11)
+    assert refreshed.linear_template_id == prepared.linear_template_id
+    assert refreshed.linear_plan_id == prepared.linear_plan_id
+    assert refreshed.numeric_version == prepared.numeric_version + 1
+    assert result.provenance.linear_plan_id == prepared.linear_plan_id
+
+
+def test_failed_implicit_root_remains_inspectable_and_checked_root_raises():
+    problem = nl.NonlinearSystemProblem(
+        lambda state, _: state**2 - 2.0,
+        problem_id="failed-implicit-root",
+    )
+    termination = _termination(maximum_steps=1)
+    result = nl.implicit_root_result(
+        problem,
+        jnp.asarray(10.0),
+        termination=termination,
+    )
+
+    assert not result.successful
+    assert result.status == int(nl.NonlinearStatus.MAXIMUM_STEPS_REACHED)
+    assert jnp.isfinite(result.state)
+    with pytest.raises(
+        eqx.EquinoxRuntimeError, match="Implicit nonlinear root solve failed"
+    ):
+        nl.implicit_root(problem, jnp.asarray(10.0), termination=termination)

--- a/tests/unit/solver/test_dae_bdf.py
+++ b/tests/unit/solver/test_dae_bdf.py
@@ -1,0 +1,211 @@
+import jax
+import jax.numpy as jnp
+import pytest
+
+import phydrax as phx
+
+
+def _decay_problem(*, initial=1.0, parameter=1.0):
+    system = phx.dynamics.DifferentialAlgebraicSystem(
+        lambda time, state, state_rate, rate: state_rate + rate * state,
+        state_shape=(1,),
+        structure=phx.dynamics.DAEStructure(("differential",)),
+        system_id="scalar-decay",
+    )
+    return phx.solver.DifferentialAlgebraicProblem(
+        system,
+        jnp.asarray((initial,)),
+        args=jnp.asarray(parameter),
+        problem_id="scalar-decay",
+    )
+
+
+def _strict_termination(*, maximum_steps=20):
+    return phx.nonlinear.NonlinearTermination(
+        absolute_residual=1e-11,
+        relative_residual=0.0,
+        absolute_step=0.0,
+        relative_step=0.0,
+        maximum_steps=maximum_steps,
+    )
+
+
+def test_bdf1_and_bdf2_follow_their_fixed_grid_discrete_maps():
+    problem = _decay_problem()
+    grid = phx.dynamics.TimeGrid(jnp.linspace(0.0, 0.5, 6), time_id="bdf-maps")
+    bdf1 = phx.solver.solve_dae(
+        problem,
+        grid,
+        policy=phx.solver.DAESolvePolicy(
+            integration_method="bdf1",
+            nonlinear_termination=_strict_termination(),
+        ),
+    )
+    bdf2 = phx.solver.solve_dae(
+        problem,
+        grid,
+        policy=phx.solver.DAESolvePolicy(
+            integration_method="bdf2",
+            nonlinear_termination=_strict_termination(),
+        ),
+    )
+    step = grid.durations[0]
+    expected_bdf1 = (1.0 + step) ** -jnp.arange(grid.num_times)
+    expected_bdf2 = [jnp.asarray(1.0), 1.0 / (1.0 + step)]
+    for _ in range(2, grid.num_times):
+        expected_bdf2.append(
+            (2.0 * expected_bdf2[-1] - 0.5 * expected_bdf2[-2]) / (1.5 + step)
+        )
+
+    assert jnp.all(bdf1.valid)
+    assert jnp.all(bdf2.valid)
+    assert jnp.allclose(bdf1.states[:, 0], expected_bdf1, rtol=1e-9, atol=1e-11)
+    assert jnp.allclose(
+        bdf2.states[:, 0],
+        jnp.asarray(expected_bdf2),
+        rtol=1e-9,
+        atol=1e-11,
+    )
+    assert jnp.array_equal(bdf1.orders, jnp.ones(grid.num_steps, dtype=jnp.int32))
+    assert jnp.array_equal(
+        bdf2.orders,
+        jnp.asarray((1, 2, 2, 2, 2), dtype=jnp.int32),
+    )
+
+
+def test_prepared_bdf_is_jittable_vmappable_and_implicitly_differentiable():
+    problem = _decay_problem()
+    grid = phx.dynamics.TimeGrid(jnp.linspace(0.0, 0.4, 5), time_id="bdf-gradient")
+    policy = phx.solver.DAESolvePolicy(
+        integration_method="bdf1",
+        nonlinear_termination=_strict_termination(),
+    )
+    prepared = phx.solver.prepare_dae(problem, grid, policy=policy)
+
+    def terminal(parameter):
+        return phx.solver.solve_dae(prepared, args=parameter).states[-1, 0]
+
+    parameters = jnp.asarray((0.5, 1.0, 2.0))
+    values, gradients = jax.jit(jax.vmap(jax.value_and_grad(terminal)))(parameters)
+    _, tangent = jax.jvp(
+        terminal,
+        (jnp.asarray(1.0),),
+        (jnp.asarray(1.0),),
+    )
+    step = grid.durations[0]
+    expected_values = (1.0 + step * parameters) ** -grid.num_steps
+    expected_gradients = (
+        -grid.num_steps * step * (1.0 + step * parameters) ** (-grid.num_steps - 1)
+    )
+
+    assert jnp.allclose(values, expected_values, rtol=1e-8, atol=1e-10)
+    assert jnp.allclose(gradients, expected_gradients, rtol=1e-7, atol=1e-9)
+    assert jnp.allclose(tangent, expected_gradients[1], rtol=1e-7, atol=1e-9)
+
+    def terminal_from_initial(initial):
+        state = jnp.asarray((initial,))
+        return phx.solver.solve_dae(
+            prepared,
+            initial_state=state,
+        ).states[-1, 0]
+
+    initial_gradient = jax.jit(jax.grad(terminal_from_initial))(jnp.asarray(1.0))
+    assert jnp.allclose(
+        initial_gradient,
+        (1.0 + step) ** -grid.num_steps,
+        rtol=1e-8,
+        atol=1e-10,
+    )
+
+
+def test_prepared_solve_reports_native_nonlinear_lifecycle_and_provenance():
+    problem = _decay_problem()
+    grid = phx.dynamics.TimeGrid(jnp.linspace(0.0, 0.2, 4), time_id="bdf-evidence")
+    prepared = phx.solver.prepare_dae(
+        problem,
+        grid,
+        policy=phx.solver.DAESolvePolicy(
+            integration_method="bdf2",
+            nonlinear_termination=_strict_termination(),
+        ),
+    )
+    solution = phx.solver.solve_dae(prepared)
+
+    assert solution.successful
+    assert solution.plan_id == prepared.plan.plan_id
+    assert solution.prepared_id == prepared.prepared_id
+    assert solution.stage_linear_plan_id == prepared.stage_linear_plan_id
+    assert (
+        solution.initialization_linear_plan_id == prepared.initialization_linear_plan_id
+    )
+    assert solution.nonlinear_method_id == prepared.plan.policy.nonlinear_method.method_id
+    assert jnp.all(solution.nonlinear_status_valid)
+    assert jnp.all(
+        solution.nonlinear_status == int(phx.nonlinear.NonlinearStatus.SUCCESS)
+    )
+    assert jnp.all(solution.nonlinear_iterations >= 0)
+    assert jnp.all(solution.residual_evaluations > 0)
+    assert jnp.all(solution.jacobian_preparations > 0)
+    assert jnp.all(solution.linear_solves >= 0)
+    assert jnp.all(solution.numeric_refreshes >= 1)
+    assert jnp.all(solution.residual_norm <= solution.residual_threshold)
+
+
+def test_failed_bdf_stage_is_reported_once_and_later_nodes_are_not_run():
+    system = phx.dynamics.DifferentialAlgebraicSystem(
+        lambda time, state, state_rate, args: state_rate + state**3,
+        state_shape=(1,),
+        structure=phx.dynamics.DAEStructure(("differential",)),
+        system_id="nonlinear-stage-failure",
+    )
+    problem = phx.solver.DifferentialAlgebraicProblem(
+        system,
+        jnp.asarray((10.0,)),
+        problem_id="nonlinear-stage-failure",
+    )
+    grid = phx.dynamics.TimeGrid(
+        jnp.asarray((0.0, 0.1, 0.2, 0.3)),
+        time_id="nonlinear-stage-failure",
+    )
+    solution = phx.solver.solve_dae(
+        problem,
+        grid,
+        policy=phx.solver.DAESolvePolicy(
+            integration_method="bdf1",
+            nonlinear_termination=_strict_termination(maximum_steps=1),
+        ),
+    )
+
+    assert jnp.array_equal(
+        solution.valid,
+        jnp.asarray((True, False, False, False)),
+    )
+    assert solution.status[1] == int(phx.solver.DAEStatus.NONLINEAR_FAILED)
+    assert jnp.array_equal(
+        solution.status[2:],
+        jnp.full((2,), int(phx.solver.DAEStatus.NOT_RUN), dtype=jnp.int32),
+    )
+    assert jnp.array_equal(
+        solution.nonlinear_status_valid,
+        jnp.asarray((True, False, False)),
+    )
+    assert solution.nonlinear_status[0] != int(phx.nonlinear.NonlinearStatus.SUCCESS)
+    assert jnp.all(jnp.isnan(solution.states[2:]))
+
+
+def test_bdf2_rejects_grid_ratios_outside_declared_stability_contract():
+    problem = _decay_problem()
+    grid = phx.dynamics.TimeGrid(
+        jnp.asarray((0.0, 0.01, 0.11)),
+        time_id="bad-bdf2-ratio",
+    )
+
+    with pytest.raises(ValueError, match="step ratios"):
+        phx.solver.plan_dae(
+            problem,
+            grid,
+            policy=phx.solver.DAESolvePolicy(
+                integration_method="bdf2",
+                max_step_ratio=2.0,
+            ),
+        )

--- a/tests/unit/solver/test_dae_initialization.py
+++ b/tests/unit/solver/test_dae_initialization.py
@@ -1,0 +1,186 @@
+import jax
+import jax.numpy as jnp
+import pytest
+
+import phydrax as phx
+
+
+def _semi_explicit_system():
+    return phx.dynamics.DifferentialAlgebraicSystem(
+        lambda time, state, state_rate, parameter: jnp.asarray(
+            (
+                state_rate[0] + parameter * state[0],
+                state[1] - state[0] ** 2,
+            )
+        ),
+        state_shape=(2,),
+        structure=phx.dynamics.DAEStructure(("differential", "algebraic")),
+        state_scale=jnp.asarray((2.0, 3.0)),
+        state_rate_scale=jnp.asarray((4.0, 5.0)),
+        residual_scale=jnp.asarray((0.5, 2.0)),
+        system_id="semi-explicit-initialization",
+    )
+
+
+def _strict_policy():
+    return phx.solver.DAESolvePolicy(
+        initialization_termination=phx.nonlinear.NonlinearTermination(
+            absolute_residual=1e-11,
+            relative_residual=0.0,
+            absolute_step=0.0,
+            relative_step=0.0,
+            maximum_steps=20,
+        )
+    )
+
+
+def test_dae_structure_broadcasts_roles_and_preserves_independent_scales():
+    structure = phx.dynamics.DAEStructure(
+        ("differential", "algebraic"),
+        component_axis=-1,
+    )
+    system = phx.dynamics.DifferentialAlgebraicSystem(
+        lambda time, state, state_rate, args: state_rate + state,
+        state_shape=(3, 2),
+        structure=structure,
+        state_scale=2.0,
+        state_rate_scale=jnp.asarray((4.0, 5.0)),
+        residual_scale=10.0,
+        system_id="spatial-roles",
+    )
+    expected_differential = jnp.asarray(((True, False), (True, False), (True, False)))
+
+    assert jnp.array_equal(
+        structure.differential_variable_mask(system.state_shape),
+        expected_differential,
+    )
+    assert jnp.array_equal(
+        structure.algebraic_equation_mask(system.state_shape),
+        ~expected_differential,
+    )
+    assert jnp.array_equal(system.state_scale, jnp.full((3, 2), 2.0))
+    assert jnp.array_equal(
+        system.state_rate_scale,
+        jnp.broadcast_to(jnp.asarray((4.0, 5.0)), (3, 2)),
+    )
+    assert jnp.array_equal(
+        system.scaled_residual(0.0, jnp.ones((3, 2)), jnp.ones((3, 2))),
+        jnp.full((3, 2), 0.2),
+    )
+
+
+def test_mass_matrix_constructor_preserves_raw_implicit_residual():
+    mass = jnp.asarray(((1.0, 0.0), (0.0, 0.0)))
+    system = phx.dynamics.DifferentialAlgebraicSystem.from_mass_matrix(
+        mass,
+        lambda time, state, args: jnp.asarray((-state[0], state[1] - state[0])),
+        state_shape=(2,),
+        structure=phx.dynamics.DAEStructure(("differential", "algebraic")),
+        system_id="mass-matrix",
+    )
+
+    actual = system(0.0, jnp.asarray((2.0, 2.0)), jnp.asarray((-2.0, 7.0)))
+
+    assert jnp.array_equal(actual, jnp.zeros(2))
+
+
+def test_index_one_initialization_fixes_differential_state_and_algebraic_rate():
+    system = _semi_explicit_system()
+    problem = phx.solver.DifferentialAlgebraicProblem(
+        system,
+        jnp.asarray((2.0, 0.0)),
+        initial_state_rate=jnp.asarray((0.0, 17.0)),
+        args=jnp.asarray(2.0),
+        problem_id="index-one-initialization",
+    )
+    result = phx.solver.initialize_dae(problem, 0.0, policy=_strict_policy())
+
+    assert result.valid
+    assert result.status == int(phx.solver.DAEInitializationStatus.SUCCESS)
+    assert jnp.allclose(result.state, jnp.asarray((2.0, 4.0)), atol=1e-10)
+    assert jnp.allclose(result.state_rate, jnp.asarray((-4.0, 17.0)), atol=1e-10)
+    assert jnp.array_equal(result.fixed_state_mask, jnp.asarray((True, False)))
+    assert jnp.array_equal(result.fixed_rate_mask, jnp.asarray((False, True)))
+    assert jnp.array_equal(result.rate_valid, jnp.asarray((True, False)))
+    assert result.nonlinear_result is not None
+    assert result.nonlinear_result.successful
+    assert result.residual_norm <= result.residual_threshold
+
+
+def test_consistent_initialization_remains_inside_parameter_gradient():
+    system = _semi_explicit_system()
+    problem = phx.solver.DifferentialAlgebraicProblem(
+        system,
+        jnp.asarray((2.0, 0.0)),
+        initial_state_rate=jnp.zeros(2),
+        args=jnp.asarray(1.0),
+        problem_id="initialization-gradient",
+    )
+
+    def differential_rate(parameter):
+        result = phx.solver.initialize_dae(
+            problem,
+            0.0,
+            policy=_strict_policy(),
+            args=parameter,
+        )
+        return result.state_rate[0]
+
+    value, gradient = jax.jit(jax.value_and_grad(differential_rate))(jnp.asarray(2.0))
+
+    assert jnp.allclose(value, -4.0, atol=1e-10)
+    assert jnp.allclose(gradient, -2.0, atol=1e-9)
+
+
+def test_fixed_rate_and_check_only_modes_have_distinct_validity_contracts():
+    system = _semi_explicit_system()
+    fixed_rate_problem = phx.solver.DifferentialAlgebraicProblem(
+        system,
+        jnp.asarray((9.0, -3.0)),
+        initial_state_rate=jnp.asarray((-1.0, 8.0)),
+        args=jnp.asarray(2.0),
+        initialization=phx.solver.DAEInitializationSpec.fixed_rate_state(),
+        problem_id="fixed-rate-initialization",
+    )
+    fixed_rate = phx.solver.initialize_dae(
+        fixed_rate_problem,
+        0.0,
+        policy=_strict_policy(),
+    )
+
+    assert fixed_rate.valid
+    assert jnp.allclose(fixed_rate.state, jnp.asarray((0.5, 0.25)), atol=1e-10)
+    assert jnp.array_equal(fixed_rate.state_rate, jnp.asarray((-1.0, 8.0)))
+    assert jnp.all(fixed_rate.rate_valid)
+
+    check_problem = phx.solver.DifferentialAlgebraicProblem(
+        system,
+        jnp.asarray((1.0, 0.0)),
+        initial_state_rate=jnp.zeros(2),
+        args=jnp.asarray(1.0),
+        initialization=phx.solver.DAEInitializationSpec.check_only(),
+        problem_id="check-only-initialization",
+    )
+    checked = phx.solver.initialize_dae(check_problem, 0.0, policy=_strict_policy())
+
+    assert not checked.valid
+    assert checked.status == int(phx.solver.DAEInitializationStatus.RESIDUAL_TOO_LARGE)
+    assert checked.nonlinear_result is None
+    assert jnp.array_equal(checked.state, check_problem.initial_state)
+    assert jnp.array_equal(checked.state_rate, check_problem.initial_state_rate)
+
+
+def test_custom_initialization_requires_one_unknown_per_residual_scalar():
+    system = _semi_explicit_system()
+    problem = phx.solver.DifferentialAlgebraicProblem(
+        system,
+        jnp.asarray((1.0, 1.0)),
+        initialization=phx.solver.DAEInitializationSpec.from_masks(
+            jnp.asarray((True, True)),
+            jnp.asarray((True, False)),
+        ),
+        problem_id="invalid-custom-initialization",
+    )
+
+    with pytest.raises(ValueError, match="exactly one free state/rate unknown"):
+        phx.solver.initialize_dae(problem, 0.0)

--- a/tests/unit/solver/test_semidiscrete_dae.py
+++ b/tests/unit/solver/test_semidiscrete_dae.py
@@ -1,0 +1,212 @@
+import jax
+import jax.numpy as jnp
+import pytest
+
+import phydrax as phx
+
+
+def _spatial(points=8):
+    axis = phx.domain.FourierAxisSpec(points).materialize(0.0, 1.0)
+    return axis, phx.solver.TensorGridDiscretization((axis,))
+
+
+def _mixed_problem():
+    coordinate = phx.equations.PDECoordinate(
+        "x",
+        "space",
+        bounds=(0.0, 1.0),
+        periodic=True,
+    )
+    time = phx.equations.PDECoordinate("t", "time", bounds=(0.0, 1.0))
+    fields = (
+        phx.equations.PDEField("u", coordinates=("x", "t")),
+        phx.equations.PDEField("p", coordinates=("x", "t")),
+    )
+    u = phx.equations.PDEExpression.field("u")
+    p = phx.equations.PDEExpression.field("p")
+    return phx.equations.PDEProblemIR(
+        coordinates=(coordinate, time),
+        fields=fields,
+        parameters=(phx.equations.PDEParameter("kappa", value=0.1),),
+        equations=(
+            phx.equations.PDEEquation(
+                "diffusion",
+                u.derivative("t"),
+                phx.equations.PDEExpression.parameter("kappa") * u.laplacian("x"),
+            ),
+            phx.equations.PDEEquation("constraint", p, u),
+        ),
+    )
+
+
+def _compile_mixed(*, points=8):
+    axis, spatial = _spatial(points)
+    compiled = phx.equations.compile_semidiscrete_dae(
+        _mixed_problem(),
+        spatial,
+        equation_targets={"diffusion": "u", "constraint": "p"},
+        state_scale=2.0,
+        state_rate_scale=3.0,
+        residual_scale=0.5,
+    )
+    return axis, spatial, compiled
+
+
+def test_semidiscrete_dae_compiles_aligned_residual_and_honest_structure():
+    axis, spatial, compiled = _compile_mixed()
+    u = jnp.sin(2.0 * jnp.pi * axis.nodes)
+    state = compiled.layout.pack({"u": u, "p": u})
+    rate = compiled.layout.pack({"u": 0.1 * spatial.laplacian(u), "p": jnp.zeros_like(u)})
+
+    residual = compiled(0.0, state, rate, None)
+    rate_jacobian = compiled.rate_jacobian(0.0, state, rate)
+
+    assert compiled.state_shape == (axis.nodes.size, 2)
+    assert compiled.structure.variable_roles == ("differential", "algebraic")
+    assert compiled.structural_report.equation_targets == (
+        ("diffusion", "u"),
+        ("constraint", "p"),
+    )
+    assert compiled.structural_report.temporal_derivative_counts == (1, 0)
+    assert not compiled.structural_report.regularity_verified
+    assert (
+        compiled.structural_report.index_assumption
+        == "regular-index-1-required-unverified"
+    )
+    assert jnp.max(jnp.abs(residual)) < 1e-11
+    assert rate_jacobian.shape == (2 * axis.nodes.size,) * 2
+    assert jnp.array_equal(
+        compiled.system.state_rate_scale,
+        jnp.full(compiled.state_shape, 3.0),
+    )
+
+
+def test_semidiscrete_dae_requires_bijective_targets_and_direct_time_rates():
+    _, spatial = _spatial()
+    problem = _mixed_problem()
+
+    with pytest.raises(ValueError, match="every PDE equation"):
+        phx.equations.compile_semidiscrete_dae(
+            problem,
+            spatial,
+            equation_targets={"diffusion": "u"},
+        )
+    with pytest.raises(ValueError, match="bijectively"):
+        phx.equations.compile_semidiscrete_dae(
+            problem,
+            spatial,
+            equation_targets={"diffusion": "u", "constraint": "u"},
+        )
+
+    u = phx.equations.PDEExpression.field("u")
+    invalid = phx.equations.PDEProblemIR(
+        coordinates=problem.coordinates,
+        fields=problem.fields,
+        parameters=problem.parameters,
+        equations=(
+            phx.equations.PDEEquation(
+                "diffusion",
+                u.derivative("t", order=2),
+                u.laplacian("x"),
+            ),
+            problem.equations[1],
+        ),
+    )
+    with pytest.raises(ValueError, match="unsupported temporal derivative"):
+        phx.equations.compile_semidiscrete_dae(
+            invalid,
+            spatial,
+            equation_targets={"diffusion": "u", "constraint": "p"},
+        )
+
+
+def test_explicit_and_implicit_compilers_agree_for_eliminable_heat_equation():
+    base = _mixed_problem()
+    heat = phx.equations.PDEProblemIR(
+        coordinates=base.coordinates,
+        fields=(base.fields[0],),
+        parameters=base.parameters,
+        equations=(base.equations[0],),
+    )
+    axis, spatial = _spatial()
+    explicit = phx.equations.compile_semidiscrete_pde(heat, spatial, method="direct")
+    implicit = phx.equations.compile_semidiscrete_dae(
+        heat,
+        spatial,
+        equation_targets={"diffusion": "u"},
+    )
+    state = jnp.sin(2.0 * jnp.pi * axis.nodes)
+    rate = explicit(0.0, state, None)
+
+    assert implicit.structure.component_axis is None
+    assert jnp.max(jnp.abs(implicit(0.0, state, rate, None))) < 1e-11
+
+
+def test_compiled_dae_solve_is_jittable_and_parameter_differentiable():
+    axis, spatial, compiled = _compile_mixed(points=6)
+    initial_u = jnp.sin(2.0 * jnp.pi * axis.nodes)
+    initial_state = compiled.layout.pack({"u": initial_u, "p": jnp.zeros_like(initial_u)})
+    problem = phx.solver.DifferentialAlgebraicProblem(
+        compiled.system,
+        initial_state,
+        problem_id="compiled-semipde",
+    )
+    grid = phx.dynamics.TimeGrid(
+        jnp.linspace(0.0, 0.01, 3),
+        time_id="compiled-semipde",
+    )
+    prepared = phx.solver.prepare_dae(
+        problem,
+        grid,
+        policy=phx.solver.DAESolvePolicy(integration_method="bdf1"),
+    )
+
+    def terminal_amplitude(kappa):
+        solution = phx.solver.solve_dae(prepared, args={"kappa": kappa})
+        terminal = compiled.layout.field(solution.states[-1], "u")
+        return jnp.vdot(initial_u, terminal) / jnp.vdot(initial_u, initial_u)
+
+    kappa = jnp.asarray(0.1)
+    value, gradient = jax.jit(jax.value_and_grad(terminal_amplitude))(kappa)
+    eigenvalue = jnp.vdot(initial_u, spatial.laplacian(initial_u)) / jnp.vdot(
+        initial_u, initial_u
+    )
+    step = grid.durations[0]
+    denominator = 1.0 - step * kappa * eigenvalue
+    expected = denominator**-grid.num_steps
+    expected_gradient = (
+        grid.num_steps * step * eigenvalue * denominator ** (-grid.num_steps - 1)
+    )
+
+    assert jnp.allclose(value, expected, rtol=1e-7, atol=1e-9)
+    assert jnp.allclose(gradient, expected_gradient, rtol=1e-6, atol=1e-8)
+
+
+def test_dae_trajectory_adapter_retains_rates_validity_and_provenance():
+    axis, _, compiled = _compile_mixed(points=6)
+    initial_u = jnp.sin(2.0 * jnp.pi * axis.nodes)
+    problem = phx.solver.DifferentialAlgebraicProblem(
+        compiled.system,
+        compiled.layout.pack({"u": initial_u, "p": jnp.zeros_like(initial_u)}),
+        problem_id="semipde-adapter",
+    )
+    solution = phx.solver.solve_dae(
+        problem,
+        phx.dynamics.TimeGrid(jnp.linspace(0.0, 0.01, 3), time_id="adapter"),
+        policy=phx.solver.DAESolvePolicy(integration_method="bdf1"),
+    )
+
+    data = phx.dynamics.identification.trajectory_data_from_differential_solution(
+        solution
+    )
+
+    assert jnp.array_equal(data.derivatives, solution.state_rates)
+    assert not data.derivative_valid[0]
+    assert jnp.all(data.derivative_valid[1:])
+    assert jnp.array_equal(data.sample_valid, solution.valid)
+    assert jnp.array_equal(
+        data.transition_valid,
+        solution.valid[:-1] & solution.valid[1:],
+    )
+    assert data.coordinate_id == solution.time_id
+    assert data.source_id.startswith("dae:")

--- a/tools/dae_benchmarks.py
+++ b/tools/dae_benchmarks.py
@@ -1,0 +1,895 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import platform
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+import jax.scipy as jsp
+import numpy as np
+
+import phydrax as phx
+
+
+jax.config.update("jax_enable_x64", True)
+
+
+_ROBERTSON_REFERENCE = jnp.asarray(
+    (
+        0.99960068268829472,
+        3.6450478878442331e-05,
+        0.00036286683282682475,
+    )
+)
+
+
+@dataclass(frozen=True)
+class _Case:
+    name: str
+    prepared: phx.solver.PreparedDAESolve
+    parameter: jax.Array
+    args_from_parameter: Callable[[jax.Array], Any]
+    observable: Callable[[phx.solver.DifferentialAlgebraicSolution], jax.Array]
+    trajectory_error: Callable[
+        [phx.solver.DifferentialAlgebraicSolution, jax.Array], jax.Array
+    ]
+    trajectory_reference: str
+    trajectory_tolerance: float
+    constraint_residual: (
+        Callable[[phx.solver.DifferentialAlgebraicSolution, jax.Array], jax.Array] | None
+    )
+    constraint_reference: str | None
+    constraint_tolerance: float
+    reference_gradient: Callable[[jax.Array], jax.Array] | None
+    gradient_reference: str
+    finite_difference_step: float
+    gradient_relative_tolerance: float
+    gradient_absolute_tolerance: float
+    model_setup_ms: float
+    solver_preparation_ms: float
+    metadata: dict[str, Any]
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Benchmark native differentiable fixed-grid Phydrax DAE solves."
+    )
+    parser.add_argument("--steps", type=int, default=64)
+    parser.add_argument("--spatial-points", type=int, default=16)
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("--smoke", action="store_true")
+    parser.add_argument("--output", type=Path)
+    return parser
+
+
+def _block(tree: Any, /) -> None:
+    for leaf in jax.tree.leaves(tree):
+        if isinstance(leaf, jax.Array):
+            leaf.block_until_ready()
+
+
+def _logical_array_bytes(tree: Any, /) -> int:
+    return sum(
+        int(leaf.nbytes)
+        for leaf in jax.tree.leaves(tree)
+        if isinstance(leaf, (jax.Array, np.ndarray))
+    )
+
+
+def _elapsed_ms(started: float, /) -> float:
+    return 1e3 * (time.perf_counter() - started)
+
+
+def _finite_float(value: Any, /) -> float | None:
+    number = float(np.asarray(value))
+    return number if math.isfinite(number) else None
+
+
+def _summary(samples: list[float], /) -> dict[str, float]:
+    values = np.asarray(samples, dtype=float)
+    return {
+        "mean_ms": float(np.mean(values)),
+        "standard_deviation_ms": float(np.std(values)),
+        "median_ms": float(np.median(values)),
+        "minimum_ms": float(np.min(values)),
+        "maximum_ms": float(np.max(values)),
+    }
+
+
+def _policy(*, residual_tolerance: float = 1e-10) -> phx.solver.DAESolvePolicy:
+    stage_termination = phx.nonlinear.NonlinearTermination(
+        absolute_residual=residual_tolerance,
+        relative_residual=0.0,
+        absolute_step=0.0,
+        relative_step=0.0,
+        maximum_steps=20,
+    )
+    initialization_termination = phx.nonlinear.NonlinearTermination(
+        absolute_residual=residual_tolerance,
+        relative_residual=0.0,
+        absolute_step=0.0,
+        relative_step=0.0,
+        maximum_steps=32,
+    )
+    return phx.solver.DAESolvePolicy(
+        integration_method="bdf2",
+        nonlinear_method=phx.nonlinear.NewtonKrylov(),
+        nonlinear_termination=stage_termination,
+        initialization_method=phx.nonlinear.NewtonTrustRegion(),
+        initialization_termination=initialization_termination,
+        max_step_ratio=2.0,
+        failure="status",
+    )
+
+
+def _prepare(
+    problem: phx.solver.DifferentialAlgebraicProblem,
+    grid: phx.dynamics.TimeGrid,
+    policy: phx.solver.DAESolvePolicy,
+    /,
+) -> tuple[phx.solver.PreparedDAESolve, float]:
+    started = time.perf_counter()
+    prepared = phx.solver.prepare_dae(problem, grid, policy=policy)
+    _block(prepared)
+    return prepared, _elapsed_ms(started)
+
+
+def _lower_compile(
+    function: Any,
+    argument: jax.Array,
+    /,
+) -> tuple[Any, float, float]:
+    started = time.perf_counter()
+    lowered = function.lower(argument)
+    lowering_ms = _elapsed_ms(started)
+    started = time.perf_counter()
+    compiled = lowered.compile()
+    compilation_ms = _elapsed_ms(started)
+    return compiled, lowering_ms, compilation_ms
+
+
+def _execute(function: Any, argument: jax.Array, /) -> tuple[Any, float]:
+    started = time.perf_counter()
+    result = function(argument)
+    _block(result)
+    return result, _elapsed_ms(started)
+
+
+def _status_histogram(status: jax.Array, /) -> dict[str, int]:
+    values, counts = np.unique(np.asarray(status), return_counts=True)
+    return {
+        phx.solver.DAEStatus(int(value)).name.lower(): int(count)
+        for value, count in zip(values, counts, strict=True)
+    }
+
+
+def _independent_residual_norm(
+    case: _Case,
+    solution: phx.solver.DifferentialAlgebraicSolution,
+    /,
+) -> jax.Array:
+    system = case.prepared.problem.system
+    runtime_args = case.args_from_parameter(case.parameter)
+    residuals = jax.vmap(
+        lambda time, state, state_rate: system.scaled_residual(
+            time,
+            state,
+            state_rate,
+            runtime_args,
+        )
+    )(solution.times, solution.states, solution.state_rates)
+    flattened = residuals.reshape((residuals.shape[0], -1))
+    return jnp.max(jnp.sqrt(jnp.mean(jnp.square(jnp.abs(flattened)), axis=1)))
+
+
+def _benchmark_case(case: _Case, repeats: int, /) -> dict[str, Any]:
+    solve = jax.jit(
+        lambda value: phx.solver.solve_dae(
+            case.prepared,
+            args=case.args_from_parameter(value),
+        )
+    )
+    compiled_solve, forward_lowering_ms, forward_compilation_ms = _lower_compile(
+        solve,
+        case.parameter,
+    )
+    solution, forward_first_ms = _execute(compiled_solve, case.parameter)
+    solution, forward_warmup_ms = _execute(compiled_solve, case.parameter)
+    forward_samples: list[float] = []
+    for _ in range(repeats):
+        solution, elapsed = _execute(compiled_solve, case.parameter)
+        forward_samples.append(elapsed)
+
+    value_and_grad = jax.jit(
+        jax.value_and_grad(
+            lambda value: case.observable(
+                phx.solver.solve_dae(
+                    case.prepared,
+                    args=case.args_from_parameter(value),
+                )
+            )
+        )
+    )
+    (
+        compiled_value_and_grad,
+        gradient_lowering_ms,
+        gradient_compilation_ms,
+    ) = _lower_compile(value_and_grad, case.parameter)
+    (objective, gradient), gradient_first_ms = _execute(
+        compiled_value_and_grad,
+        case.parameter,
+    )
+    (objective, gradient), gradient_warmup_ms = _execute(
+        compiled_value_and_grad,
+        case.parameter,
+    )
+    gradient_samples: list[float] = []
+    for _ in range(repeats):
+        (objective, gradient), elapsed = _execute(
+            compiled_value_and_grad,
+            case.parameter,
+        )
+        gradient_samples.append(elapsed)
+
+    finite_difference_step: float | None = None
+    if case.reference_gradient is None:
+        epsilon = jnp.asarray(case.finite_difference_step, dtype=case.parameter.dtype)
+        upper_solution = compiled_solve(case.parameter + epsilon)
+        lower_solution = compiled_solve(case.parameter - epsilon)
+        upper = case.observable(upper_solution)
+        lower = case.observable(lower_solution)
+        gradient_reference = (upper - lower) / (2.0 * epsilon)
+        finite_difference_step = case.finite_difference_step
+    else:
+        gradient_reference = case.reference_gradient(case.parameter)
+    _block(gradient_reference)
+
+    trajectory_error = case.trajectory_error(solution, case.parameter)
+    constraint_residual = (
+        jnp.asarray(0.0)
+        if case.constraint_residual is None
+        else case.constraint_residual(solution, case.parameter)
+    )
+    independent_residual = _independent_residual_norm(case, solution)
+    reported_residual = jnp.max(solution.residual_norm)
+    reported_constraint = jnp.max(solution.constraint_norm)
+    residual_threshold = jnp.max(solution.residual_threshold)
+    gradient_absolute_error = jnp.abs(gradient - gradient_reference)
+    gradient_relative_error = gradient_absolute_error / jnp.maximum(
+        jnp.abs(gradient_reference),
+        jnp.asarray(1e-30, dtype=gradient.dtype),
+    )
+    _block(
+        (
+            trajectory_error,
+            constraint_residual,
+            independent_residual,
+            reported_residual,
+            reported_constraint,
+            residual_threshold,
+            gradient_absolute_error,
+            gradient_relative_error,
+        )
+    )
+
+    finite_outputs = bool(
+        jnp.all(jnp.isfinite(solution.states))
+        & jnp.all(jnp.isfinite(solution.state_rates))
+        & jnp.isfinite(objective)
+        & jnp.isfinite(gradient)
+        & jnp.isfinite(gradient_reference)
+        & jnp.isfinite(trajectory_error)
+        & jnp.isfinite(constraint_residual)
+        & jnp.isfinite(independent_residual)
+    )
+    gradient_within_tolerance = bool(
+        gradient_absolute_error
+        <= case.gradient_absolute_tolerance
+        + case.gradient_relative_tolerance * jnp.abs(gradient_reference)
+    )
+    residual_within_tolerance = bool(independent_residual <= residual_threshold)
+    trajectory_within_tolerance = bool(trajectory_error <= case.trajectory_tolerance)
+    constraint_within_tolerance = bool(constraint_residual <= case.constraint_tolerance)
+    passed = (
+        bool(solution.successful)
+        and finite_outputs
+        and gradient_within_tolerance
+        and residual_within_tolerance
+        and trajectory_within_tolerance
+        and constraint_within_tolerance
+    )
+
+    initialization_iterations = int(solution.initialization.nonlinear_iterations)
+    initialization_linear_iterations = int(solution.initialization.linear_iterations)
+    return {
+        "name": case.name,
+        "metadata": case.metadata,
+        "problem_id": solution.problem_id,
+        "system_id": solution.system_id,
+        "time_id": solution.time_id,
+        "plan_id": solution.plan_id,
+        "prepared_id": solution.prepared_id,
+        "grid_points": int(solution.times.size),
+        "state_shape": list(solution.state_shape),
+        "successful": bool(solution.successful),
+        "finite_outputs": finite_outputs,
+        "status_histogram": _status_histogram(solution.status),
+        "initialization_status": phx.solver.DAEInitializationStatus(
+            int(solution.initialization.status)
+        ).name.lower(),
+        "certificates": {
+            "trajectory": {
+                "reference": case.trajectory_reference,
+                "relative_error": _finite_float(trajectory_error),
+                "tolerance": case.trajectory_tolerance,
+                "passed": trajectory_within_tolerance,
+            },
+            "constraint": {
+                "applicable": case.constraint_residual is not None,
+                "reference": case.constraint_reference,
+                "maximum_absolute_residual": _finite_float(constraint_residual),
+                "tolerance": case.constraint_tolerance,
+                "passed": constraint_within_tolerance,
+            },
+            "residual": {
+                "independent_maximum_scaled_rms": _finite_float(independent_residual),
+                "reported_maximum_scaled_rms": _finite_float(reported_residual),
+                "reported_maximum_constraint_rms": _finite_float(reported_constraint),
+                "threshold": _finite_float(residual_threshold),
+                "passed": residual_within_tolerance,
+            },
+            "gradient": {
+                "objective": _finite_float(objective),
+                "value": _finite_float(gradient),
+                "reference_value": _finite_float(gradient_reference),
+                "reference": case.gradient_reference,
+                "symmetric_finite_difference_step": finite_difference_step,
+                "absolute_error": _finite_float(gradient_absolute_error),
+                "relative_error": _finite_float(gradient_relative_error),
+                "absolute_tolerance": case.gradient_absolute_tolerance,
+                "relative_tolerance": case.gradient_relative_tolerance,
+                "passed": gradient_within_tolerance,
+            },
+        },
+        "solver_evidence": {
+            "integration_method": solution.integration_method,
+            "nonlinear_method_id": solution.nonlinear_method_id,
+            "differentiation_mode": solution.differentiation_mode,
+            "grid_origin": solution.grid_origin,
+            "approximation_id": solution.approximation_id,
+            "stage_linear_plan_id": solution.stage_linear_plan_id,
+            "initialization_linear_plan_id": solution.initialization_linear_plan_id,
+            "stage_linear_template_reused": (
+                solution.stage_linear_plan_id == case.prepared.stage_solve.linear_plan_id
+            ),
+            "initialization_nonlinear_iterations": initialization_iterations,
+            "initialization_linear_iterations": initialization_linear_iterations,
+            "maximum_stage_nonlinear_iterations": int(
+                jnp.max(solution.nonlinear_iterations)
+            ),
+            "total_stage_nonlinear_iterations": int(
+                jnp.sum(solution.nonlinear_iterations)
+            ),
+            "total_residual_evaluations": int(jnp.sum(solution.residual_evaluations)),
+            "total_jacobian_preparations": int(jnp.sum(solution.jacobian_preparations)),
+            "total_linear_solves": int(jnp.sum(solution.linear_solves)),
+            "total_linear_iterations": int(jnp.sum(solution.linear_iterations)),
+            "total_globalization_rejections": int(
+                jnp.sum(solution.globalization_rejections)
+            ),
+            "total_setup_refreshes": int(jnp.sum(solution.setup_refreshes)),
+            "total_numeric_refreshes": int(jnp.sum(solution.numeric_refreshes)),
+        },
+        "timing": {
+            "unit": "milliseconds",
+            "model_setup_ms": case.model_setup_ms,
+            "solver_preparation_ms": case.solver_preparation_ms,
+            "forward": {
+                "lowering_ms": forward_lowering_ms,
+                "compilation_ms": forward_compilation_ms,
+                "first_execution_ms": forward_first_ms,
+                "warmup_execution_ms": forward_warmup_ms,
+                "steady_samples_ms": forward_samples,
+                "steady_summary": _summary(forward_samples),
+            },
+            "value_and_grad": {
+                "lowering_ms": gradient_lowering_ms,
+                "compilation_ms": gradient_compilation_ms,
+                "first_execution_ms": gradient_first_ms,
+                "warmup_execution_ms": gradient_warmup_ms,
+                "steady_samples_ms": gradient_samples,
+                "steady_summary": _summary(gradient_samples),
+            },
+        },
+        "storage": {
+            "scope": (
+                "logical array payloads; excludes allocator pools and compiled "
+                "executables"
+            ),
+            "prepared_array_bytes": _logical_array_bytes(case.prepared),
+            "solution_array_bytes": _logical_array_bytes(solution),
+            "state_trajectory_bytes": int(solution.states.nbytes),
+            "state_rate_trajectory_bytes": int(solution.state_rates.nbytes),
+        },
+        "passed": passed,
+    }
+
+
+def _scalar_linear(steps: int) -> _Case:
+    started = time.perf_counter()
+    system = phx.dynamics.DifferentialAlgebraicSystem(
+        lambda time, state, state_rate, rate: state_rate + rate * state,
+        state_shape=(1,),
+        structure=phx.dynamics.DAEStructure(("differential",)),
+        system_id="benchmark:dae:scalar-linear",
+    )
+    problem = phx.solver.DifferentialAlgebraicProblem(
+        system,
+        jnp.ones(1),
+        args=jnp.asarray(1.0),
+        problem_id="benchmark:dae:scalar-linear",
+    )
+    grid = phx.dynamics.TimeGrid(
+        jnp.linspace(0.0, 1.0, steps + 1),
+        time_id=f"benchmark:dae:scalar-linear:{steps}",
+    )
+    _block((problem, grid))
+    model_setup_ms = _elapsed_ms(started)
+    prepared, preparation_ms = _prepare(problem, grid, _policy())
+    return _Case(
+        name="scalar-linear",
+        prepared=prepared,
+        parameter=jnp.asarray(1.0),
+        args_from_parameter=lambda value: value,
+        observable=lambda solution: solution.states[-1, 0],
+        trajectory_error=lambda solution, rate: (
+            jnp.linalg.norm(solution.states[:, 0] - jnp.exp(-rate * solution.times))
+            / jnp.linalg.norm(jnp.exp(-rate * solution.times))
+        ),
+        trajectory_reference="closed-form exponential trajectory",
+        trajectory_tolerance=max(5.0 / steps**2, 2e-4),
+        constraint_residual=None,
+        constraint_reference=None,
+        constraint_tolerance=0.0,
+        reference_gradient=lambda rate: -jnp.exp(-rate),
+        gradient_reference="closed-form terminal derivative",
+        finite_difference_step=1e-4,
+        gradient_relative_tolerance=max(10.0 / steps**2, 5e-3),
+        gradient_absolute_tolerance=1e-8,
+        model_setup_ms=model_setup_ms,
+        solver_preparation_ms=preparation_ms,
+        metadata={"class": "linear ODE in implicit residual form"},
+    )
+
+
+def _vector_linear(steps: int) -> _Case:
+    started = time.perf_counter()
+    mass = jnp.asarray((1.0, 2.0, 3.0, 4.0))
+    stiffness = jnp.asarray((1.0, 4.0, 9.0, 16.0))
+    initial = jnp.asarray((1.0, -0.5, 0.25, 0.75))
+    rates = stiffness / mass
+    system = phx.dynamics.DifferentialAlgebraicSystem.from_mass_matrix(
+        jnp.diag(mass),
+        lambda time, state, scale: -scale * stiffness * state,
+        state_shape=(4,),
+        structure=phx.dynamics.DAEStructure(("differential",) * 4),
+        state_scale=jnp.abs(initial),
+        system_id="benchmark:dae:vector-linear",
+    )
+    problem = phx.solver.DifferentialAlgebraicProblem(
+        system,
+        initial,
+        args=jnp.asarray(0.7),
+        problem_id="benchmark:dae:vector-linear",
+    )
+    grid = phx.dynamics.TimeGrid(
+        jnp.linspace(0.0, 0.5, steps + 1),
+        time_id=f"benchmark:dae:vector-linear:{steps}",
+    )
+    _block((problem, grid))
+    model_setup_ms = _elapsed_ms(started)
+    prepared, preparation_ms = _prepare(problem, grid, _policy())
+
+    def exact(scale: jax.Array, times: jax.Array) -> jax.Array:
+        return initial * jnp.exp(-scale * times[..., None] * rates)
+
+    return _Case(
+        name="vector-linear-mass",
+        prepared=prepared,
+        parameter=jnp.asarray(0.7),
+        args_from_parameter=lambda value: value,
+        observable=lambda solution: jnp.sum(solution.states[-1]),
+        trajectory_error=lambda solution, scale: (
+            jnp.linalg.norm(solution.states - exact(scale, solution.times))
+            / jnp.linalg.norm(exact(scale, solution.times))
+        ),
+        trajectory_reference="closed-form diagonal mass-matrix trajectory",
+        trajectory_tolerance=max(12.0 / steps**2, 5e-4),
+        constraint_residual=None,
+        constraint_reference=None,
+        constraint_tolerance=0.0,
+        reference_gradient=lambda scale: jnp.sum(
+            -0.5 * rates * exact(scale, jnp.asarray(0.5))
+        ),
+        gradient_reference="closed-form terminal derivative",
+        finite_difference_step=1e-4,
+        gradient_relative_tolerance=max(20.0 / steps**2, 8e-3),
+        gradient_absolute_tolerance=1e-8,
+        model_setup_ms=model_setup_ms,
+        solver_preparation_ms=preparation_ms,
+        metadata={"class": "diagonal nonsingular mass matrix", "state_size": 4},
+    )
+
+
+def _robertson(steps: int) -> _Case:
+    started = time.perf_counter()
+
+    def residual(time, state, state_rate, scale):
+        first, second, third = state
+        forward = 0.04 * first - 1e4 * second * third
+        return jnp.asarray(
+            (
+                state_rate[0] + scale * forward,
+                state_rate[1] - scale * (forward - 3e7 * second**2),
+                first + second + third - 1.0,
+            )
+        )
+
+    system = phx.dynamics.DifferentialAlgebraicSystem(
+        residual,
+        state_shape=(3,),
+        structure=phx.dynamics.DAEStructure(
+            ("differential", "differential", "algebraic")
+        ),
+        state_scale=jnp.asarray((1.0, 1e-4, 1e-3)),
+        state_rate_scale=jnp.asarray((0.04, 0.04, 1.0)),
+        residual_scale=jnp.asarray((0.04, 0.04, 1.0)),
+        system_id="benchmark:dae:robertson",
+    )
+    problem = phx.solver.DifferentialAlgebraicProblem(
+        system,
+        jnp.asarray((1.0, 0.0, 0.0)),
+        args=jnp.asarray(1.0),
+        problem_id="benchmark:dae:robertson",
+    )
+    grid = phx.dynamics.TimeGrid(
+        jnp.linspace(0.0, 1e-2, steps + 1),
+        time_id=f"benchmark:dae:robertson:{steps}",
+    )
+    _block((problem, grid))
+    model_setup_ms = _elapsed_ms(started)
+    prepared, preparation_ms = _prepare(
+        problem,
+        grid,
+        _policy(residual_tolerance=1e-9),
+    )
+    return _Case(
+        name="robertson-semi-explicit",
+        prepared=prepared,
+        parameter=jnp.asarray(1.0),
+        args_from_parameter=lambda value: value,
+        observable=lambda solution: solution.states[-1, 2],
+        trajectory_error=lambda solution, scale: (
+            jnp.linalg.norm(solution.states[-1] - _ROBERTSON_REFERENCE)
+            / jnp.linalg.norm(_ROBERTSON_REFERENCE)
+        ),
+        trajectory_reference="high-accuracy Robertson terminal state at t=0.01",
+        trajectory_tolerance=max(2e-3 / steps**2, 5e-7),
+        constraint_residual=lambda solution, scale: jnp.max(
+            jnp.abs(jnp.sum(solution.states, axis=1) - 1.0)
+        ),
+        constraint_reference="species conservation y1 + y2 + y3 = 1",
+        constraint_tolerance=2e-9,
+        reference_gradient=None,
+        gradient_reference="symmetric finite difference of the discrete BDF solve",
+        finite_difference_step=1e-4,
+        gradient_relative_tolerance=5e-4,
+        gradient_absolute_tolerance=1e-8,
+        model_setup_ms=model_setup_ms,
+        solver_preparation_ms=preparation_ms,
+        metadata={
+            "class": "stiff semi-explicit chemical kinetics DAE",
+            "reference_time": 0.01,
+        },
+    )
+
+
+def _circuit(steps: int) -> _Case:
+    started = time.perf_counter()
+    inductance = 0.3
+    resistance = 0.4
+    load_resistance = 1.2
+
+    def residual(time, state, state_rate, capacitance):
+        voltage, current, branch_current = state
+        return jnp.asarray(
+            (
+                capacitance * state_rate[0] + branch_current - 1.0,
+                inductance * state_rate[1] - voltage + resistance * current,
+                branch_current - current - voltage / load_resistance,
+            )
+        )
+
+    system = phx.dynamics.DifferentialAlgebraicSystem(
+        residual,
+        state_shape=(3,),
+        structure=phx.dynamics.DAEStructure(
+            ("differential", "differential", "algebraic")
+        ),
+        system_id="benchmark:dae:rlc-circuit",
+    )
+    problem = phx.solver.DifferentialAlgebraicProblem(
+        system,
+        jnp.zeros(3),
+        args=jnp.asarray(0.8),
+        problem_id="benchmark:dae:rlc-circuit",
+    )
+    grid = phx.dynamics.TimeGrid(
+        jnp.linspace(0.0, 1.0, steps + 1),
+        time_id=f"benchmark:dae:circuit:{steps}",
+    )
+    _block((problem, grid))
+    model_setup_ms = _elapsed_ms(started)
+    prepared, preparation_ms = _prepare(problem, grid, _policy())
+
+    def exact(capacitance: jax.Array, times: jax.Array) -> jax.Array:
+        matrix = jnp.asarray(
+            (
+                (-1.0 / (capacitance * load_resistance), -1.0 / capacitance),
+                (1.0 / inductance, -resistance / inductance),
+            )
+        )
+        forcing = jnp.asarray((1.0 / capacitance, 0.0))
+
+        def state_at(time):
+            dynamic = jnp.linalg.solve(
+                matrix,
+                (jsp.linalg.expm(matrix * time) - jnp.eye(2)) @ forcing,
+            )
+            voltage, current = dynamic
+            branch_current = current + voltage / load_resistance
+            return jnp.asarray((voltage, current, branch_current))
+
+        return jax.vmap(state_at)(jnp.atleast_1d(times))
+
+    terminal_voltage_gradient = jax.grad(
+        lambda capacitance: exact(capacitance, jnp.asarray((1.0,)))[0, 0]
+    )
+    return _Case(
+        name="singular-mass-circuit",
+        prepared=prepared,
+        parameter=jnp.asarray(0.8),
+        args_from_parameter=lambda value: value,
+        observable=lambda solution: solution.states[-1, 0],
+        trajectory_error=lambda solution, capacitance: (
+            jnp.linalg.norm(solution.states - exact(capacitance, solution.times))
+            / jnp.linalg.norm(exact(capacitance, solution.times))
+        ),
+        trajectory_reference="closed-form reduced linear circuit trajectory",
+        trajectory_tolerance=max(15.0 / steps**2, 8e-4),
+        constraint_residual=lambda solution, capacitance: jnp.max(
+            jnp.abs(
+                solution.states[:, 2]
+                - solution.states[:, 1]
+                - solution.states[:, 0] / load_resistance
+            )
+        ),
+        constraint_reference="Kirchhoff branch-current constraint",
+        constraint_tolerance=1e-10,
+        reference_gradient=terminal_voltage_gradient,
+        gradient_reference="closed-form matrix-exponential terminal derivative",
+        finite_difference_step=1e-4,
+        gradient_relative_tolerance=max(70.0 / steps**2, 1.2e-2),
+        gradient_absolute_tolerance=1e-8,
+        model_setup_ms=model_setup_ms,
+        solver_preparation_ms=preparation_ms,
+        metadata={"class": "linear circuit with singular mass matrix"},
+    )
+
+
+def _reaction_diffusion(steps: int, spatial_points: int) -> _Case:
+    started = time.perf_counter()
+    x = phx.equations.PDECoordinate(
+        "x",
+        "space",
+        bounds=(0.0, 1.0),
+        periodic=True,
+    )
+    time_coordinate = phx.equations.PDECoordinate(
+        "t",
+        "time",
+        bounds=(0.0, 0.02),
+    )
+    fields = (
+        phx.equations.PDEField("u", coordinates=("x", "t")),
+        phx.equations.PDEField("equilibrium", coordinates=("x", "t")),
+    )
+    diffusivity = phx.equations.PDEParameter("diffusivity", value=0.05)
+    u = phx.equations.PDEExpression.field("u")
+    equilibrium = phx.equations.PDEExpression.field("equilibrium")
+    problem_ir = phx.equations.PDEProblemIR(
+        coordinates=(x, time_coordinate),
+        fields=fields,
+        parameters=(diffusivity,),
+        equations=(
+            phx.equations.PDEEquation(
+                "diffusion",
+                u.derivative("t"),
+                phx.equations.PDEExpression.parameter("diffusivity") * u.laplacian("x"),
+            ),
+            phx.equations.PDEEquation("local-equilibrium", equilibrium, u**2),
+        ),
+    )
+    axis = phx.domain.FourierAxisSpec(spatial_points).materialize(0.0, 1.0)
+    spatial = phx.solver.TensorGridDiscretization((axis,))
+    compiled = phx.equations.compile_semidiscrete_dae(
+        problem_ir,
+        spatial,
+        equation_targets={"diffusion": "u", "local-equilibrium": "equilibrium"},
+        state_scale=jnp.asarray((1.0, 1.0)),
+        state_rate_scale=jnp.asarray((1.0, 1.0)),
+        residual_scale=jnp.asarray((1.0, 1.0)),
+    )
+    initial_u = jnp.sin(2.0 * jnp.pi * axis.nodes)
+    initial = compiled.layout.pack(
+        {"u": initial_u, "equilibrium": jnp.zeros_like(initial_u)}
+    )
+    problem = phx.solver.DifferentialAlgebraicProblem(
+        compiled.system,
+        initial,
+        args={"diffusivity": jnp.asarray(0.05)},
+        problem_id="benchmark:dae:reaction-diffusion",
+    )
+    grid = phx.dynamics.TimeGrid(
+        jnp.linspace(0.0, 0.02, steps + 1),
+        time_id=f"benchmark:dae:reaction-diffusion:{steps}:{spatial_points}",
+    )
+    _block((problem, grid, compiled))
+    model_setup_ms = _elapsed_ms(started)
+    prepared, preparation_ms = _prepare(problem, grid, _policy())
+    eigenvalue = jnp.vdot(initial_u, spatial.laplacian(initial_u)) / jnp.vdot(
+        initial_u, initial_u
+    )
+
+    def exact(diffusivity: jax.Array, times: jax.Array) -> jax.Array:
+        physical_u = (
+            jnp.exp(diffusivity * eigenvalue * times[:, None]) * initial_u[None, :]
+        )
+        return jnp.stack((physical_u, physical_u**2), axis=-1)
+
+    def amplitude(solution: phx.solver.DifferentialAlgebraicSolution) -> jax.Array:
+        terminal = compiled.layout.field(solution.states[-1], "u")
+        return jnp.vdot(initial_u, terminal) / jnp.vdot(initial_u, initial_u)
+
+    def equilibrium_residual(
+        solution: phx.solver.DifferentialAlgebraicSolution,
+        parameter: jax.Array,
+    ) -> jax.Array:
+        del parameter
+        physical_u = jax.vmap(lambda state: compiled.layout.field(state, "u"))(
+            solution.states
+        )
+        physical_equilibrium = jax.vmap(
+            lambda state: compiled.layout.field(state, "equilibrium")
+        )(solution.states)
+        return jnp.max(jnp.abs(physical_equilibrium - physical_u**2))
+
+    return _Case(
+        name="constrained-reaction-diffusion",
+        prepared=prepared,
+        parameter=jnp.asarray(0.05),
+        args_from_parameter=lambda value: {"diffusivity": value},
+        observable=amplitude,
+        trajectory_error=lambda solution, parameter: (
+            jnp.linalg.norm(solution.states - exact(parameter, solution.times))
+            / jnp.linalg.norm(exact(parameter, solution.times))
+        ),
+        trajectory_reference="exact semidiscrete Fourier-mode trajectory",
+        trajectory_tolerance=max(15.0 / steps**2, 5e-4),
+        constraint_residual=equilibrium_residual,
+        constraint_reference="pointwise equilibrium = u**2",
+        constraint_tolerance=1e-9,
+        reference_gradient=lambda parameter: (
+            0.02 * eigenvalue * jnp.exp(0.02 * parameter * eigenvalue)
+        ),
+        gradient_reference="exact semidiscrete Fourier-mode terminal derivative",
+        finite_difference_step=1e-4,
+        gradient_relative_tolerance=max(20.0 / steps**2, 8e-3),
+        gradient_absolute_tolerance=1e-8,
+        model_setup_ms=model_setup_ms,
+        solver_preparation_ms=preparation_ms,
+        metadata={
+            "class": "semidiscrete PDE DAE",
+            "spatial_points": spatial_points,
+            "structural_assumption": compiled.structural_report.index_assumption,
+            "regularity_verified": compiled.structural_report.regularity_verified,
+        },
+    )
+
+
+def _environment() -> dict[str, Any]:
+    device = jax.devices()[0]
+    return {
+        "python_version": platform.python_version(),
+        "jax_version": jax.__version__,
+        "backend": jax.default_backend(),
+        "device_kind": device.device_kind,
+        "machine": platform.machine(),
+        "system": platform.system(),
+        "system_release": platform.release(),
+        "x64_enabled": bool(jax.config.read("jax_enable_x64")),
+    }
+
+
+def main() -> None:
+    arguments = _parser().parse_args()
+    requested_steps = int(arguments.steps)
+    requested_spatial_points = int(arguments.spatial_points)
+    requested_repeats = int(arguments.repeats)
+    steps = min(requested_steps, 8) if arguments.smoke else requested_steps
+    spatial_points = (
+        min(requested_spatial_points, 8) if arguments.smoke else requested_spatial_points
+    )
+    repeats = 1 if arguments.smoke else requested_repeats
+    if steps < 4 or spatial_points < 4 or repeats < 1:
+        raise ValueError("steps, spatial-points, and repeats are below benchmark minima.")
+
+    cases = (
+        _scalar_linear(steps),
+        _vector_linear(steps),
+        _robertson(steps),
+        _circuit(steps),
+        _reaction_diffusion(steps, spatial_points),
+    )
+    records = tuple(_benchmark_case(case, repeats) for case in cases)
+    report = {
+        "schema_version": "phydrax-dae-benchmark-v2",
+        "protocol": {
+            "timing": (
+                "model setup, solver preparation, lowering, compilation, first "
+                "execution, warmup, and synchronized steady executions are separate"
+            ),
+            "synchronization": "every measured JAX execution blocks all array leaves",
+            "gradient": (
+                "discrete implicit value-and-grad compared with an independent "
+                "closed-form or symmetric finite-difference reference"
+            ),
+            "memory": "logical result payload only; no cumulative allocator counters",
+        },
+        "configuration": {
+            "requested": {
+                "steps": requested_steps,
+                "spatial_points": requested_spatial_points,
+                "repeats": requested_repeats,
+            },
+            "effective": {
+                "steps": steps,
+                "spatial_points": spatial_points,
+                "repeats": repeats,
+                "smoke": bool(arguments.smoke),
+            },
+        },
+        "environment": _environment(),
+        "cases": records,
+        "passed": all(record["passed"] for record in records),
+    }
+    rendered = json.dumps(report, indent=2, sort_keys=True, allow_nan=False)
+    if arguments.output is not None:
+        arguments.output.parent.mkdir(parents=True, exist_ok=True)
+        arguments.output.write_text(rendered + "\n", encoding="utf-8")
+    print(rendered)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Overview

This PR adds Phydrax's first native integration path for finite-dimensional differential-algebraic equations in general implicit form:

```text
F(t, y, ydot, args) = 0
```

The implementation targets caller-declared, regular index-one systems on a fixed `TimeGrid`. It is built directly on the existing Phydrax nonlinear and linear-solve lifecycles rather than wrapping Optimistix, lowering a singular mass matrix into an explicit Diffrax vector field, or creating a second solver stack.

The core architectural decision is to keep five concerns separate:

1. **Model structure** — the residual, state shape, differential/algebraic roles, geometry, and physical scales.
2. **Consistency** — an explicit contract describing which initial state and rate coordinates are fixed or solved.
3. **Integration policy** — BDF order, nonlinear methods, termination criteria, step-ratio bounds, and failure behavior.
4. **Prepared execution** — stable symbolic nonlinear/linear templates with numeric refresh at runtime.
5. **Evidence** — node validity, residual certification, solver status, work counts, and provenance remain first-class output rather than being inferred from finite-looking states.

## Motivation

The existing explicit differential path is appropriate when a model can be written as `ydot = f(t, y, args)`. It cannot honestly represent algebraic constraints, singular mass matrices, or implicit constitutive laws without eliminating variables or hiding a nonlinear solve inside the vector field. `FunctionalSolver` addresses a different problem: minimization of physics/data functionals rather than direct initial-value integration.

This PR fills that gap without broadening the claim beyond what the numerical and structural contracts can support. In particular, temporal incidence is recorded, but it is never presented as proof of index regularity; fixed-grid discrete gradients are provided, but they are never presented as gradients of an adaptive controller.

## Architecture

```text
DifferentialAlgebraicSystem
        +
DifferentialAlgebraicProblem
        +
DAEInitializationSpec
        +
TimeGrid / DAESolvePolicy
        |
        v
     plan_dae
        |
        v
    prepare_dae
  /             \
prepared       prepared
consistency    BDF-stage root
  \             /
        v
      solve_dae
        |
        v
DifferentialAlgebraicSolution
        |
        v
trajectory_data_from_differential_solution
```

For PDE models, `compile_semidiscrete_dae` feeds the same runtime path:

```text
PDEProblemIR + spatial discretization + equation_targets
        |
        v
CompiledSpatialResidual + SemidiscreteDAEStructuralReport
        |
        v
DifferentialAlgebraicSystem
```

## 1. DAE model and structural contracts

### `DAEStructure`

`DAEStructure` declares differential/algebraic roles independently for variables and residual equations. Roles are broadcast along one explicit component axis, which supports both ordinary vector states and packed spatial states such as `(spatial_points, components)`.

The constructor enforces:

- non-empty role declarations;
- only `"differential"` and `"algebraic"` roles;
- matching variable/equation role counts;
- matching numbers of differential variable and equation components;
- a component-axis size consistent with the role declaration;
- `component_axis=None` only when one role applies to the entire state.

The resulting differential/algebraic masks are reused by initialization, residual diagnostics, and trajectory-rate semantics. The solver therefore does not re-infer structure from a Jacobian or mass-matrix diagonal at runtime.

### `DifferentialAlgebraicSystem`

`DifferentialAlgebraicSystem` owns a state-shaped residual and validates its complete call contract:

- scalar real time;
- state and state-rate arrays with exactly `state_shape`;
- matching state/rate dtypes;
- a residual with exactly `state_shape`;
- a stable, non-empty `system_id`.

It carries three independently configurable positive finite real scales:

- `state_scale` for state coordinates;
- `state_rate_scale` for rate coordinates, defaulting to `state_scale`;
- `residual_scale` for equation coordinates and convergence certification.

The raw residual remains physical. Scaling is applied explicitly through `scaled_residual`; it does not silently alter `system(...)`.

The current backend requires Euclidean state geometry. A nontrivial manifold geometry is rejected up front because ambient BDF combinations do not supply the local tangent/retraction semantics needed for a correct manifold method.

`DifferentialAlgebraicSystem.from_mass_matrix` provides a convenience route for

```text
M(t, y, args) @ ydot - f(t, y, args) = 0
```

with constant dense arrays, dynamic mass callables, or native linear operators. The caller still declares the DAE roles; matrix singularity alone is not treated as an index certificate.

## 2. Explicit consistent-initialization semantics

`DifferentialAlgebraicProblem` stores both state and state-rate guesses together with a `DAEInitializationSpec`. The default `index_one()` contract is the standard semi-explicit choice:

| Coordinate class | State | State rate |
| --- | --- | --- |
| Differential variable | fixed | solved |
| Algebraic variable | solved | fixed |

The other modes are deliberate rather than heuristic:

| Mode | Contract |
| --- | --- |
| `index_one()` | Fix differential states and algebraic rates; solve algebraic states and differential rates. |
| `fixed_rate_state()` | Fix the full supplied state and solve the full state rate. |
| `check_only()` | Preserve the supplied state/rate pair and certify its residual without running a nonlinear solve. |
| `from_masks(...)` | Use caller-supplied Boolean fixed-state and fixed-rate masks. |

Custom masks must expose exactly one free state-or-rate scalar for each residual scalar. The implementation does not fall back to least squares, silently free additional coordinates, or replace an unsuccessful consistency solve with the original guess.

Initialization uses the native prepared nonlinear lifecycle. State unknowns are weighted by `state_scale`; rate unknowns are weighted by `state_rate_scale`; equations are evaluated through the already scaled residual. Runtime state, rate, and parameter values refresh numeric data while preserving the prepared symbolic linear template.

`DAEInitializationResult` retains:

- the consistent state and rate;
- state and rate corrections relative to the supplied guesses;
- fixed-state and fixed-rate masks;
- componentwise rate validity;
- total, differential-equation, and algebraic-constraint residual norms;
- the accepted residual threshold;
- native nonlinear result and work counts when a solve ran;
- one of `SUCCESS`, `RESIDUAL_TOO_LARGE`, `NONLINEAR_FAILED`, or `NONFINITE`.

For default index-one initialization, algebraic rates remain semantically unavailable even when a finite placeholder was supplied. This distinction is propagated into the saved trajectory instead of treating every finite array entry as meaningful derivative data.

## 3. Status-preserving implicit root differentiation

The nonlinear layer gains `implicit_root_result`, which removes a prior tension between implicit differentiation and solver evidence.

The previous strict `implicit_root` path returned only a successful state. Callers that needed status and diagnostics had to run a separate explicit solve, which would duplicate work and could produce evidence for a different numerical root. The new function:

- runs the native primal nonlinear solve once;
- returns a complete `NonlinearResult`;
- reevaluates state, residual, and user auxiliary output at the accepted root;
- retains status, diagnostics, and provenance as nondifferentiable evidence;
- supports both ordinary problem/state inputs and an existing `PreparedNonlinearSolve`;
- requires a square state-to-residual coordinate map;
- rejects transformed nonlinear evidence rather than returning ambiguous physical/transformed derivatives.

The derivative rule uses `jax.lax.custom_root` and a checked `jax.lax.custom_linear_solve`. Forward and transpose actions reuse the declared native `LinearSolvePolicy`; unresolved or singular root Jacobians raise rather than returning an unverified tangent or cotangent. Matrix-free GMRES/FGMRES policies retain a callable fast path with an independent residual check.

`implicit_root` remains the strict convenience API: it delegates to `implicit_root_result`, checks the retained status, and returns only a successful state.

A small tracer-safe refinement in the Newton implementation keeps eager initial-status short-circuiting out of traced control flow while preserving the existing eager behavior.

## 4. Prepared fixed-grid BDF integration

### Policy and planning

`DAESolvePolicy` owns:

- `integration_method`: `"bdf1"` or `"bdf2"`;
- separate native `NewtonKrylov`/`NewtonTrustRegion` choices for consistency and stages;
- separate `NonlinearTermination` contracts for consistency and stages;
- `max_step_ratio` for variable-step BDF2 grids;
- `failure="status"` or `failure="error"`.

`DAESolvePlan` validates the full static contract and fingerprints the system, problem, grid, dtype, state shape, BDF method, step-ratio bound, nonlinear method identities, derivative/linear policies, globalization policies, and termination settings.

For BDF2, adjacent interval ratios are checked in both directions during planning. An unsupported grid is rejected; it is not silently downgraded to BDF1.

### Preparation and numeric refresh

`prepare_dae` builds two distinct reusable native artifacts:

1. a prepared consistency problem matching the initialization contract;
2. a prepared BDF-stage nonlinear problem with one stable symbolic linear template.

`solve_dae(prepared, ...)` can refresh runtime arguments and initial guesses without replanning. Prepared and solution objects retain separate plan, preparation, initialization-linear-plan, and stage-linear-plan identities so template reuse is inspectable rather than implied.

### BDF execution

BDF1 reconstructs the state rate from the current and previous accepted states. BDF2 uses a BDF1 startup step, then the exact coefficients for the ratio between the current and previous interval sizes. Predictors use the same accepted state/rate history.

The complete fixed-capacity trajectory executes through `jax.lax.scan`:

- each stage refreshes the prepared numeric nonlinear state;
- each accepted root is returned through `implicit_root_result`;
- the BDF rate is reconstructed from the differentiable accepted state;
- the physical/scaled residual is reevaluated independently at that state and rate;
- nonlinear success, finiteness, and residual acceptance are all required;
- once a node fails, all later nodes become `NOT_RUN` with no explicit fallback step or repaired trajectory.

`DAEStatus` distinguishes initialization failure, nonlinear failure, linear failure, nonfinite output, residual rejection, and nodes not run after an earlier failure. `failure="status"` returns the complete evidence-bearing solution; `failure="error"` raises at the call boundary if any node is invalid.

### Solution evidence

`DifferentialAlgebraicSolution` stores node-aligned:

- times, states, reconstructed state rates, and componentwise rate validity;
- node validity and portable DAE status;
- total scaled residual norm and accepted threshold;
- differential-equation and algebraic-constraint norms.

It stores step-aligned:

- step sizes and BDF orders;
- native nonlinear status and status validity;
- nonlinear iterations and residual evaluations;
- Jacobian preparations;
- linear solves and linear iterations;
- globalization rejections;
- setup and numeric refresh counts.

Static provenance includes system/problem/time/plan/prepared IDs, native nonlinear method ID, initialization and stage linear-plan IDs, integration method, fixed-grid origin, approximation ID, and the explicit differentiation mode `fixed-grid-discrete-implicit`.

## 5. Differentiation contract

The differentiable object is the declared discrete fixed-grid map, not an adaptive continuous-time algorithm.

- Each consistency/stage root uses implicit differentiation through its accepted residual Jacobian.
- Dependencies on runtime parameter PyTrees and prior accepted states chain through the outer fixed-length scan.
- Initial-state overrides participate in that discrete dependency chain.
- Grid times are stop-gradient inputs; there is no derivative through step acceptance or controller logic because there is no adaptive controller in this path.
- Nonlinear iteration history, statuses, work counters, masks, and provenance remain evidence rather than differentiable model parameters.
- A failed primal or derivative linear solve remains explicit failure; no zero-gradient or finite-difference fallback is introduced.

This makes `jit`, `jvp`, `vjp`, `grad`, and `vmap` composable over the same prepared solve without exposing nonlinear iteration bookkeeping to users.

## 6. Semidiscrete implicit PDE compilation

`compile_semidiscrete_dae` lowers validated `PDEProblemIR` directly into a `CompiledSpatialResidual` and a `DifferentialAlgebraicSystem`.

The semidiscrete compiler was refactored so explicit and implicit paths share the same setup for:

- time/spatial coordinate validation;
- field layout construction;
- coordinate-axis mapping;
- boundary-lift validation and binding;
- parameter defaults and runtime bindings;
- region-axis mapping;
- expression validation and physical-state reconstruction.

The implicit path adds an explicit `equation_targets` mapping. It must name every equation exactly once and map bijectively onto every packed field. This removes positional equation/field matching and makes residual component order stable under source-level equation ordering.

Temporal derivative nodes must be direct first derivatives of the equation's target field. They may participate in a general implicit residual; the compiler routes them to the packed `state_rate` field rather than eliminating them. Equations with temporal incidence become differential components; equations without it become algebraic components. Roles are expanded across every scalar component of each packed field.

`SemidiscreteDAEStructuralReport` records:

- field and equation names;
- the resolved equation-to-field mapping;
- variable and equation roles;
- temporal-derivative counts;
- a stable report ID;
- `regularity_verified=False`;
- `index_assumption="regular-index-1-required-unverified"`.

That wording is intentional: incidence is useful compilation evidence, but it is not a rank calculation, symbolic tearing result, or differentiation-index proof.

`CompiledSpatialResidual` retains the residual callable, generated DAE system, field layout, spatial discretization, structural report, boundary lifts, source hash, and compilation ID. It also exposes a dense `rate_jacobian` materialization for diagnostics; the runtime solver remains matrix-free unless the selected nonlinear/linear policy requests otherwise.

## 7. Canonical trajectory interoperability

`trajectory_data_from_differential_solution` now accepts `DifferentialAlgebraicSolution` alongside the existing differential, delay/memory, rough, and controlled outputs.

The adapter:

- preserves accepted DAE states and reconstructed BDF state rates;
- derives transition validity from adjacent valid nodes;
- marks a derivative sample valid only when every component rate at that node is meaningful;
- therefore keeps default index-one initialization derivative-invalid when algebraic rates were not determined;
- uses the DAE `time_id` as the coordinate identity;
- includes problem ID, integration method, and plan ID in source provenance;
- reuses the existing `TrajectoryData` and `StateLayout` contracts rather than adding a DAE-specific identification container.

This allows downstream identification and equation-discovery workflows to consume DAE trajectories without discarding solver masks or pretending unavailable initialization rates are observations.

## 8. Public API additions

### Dynamics

- `DAERole`
- `DAEStructure`
- `DifferentialAlgebraicResidual`
- `DifferentialAlgebraicSystem`

### Nonlinear

- `implicit_root_result`

### Solver

- `DAEInitializationMode`
- `DAEInitializationStatus`
- `DAEInitializationSpec`
- `DAEInitializationResult`
- `DAEIntegrationMethod`
- `DAEFailureMode`
- `DAEStatus`
- `DAESolvePolicy`
- `DAESolvePlan`
- `PreparedDAESolve`
- `DifferentialAlgebraicProblem`
- `DifferentialAlgebraicSolution`
- `initialize_dae`
- `plan_dae`
- `prepare_dae`
- `solve_dae`

### Equations

- `SemidiscreteDAEStructuralReport`
- `CompiledSpatialResidual`
- `compile_semidiscrete_dae`

## 9. Scientific benchmark artifact

`tools/dae_benchmarks.py` adds a schema-versioned benchmark protocol covering:

- scalar implicit decay;
- a vector diagonal mass-matrix system;
- the stiff semi-explicit Robertson kinetics problem;
- a singular-mass linear circuit;
- a constrained semidiscrete reaction-diffusion PDE.

The protocol separates model setup, solver preparation, JAX lowering, compilation, first execution, warmup, and synchronized steady execution. It records raw timing samples, closed-form or symmetric finite-difference gradient references, independent trajectory/constraint/residual certificates, native solver/template evidence, and logical result payload sizes. It deliberately excludes cumulative allocator counters that cannot be attributed to one case and serializes with `allow_nan=False`.

The corresponding `benchmarks/dae_benchmark_artifact.json` is tracked explicitly despite the general generated-benchmark ignore rule.

## 10. Documentation and discoverability

A dedicated `docs/api/solver/differential_algebraic.md` page documents:

- residual and scaling contracts;
- every initialization mode;
- plan/prepare/solve usage;
- BDF and differentiation semantics;
- failure/status behavior;
- semidiscrete compilation;
- trajectory interoperability;
- the complete API surface.

Solver navigation, nonlinear implicit-root documentation, dynamics interoperability guidance, the inverse-problem cookbook, the all-of-Phydrax overview, and the changelog are updated consistently.

## Compatibility and impact

- The DAE public surface is additive.
- Existing explicit ODE/SDE, delay, rough, memory, and controlled solution adapters retain their previous behavior.
- The semidiscrete explicit compiler keeps its public API; shared setup was extracted internally so explicit and implicit lowering use one validation/layout convention.
- `implicit_root` retains its strict state-returning behavior and now delegates to the status-preserving result path.
- No new optional runtime dependency or provider-specific solver path is introduced.

## Deliberate scope boundaries

This PR does **not** add or claim:

- automatic differentiation-index analysis or index reduction;
- symbolic tearing, Pantelides-style reduction, or connector/acausal assembly;
- adaptive step-size control or gradients through accepted-grid selection;
- event localization, reset maps, or event jump adjoints;
- manifold-valued BDF integration;
- sparse Jacobian inference from PDE incidence;
- automatic consistency repair outside the declared fixed/free contract;
- silent explicit fallback after a failed implicit stage.

These are separate architectural layers. Keeping them out of this change preserves a small, auditable substrate on which they can be added without weakening the meaning of current statuses, derivatives, or structural evidence.

## Reviewer map

- `phydrax/dynamics/_differential_algebraic.py` — model, structure, scale, geometry, and mass-matrix contracts.
- `phydrax/solver/_dae_initialization.py` — fixed/free consistency preparation, solve, certification, and evidence.
- `phydrax/nonlinear/_implicit.py` — one-solve status-preserving implicit-root differentiation.
- `phydrax/solver/_differential_algebraic.py` — policy, planning, preparation, BDF scan, status mapping, and solution provenance.
- `phydrax/equations/_semidiscrete.py` — shared semidiscrete setup and implicit PDE residual compilation.
- `phydrax/dynamics/identification/_adapters.py` — canonical trajectory conversion and derivative-validity semantics.
- `tools/dae_benchmarks.py` — reproducible benchmark schema, certificates, timing phases, and artifact generation.
- `docs/api/solver/differential_algebraic.md` — complete user-facing contract and workflow.
