### PR TITLE
feat: add causal sequence and variational inference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,19 @@
   Gaussian expectations, irregular masked schedules, per-case backtracking,
   coherent posterior paths, fixed-posterior ELBO gradients, portable archives,
   diagnostics, tests, documentation, benchmarks, and explicit numerical status.
+- Certified causal nonlinear recurrence with associative temporal linear solves,
+  exact implicit adjoints, dense and quasi-Newton linearizations, and ELK-style
+  Levenberg--Marquardt damping; plus opt-in recurrent-layer and fixed-trajectory HMC
+  consumers with explicit convergence and fallback diagnostics.
+- Normalized mean-field and FlowJAX reverse-KL variational inference with deterministic
+  checkpoint replay, full-path Gaussian Markov state-space VI, reusable amortized
+  encoders, and inverse-inclusion-weighted buffered target windows.
+- Normalized latent-path and parameterized state-space density contracts that preserve
+  the existing prior, transition, observation, schedule, mask, physical-time, and
+  exogenous-input model hierarchy.
+- JAX-compiled bootstrap particle filtering, retained initial genealogy, complete-model
+  `O(TN)` genealogical scores, replaceable SG-MCMC gradient estimators, and
+  complete-sequence particle-driven SGLD/SGNHT.
 - `phydrax.nonlinear` contracts for algebraic systems, Newton line-search and
   trust-region roots, nonlinear GMRES and preconditioning, fixed-point acceleration,
   full-approximation multigrid cycles, variational inequalities, semismooth
@@ -116,6 +129,8 @@
 - DeepONet now accepts generalized coordinate-evaluated basis trunks, exposes
   explicit output-bias control, and preserves existing pointwise and POD
   behavior while supporting projection branches and frozen nested models.
+- Associative Gaussian-chain primitives now live in the lower-level linear-algebra
+  implementation while their existing `phydrax.uq` public names remain unchanged.
 - Nonlinear algebraic systems now have one public owner, `phydrax.nonlinear`, and
   generic continuation/bifurcation workflows have one public owner,
   `phydrax.continuation`; obsolete optimization and dynamics-analysis continuation

--- a/LICENSES/ELK-BSD-3-CLAUSE.txt
+++ b/LICENSES/ELK-BSD-3-CLAUSE.txt
@@ -1,0 +1,28 @@
+BSD 3-Clause License
+
+Copyright (c) 2024, Linderman Lab
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSES/PARALLEL-MCMC-BSD-3-CLAUSE.txt
+++ b/LICENSES/PARALLEL-MCMC-BSD-3-CLAUSE.txt
@@ -1,0 +1,28 @@
+BSD 3-Clause License
+
+Copyright (c) 2025, Linderman Lab
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSES/SEQJAX-MIT.txt
+++ b/LICENSES/SEQJAX-MIT.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Tennessee Hickling
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/NOTICE
+++ b/NOTICE
@@ -58,6 +58,33 @@ coloring dependency through its public Python API. ASDEX artifacts are
 normalized before Phydrax evaluates compressed derivatives through native JAX.
 See LICENSES/ASDEX-MIT.txt.
 
+SeqJAX
+Copyright (c) 2024 Tennessee Hickling
+Licensed under the MIT License.
+The amortized sequence-inference, buffered-window, and particle-genealogy
+designs are informed by SeqJAX at commit
+6e40d3459eb7fe654eb6250a6cb9274a76eba738. Phydrax retains its own state-space,
+parameter, result, checkpoint, and experiment contracts.
+See LICENSES/SEQJAX-MIT.txt.
+
+ELK
+Copyright (c) 2024 Linderman Lab
+Licensed under the BSD 3-Clause License.
+The causal nonlinear recurrence, quasi-Newton temporal linearization, and
+Kalman-form Levenberg--Marquardt stabilization are informed by ELK at commit
+58782bd07a58c28b48c651ac9bd9ac2fec527d58 and the associated NeurIPS 2024
+paper.
+See LICENSES/ELK-BSD-3-CLAUSE.txt.
+
+Parallel MCMC
+Copyright (c) 2025 Linderman Lab
+Licensed under the BSD 3-Clause License.
+The fixed-trajectory causal HMC execution and position--momentum block
+linearization are informed by parallel-mcmc at commit
+5e5b637b1214580d0be4e495215e0e5ed6eb2688 and the associated NeurIPS 2025
+paper.
+See LICENSES/PARALLEL-MCMC-BSD-3-CLAUSE.txt.
+
 Research and design acknowledgments
 
 The moment-calibration formulation follows Shane Barratt, Guillermo Angeris,

--- a/docs/api/nn/layers.md
+++ b/docs/api/nn/layers.md
@@ -82,17 +82,35 @@ Low-level runners distinguish the streaming
 `initial_state` entering a chunk from the canonical state used by resets; an
 explicit `reset_state` overrides the latter when required.
 
-`run_recurrent` executes any `AbstractRecurrentCell` serially. Affine cells can
-instead use `run_affine_recurrence`, whose serial and associative routes compose
-the same transition monoid. `RNNCell`, `GRUCell`, `LSTMCell`, and
-`StackedRecurrentCell` use the same batching, masking, reset, and continuation
-rules.
+`run_recurrent` executes every cell serially. Affine cells can instead use
+`run_affine_recurrence`, whose serial and associative routes compose the same
+transition monoid. Nonlinear cells may opt into `run_causal_recurrent`, which
+uses the certified causal nonlinear solver while preserving the identical
+padding, reset, explicit-key, initial-state, output, and continuation semantics.
+`RNNCell`, `GRUCell`, `LSTMCell`, and `StackedRecurrentCell` support the adapter.
+
+Causal execution is never selected automatically. It can require more work and
+memory than `lax.scan`, especially for short sequences or wide states.
+`CausalRecurrentConfig` makes nonconvergence either an error or an explicit
+recorded serial fallback. A converged result uses the exact implicit recurrence
+adjoint even when its forward direction used a quasi-Newton approximation.
 
 `LinearRecurrentUnit` parameterizes stable complex-conjugate modes with real
 input/output maps. `SelectiveStateSpaceBlock` combines reset-aware causal
 convolution with input-dependent affine state transitions.
 `WeightSpaceRecurrence` applies a diagonal stable recurrence to one explicit
 parameter vector; it never materializes a dense parameter-by-parameter matrix.
+
+::: phydrax.nn.layers.CausalRecurrentConfig
+
+---
+
+::: phydrax.nn.layers.CausalRecurrentResult
+
+---
+
+::: phydrax.nn.layers.run_causal_recurrent
+
 
 ::: phydrax.nn.layers.RNNCell
 
@@ -171,25 +189,3 @@ parameter vector; it never materializes a dense parameter-by-parameter matrix.
 
 ::: phydrax.nn.layers.inference_mode
 
-## Recurrent execution
-
-`RecurrentBatch` is the canonical packed-sequence contract. Every input leaf
-begins with `case_shape + (sequence_length,)`; `valid`, `reset`, and optional
-physical `time` arrays use exactly that shape. Invalid padding preserves state
-and emits zero output. A valid reset restarts from the cell's canonical state
-before evaluating that step. `run_recurrent` returns the post-step state and
-output trajectories together with streaming-ready final values.
-
-::: phydrax.nn.layers.AbstractRecurrentCell
-
----
-
-::: phydrax.nn.layers.RecurrentBatch
-
----
-
-::: phydrax.nn.layers.RecurrentResult
-
----
-
-::: phydrax.nn.layers.run_recurrent

--- a/docs/api/nonlinear.md
+++ b/docs/api/nonlinear.md
@@ -183,6 +183,50 @@ symbolic linear template while refreshing runtime parameters. Singular or
 incompatible derivative systems fail according to the supplied linear policy instead
 of returning an unverified gradient.
 
+## Causal nonlinear recurrence
+
+`CausalRecurrenceProblem` represents a fixed-length first-order recurrence as the
+direct residual `state[t] - transition(parameters, state[t - 1], driver[t])`.
+`solve_causal_recurrence` evaluates all local transitions concurrently and solves
+the resulting affine temporal system with associative scans. The core contract is
+one trajectory; consumers use `vmap` for physical cases.
+
+`CausalNewton` supplies exact dense DEER or an explicitly identified quasi-Newton
+linearization. `CausalLevenbergMarquardt` supplies ELK-style damping with
+actual-versus-predicted reduction checks. Dense, diagonal, fixed-block, and
+fixed-probe Hutchinson diagonal policies are available through
+`CausalLinearizationPolicy`. Approximate linearizations alter only the proposed
+direction: success is always certified by the direct recurrence residual.
+
+The returned histories distinguish convergence, stagnation, nonfinite evaluation,
+damping rejection, and exhausted work. Maximum steps never imply success.
+The solved trajectory carries an exact implicit derivative: the backward pass solves
+the exact reverse block-bidiagonal recurrence at the converged state and does not
+differentiate through iteration counts, damping choices, or quasi-Newton probes.
+Differentiating a failed solve raises instead of returning an approximate gradient.
+
+::: phydrax.nonlinear.CausalRecurrenceProblem
+
+---
+
+::: phydrax.nonlinear.CausalLinearizationPolicy
+
+---
+
+::: phydrax.nonlinear.CausalNewton
+
+---
+
+::: phydrax.nonlinear.CausalLevenbergMarquardt
+
+---
+
+::: phydrax.nonlinear.CausalRecurrenceResult
+
+---
+
+::: phydrax.nonlinear.solve_causal_recurrence
+
 ## API reference
 
 ::: phydrax.nonlinear.NonlinearSystemProblem

--- a/docs/api/stochastic/state_space.md
+++ b/docs/api/stochastic/state_space.md
@@ -373,6 +373,21 @@ component metadata.
 
 ---
 
+## Latent-path and parameter-learning convention
+
+Inference over a complete continuous-state path uses
+`case_shape + (num_steps + 1,) + state_shape`. Index zero is the state at
+`StateSpaceProblem.initial_time`; index `t + 1` is aligned with observation step
+`t`. This differs intentionally from filter result arrays, which contain only
+post-transition states at observation times.
+
+State-space roles continue to own simulation and normalized densities. Global
+parameter learning does not introduce parallel prior/transition/observation
+interfaces. `phydrax.uq.ParameterizedStateSpaceProblem` instead binds physical
+parameters into `StateSpaceStepContext.args`; existing callable transitions and
+observations read them there. A parameter-dependent initial density is an explicit
+optional callback because the original prior object also owns initial sampling.
+
 ## Model and problem
 
 ::: phydrax.stochastic.StateSpaceModel

--- a/docs/api/uq/inference.md
+++ b/docs/api/uq/inference.md
@@ -1202,3 +1202,153 @@ omitting it selects exact inference.
 ---
 
 ::: phydrax.uq.randomized_prior_ensemble
+
+## Variational posterior inference
+
+`fit_variational` minimizes reverse KL in the unconstrained coordinates of a
+`PosteriorProblem`. The target therefore includes the physical prior and each
+bijector Jacobian exactly once. `MeanFieldGaussianFamily` is the default normalized
+family. It is scalable but cannot represent posterior correlation or disconnected
+modes and commonly underestimates uncertainty.
+
+`fit_flow_variational` first obtains a mean-field approximation, initializes a
+FlowJAX spline distribution from its draws, and then optimizes the flow against the
+target density. This reverse-KL objective is distinct from the sample maximum-
+likelihood objective used by flow-assisted NUTS.
+
+Both results retain unconstrained and physical draws, target and family log
+densities, ELBO and gradient histories, deterministic root-key lineage, portable
+checkpoint state, prediction methods, memory, duration, and approximation identity.
+
+::: phydrax.uq.MeanFieldGaussianFamily
+
+---
+
+::: phydrax.uq.VariationalConfig
+
+---
+
+::: phydrax.uq.VariationalResult
+
+---
+
+::: phydrax.uq.fit_variational
+
+---
+
+::: phydrax.uq.FlowVariationalConfig
+
+---
+
+::: phydrax.uq.FlowVariationalFamily
+
+---
+
+::: phydrax.uq.fit_flow_variational
+
+## Full-path and amortized state-space inference
+
+`state_space_path_log_density` evaluates a normalized latent path containing the
+initial state followed by one state per observation step. It returns initial,
+transition, and observation terms separately. Inactive padded steps contribute zero
+and must preserve their predecessor exactly.
+
+`GaussianMarkovVariationalFamily` is a normalized directed Gaussian Markov path
+with dense affine transitions and diagonal innovations.
+`fit_state_space_variational` is the fixed-model full-path reference.
+`AmortizedGaussianMarkovFamily` replaces case-specific free parameters with one
+shared bidirectional context encoder and can be rebound to a compatible observation
+sequence without retraining.
+
+`fit_buffered_state_space_variational` samples fixed-length target intervals.
+`StateSpaceWindowPlan` records exact edge inclusion probabilities; target terms use
+inverse-inclusion weights. Left and right buffers control only encoder context.
+This remains an explicitly identified approximation because its boundary states are
+provided by the amortized family rather than an exact full-data smoother.
+
+::: phydrax.uq.StateSpacePathLogDensity
+
+---
+
+::: phydrax.uq.GaussianMarkovVariationalFamily
+
+---
+
+::: phydrax.uq.fit_state_space_variational
+
+---
+
+::: phydrax.uq.AmortizedGaussianMarkovFamily
+
+---
+
+::: phydrax.uq.fit_amortized_state_space_variational
+
+---
+
+::: phydrax.uq.StateSpaceWindowPlan
+
+---
+
+::: phydrax.uq.BufferedStateSpaceVariationalResult
+
+---
+
+::: phydrax.uq.fit_buffered_state_space_variational
+
+## Causal fixed-trajectory HMC
+
+`sample_hmc(..., trajectory_method="causal")` keeps BlackJAX warmup, momentum
+generation, energy evaluation, momentum flip, and Metropolis decision unchanged.
+Only the fixed-length velocity-Verlet trajectory is solved through the causal
+nonlinear recurrence. Production supports diagonal adapted inverse mass matrices,
+static leapfrog counts, dense-exact or position--momentum pair Hutchinson
+linearization, and explicit trajectory blocking.
+
+Every block must converge to the sequential trajectory before the proposal is
+treated as ordinary HMC. `failure_policy="raise"` is the default; an explicit
+sequential fallback is recorded in `CausalHMCDiagnostics`. NUTS is not supported
+because dynamic tree construction does not satisfy the fixed causal layout.
+
+::: phydrax.uq.CausalHMCConfig
+
+---
+
+::: phydrax.uq.CausalHMCDiagnostics
+
+## Particle genealogical scores and stochastic gradients
+
+`particle_genealogical_score` propagates normalized prior, transition, and
+observation score increments through realized stopped-gradient ancestry. Its stored
+state scales as `O(TN)`, unlike the existing density-based pair smoother's
+`O(TN²)` score. The lower cost trades for greater resampling and genealogy variance;
+the existing Fisher score remains available.
+
+`ParameterizedStateSpaceProblem` binds unconstrained global coordinates into the
+existing `StateSpaceStepContext.args` contract without defining a second model
+hierarchy. `ParticleGenealogicalGradientEstimator` uses its complete-sequence
+particle score plus the exact parameter prior and can drive `sample_sgld` or
+`sample_sgnht` through the common `AbstractStochasticGradientEstimator` interface.
+The existing autodiff minibatch estimator remains the default and replay-compatible.
+
+Buffered particle SG-MCMC is deliberately not exposed: the current buffered
+variational boundary law has not established a sufficiently accurate particle-score
+boundary correction. Complete-sequence particle gradients are supported.
+
+::: phydrax.uq.ParticleGenealogicalScoreResult
+
+---
+
+::: phydrax.uq.particle_genealogical_score
+
+---
+
+::: phydrax.uq.ParameterizedStateSpaceProblem
+
+---
+
+::: phydrax.uq.AbstractStochasticGradientEstimator
+
+---
+
+::: phydrax.uq.ParticleGenealogicalGradientEstimator

--- a/docs/guides_uncertainty.md
+++ b/docs/guides_uncertainty.md
@@ -1294,6 +1294,28 @@ Flow-assisted NUTS does not currently accept the interleaved method. The schedul
 construction follows [Efficiently Vectorized MCMC on Modern
 Accelerators](https://arxiv.org/abs/2503.17405).
 
+Fixed-trajectory HMC can opt into causal leapfrog execution:
+
+```python
+causal_hmc = phx.uq.sample_hmc(
+    posterior,
+    key=jr.key(13),
+    num_integration_steps=128,
+    trajectory_method="causal",
+    causal_config=phx.uq.CausalHMCConfig(
+        trajectory_block_size=128,
+        linearization="pair-hutchinson",
+    ),
+)
+```
+
+Warmup and the Metropolis correction remain BlackJAX operations. Each production
+trajectory block must converge to the sequential velocity-Verlet endpoint. Inspect
+`causal_hmc.causal_diagnostics`; any fallback or failed residual gate invalidates a
+claim of causal acceleration. Causal HMC exchanges extra parallel work and memory for
+lower temporal depth and can be slower for short trajectories. It does not apply to
+NUTS's dynamic tree.
+
 `convergence_report(...)` applies caller-controlled release gates and reports exact
 failing PyTree leaves. `MCMCResult` retains tuned warmup parameters, final chain
 states, energies, integration depths, deterministic keys, adaptation and sampling
@@ -1345,6 +1367,41 @@ adaptive collocation, minibatch likelihoods, active dropout, or other random sam
 inside `log_density`. NUTS is the default for low-dimensional physical parameters,
 noise scales, and explicitly selected small subspaces. Sampling every neural-network
 weight is deliberately not the default.
+
+## Variational and long-sequence posterior approximation
+
+Use `fit_variational` when an optimized normalized approximation is more useful than
+a short, poorly mixed exact chain:
+
+```python
+variational = phx.uq.fit_variational(
+    posterior,
+    key=jr.key(14),
+    family=phx.uq.MeanFieldGaussianFamily.from_position(
+        posterior.initial_position
+    ),
+)
+```
+
+The family lives in unconstrained coordinates. Mean-field Gaussian VI is fast but
+misses correlation, tails, and separated modes. Flow VI can represent curved
+geometry but reverse KL can still collapse onto one mode. Compare both against NUTS
+or tempered SMC on a tractable reference and report target and family log densities,
+not ELBO alone.
+
+For a fixed `StateSpaceProblem`, `fit_state_space_variational` supplies the
+full-path Gaussian Markov reference. Train amortized and buffered variants only
+after this reference is credible:
+
+1. check the Gaussian Markov posterior against Kalman smoothing on a linear model;
+2. train the shared amortized encoder on complete sequences;
+3. compare complete-sequence amortized and free-family marginals;
+4. sweep left and right buffer lengths;
+5. report boundary-sensitive latent marginals, not observation prediction alone.
+
+`StateSpaceWindowPlan` uses exact inverse inclusion probabilities for target terms.
+That corrects target sampling frequency; it does not make the amortized boundary law
+exact. Buffered particle SG-MCMC is therefore not exposed.
 
 ## Fixed-step stochastic-gradient MCMC
 
@@ -1451,6 +1508,14 @@ locations. SGNHT additionally retains thermostat and momentum-norm traces.
 Checkpointing resumes the indexed source/transition schedule exactly and rejects
 changed problem, source, control-variate, PyTree, or sampler identities.
 
+`gradient_estimator` can replace the default autodiff factor gradient without
+changing the diffusion convention or transition-key schedule. The
+`ParticleGenealogicalGradientEstimator` runs a complete-sequence JAX particle filter,
+propagates stopped-ancestry prior/transition/observation scores in `O(TN)` state, and
+adds the exact global parameter prior. It is higher variance than the existing
+`O(TN²)` pair-smoothing score. The existing `SGMCMCControlVariate` is rejected for
+this estimator because its reference gradient has different semantics.
+
 These are unadjusted fixed-step approximations. Burn-in discards early states; it
 is not adaptation. Rank diagnostics measure between-chain mixing and do not detect
 stationary discretization bias. For every scientific use:
@@ -1461,11 +1526,12 @@ stationary discretization bias. For every scientific use:
 4. report the batch definition, population size, step size, burn-in, thinning,
    update count, and approximation label.
 
-Prefer NUTS or Laplace when full-data inference is feasible. Current SG-MCMC
-sources support uniform factor subsampling only: no decreasing-step schedule,
-automatic step-size adaptation, query-anchor subsampling, likelihood-dependent
-sampling, multi-host source execution, SGHMC, pSGLD/RMSProp geometry, or online
-gradient-noise covariance estimation is implied.
+Prefer NUTS or Laplace when full-data inference is feasible. Uniform factor
+minibatching and complete-sequence particle genealogical gradients are supported.
+No decreasing-step schedule, automatic step-size adaptation, query-anchor
+subsampling, buffered particle-score correction, multi-host source execution,
+SGHMC, pSGLD/RMSProp geometry, or online gradient-noise covariance estimation is
+implied.
 
 ## Flow-assisted NUTS
 

--- a/phydrax/linalg/_causal_linear.py
+++ b/phydrax/linalg/_causal_linear.py
@@ -1,0 +1,247 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import opt_einsum as oe
+from jaxtyping import Array
+
+from ._gaussian_chain import (
+    associative_gaussian_filter,
+    associative_gaussian_smoother,
+)
+
+
+def _validate_causal_arrays(
+    transitions: Array,
+    vectors: Array,
+    /,
+    *,
+    vector_name: str,
+) -> tuple[Array, Array]:
+    matrices = jnp.asarray(transitions)
+    values = jnp.asarray(vectors)
+    if matrices.ndim != 3 or matrices.shape[-2] != matrices.shape[-1]:
+        raise ValueError("transitions must have shape (time, state, state).")
+    if values.ndim != 2 or values.shape != matrices.shape[:1] + matrices.shape[-1:]:
+        raise ValueError(
+            f"{vector_name} must have shape (time, state) matching transitions."
+        )
+    if matrices.shape[0] < 1:
+        raise ValueError("A causal linear system requires at least one time step.")
+    if not jnp.issubdtype(matrices.dtype, jnp.inexact) or not jnp.issubdtype(
+        values.dtype, jnp.inexact
+    ):
+        raise TypeError("Causal linear systems require inexact arrays.")
+    dtype = jnp.result_type(matrices, values)
+    return matrices.astype(dtype), values.astype(dtype)
+
+
+def _compose_affine(
+    earlier: tuple[Array, Array],
+    later: tuple[Array, Array],
+    /,
+) -> tuple[Array, Array]:
+    earlier_transition, earlier_offset = earlier
+    later_transition, later_offset = later
+    transition = oe.contract("...ij,...jk->...ik", later_transition, earlier_transition)
+    offset = (
+        oe.contract("...ij,...j->...i", later_transition, earlier_offset) + later_offset
+    )
+    return transition, offset
+
+
+def associative_affine_solve(
+    transitions: Array,
+    offsets: Array,
+    /,
+) -> Array:
+    """Solve ``x[t] = A[t] x[t - 1] + b[t]`` by associative composition.
+
+    The first transition is applied to an implicit zero predecessor. Callers
+    represent a fixed initial boundary by setting ``transitions[0]`` to zero and
+    placing the complete first value in ``offsets[0]``.
+    """
+
+    matrices, vectors = _validate_causal_arrays(
+        transitions,
+        offsets,
+        vector_name="offsets",
+    )
+    _, prefixes = jax.lax.associative_scan(
+        _compose_affine,
+        (matrices, vectors),
+        axis=0,
+    )
+    return prefixes
+
+
+def associative_transpose_solve(
+    transitions: Array,
+    right_hand_side: Array,
+    /,
+) -> Array:
+    """Solve the transpose of a unit block-bidiagonal causal system.
+
+    ``transitions[t]`` is the derivative mapping state ``t - 1`` to state
+    ``t``. The represented forward operator has identity diagonal blocks and
+    lower blocks ``-transitions[t]``.
+    """
+
+    matrices, right = _validate_causal_arrays(
+        transitions,
+        right_hand_side,
+        vector_name="right_hand_side",
+    )
+    zero = jnp.zeros_like(matrices[:1])
+    reverse_transitions = jnp.concatenate(
+        (zero, jnp.swapaxes(matrices[1:][::-1], -1, -2)),
+        axis=0,
+    )
+    reverse_solution = associative_affine_solve(
+        reverse_transitions,
+        right[::-1],
+    )
+    return reverse_solution[::-1]
+
+
+def causal_linearized_residual(
+    transitions: Array,
+    residuals: Array,
+    step: Array,
+    /,
+) -> Array:
+    """Evaluate ``r + J step`` without assembling the temporal Jacobian."""
+
+    matrices, residual = _validate_causal_arrays(
+        transitions,
+        residuals,
+        vector_name="residuals",
+    )
+    direction = jnp.asarray(step, dtype=residual.dtype)
+    if direction.shape != residual.shape:
+        raise ValueError("step must have the same shape as residuals.")
+    predecessor = jnp.concatenate((jnp.zeros_like(direction[:1]), direction[:-1]), axis=0)
+    propagated = oe.contract("tij,tj->ti", matrices, predecessor)
+    return residual + direction - propagated
+
+
+def _damped_causal_least_squares(
+    transitions: Array,
+    residuals: Array,
+    damping: Array,
+    /,
+) -> Array:
+    num_steps, state_size = residuals.shape
+    dtype = residuals.dtype
+    identity = jnp.eye(state_size, dtype=dtype)
+    process_covariances = (
+        jnp.broadcast_to(
+            identity,
+            (num_steps, state_size, state_size),
+        )
+        .at[0]
+        .set(jnp.zeros_like(identity))
+    )
+    filter_transitions = transitions.at[0].set(identity)
+    filter_offsets = (-residuals).at[0].set(jnp.zeros_like(residuals[0]))
+    observation_matrices = jnp.broadcast_to(
+        identity,
+        (num_steps, state_size, state_size),
+    )
+    observation_offsets = jnp.zeros((num_steps, state_size), dtype=dtype)
+    observation_covariances = jnp.broadcast_to(
+        identity / damping,
+        (num_steps, state_size, state_size),
+    )
+    observations = jnp.zeros((num_steps, state_size), dtype=dtype)
+    masks = jnp.ones((num_steps, state_size), dtype=bool)
+    initial_mean = -residuals[0]
+    initial_covariance = identity
+
+    filtered_means, filtered_covariances = associative_gaussian_filter(
+        initial_mean[None, :],
+        initial_covariance[None, :, :],
+        filter_transitions[:, None, :, :],
+        filter_offsets[:, None, :],
+        process_covariances[:, None, :, :],
+        observation_matrices[:, None, :, :],
+        observation_offsets[:, None, :],
+        observation_covariances[:, None, :, :],
+        observations[:, None, :],
+        masks[:, None, :],
+    )
+    filtered_means = filtered_means[:, 0]
+    filtered_covariances = filtered_covariances[:, 0]
+
+    predecessor_means = jnp.concatenate(
+        (initial_mean[None, :], filtered_means[:-1]), axis=0
+    )
+    predecessor_covariances = jnp.concatenate(
+        (initial_covariance[None, :, :], filtered_covariances[:-1]),
+        axis=0,
+    )
+    predicted_means = (
+        oe.contract("tij,tj->ti", filter_transitions, predecessor_means) + filter_offsets
+    )
+    predicted_covariances = (
+        filter_transitions
+        @ predecessor_covariances
+        @ jnp.swapaxes(filter_transitions, -1, -2)
+        + process_covariances
+    )
+    smoothed_means, _, _ = associative_gaussian_smoother(
+        filtered_means[:, None, :],
+        filtered_covariances[:, None, :, :],
+        predicted_means[:, None, :],
+        predicted_covariances[:, None, :, :],
+        filter_transitions[:, None, :, :],
+        jnp.ones((num_steps, 1), dtype=bool),
+    )
+    return smoothed_means[:, 0]
+
+
+def solve_causal_least_squares(
+    transitions: Array,
+    residuals: Array,
+    damping: Array,
+    /,
+) -> Array:
+    """Solve a scalar-damped causal linearized least-squares subproblem."""
+
+    matrices, residual = _validate_causal_arrays(
+        transitions,
+        residuals,
+        vector_name="residuals",
+    )
+    damping_value = jnp.asarray(damping, dtype=residual.real.dtype)
+    if damping_value.shape != ():
+        raise ValueError("damping must be scalar.")
+    damping_value = eqx.error_if(
+        damping_value,
+        (~jnp.isfinite(damping_value)) | (damping_value < 0.0),
+        "damping must be finite and nonnegative.",
+    )
+    direct_transitions = matrices.at[0].set(jnp.zeros_like(matrices[0]))
+    return jax.lax.cond(
+        damping_value > 0.0,
+        lambda _: _damped_causal_least_squares(
+            direct_transitions,
+            residual,
+            damping_value,
+        ),
+        lambda _: associative_affine_solve(direct_transitions, -residual),
+        operand=None,
+    )
+
+
+__all__ = [
+    "associative_affine_solve",
+    "associative_transpose_solve",
+    "causal_linearized_residual",
+    "solve_causal_least_squares",
+]

--- a/phydrax/linalg/_gaussian_chain.py
+++ b/phydrax/linalg/_gaussian_chain.py
@@ -16,14 +16,11 @@ import opt_einsum as oe
 from jaxtyping import Array, ArrayLike, Key
 
 from .._strict import StrictModule
-from ..linalg import (
-    DenseLinearOperator,
-    DenseLU,
-    LinearSolvePolicy,
-    LinearSystem,
-    RHSLayout,
-    solve,
-)
+from ._operators import DenseLinearOperator
+from ._policies import DenseLU, LinearSolvePolicy
+from ._problems import LinearSystem
+from ._runtime import solve
+from ._spaces import RHSLayout
 
 
 class GaussianFilterElement(StrictModule):

--- a/phydrax/nn/layers/__init__.py
+++ b/phydrax/nn/layers/__init__.py
@@ -5,6 +5,13 @@
 """Reusable neural network layers."""
 
 from ._adaptive_residual import AdaptiveResidual
+from ._causal_recurrent import (
+    CausalRecurrentConfig,
+    CausalRecurrentDiagnostics,
+    CausalRecurrentFailurePolicy,
+    CausalRecurrentResult,
+    run_causal_recurrent,
+)
 from ._dropout import Dropout, inference_mode
 from ._fourier_embeddings import (
     ExplicitFourierFeatureEmbeddings,
@@ -67,6 +74,10 @@ __all__ = [
     "AbstractRecurrentCell",
     "AffineRecurrence",
     "AttentionExecution",
+    "CausalRecurrentConfig",
+    "CausalRecurrentDiagnostics",
+    "CausalRecurrentFailurePolicy",
+    "CausalRecurrentResult",
     "AttentionKernel",
     "MeasureAwareAttention",
     "MeasureNormalizedConvND",
@@ -110,5 +121,6 @@ __all__ = [
     "WarpBoundaryMode",
     "inference_mode",
     "run_affine_recurrence",
+    "run_causal_recurrent",
     "run_recurrent",
 ]

--- a/phydrax/nn/layers/_causal_recurrent.py
+++ b/phydrax/nn/layers/_causal_recurrent.py
@@ -1,0 +1,423 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from math import prod
+from typing import Any, Literal, TypeAlias
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+from jaxtyping import Array
+
+from ..._strict import StrictModule
+from ...linalg._gaussian_chain import associative_freeze
+from ...nonlinear import (
+    CausalLevenbergMarquardt,
+    CausalNewton,
+    CausalRecurrenceDiagnostics,
+    CausalRecurrenceProblem,
+    NonlinearStatus,
+    NonlinearTermination,
+    solve_causal_recurrence,
+)
+from .._keys import EvalKey
+from ._recurrent import (
+    _recurrent_output_from_state,
+    _resolve_initial_state,
+    _tree_where,
+    _tree_zero_where_invalid,
+    AbstractRecurrentCell,
+    RecurrentBatch,
+    RecurrentResult,
+    run_recurrent,
+)
+
+
+CausalRecurrentFailurePolicy: TypeAlias = Literal["raise", "serial"]
+
+
+class CausalRecurrentConfig(StrictModule):
+    """Causal nonlinear method, termination, and explicit failure behavior."""
+
+    method: CausalNewton | CausalLevenbergMarquardt
+    termination: NonlinearTermination
+    failure_policy: CausalRecurrentFailurePolicy = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        method: CausalNewton | CausalLevenbergMarquardt | None = None,
+        termination: NonlinearTermination | None = None,
+        failure_policy: CausalRecurrentFailurePolicy = "raise",
+    ):
+        method_ = CausalLevenbergMarquardt() if method is None else method
+        termination_ = NonlinearTermination() if termination is None else termination
+        if not isinstance(method_, (CausalNewton, CausalLevenbergMarquardt)):
+            raise TypeError("method must be a causal recurrence method or None.")
+        if not isinstance(termination_, NonlinearTermination):
+            raise TypeError("termination must be NonlinearTermination or None.")
+        if failure_policy not in ("raise", "serial"):
+            raise ValueError("failure_policy must be 'raise' or 'serial'.")
+        self.method = method_
+        self.termination = termination_
+        self.failure_policy = failure_policy
+
+
+class CausalRecurrentDiagnostics(StrictModule):
+    """Per-case causal solve diagnostics and explicit fallback record."""
+
+    causal: CausalRecurrenceDiagnostics
+    status: Array
+    fallback_used: Array
+
+
+class CausalRecurrentResult(StrictModule):
+    """Recurrent outputs with causal convergence and fallback provenance."""
+
+    states: Any
+    outputs: Any
+    final_state: Any
+    final_output: Any
+    diagnostics: CausalRecurrentDiagnostics
+    approximation_id: str = eqx.field(static=True)
+
+    @property
+    def successful(self) -> Array:
+        return self.diagnostics.status == int(NonlinearStatus.SUCCESS)
+
+    @property
+    def recurrent(self) -> RecurrentResult:
+        return RecurrentResult(
+            states=self.states,
+            outputs=self.outputs,
+            final_state=self.final_state,
+            final_output=self.final_output,
+        )
+
+
+def _case_count(batch: RecurrentBatch, /) -> int:
+    return prod(batch.case_shape) if batch.case_shape else 1
+
+
+def _flatten_state_cases(tree: Any, case_shape: tuple[int, ...], /) -> Any:
+    count = prod(case_shape) if case_shape else 1
+    rank = len(case_shape)
+    return jax.tree.map(
+        lambda leaf: jnp.asarray(leaf).reshape((count,) + jnp.asarray(leaf).shape[rank:]),
+        tree,
+    )
+
+
+def _flatten_sequence_cases(
+    tree: Any,
+    case_shape: tuple[int, ...],
+    sequence_length: int,
+    /,
+) -> Any:
+    count = prod(case_shape) if case_shape else 1
+    rank = len(case_shape)
+
+    def flatten(leaf):
+        value = jnp.asarray(leaf)
+        moved = jnp.moveaxis(value, rank, 0)
+        return jnp.moveaxis(
+            moved.reshape((sequence_length, count) + value.shape[rank + 1 :]),
+            0,
+            1,
+        )
+
+    return jax.tree.map(flatten, tree)
+
+
+def _restore_state_cases(tree: Any, case_shape: tuple[int, ...], /) -> Any:
+    return jax.tree.map(
+        lambda leaf: leaf.reshape(case_shape + leaf.shape[1:]),
+        tree,
+    )
+
+
+def _restore_sequence_cases(tree: Any, case_shape: tuple[int, ...], /) -> Any:
+    return jax.tree.map(
+        lambda leaf: leaf.reshape(case_shape + leaf.shape[1:]),
+        tree,
+    )
+
+
+def _latest_valid_output(initial: Any, values: Any, valid: Array, /) -> Any:
+    return jax.tree.map(
+        lambda initial_leaf, value_leaf: associative_freeze(
+            initial_leaf,
+            value_leaf,
+            valid,
+        )[-1],
+        initial,
+        values,
+    )
+
+
+def run_causal_recurrent(
+    cell: AbstractRecurrentCell,
+    batch: RecurrentBatch,
+    /,
+    *,
+    initial_state: Any | None = None,
+    reset_state: Any | None = None,
+    initial_trajectory: Any | None = None,
+    key: EvalKey = None,
+    probe_key: Array | None = None,
+    config: CausalRecurrentConfig | None = None,
+) -> CausalRecurrentResult:
+    """Evaluate a recurrent cell through a certified causal nonlinear solve."""
+
+    if not isinstance(cell, AbstractRecurrentCell):
+        raise TypeError("cell must be an AbstractRecurrentCell.")
+    if not isinstance(batch, RecurrentBatch):
+        raise TypeError("batch must be a RecurrentBatch.")
+    configuration = CausalRecurrentConfig() if config is None else config
+    if not isinstance(configuration, CausalRecurrentConfig):
+        raise TypeError("config must be CausalRecurrentConfig or None.")
+
+    canonical_state = _resolve_initial_state(cell, batch, None)
+    state0 = (
+        canonical_state
+        if initial_state is None
+        else _resolve_initial_state(cell, batch, initial_state)
+    )
+    restart_state = (
+        canonical_state
+        if reset_state is None
+        else _resolve_initial_state(cell, batch, reset_state)
+    )
+    count = _case_count(batch)
+    flat_initial = _flatten_state_cases(state0, batch.case_shape)
+    flat_restart = _flatten_state_cases(restart_state, batch.case_shape)
+    flat_inputs = _flatten_sequence_cases(
+        batch.inputs,
+        batch.case_shape,
+        batch.sequence_length,
+    )
+    flat_valid = batch.valid.reshape((count, batch.sequence_length))
+    flat_reset = batch.reset.reshape((count, batch.sequence_length))
+    flat_initial_trajectory = (
+        None
+        if initial_trajectory is None
+        else _flatten_sequence_cases(
+            initial_trajectory,
+            batch.case_shape,
+            batch.sequence_length,
+        )
+    )
+    step_keys = None if key is None else jr.split(key, batch.sequence_length)
+    if (
+        configuration.method.linearization.mode == "diagonal-hutchinson"
+        and probe_key is None
+    ):
+        raise ValueError("Hutchinson causal recurrence requires probe_key.")
+    probe_root = jr.key(0) if probe_key is None else probe_key
+    case_probe_keys = jr.split(probe_root, count)
+
+    def solve_case(
+        current_cell,
+        case_initial,
+        case_restart,
+        case_inputs,
+        case_valid,
+        case_reset,
+        case_initial_trajectory,
+        case_probe_key,
+    ):
+        if step_keys is None:
+            drivers = (case_inputs, case_valid, case_reset)
+
+            def transition(parameters, previous, driver):
+                recurrent_cell, recurrent_restart = parameters
+                inputs, valid, reset = driver
+                restarted = _tree_where(reset & valid, recurrent_restart, previous)
+                safe_inputs = _tree_zero_where_invalid(valid, inputs)
+                proposed, _ = recurrent_cell.step(restarted, safe_inputs, key=None)
+                return _tree_where(valid, proposed, previous)
+
+        else:
+            drivers = (case_inputs, case_valid, case_reset, step_keys)
+
+            def transition(parameters, previous, driver):
+                recurrent_cell, recurrent_restart = parameters
+                inputs, valid, reset, step_key = driver
+                restarted = _tree_where(reset & valid, recurrent_restart, previous)
+                safe_inputs = _tree_zero_where_invalid(valid, inputs)
+                proposed, _ = recurrent_cell.step(
+                    restarted,
+                    safe_inputs,
+                    key=step_key,
+                )
+                return _tree_where(valid, proposed, previous)
+
+        problem = CausalRecurrenceProblem(
+            transition,
+            case_initial,
+            drivers,
+            parameters=(current_cell, case_restart),
+            problem_id="causal-recurrent-cell",
+        )
+        result = solve_causal_recurrence(
+            problem,
+            initial_trajectory=case_initial_trajectory,
+            method=configuration.method,
+            termination=configuration.termination,
+            probe_key=case_probe_key,
+        )
+        return result.states, result.status, result.diagnostics
+
+    if flat_initial_trajectory is None:
+        flat_initial_trajectory = jax.tree.map(
+            lambda leaf: jnp.broadcast_to(
+                leaf[:, None, ...],
+                (count, batch.sequence_length) + leaf.shape[1:],
+            ),
+            flat_initial,
+        )
+    if case_probe_keys is None:
+        case_probe_keys = jnp.zeros((count, 2), dtype=jnp.uint32)
+
+    flat_states, flat_status, flat_diagnostics = jax.vmap(
+        solve_case,
+        in_axes=(None, 0, 0, 0, 0, 0, 0, 0),
+    )(
+        cell,
+        flat_initial,
+        flat_restart,
+        flat_inputs,
+        flat_valid,
+        flat_reset,
+        flat_initial_trajectory,
+        case_probe_keys,
+    )
+
+    def output_case(
+        current_cell,
+        case_initial,
+        case_restart,
+        case_inputs,
+        case_valid,
+        case_reset,
+        case_states,
+    ):
+        predecessors = jax.tree.map(
+            lambda initial_leaf, state_leaf: jnp.concatenate(
+                (initial_leaf[None, ...], state_leaf[:-1]),
+                axis=0,
+            ),
+            case_initial,
+            case_states,
+        )
+        output_initial = _recurrent_output_from_state(current_cell, case_initial)
+
+        if step_keys is None:
+
+            def evaluate(previous, inputs, valid, reset):
+                restarted = _tree_where(reset & valid, case_restart, previous)
+                safe_inputs = _tree_zero_where_invalid(valid, inputs)
+                _, output = current_cell.step(restarted, safe_inputs, key=None)
+                return output
+
+            raw_outputs = jax.vmap(evaluate)(
+                predecessors,
+                case_inputs,
+                case_valid,
+                case_reset,
+            )
+        else:
+
+            def evaluate(previous, inputs, valid, reset, step_key):
+                restarted = _tree_where(reset & valid, case_restart, previous)
+                safe_inputs = _tree_zero_where_invalid(valid, inputs)
+                _, output = current_cell.step(restarted, safe_inputs, key=step_key)
+                return output
+
+            raw_outputs = jax.vmap(evaluate)(
+                predecessors,
+                case_inputs,
+                case_valid,
+                case_reset,
+                step_keys,
+            )
+        masked_outputs = _tree_zero_where_invalid(case_valid, raw_outputs)
+        final_output = _latest_valid_output(output_initial, raw_outputs, case_valid)
+        final_state = jax.tree.map(lambda leaf: leaf[-1], case_states)
+        return masked_outputs, final_state, final_output
+
+    flat_outputs, flat_final_state, flat_final_output = jax.vmap(
+        output_case,
+        in_axes=(None, 0, 0, 0, 0, 0, 0),
+    )(
+        cell,
+        flat_initial,
+        flat_restart,
+        flat_inputs,
+        flat_valid,
+        flat_reset,
+        flat_states,
+    )
+
+    successful = flat_status == int(NonlinearStatus.SUCCESS)
+    fallback_used = ~successful
+    states = _restore_sequence_cases(flat_states, batch.case_shape)
+    outputs = _restore_sequence_cases(flat_outputs, batch.case_shape)
+    final_state = _restore_state_cases(flat_final_state, batch.case_shape)
+    final_output = _restore_state_cases(flat_final_output, batch.case_shape)
+
+    if configuration.failure_policy == "raise":
+        checked = eqx.error_if(
+            jax.tree.leaves(states)[0],
+            jnp.any(~successful),
+            "Causal recurrent evaluation failed; inspect a record-mode core solve or use explicit serial fallback.",
+        )
+        states = eqx.tree_at(lambda tree: jax.tree.leaves(tree)[0], states, checked)
+    else:
+        serial = run_recurrent(
+            cell,
+            batch,
+            initial_state=initial_state,
+            reset_state=reset_state,
+            key=key,
+        )
+        case_success = successful.reshape(batch.case_shape)
+        states = _tree_where(case_success, states, serial.states)
+        outputs = _tree_where(case_success, outputs, serial.outputs)
+        final_state = _tree_where(case_success, final_state, serial.final_state)
+        final_output = _tree_where(case_success, final_output, serial.final_output)
+
+    diagnostics = CausalRecurrentDiagnostics(
+        causal=jax.tree.map(
+            lambda leaf: leaf.reshape(batch.case_shape + leaf.shape[1:]),
+            flat_diagnostics,
+        ),
+        status=flat_status.reshape(batch.case_shape),
+        fallback_used=fallback_used.reshape(batch.case_shape),
+    )
+    approximation = (
+        "causal-recurrent"
+        if configuration.failure_policy == "raise"
+        else "causal-recurrent-with-explicit-serial-fallback"
+    )
+    return CausalRecurrentResult(
+        states=states,
+        outputs=outputs,
+        final_state=final_state,
+        final_output=final_output,
+        diagnostics=diagnostics,
+        approximation_id=approximation,
+    )
+
+
+__all__ = [
+    "CausalRecurrentConfig",
+    "CausalRecurrentDiagnostics",
+    "CausalRecurrentFailurePolicy",
+    "CausalRecurrentResult",
+    "run_causal_recurrent",
+]

--- a/phydrax/nonlinear/__init__.py
+++ b/phydrax/nonlinear/__init__.py
@@ -5,6 +5,17 @@
 """Nonlinear algebraic systems, fixed points, and implicit root calculus."""
 
 from .._bounds import Bounds
+from ._causal import (
+    CausalLevenbergMarquardt,
+    CausalLinearizationMode,
+    CausalLinearizationPolicy,
+    CausalNewton,
+    CausalProbeDistribution,
+    CausalRecurrenceDiagnostics,
+    CausalRecurrenceProblem,
+    CausalRecurrenceResult,
+    solve_causal_recurrence,
+)
 from ._fas import (
     fas_cycle,
     FASCycleKind,
@@ -83,6 +94,14 @@ __all__ = [
     "AndersonAcceleration",
     "AbstractRightNonlinearPreconditioner",
     "Bounds",
+    "CausalLevenbergMarquardt",
+    "CausalLinearizationMode",
+    "CausalLinearizationPolicy",
+    "CausalNewton",
+    "CausalProbeDistribution",
+    "CausalRecurrenceDiagnostics",
+    "CausalRecurrenceProblem",
+    "CausalRecurrenceResult",
     "ComplementarityCertificate",
     "ComplementarityFormulation",
     "FASCycleKind",
@@ -136,4 +155,5 @@ __all__ = [
     "refresh_nonlinear",
     "right_precondition",
     "solve_prepared_nonlinear",
+    "solve_causal_recurrence",
 ]

--- a/phydrax/nonlinear/_causal.py
+++ b/phydrax/nonlinear/_causal.py
@@ -1,0 +1,866 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from math import isfinite
+from typing import Any, Literal, TypeAlias
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+from jax.flatten_util import ravel_pytree
+from jaxtyping import Array, PyTree
+
+from .._strict import StrictModule
+from ..linalg._causal_linear import (
+    causal_linearized_residual,
+    solve_causal_least_squares,
+)
+from ._causal_adjoint import attach_causal_implicit_derivative
+from ._types import NonlinearStatus, NonlinearTermination
+
+
+CausalLinearizationMode: TypeAlias = Literal[
+    "dense-exact",
+    "diagonal-exact",
+    "diagonal-hutchinson",
+    "fixed-block",
+]
+CausalProbeDistribution: TypeAlias = Literal["rademacher", "normal"]
+
+
+def _tree_all_finite(tree: PyTree[Any], /) -> Array:
+    leaves = jax.tree.leaves(tree)
+    if not leaves:
+        return jnp.asarray(False)
+    return jnp.all(
+        jnp.stack([jnp.all(jnp.isfinite(jnp.asarray(leaf))) for leaf in leaves])
+    )
+
+
+def _flat_maximum_norm(value: Array, /) -> Array:
+    return jnp.max(jnp.abs(value))
+
+
+class CausalRecurrenceProblem(StrictModule):
+    """One explicit first-order causal recurrence over a fixed driver sequence."""
+
+    transition_function: Callable[[Any, PyTree[Any], PyTree[Any]], PyTree[Any]] = (
+        eqx.field(static=True)
+    )
+    initial_state: PyTree[Array]
+    drivers: PyTree[Array]
+    parameters: Any
+    unravel_state: Callable[[Array], PyTree[Array]] = eqx.field(static=True)
+    num_steps: int = eqx.field(static=True)
+    state_size: int = eqx.field(static=True)
+    problem_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        transition: Callable[[Any, PyTree[Any], PyTree[Any]], PyTree[Any]],
+        initial_state: PyTree[Any],
+        drivers: PyTree[Any],
+        /,
+        *,
+        parameters: Any = None,
+        problem_id: str = "causal-recurrence",
+    ):
+        if not callable(transition):
+            raise TypeError("transition must be callable.")
+        identifier = str(problem_id)
+        if not identifier:
+            raise ValueError("problem_id must be non-empty.")
+        state = jax.tree.map(jnp.asarray, initial_state)
+        state_leaves = jax.tree.leaves(state)
+        if not state_leaves:
+            raise ValueError("initial_state must contain at least one array leaf.")
+        if any(not jnp.issubdtype(leaf.dtype, jnp.floating) for leaf in state_leaves):
+            raise TypeError("Causal recurrence states must be real floating arrays.")
+        flat_state, unravel = ravel_pytree(state)
+        if flat_state.size == 0:
+            raise ValueError("initial_state must contain at least one scalar coordinate.")
+
+        driver_tree = jax.tree.map(jnp.asarray, drivers)
+        driver_leaves = jax.tree.leaves(driver_tree)
+        if not driver_leaves:
+            raise ValueError("drivers must contain at least one array leaf.")
+        if any(leaf.ndim < 1 for leaf in driver_leaves):
+            raise ValueError("Every driver leaf must have a leading temporal axis.")
+        steps = int(driver_leaves[0].shape[0])
+        if steps < 1 or any(int(leaf.shape[0]) != steps for leaf in driver_leaves):
+            raise ValueError("Every driver leaf must share one nonempty temporal axis.")
+
+        first_driver = jax.tree.map(lambda leaf: leaf[0], driver_tree)
+        first_output = jax.tree.map(
+            jnp.asarray, transition(parameters, state, first_driver)
+        )
+        if jax.tree.structure(first_output) != jax.tree.structure(state) or any(
+            output.shape != expected.shape
+            for output, expected in zip(
+                jax.tree.leaves(first_output),
+                state_leaves,
+                strict=True,
+            )
+        ):
+            raise ValueError(
+                "transition outputs must match the initial-state PyTree and leaf shapes."
+            )
+        output_flat, _ = ravel_pytree(first_output)
+        if not jnp.issubdtype(output_flat.dtype, jnp.floating):
+            raise TypeError(
+                "Causal recurrence transitions must return real floating arrays."
+            )
+
+        self.transition_function = transition
+        self.initial_state = state
+        self.drivers = driver_tree
+        self.parameters = parameters
+        self.unravel_state = unravel
+        self.num_steps = steps
+        self.state_size = int(flat_state.size)
+        self.problem_id = identifier
+
+    @property
+    def flat_initial_state(self) -> Array:
+        return ravel_pytree(self.initial_state)[0]
+
+    def transition_flat(
+        self,
+        previous_state: Array,
+        driver: PyTree[Any],
+        /,
+    ) -> Array:
+        previous = self.unravel_state(previous_state)
+        output = self.transition_function(self.parameters, previous, driver)
+        return ravel_pytree(output)[0]
+
+    def evaluate_flat(self, trajectory: Array, /) -> tuple[Array, Array]:
+        values = jnp.asarray(trajectory)
+        expected = (self.num_steps, self.state_size)
+        if values.shape != expected:
+            raise ValueError(f"trajectory must have shape {expected}.")
+        predecessors = jnp.concatenate(
+            (self.flat_initial_state[None, :], values[:-1]), axis=0
+        )
+        proposed = jax.vmap(self.transition_flat)(predecessors, self.drivers)
+        return values - proposed, proposed
+
+    def unravel_trajectory(self, trajectory: Array, /) -> PyTree[Array]:
+        return jax.vmap(self.unravel_state)(trajectory)
+
+
+class CausalLinearizationPolicy(StrictModule):
+    """Per-step Jacobian representation for one causal nonlinear solve."""
+
+    block_builder: Callable[[Any, PyTree[Any], PyTree[Any]], Array] | None = eqx.field(
+        static=True
+    )
+    mode: CausalLinearizationMode = eqx.field(static=True)
+    probe_count: int = eqx.field(static=True)
+    probe_distribution: CausalProbeDistribution = eqx.field(static=True)
+    linearization_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        mode: CausalLinearizationMode = "dense-exact",
+        /,
+        *,
+        probe_count: int = 1,
+        probe_distribution: CausalProbeDistribution = "rademacher",
+        block_builder: Callable[[Any, PyTree[Any], PyTree[Any]], Array] | None = None,
+        linearization_id: str | None = None,
+    ):
+        if mode not in (
+            "dense-exact",
+            "diagonal-exact",
+            "diagonal-hutchinson",
+            "fixed-block",
+        ):
+            raise ValueError("Unknown causal linearization mode.")
+        probes = int(probe_count)
+        if probes < 1:
+            raise ValueError("probe_count must be positive.")
+        if probe_distribution not in ("rademacher", "normal"):
+            raise ValueError("Unknown causal probe distribution.")
+        if mode == "fixed-block" and not callable(block_builder):
+            raise TypeError("fixed-block mode requires block_builder.")
+        if mode != "fixed-block" and block_builder is not None:
+            raise ValueError("block_builder is only valid for fixed-block mode.")
+        identifier = mode if linearization_id is None else str(linearization_id)
+        if not identifier:
+            raise ValueError("linearization_id must be non-empty.")
+        self.mode = mode
+        self.probe_count = probes
+        self.probe_distribution = probe_distribution
+        self.block_builder = block_builder
+        self.linearization_id = identifier
+
+    @property
+    def exact(self) -> bool:
+        return self.mode == "dense-exact"
+
+
+class CausalNewton(StrictModule):
+    """Undamped exact or quasi-Newton causal recurrence evaluation."""
+
+    linearization: CausalLinearizationPolicy
+
+    def __init__(self, *, linearization: CausalLinearizationPolicy | None = None):
+        policy = CausalLinearizationPolicy() if linearization is None else linearization
+        if not isinstance(policy, CausalLinearizationPolicy):
+            raise TypeError("linearization must be CausalLinearizationPolicy or None.")
+        self.linearization = policy
+
+    @property
+    def method_id(self) -> str:
+        return "causal-newton"
+
+
+class CausalLevenbergMarquardt(StrictModule):
+    """ELK-style damped causal least squares with ratio-based acceptance."""
+
+    linearization: CausalLinearizationPolicy
+    initial_damping: float = eqx.field(static=True)
+    minimum_damping: float = eqx.field(static=True)
+    maximum_damping: float = eqx.field(static=True)
+    damping_increase: float = eqx.field(static=True)
+    damping_decrease: float = eqx.field(static=True)
+    acceptance_ratio: float = eqx.field(static=True)
+    decrease_ratio: float = eqx.field(static=True)
+    increase_ratio: float = eqx.field(static=True)
+    maximum_trials: int = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        linearization: CausalLinearizationPolicy | None = None,
+        initial_damping: float = 1e-3,
+        minimum_damping: float = 1e-12,
+        maximum_damping: float = 1e12,
+        damping_increase: float = 2.0,
+        damping_decrease: float = 0.5,
+        acceptance_ratio: float = 1e-4,
+        decrease_ratio: float = 0.75,
+        increase_ratio: float = 0.25,
+        maximum_trials: int = 12,
+    ):
+        policy = CausalLinearizationPolicy() if linearization is None else linearization
+        if not isinstance(policy, CausalLinearizationPolicy):
+            raise TypeError("linearization must be CausalLinearizationPolicy or None.")
+        damping_values = (
+            float(initial_damping),
+            float(minimum_damping),
+            float(maximum_damping),
+        )
+        if any(not isfinite(value) or value <= 0.0 for value in damping_values):
+            raise ValueError("Causal LM damping values must be positive and finite.")
+        if not damping_values[1] <= damping_values[0] <= damping_values[2]:
+            raise ValueError("initial_damping must lie inside the damping bounds.")
+        increase = float(damping_increase)
+        decrease = float(damping_decrease)
+        if not isfinite(increase) or increase <= 1.0:
+            raise ValueError("damping_increase must exceed one.")
+        if not isfinite(decrease) or not 0.0 < decrease < 1.0:
+            raise ValueError("damping_decrease must lie strictly inside (0, 1).")
+        ratios = (
+            float(acceptance_ratio),
+            float(decrease_ratio),
+            float(increase_ratio),
+        )
+        if any(not isfinite(value) or not 0.0 <= value <= 1.0 for value in ratios):
+            raise ValueError("Causal LM ratios must lie in [0, 1].")
+        if not ratios[0] <= ratios[2] < ratios[1]:
+            raise ValueError(
+                "Ratios must satisfy acceptance_ratio <= increase_ratio < decrease_ratio."
+            )
+        trials = int(maximum_trials)
+        if trials < 1:
+            raise ValueError("maximum_trials must be positive.")
+        self.linearization = policy
+        self.initial_damping, self.minimum_damping, self.maximum_damping = damping_values
+        self.damping_increase = increase
+        self.damping_decrease = decrease
+        self.acceptance_ratio, self.decrease_ratio, self.increase_ratio = ratios
+        self.maximum_trials = trials
+
+    @property
+    def method_id(self) -> str:
+        return "causal-levenberg-marquardt"
+
+
+CausalMethod: TypeAlias = CausalNewton | CausalLevenbergMarquardt
+
+
+class CausalRecurrenceDiagnostics(StrictModule):
+    """Fixed-shape nonlinear histories and exact temporal work counts."""
+
+    residual_norm: Array
+    step_norm: Array
+    damping: Array
+    actual_reduction: Array
+    predicted_reduction: Array
+    reduction_ratio: Array
+    accepted: Array
+    finite: Array
+    iteration_count: Array
+    accepted_steps: Array
+    rejected_steps: Array
+    transition_evaluations: Array
+    jacobian_evaluations: Array
+    jvp_evaluations: Array
+
+
+class CausalRecurrenceResult(StrictModule):
+    """Certified trajectory from one causal nonlinear recurrence solve."""
+
+    problem: CausalRecurrenceProblem
+    states: PyTree[Array]
+    residuals: PyTree[Array]
+    flat_states: Array
+    flat_residuals: Array
+    final_state: PyTree[Array]
+    status: Array
+    diagnostics: CausalRecurrenceDiagnostics
+    method_id: str = eqx.field(static=True)
+    linearization_id: str = eqx.field(static=True)
+    approximation_id: str = eqx.field(static=True)
+
+    @property
+    def successful(self) -> Array:
+        return self.status == int(NonlinearStatus.SUCCESS)
+
+
+def _initial_flat_trajectory(
+    problem: CausalRecurrenceProblem,
+    initial_trajectory: PyTree[Any] | None,
+    /,
+) -> Array:
+    if initial_trajectory is None:
+        return jnp.broadcast_to(
+            problem.flat_initial_state,
+            (problem.num_steps, problem.state_size),
+        )
+    trajectory = jax.tree.map(jnp.asarray, initial_trajectory)
+    leaves = jax.tree.leaves(trajectory)
+    if not leaves or any(leaf.ndim < 1 for leaf in leaves):
+        raise ValueError("initial_trajectory leaves need a leading temporal axis.")
+    if any(int(leaf.shape[0]) != problem.num_steps for leaf in leaves):
+        raise ValueError("initial_trajectory must match the driver sequence length.")
+    flat = jax.vmap(lambda state: ravel_pytree(state)[0])(trajectory)
+    if flat.shape != (problem.num_steps, problem.state_size):
+        raise ValueError("initial_trajectory does not match the recurrence state layout.")
+    return flat
+
+
+def _probe_bank(
+    policy: CausalLinearizationPolicy,
+    key: Array | None,
+    *,
+    num_steps: int,
+    state_size: int,
+    dtype: Any,
+) -> Array:
+    if policy.mode != "diagonal-hutchinson":
+        return jnp.empty((0, num_steps, state_size), dtype=dtype)
+    if key is None:
+        raise ValueError("diagonal-hutchinson linearization requires probe_key.")
+    shape = (policy.probe_count, num_steps, state_size)
+    if policy.probe_distribution == "rademacher":
+        return jr.rademacher(key, shape, dtype=dtype)
+    return jr.normal(key, shape, dtype=dtype)
+
+
+def _linearize_transitions(
+    problem: CausalRecurrenceProblem,
+    trajectory: Array,
+    policy: CausalLinearizationPolicy,
+    probes: Array,
+    /,
+) -> tuple[Array, Array, Array]:
+    predecessors = jnp.concatenate(
+        (problem.flat_initial_state[None, :], trajectory[:-1]),
+        axis=0,
+    )
+    if policy.mode in ("dense-exact", "diagonal-exact"):
+        dense = jax.vmap(jax.jacfwd(problem.transition_flat))(
+            predecessors,
+            problem.drivers,
+        )
+        if policy.mode == "dense-exact":
+            matrices = dense
+        else:
+            matrices = jax.vmap(jnp.diag)(jax.vmap(jnp.diag)(dense))
+        matrices = matrices.at[0].set(jnp.zeros_like(matrices[0]))
+        return (
+            matrices,
+            jnp.asarray(problem.num_steps, dtype=jnp.int32),
+            jnp.asarray(0, dtype=jnp.int32),
+        )
+
+    if policy.mode == "fixed-block":
+        block_builder = policy.block_builder
+        if block_builder is None:
+            raise RuntimeError("fixed-block policy lost its block builder.")
+
+        def build(previous, driver):
+            state = problem.unravel_state(previous)
+            return jnp.asarray(block_builder(problem.parameters, state, driver))
+
+        matrices = jax.vmap(build)(predecessors, problem.drivers)
+        expected = (problem.num_steps, problem.state_size, problem.state_size)
+        if matrices.shape != expected:
+            raise ValueError(
+                f"block_builder must return local matrices with shape {expected}."
+            )
+        matrices = matrices.at[0].set(jnp.zeros_like(matrices[0]))
+        return matrices, jnp.asarray(0, dtype=jnp.int32), jnp.asarray(0, dtype=jnp.int32)
+
+    def probe_action(probe):
+        def one(previous, driver, direction):
+            _, tangent = jax.jvp(
+                lambda candidate: problem.transition_flat(candidate, driver),
+                (previous,),
+                (direction,),
+            )
+            return tangent
+
+        return jax.vmap(one)(predecessors, problem.drivers, probe)
+
+    actions = jax.vmap(probe_action)(probes)
+    diagonal = jnp.mean(probes * actions, axis=0)
+    matrices = jax.vmap(jnp.diag)(diagonal)
+    matrices = matrices.at[0].set(jnp.zeros_like(matrices[0]))
+    jvp_count = policy.probe_count * problem.num_steps
+    return (
+        matrices,
+        jnp.asarray(0, dtype=jnp.int32),
+        jnp.asarray(jvp_count, dtype=jnp.int32),
+    )
+
+
+def _empty_histories(steps: int, dtype: Any, /) -> tuple[Array, ...]:
+    nan = jnp.full((steps,), jnp.nan, dtype=dtype)
+    return (
+        nan,
+        nan,
+        nan,
+        nan,
+        nan,
+        nan,
+        jnp.zeros((steps,), dtype=bool),
+        jnp.zeros((steps,), dtype=bool),
+    )
+
+
+def _solve_causal_forward(
+    problem: CausalRecurrenceProblem,
+    initial_trajectory: PyTree[Any] | None,
+    method: CausalMethod,
+    termination: NonlinearTermination,
+    probe_key: Array | None,
+    /,
+) -> CausalRecurrenceResult:
+    trajectory = _initial_flat_trajectory(problem, initial_trajectory)
+    residual, _ = problem.evaluate_flat(trajectory)
+    initial_norm = _flat_maximum_norm(residual)
+    threshold = termination.residual_threshold(initial_norm)
+    dtype = trajectory.dtype
+    histories = _empty_histories(termination.maximum_steps, dtype)
+    converged = jnp.isfinite(initial_norm) & (initial_norm <= threshold)
+    failed = ~jnp.isfinite(initial_norm)
+    status = jnp.where(
+        converged,
+        int(NonlinearStatus.SUCCESS),
+        jnp.where(
+            failed,
+            int(NonlinearStatus.NONFINITE_EVALUATION),
+            int(NonlinearStatus.ITERATING),
+        ),
+    ).astype(jnp.int32)
+    damping = jnp.asarray(
+        method.initial_damping if isinstance(method, CausalLevenbergMarquardt) else 0.0,
+        dtype=dtype,
+    )
+    probes = _probe_bank(
+        method.linearization,
+        probe_key,
+        num_steps=problem.num_steps,
+        state_size=problem.state_size,
+        dtype=dtype,
+    )
+
+    carry = (
+        trajectory,
+        residual,
+        converged,
+        failed,
+        status,
+        damping,
+        jnp.asarray(0, dtype=jnp.int32),
+        jnp.asarray(0, dtype=jnp.int32),
+        jnp.asarray(problem.num_steps, dtype=jnp.int32),
+        jnp.asarray(0, dtype=jnp.int32),
+        jnp.asarray(0, dtype=jnp.int32),
+        *histories,
+    )
+
+    def iteration(index, state):
+        (
+            current,
+            current_residual,
+            already_converged,
+            already_failed,
+            current_status,
+            current_damping,
+            accepted_count,
+            rejected_count,
+            transition_evaluations,
+            jacobian_evaluations,
+            jvp_evaluations,
+            residual_history,
+            step_history,
+            damping_history,
+            actual_history,
+            predicted_history,
+            ratio_history,
+            accepted_history,
+            finite_history,
+        ) = state
+        active = ~(already_converged | already_failed)
+
+        def active_iteration(_):
+            matrices, jacobian_increment, jvp_increment = _linearize_transitions(
+                problem,
+                current,
+                method.linearization,
+                probes,
+            )
+            current_objective = 0.5 * jnp.sum(jnp.square(current_residual))
+
+            if isinstance(method, CausalNewton):
+                step = solve_causal_least_squares(
+                    matrices,
+                    current_residual,
+                    jnp.asarray(0.0, dtype=dtype),
+                )
+                candidate = current + step
+                candidate_residual, _ = problem.evaluate_flat(candidate)
+                linear_residual = causal_linearized_residual(
+                    matrices,
+                    current_residual,
+                    step,
+                )
+                candidate_objective = 0.5 * jnp.sum(jnp.square(candidate_residual))
+                predicted = current_objective - 0.5 * jnp.sum(jnp.square(linear_residual))
+                actual = current_objective - candidate_objective
+                finite = (
+                    jnp.all(jnp.isfinite(step))
+                    & jnp.all(jnp.isfinite(candidate))
+                    & jnp.all(jnp.isfinite(candidate_residual))
+                )
+                accepted = finite
+                ratio = jnp.where(predicted > 0.0, actual / predicted, -jnp.inf)
+                next_damping = current_damping
+                trial_count = jnp.asarray(1, dtype=jnp.int32)
+            else:
+                trial_initial = (
+                    jnp.asarray(0, dtype=jnp.int32),
+                    current_damping,
+                    jnp.asarray(False),
+                    current,
+                    current_residual,
+                    jnp.zeros_like(current),
+                    jnp.asarray(-jnp.inf, dtype=dtype),
+                    jnp.asarray(0.0, dtype=dtype),
+                    jnp.asarray(0.0, dtype=dtype),
+                    jnp.asarray(False),
+                )
+
+                def trial_body(_, trial_state):
+                    (
+                        trial_number,
+                        trial_damping,
+                        trial_accepted,
+                        saved_candidate,
+                        saved_residual,
+                        saved_step,
+                        saved_ratio,
+                        saved_actual,
+                        saved_predicted,
+                        finite_seen,
+                    ) = trial_state
+
+                    def evaluate_trial(_):
+                        direction = solve_causal_least_squares(
+                            matrices,
+                            current_residual,
+                            trial_damping,
+                        )
+                        proposed = current + direction
+                        proposed_residual, _ = problem.evaluate_flat(proposed)
+                        linear_residual = causal_linearized_residual(
+                            matrices,
+                            current_residual,
+                            direction,
+                        )
+                        proposed_objective = 0.5 * jnp.sum(jnp.square(proposed_residual))
+                        predicted_reduction = current_objective - 0.5 * jnp.sum(
+                            jnp.square(linear_residual)
+                        )
+                        actual_reduction = current_objective - proposed_objective
+                        finite_trial = (
+                            jnp.all(jnp.isfinite(direction))
+                            & jnp.all(jnp.isfinite(proposed))
+                            & jnp.all(jnp.isfinite(proposed_residual))
+                            & jnp.isfinite(predicted_reduction)
+                            & jnp.isfinite(actual_reduction)
+                        )
+                        reduction_ratio = jnp.where(
+                            finite_trial & (predicted_reduction > 0.0),
+                            actual_reduction / predicted_reduction,
+                            -jnp.inf,
+                        )
+                        use = finite_trial & (reduction_ratio >= method.acceptance_ratio)
+                        adjusted_damping = jnp.where(
+                            reduction_ratio > method.decrease_ratio,
+                            jnp.maximum(
+                                method.minimum_damping,
+                                trial_damping * method.damping_decrease,
+                            ),
+                            jnp.where(
+                                reduction_ratio < method.increase_ratio,
+                                jnp.minimum(
+                                    method.maximum_damping,
+                                    trial_damping * method.damping_increase,
+                                ),
+                                trial_damping,
+                            ),
+                        )
+                        return (
+                            trial_number + 1,
+                            adjusted_damping,
+                            use,
+                            jnp.where(use, proposed, saved_candidate),
+                            jnp.where(use, proposed_residual, saved_residual),
+                            jnp.where(use, direction, saved_step),
+                            reduction_ratio,
+                            actual_reduction,
+                            predicted_reduction,
+                            finite_seen | finite_trial,
+                        )
+
+                    return jax.lax.cond(
+                        trial_accepted,
+                        lambda _: trial_state,
+                        evaluate_trial,
+                        operand=None,
+                    )
+
+                trial_final = jax.lax.fori_loop(
+                    0,
+                    method.maximum_trials,
+                    trial_body,
+                    trial_initial,
+                )
+                (
+                    trial_count,
+                    next_damping,
+                    accepted,
+                    candidate,
+                    candidate_residual,
+                    step,
+                    ratio,
+                    actual,
+                    predicted,
+                    finite,
+                ) = trial_final
+
+            next_residual = jnp.where(accepted, candidate_residual, current_residual)
+            next_trajectory = jnp.where(accepted, candidate, current)
+            residual_norm = _flat_maximum_norm(next_residual)
+            step_norm = _flat_maximum_norm(step)
+            now_converged = (
+                accepted & jnp.isfinite(residual_norm) & (residual_norm <= threshold)
+            )
+            stagnated = (
+                accepted
+                & ~now_converged
+                & (
+                    step_norm
+                    <= termination.step_threshold(_flat_maximum_norm(next_trajectory))
+                )
+            )
+            diverged = jnp.isfinite(residual_norm) & (
+                residual_norm
+                > termination.divergence_factor * jnp.maximum(initial_norm, 1.0)
+            )
+            failed_trial = ~accepted
+            now_failed = (
+                failed_trial | stagnated | diverged | (~jnp.isfinite(residual_norm))
+            )
+            next_status = jnp.where(
+                now_converged,
+                int(NonlinearStatus.SUCCESS),
+                jnp.where(
+                    ~jnp.isfinite(residual_norm),
+                    int(NonlinearStatus.NONFINITE_EVALUATION),
+                    jnp.where(
+                        failed_trial,
+                        (
+                            int(NonlinearStatus.TRUST_REGION_FAILED)
+                            if isinstance(method, CausalLevenbergMarquardt)
+                            else int(NonlinearStatus.NONFINITE_EVALUATION)
+                        ),
+                        jnp.where(
+                            stagnated,
+                            int(NonlinearStatus.RESIDUAL_STAGNATION),
+                            jnp.where(
+                                diverged,
+                                int(NonlinearStatus.DIVERGENCE),
+                                int(NonlinearStatus.ITERATING),
+                            ),
+                        ),
+                    ),
+                ),
+            ).astype(jnp.int32)
+            transition_increment = problem.num_steps * trial_count
+            return (
+                next_trajectory,
+                next_residual,
+                now_converged,
+                now_failed,
+                next_status,
+                next_damping,
+                accepted_count + accepted.astype(jnp.int32),
+                rejected_count + (trial_count - accepted.astype(jnp.int32)),
+                transition_evaluations + transition_increment,
+                jacobian_evaluations + jacobian_increment,
+                jvp_evaluations + jvp_increment,
+                residual_history.at[index].set(residual_norm),
+                step_history.at[index].set(step_norm),
+                damping_history.at[index].set(current_damping),
+                actual_history.at[index].set(actual),
+                predicted_history.at[index].set(predicted),
+                ratio_history.at[index].set(ratio),
+                accepted_history.at[index].set(accepted),
+                finite_history.at[index].set(finite),
+            )
+
+        return jax.lax.cond(active, active_iteration, lambda _: state, operand=None)
+
+    final = jax.lax.fori_loop(0, termination.maximum_steps, iteration, carry)
+    (
+        final_trajectory,
+        final_residual,
+        final_converged,
+        final_failed,
+        final_status,
+        _,
+        accepted_steps,
+        rejected_steps,
+        transition_evaluations,
+        jacobian_evaluations,
+        jvp_evaluations,
+        residual_history,
+        step_history,
+        damping_history,
+        actual_history,
+        predicted_history,
+        ratio_history,
+        accepted_history,
+        finite_history,
+    ) = final
+    final_status = jnp.where(
+        final_converged,
+        int(NonlinearStatus.SUCCESS),
+        jnp.where(
+            final_failed,
+            final_status,
+            int(NonlinearStatus.MAXIMUM_STEPS_REACHED),
+        ),
+    ).astype(jnp.int32)
+    iteration_count = jnp.sum(~jnp.isnan(residual_history), dtype=jnp.int32)
+    states = problem.unravel_trajectory(final_trajectory)
+    residuals = problem.unravel_trajectory(final_residual)
+    final_state = jax.tree.map(lambda leaf: leaf[-1], states)
+    diagnostics = CausalRecurrenceDiagnostics(
+        residual_norm=residual_history,
+        step_norm=step_history,
+        damping=damping_history,
+        actual_reduction=actual_history,
+        predicted_reduction=predicted_history,
+        reduction_ratio=ratio_history,
+        accepted=accepted_history,
+        finite=finite_history,
+        iteration_count=iteration_count,
+        accepted_steps=accepted_steps,
+        rejected_steps=rejected_steps,
+        transition_evaluations=transition_evaluations,
+        jacobian_evaluations=jacobian_evaluations,
+        jvp_evaluations=jvp_evaluations,
+    )
+    approximation = (
+        "exact-dense-causal-root"
+        if method.linearization.exact
+        else f"quasi-causal-root/{method.linearization.linearization_id}"
+    )
+    return CausalRecurrenceResult(
+        problem=problem,
+        states=states,
+        residuals=residuals,
+        flat_states=final_trajectory,
+        flat_residuals=final_residual,
+        final_state=final_state,
+        status=final_status,
+        diagnostics=diagnostics,
+        method_id=method.method_id,
+        linearization_id=method.linearization.linearization_id,
+        approximation_id=approximation,
+    )
+
+
+def solve_causal_recurrence(
+    problem: CausalRecurrenceProblem,
+    /,
+    *,
+    initial_trajectory: PyTree[Any] | None = None,
+    method: CausalMethod | None = None,
+    termination: NonlinearTermination | None = None,
+    probe_key: Array | None = None,
+) -> CausalRecurrenceResult:
+    """Solve and certify one causal recurrence from its direct temporal residual."""
+
+    if not isinstance(problem, CausalRecurrenceProblem):
+        raise TypeError("problem must be a CausalRecurrenceProblem.")
+    method_ = CausalLevenbergMarquardt() if method is None else method
+    if not isinstance(method_, (CausalNewton, CausalLevenbergMarquardt)):
+        raise TypeError("method must be a causal recurrence method or None.")
+    termination_ = NonlinearTermination() if termination is None else termination
+    if not isinstance(termination_, NonlinearTermination):
+        raise TypeError("termination must be NonlinearTermination or None.")
+    result = _solve_causal_forward(
+        problem,
+        initial_trajectory,
+        method_,
+        termination_,
+        probe_key,
+    )
+    return attach_causal_implicit_derivative(problem, result)
+
+
+__all__ = [
+    "CausalLevenbergMarquardt",
+    "CausalLinearizationMode",
+    "CausalLinearizationPolicy",
+    "CausalNewton",
+    "CausalProbeDistribution",
+    "CausalRecurrenceDiagnostics",
+    "CausalRecurrenceProblem",
+    "CausalRecurrenceResult",
+    "solve_causal_recurrence",
+]

--- a/phydrax/nonlinear/_causal_adjoint.py
+++ b/phydrax/nonlinear/_causal_adjoint.py
@@ -1,0 +1,80 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array
+
+from ..linalg._causal_linear import (
+    associative_affine_solve,
+    associative_transpose_solve,
+)
+from ._types import NonlinearStatus
+
+
+def _exact_transition_matrices(problem, trajectory: Array, /) -> Array:
+    predecessors = jnp.concatenate(
+        (problem.flat_initial_state[None, :], trajectory[:-1]),
+        axis=0,
+    )
+    matrices = jax.vmap(jax.jacfwd(problem.transition_flat))(
+        predecessors,
+        problem.drivers,
+    )
+    return matrices.at[0].set(jnp.zeros_like(matrices[0]))
+
+
+def attach_causal_implicit_derivative(problem, result, /):
+    """Attach the exact implicit solution derivative to a certified trajectory."""
+
+    forward_states = jax.lax.stop_gradient(result.flat_states)
+
+    def residual_function(trajectory):
+        residual, _ = problem.evaluate_flat(trajectory)
+        return residual
+
+    def primal_solve(_, __):
+        return forward_states
+
+    def tangent_solve(linearized, right_hand_side):
+        checked = eqx.error_if(
+            right_hand_side,
+            result.status != int(NonlinearStatus.SUCCESS),
+            "Implicit causal derivative requires a successfully converged trajectory.",
+        )
+        matrices = _exact_transition_matrices(problem, forward_states)
+        return jax.lax.custom_linear_solve(
+            linearized,
+            checked,
+            solve=lambda _, rhs: associative_affine_solve(matrices, rhs),
+            transpose_solve=lambda _, rhs: associative_transpose_solve(matrices, rhs),
+        )
+
+    implicit_states = jax.lax.custom_root(
+        residual_function,
+        forward_states,
+        solve=primal_solve,
+        tangent_solve=tangent_solve,
+    )
+    implicit_residuals, _ = problem.evaluate_flat(implicit_states)
+    states = problem.unravel_trajectory(implicit_states)
+    residuals = problem.unravel_trajectory(implicit_residuals)
+    final_state = jax.tree.map(lambda leaf: leaf[-1], states)
+    return eqx.tree_at(
+        lambda value: (
+            value.states,
+            value.residuals,
+            value.flat_states,
+            value.flat_residuals,
+            value.final_state,
+        ),
+        result,
+        (states, residuals, implicit_states, implicit_residuals, final_state),
+    )
+
+
+__all__ = ["attach_causal_implicit_derivative"]

--- a/phydrax/uq/__init__.py
+++ b/phydrax/uq/__init__.py
@@ -47,6 +47,28 @@ from .._likelihoods import (
     StudentTLikelihood,
 )
 from .._probability import AbstractProbabilityLaw
+from ..linalg._gaussian_chain import (
+    combine_gaussian_filter_elements,
+    combine_gaussian_information_elements,
+    gaussian_markov_information_from_moments,
+    GAUSSIAN_MARKOV_INVALID_NODE_MASK,
+    gaussian_markov_log_normalizer,
+    gaussian_markov_moments,
+    gaussian_markov_moments_from_marginals,
+    GAUSSIAN_MARKOV_NON_HERMITIAN,
+    GAUSSIAN_MARKOV_NONFINITE,
+    GAUSSIAN_MARKOV_NOT_POSITIVE_DEFINITE,
+    gaussian_markov_status_name,
+    GAUSSIAN_MARKOV_SUCCESS,
+    GaussianFilterElement,
+    GaussianInformationElement,
+    GaussianMarkovExecutionMethod,
+    GaussianMarkovInformation,
+    GaussianMarkovLogNormalizerResult,
+    GaussianMarkovMoments,
+    GaussianMarkovStatus,
+    sample_gaussian_markov,
+)
 from ._bellman import (
     bellman_filter,
     bellman_filter_status_name,
@@ -69,6 +91,12 @@ from ._bellman import (
     BellmanStatus,
     initialize_bellman_filter,
     StateSpaceLaplaceLikelihood,
+)
+from ._causal_hmc import (
+    CausalHMCConfig,
+    CausalHMCDiagnostics,
+    CausalHMCFailurePolicy,
+    CausalHMCLinearization,
 )
 from ._checkpoint import (
     CheckpointCompatibilityError,
@@ -193,27 +221,11 @@ from ._fixed_lag import (
     FixedLagParticleSmootherResult,
 )
 from ._flow_mcmc import FlowNUTSConfig, FlowNUTSResult, sample_flow_nuts
-from ._gaussian_chain import (
-    combine_gaussian_filter_elements,
-    combine_gaussian_information_elements,
-    gaussian_markov_information_from_moments,
-    GAUSSIAN_MARKOV_INVALID_NODE_MASK,
-    gaussian_markov_log_normalizer,
-    gaussian_markov_moments,
-    gaussian_markov_moments_from_marginals,
-    GAUSSIAN_MARKOV_NON_HERMITIAN,
-    GAUSSIAN_MARKOV_NONFINITE,
-    GAUSSIAN_MARKOV_NOT_POSITIVE_DEFINITE,
-    gaussian_markov_status_name,
-    GAUSSIAN_MARKOV_SUCCESS,
-    GaussianFilterElement,
-    GaussianInformationElement,
-    GaussianMarkovExecutionMethod,
-    GaussianMarkovInformation,
-    GaussianMarkovLogNormalizerResult,
-    GaussianMarkovMoments,
-    GaussianMarkovStatus,
-    sample_gaussian_markov,
+from ._flow_variational import (
+    fit_flow_variational,
+    FlowVariationalConfig,
+    FlowVariationalFamily,
+    FlowVariationalResult,
 )
 from ._gaussian_factor import (
     add_independent_gaussian_factors,
@@ -399,6 +411,10 @@ from ._operator_metrics import (
     operator_interval_coverage,
     operator_interval_width,
 )
+from ._parameterized_state_space import (
+    ParameterizedStateSpacePathLogDensity,
+    ParameterizedStateSpaceProblem,
+)
 from ._particle import (
     bootstrap_particle_filter,
     effective_sample_size,
@@ -435,6 +451,11 @@ from ._particle import (
     sample_particle_backward_paths,
     write_particle_filter_checkpoint,
 )
+from ._particle_genealogical_score import (
+    particle_genealogical_score,
+    ParticleGenealogicalScoreResult,
+    StateSpaceModelScore,
+)
 from ._particle_mcmc import (
     AbstractParameterProposal,
     CallableParameterProposal,
@@ -446,6 +467,10 @@ from ._particle_mcmc import (
     ParticleGibbsResult,
     ParticleMarginalMetropolisHastingsResult,
     sample_conditional_particle_path,
+)
+from ._particle_parameter_score import (
+    parameterized_particle_genealogical_score,
+    ParameterizedParticleGenealogicalScoreResult,
 )
 from ._pathfinder import fit_pathfinder, PathfinderResult
 from ._posterior import (
@@ -605,6 +630,21 @@ from ._sing import (
     SINGStepResult,
 )
 from ._smc import sample_tempered_smc, TemperedSMCResult
+from ._state_space_amortized import (
+    AmortizedGaussianMarkovEncoder,
+    AmortizedGaussianMarkovFamily,
+    AmortizedStateSpaceVariationalConfig,
+    AmortizedStateSpaceVariationalResult,
+    fit_amortized_state_space_variational,
+)
+from ._state_space_buffered import (
+    BufferedStateSpaceVariationalConfig,
+    BufferedStateSpaceVariationalDiagnostics,
+    BufferedStateSpaceVariationalResult,
+    fit_buffered_state_space_variational,
+    StateSpaceWindowBatch,
+    StateSpaceWindowPlan,
+)
 from ._state_space_estimation import (
     ApproximateStateSpaceLikelihoodResult,
     ExperimentStateSpaceLikelihood,
@@ -642,6 +682,24 @@ from ._state_space_inference import (
     StateSpaceIdentifiabilityReport,
     StateSpaceMarginalLikelihood,
 )
+from ._state_space_path_density import (
+    state_space_path_log_density,
+    StateSpacePathLogDensity,
+)
+from ._state_space_variational import (
+    fit_state_space_variational,
+    GaussianMarkovVariationalFamily,
+    StateSpaceVariationalConfig,
+    StateSpaceVariationalResult,
+)
+from ._stochastic_gradient import (
+    AbstractStochasticGradientEstimator,
+    AutodiffStochasticGradientEstimator,
+    ParticleGenealogicalGradientEstimator,
+    STOCHASTIC_GRADIENT_INVALID,
+    STOCHASTIC_GRADIENT_SUCCESS,
+    StochasticGradientEstimate,
+)
 from ._stochastic_spectra import (
     linear_gaussian_spectral_densities,
     linear_gaussian_transfer_function,
@@ -670,6 +728,14 @@ from ._transport_resampling import (
     OptimalTransportEnsembleTransformResult,
 )
 from ._unbalanced_transport import spatial_unbalanced_sinkhorn_divergence
+from ._variational import (
+    AbstractVariationalFamily,
+    fit_variational,
+    MeanFieldGaussianFamily,
+    VariationalConfig,
+    VariationalDiagnostics,
+    VariationalResult,
+)
 from ._whitening import GaussianPriorWhitening
 
 
@@ -970,6 +1036,11 @@ __all__ = [
     "ParticleFisherInformationResult",
     "particle_fisher_score",
     "ParticleFisherScoreResult",
+    "particle_genealogical_score",
+    "ParticleGenealogicalScoreResult",
+    "StateSpaceModelScore",
+    "parameterized_particle_genealogical_score",
+    "ParameterizedParticleGenealogicalScoreResult",
     "ParticleSmootherResult",
     "particle_posterior_measure",
     "resample_indices",
@@ -1146,6 +1217,20 @@ __all__ = [
     "search_map_candidates",
     "FlowNUTSConfig",
     "FlowNUTSResult",
+    "fit_flow_variational",
+    "FlowVariationalConfig",
+    "FlowVariationalFamily",
+    "FlowVariationalResult",
+    "CausalHMCConfig",
+    "AbstractStochasticGradientEstimator",
+    "AutodiffStochasticGradientEstimator",
+    "ParticleGenealogicalGradientEstimator",
+    "STOCHASTIC_GRADIENT_INVALID",
+    "STOCHASTIC_GRADIENT_SUCCESS",
+    "StochasticGradientEstimate",
+    "CausalHMCDiagnostics",
+    "CausalHMCFailurePolicy",
+    "CausalHMCLinearization",
     "MCMCChainWarmup",
     "MCMCConvergenceError",
     "MCMCConvergenceReport",
@@ -1158,12 +1243,37 @@ __all__ = [
     "build_sgmcmc_control_variate",
     "sample_sgld",
     "sample_sgnht",
+    "AmortizedGaussianMarkovEncoder",
+    "AmortizedGaussianMarkovFamily",
+    "AmortizedStateSpaceVariationalConfig",
+    "AmortizedStateSpaceVariationalResult",
+    "fit_amortized_state_space_variational",
+    "BufferedStateSpaceVariationalConfig",
+    "BufferedStateSpaceVariationalDiagnostics",
+    "BufferedStateSpaceVariationalResult",
+    "fit_buffered_state_space_variational",
+    "StateSpaceWindowBatch",
+    "StateSpaceWindowPlan",
     "SGMCMCControlVariate",
     "SGMCMCDiagnostics",
     "SGMCMCMixingError",
     "SGMCMCMixingReport",
     "SGMCMCMixingThresholds",
     "SGMCMCResult",
+    "AbstractVariationalFamily",
+    "fit_variational",
+    "ParameterizedStateSpacePathLogDensity",
+    "ParameterizedStateSpaceProblem",
+    "MeanFieldGaussianFamily",
+    "VariationalConfig",
+    "VariationalDiagnostics",
+    "VariationalResult",
+    "state_space_path_log_density",
+    "StateSpacePathLogDensity",
+    "fit_state_space_variational",
+    "GaussianMarkovVariationalFamily",
+    "StateSpaceVariationalConfig",
+    "StateSpaceVariationalResult",
     "PathfinderResult",
     "fit_pathfinder",
     "TemperedSMCResult",

--- a/phydrax/uq/_causal_hmc.py
+++ b/phydrax/uq/_causal_hmc.py
@@ -1,0 +1,437 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from math import isfinite
+from typing import Any, Literal, NamedTuple, TypeAlias
+
+import blackjax.mcmc.hmc as blackjax_hmc
+import blackjax.mcmc.integrators as integrators
+import blackjax.mcmc.metrics as metrics
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+from blackjax.mcmc.proposal import safe_energy_diff, static_binomial_sampling
+from blackjax.mcmc.trajectory import hmc_energy
+from jax.flatten_util import ravel_pytree
+from jaxtyping import Array
+
+from .._strict import StrictModule
+from ..nonlinear import (
+    CausalLevenbergMarquardt,
+    CausalLinearizationPolicy,
+    CausalNewton,
+    CausalRecurrenceProblem,
+    NonlinearStatus,
+    NonlinearTermination,
+    solve_causal_recurrence,
+)
+
+
+CausalHMCLinearization: TypeAlias = Literal["dense-exact", "pair-hutchinson"]
+CausalHMCFailurePolicy: TypeAlias = Literal["raise", "sequential"]
+
+
+class CausalHMCConfig(StrictModule):
+    """Static causal velocity-Verlet solve and explicit failure controls."""
+
+    trajectory_block_size: int = eqx.field(static=True)
+    linearization: CausalHMCLinearization = eqx.field(static=True)
+    probe_count: int = eqx.field(static=True)
+    absolute_residual: float = eqx.field(static=True)
+    relative_residual: float = eqx.field(static=True)
+    maximum_outer_iterations: int = eqx.field(static=True)
+    initial_damping: float = eqx.field(static=True)
+    failure_policy: CausalHMCFailurePolicy = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        trajectory_block_size: int = 128,
+        linearization: CausalHMCLinearization = "pair-hutchinson",
+        probe_count: int = 2,
+        absolute_residual: float = 1e-6,
+        relative_residual: float = 1e-6,
+        maximum_outer_iterations: int = 128,
+        initial_damping: float = 1e-3,
+        failure_policy: CausalHMCFailurePolicy = "raise",
+    ):
+        block_size = int(trajectory_block_size)
+        probes = int(probe_count)
+        iterations = int(maximum_outer_iterations)
+        if block_size < 1:
+            raise ValueError("trajectory_block_size must be positive.")
+        if linearization not in ("dense-exact", "pair-hutchinson"):
+            raise ValueError("Unknown causal HMC linearization.")
+        if probes < 1:
+            raise ValueError("probe_count must be positive.")
+        absolute = float(absolute_residual)
+        relative = float(relative_residual)
+        damping = float(initial_damping)
+        if any(not isfinite(value) or value < 0.0 for value in (absolute, relative)):
+            raise ValueError(
+                "Causal HMC residual tolerances must be finite and nonnegative."
+            )
+        if iterations < 1:
+            raise ValueError("maximum_outer_iterations must be positive.")
+        if not isfinite(damping) or damping <= 0.0:
+            raise ValueError("initial_damping must be positive and finite.")
+        if failure_policy not in ("raise", "sequential"):
+            raise ValueError("failure_policy must be 'raise' or 'sequential'.")
+        self.trajectory_block_size = block_size
+        self.linearization = linearization
+        self.probe_count = probes
+        self.absolute_residual = absolute
+        self.relative_residual = relative
+        self.maximum_outer_iterations = iterations
+        self.initial_damping = damping
+        self.failure_policy = failure_policy
+
+    def as_dict(self) -> dict[str, int | float | str]:
+        return {
+            "trajectory_block_size": self.trajectory_block_size,
+            "linearization": self.linearization,
+            "probe_count": self.probe_count,
+            "absolute_residual": self.absolute_residual,
+            "relative_residual": self.relative_residual,
+            "maximum_outer_iterations": self.maximum_outer_iterations,
+            "initial_damping": self.initial_damping,
+            "failure_policy": self.failure_policy,
+        }
+
+
+class CausalHMCDiagnostics(StrictModule):
+    """Production-draw causal trajectory convergence and fallback records."""
+
+    converged: Array
+    fallback_used: Array
+    outer_iterations: Array
+    maximum_residual: Array
+    accepted_nonlinear_steps: Array
+    rejected_nonlinear_steps: Array
+    transition_evaluations: Array
+
+
+class CausalHMCInfo(NamedTuple):
+    momentum: Any
+    acceptance_rate: Array
+    is_accepted: Array
+    is_divergent: Array
+    energy: Array
+    proposal: integrators.IntegratorState
+    num_integration_steps: Array
+    causal_converged: Array
+    causal_fallback_used: Array
+    causal_outer_iterations: Array
+    causal_maximum_residual: Array
+    causal_accepted_steps: Array
+    causal_rejected_steps: Array
+    causal_transition_evaluations: Array
+
+
+def _sequential_block(
+    integrator,
+    phase,
+    logdensity_fn,
+    step_size,
+    block_length: int,
+    /,
+):
+    position, momentum = phase
+    logdensity, gradient = jax.value_and_grad(logdensity_fn)(position)
+    initial = integrators.IntegratorState(position, momentum, logdensity, gradient)
+    final = jax.lax.fori_loop(
+        0,
+        block_length,
+        lambda _, state: integrator(state, step_size),
+        initial,
+    )
+    return final.position, final.momentum
+
+
+def _pair_hutchinson_builder(
+    logdensity_fn,
+    inverse_mass_matrix: Array,
+    step_size: Array,
+    /,
+):
+    inverse_mass = jnp.asarray(inverse_mass_matrix)
+
+    def build(_, previous, driver):
+        position, momentum = previous
+        flat_position, unravel = ravel_pytree(position)
+        flat_momentum, _ = ravel_pytree(momentum)
+        probes = driver["probes"]
+
+        def flat_logdensity(value):
+            return logdensity_fn(unravel(value))
+
+        gradient_fn = jax.grad(flat_logdensity)
+        gradient = gradient_fn(flat_position)
+
+        def hessian_diagonal(location):
+            def one_probe(probe):
+                _, action = jax.jvp(
+                    gradient_fn,
+                    (location,),
+                    (probe,),
+                )
+                return probe * action
+
+            return jnp.mean(jax.vmap(one_probe)(probes), axis=0)
+
+        first_hessian = hessian_diagonal(flat_position)
+        half_momentum = flat_momentum + 0.5 * step_size * gradient
+        next_position = flat_position + step_size * inverse_mass * half_momentum
+        second_hessian = hessian_diagonal(next_position)
+        momentum_position = 0.5 * step_size * first_hessian
+        position_position = 1.0 + step_size * inverse_mass * momentum_position
+        position_momentum = step_size * inverse_mass
+        final_momentum_position = (
+            momentum_position + 0.5 * step_size * second_hessian * position_position
+        )
+        final_momentum_momentum = (
+            1.0 + 0.5 * step_size * second_hessian * position_momentum
+        )
+        dimension = flat_position.size
+        matrix = jnp.zeros((2 * dimension, 2 * dimension), dtype=flat_position.dtype)
+        matrix = matrix.at[:dimension, :dimension].set(jnp.diag(position_position))
+        matrix = matrix.at[:dimension, dimension:].set(jnp.diag(position_momentum))
+        matrix = matrix.at[dimension:, :dimension].set(jnp.diag(final_momentum_position))
+        return matrix.at[dimension:, dimension:].set(jnp.diag(final_momentum_momentum))
+
+    return build
+
+
+def _causal_block(
+    logdensity_fn,
+    metric,
+    inverse_mass_matrix,
+    step_size,
+    phase,
+    block_length: int,
+    probe_key,
+    config: CausalHMCConfig,
+    /,
+):
+    integrator = integrators.velocity_verlet(logdensity_fn, metric.kinetic_energy)
+    dimension = int(jnp.asarray(inverse_mass_matrix).shape[0])
+    if config.linearization == "pair-hutchinson":
+        probes = jr.rademacher(
+            probe_key,
+            (block_length, config.probe_count, dimension),
+            dtype=ravel_pytree(phase[0])[0].dtype,
+        )
+        drivers = {
+            "step": jnp.arange(block_length, dtype=jnp.int32),
+            "probes": probes,
+        }
+        builder = _pair_hutchinson_builder(
+            logdensity_fn,
+            inverse_mass_matrix,
+            step_size,
+        )
+        method = CausalLevenbergMarquardt(
+            linearization=CausalLinearizationPolicy(
+                "fixed-block",
+                block_builder=builder,
+                linearization_id="velocity-verlet-pair-hutchinson",
+            ),
+            initial_damping=config.initial_damping,
+        )
+    else:
+        drivers = jnp.arange(block_length, dtype=jnp.int32)
+        method = CausalNewton()
+
+    def transition(_, previous, driver):
+        del driver
+        position, momentum = previous
+        logdensity, gradient = jax.value_and_grad(logdensity_fn)(position)
+        state = integrators.IntegratorState(
+            position,
+            momentum,
+            logdensity,
+            gradient,
+        )
+        next_state = integrator(state, step_size)
+        return next_state.position, next_state.momentum
+
+    problem = CausalRecurrenceProblem(
+        transition,
+        phase,
+        drivers,
+        problem_id="causal-hmc-velocity-verlet-block",
+    )
+    result = solve_causal_recurrence(
+        problem,
+        method=method,
+        termination=NonlinearTermination(
+            absolute_residual=config.absolute_residual,
+            relative_residual=config.relative_residual,
+            maximum_steps=config.maximum_outer_iterations,
+        ),
+        probe_key=None,
+    )
+    causal_phase = result.final_state
+    successful = result.status == int(NonlinearStatus.SUCCESS)
+    if config.failure_policy == "raise":
+        checked = eqx.error_if(
+            result.flat_states,
+            ~successful,
+            "Causal HMC trajectory block failed to converge.",
+        )
+        causal_phase = problem.unravel_state(checked[-1])
+        final_phase = causal_phase
+        fallback = jnp.asarray(False)
+    else:
+        sequential_phase = _sequential_block(
+            integrator,
+            phase,
+            logdensity_fn,
+            step_size,
+            block_length,
+        )
+        final_phase = jax.tree.map(
+            lambda causal, sequential: jnp.where(
+                successful,
+                causal,
+                sequential,
+            ),
+            causal_phase,
+            sequential_phase,
+        )
+        fallback = ~successful
+    diagnostics = result.diagnostics
+    return final_phase, (
+        successful,
+        fallback,
+        diagnostics.iteration_count,
+        jnp.max(jnp.abs(result.flat_residuals)),
+        diagnostics.accepted_steps,
+        diagnostics.rejected_steps,
+        diagnostics.transition_evaluations,
+    )
+
+
+def build_causal_hmc_kernel(
+    config: CausalHMCConfig,
+    /,
+    *,
+    divergence_threshold: float = 1000.0,
+):
+    """Build a BlackJAX-compatible fixed-trajectory causal HMC kernel."""
+
+    if not isinstance(config, CausalHMCConfig):
+        raise TypeError("config must be a CausalHMCConfig.")
+    threshold = float(divergence_threshold)
+    if not isfinite(threshold) or threshold <= 0.0:
+        raise ValueError("divergence_threshold must be positive and finite.")
+
+    def kernel(
+        rng_key,
+        state,
+        logdensity_fn,
+        step_size,
+        inverse_mass_matrix,
+        num_integration_steps,
+    ):
+        inverse_mass = jnp.asarray(inverse_mass_matrix)
+        if inverse_mass.ndim != 1:
+            raise ValueError(
+                "Causal HMC initially requires a diagonal inverse mass matrix."
+            )
+        steps = int(num_integration_steps)
+        if steps < 1:
+            raise ValueError("num_integration_steps must be positive.")
+        metric = metrics.default_metric(inverse_mass)
+        key_momentum, key_integrator = jr.split(rng_key, 2)
+        momentum: Any = metric.sample_momentum(key_momentum, state.position)
+        phase: tuple[Any, Any] = (state.position, momentum)
+        block_records = []
+        block_start = 0
+        block_index = 0
+        while block_start < steps:
+            block_length = min(config.trajectory_block_size, steps - block_start)
+            block_probe_key = jr.fold_in(key_integrator, 0xCA551 + block_index)
+            phase, record = _causal_block(
+                logdensity_fn,
+                metric,
+                inverse_mass,
+                step_size,
+                phase,
+                block_length,
+                block_probe_key,
+                config,
+            )
+            block_records.append(record)
+            block_start += block_length
+            block_index += 1
+
+        position, final_momentum = phase
+        logdensity, gradient = jax.value_and_grad(logdensity_fn)(position)
+        end_state = blackjax_hmc.flip_momentum(
+            integrators.IntegratorState(
+                position,
+                final_momentum,
+                logdensity,
+                gradient,
+            )
+        )
+        initial_integrator_state = integrators.IntegratorState(
+            state.position,
+            momentum,
+            state.logdensity,
+            state.logdensity_grad,
+        )
+        energy_fn = hmc_energy(metric.kinetic_energy)
+        initial_energy = energy_fn(initial_integrator_state)
+        new_energy = energy_fn(end_state)
+        delta_energy = safe_energy_diff(initial_energy, new_energy)
+        is_divergent: Array = jnp.asarray(-delta_energy > threshold)
+        sampled, acceptance_info = static_binomial_sampling(
+            key_integrator,
+            delta_energy,
+            initial_integrator_state,
+            end_state,
+        )
+        is_accepted, acceptance_rate, _ = acceptance_info
+        converged, fallback, iterations, residual, accepted, rejected, evaluations = (
+            jax.tree.map(lambda *values: jnp.stack(values), *block_records)
+        )
+        next_state = blackjax_hmc.HMCState(
+            sampled.position,
+            sampled.logdensity,
+            sampled.logdensity_grad,
+        )
+        info = CausalHMCInfo(
+            momentum=momentum,
+            acceptance_rate=acceptance_rate,
+            is_accepted=is_accepted,
+            is_divergent=is_divergent,
+            energy=new_energy,
+            proposal=end_state,
+            num_integration_steps=jnp.asarray(steps, dtype=jnp.int32),
+            causal_converged=jnp.all(converged),
+            causal_fallback_used=jnp.any(fallback),
+            causal_outer_iterations=jnp.max(iterations),
+            causal_maximum_residual=jnp.max(residual),
+            causal_accepted_steps=jnp.sum(accepted),
+            causal_rejected_steps=jnp.sum(rejected),
+            causal_transition_evaluations=jnp.sum(evaluations),
+        )
+        return next_state, info
+
+    return kernel
+
+
+__all__ = [
+    "build_causal_hmc_kernel",
+    "CausalHMCConfig",
+    "CausalHMCDiagnostics",
+    "CausalHMCFailurePolicy",
+    "CausalHMCInfo",
+    "CausalHMCLinearization",
+]

--- a/phydrax/uq/_flow_family.py
+++ b/phydrax/uq/_flow_family.py
@@ -1,0 +1,89 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+from flowjax.bijections import RationalQuadraticSpline
+from flowjax.distributions import AbstractDistribution, Normal
+from flowjax.flows import coupling_flow, triangular_spline_flow
+from jaxtyping import Array
+
+
+def build_default_flow(
+    key: Array,
+    data: Array,
+    /,
+    *,
+    flow_layers: int,
+    num_knots: int,
+    nn_width: int,
+    nn_depth: int,
+) -> AbstractDistribution:
+    """Initialize one unconditional spline flow from a sample matrix."""
+
+    samples = jnp.asarray(data)
+    if samples.ndim != 2 or samples.shape[0] < 2 or samples.shape[1] < 1:
+        raise ValueError("Flow initialization requires a non-empty matrix of samples.")
+    if not jnp.issubdtype(samples.dtype, jnp.floating):
+        raise TypeError("Flow samples must use a real floating dtype.")
+    location = jnp.mean(samples, axis=0)
+    scale = jnp.std(samples, axis=0)
+    tolerance = jnp.sqrt(jnp.finfo(samples.dtype).eps) * jnp.maximum(
+        jnp.ones_like(location), jnp.abs(location)
+    )
+    base = Normal(location, jnp.maximum(scale, tolerance))
+    dimension = int(samples.shape[1])
+    if dimension == 1:
+        return triangular_spline_flow(
+            key,
+            base_dist=base,
+            flow_layers=int(flow_layers),
+            knots=int(num_knots),
+            invert=True,
+        )
+    transformer = RationalQuadraticSpline(knots=int(num_knots), interval=3.0)
+    return coupling_flow(
+        key,
+        base_dist=base,
+        transformer=transformer,
+        flow_layers=int(flow_layers),
+        nn_width=int(nn_width),
+        nn_depth=int(nn_depth),
+        invert=True,
+    )
+
+
+def validate_flow(
+    flow: AbstractDistribution,
+    data: Array,
+    key: Array,
+    /,
+) -> None:
+    """Validate event shape and finite sample/density behavior."""
+
+    samples = jnp.asarray(data)
+    expected_shape = (int(samples.shape[-1]),)
+    if flow.shape != expected_shape:
+        raise ValueError(
+            f"Flow event shape {flow.shape} does not match {expected_shape}."
+        )
+    if flow.cond_shape is not None:
+        raise ValueError("Flow proposal must be unconditional.")
+    data_log_density = flow.log_prob(samples)
+    proposed, proposed_log_density = flow.sample_and_log_prob(
+        key,
+        sample_shape=(min(8, int(samples.shape[0])),),
+    )
+    if proposed.shape[1:] != expected_shape:
+        raise ValueError("Flow proposal samples have an incompatible event shape.")
+    if not bool(jnp.all(jnp.isfinite(data_log_density))):
+        raise FloatingPointError("Flow density is nonfinite on its training data.")
+    if not bool(jnp.all(jnp.isfinite(proposed))) or not bool(
+        jnp.all(jnp.isfinite(proposed_log_density))
+    ):
+        raise FloatingPointError("Flow proposal produced a nonfinite sample or density.")
+
+
+__all__ = ["build_default_flow", "validate_flow"]

--- a/phydrax/uq/_flow_mcmc.py
+++ b/phydrax/uq/_flow_mcmc.py
@@ -39,8 +39,11 @@ from ._checkpoint import (
     write_checkpoint_archive,
 )
 from ._diagnostics import mcmc_diagnostics, MCMCConvergenceReport
+from ._flow_family import (
+    build_default_flow as _build_default_flow,
+    validate_flow as _validate_flow,
+)
 from ._flow_proposal import (
-    _build_default_flow,
     _fit_flow,
     _initialize_replay,
     _proposal_effective_sample_size,
@@ -48,7 +51,6 @@ from ._flow_proposal import (
     _ReplayBuffer,
     _run_flow_block,
     _update_replay,
-    _validate_flow,
 )
 from ._mcmc import _adapt_mcmc, MCMCChainWarmup, MCMCResult
 from ._posterior import PosteriorProblem

--- a/phydrax/uq/_flow_proposal.py
+++ b/phydrax/uq/_flow_proposal.py
@@ -9,9 +9,7 @@ from typing import Any, NamedTuple
 import jax
 import jax.numpy as jnp
 import jax.random as jr
-from flowjax.bijections import RationalQuadraticSpline
-from flowjax.distributions import AbstractDistribution, Normal
-from flowjax.flows import coupling_flow, triangular_spline_flow
+from flowjax.distributions import AbstractDistribution
 from flowjax.train import fit_to_data
 from jaxtyping import Array
 
@@ -125,50 +123,6 @@ def _replay_data(replay: _ReplayBuffer) -> Array:
     return replay.values[:, :size, :].reshape((-1, replay.values.shape[-1]))
 
 
-def _build_default_flow(
-    key: Array,
-    data: Array,
-    /,
-    *,
-    flow_layers: int,
-    num_knots: int,
-    nn_width: int,
-    nn_depth: int,
-) -> AbstractDistribution:
-    samples = jnp.asarray(data)
-    if samples.ndim != 2 or samples.shape[0] < 2 or samples.shape[1] < 1:
-        raise ValueError("Flow initialization requires a non-empty matrix of samples.")
-    if not jnp.issubdtype(samples.dtype, jnp.floating):
-        raise TypeError("Flow samples must use a real floating dtype.")
-
-    location = jnp.mean(samples, axis=0)
-    scale = jnp.std(samples, axis=0)
-    tolerance = jnp.sqrt(jnp.finfo(samples.dtype).eps) * jnp.maximum(
-        jnp.ones_like(location), jnp.abs(location)
-    )
-    base = Normal(location, jnp.maximum(scale, tolerance))
-    dimension = int(samples.shape[1])
-    if dimension == 1:
-        return triangular_spline_flow(
-            key,
-            base_dist=base,
-            flow_layers=int(flow_layers),
-            knots=int(num_knots),
-            invert=True,
-        )
-
-    transformer = RationalQuadraticSpline(knots=int(num_knots), interval=3.0)
-    return coupling_flow(
-        key,
-        base_dist=base,
-        transformer=transformer,
-        flow_layers=int(flow_layers),
-        nn_width=int(nn_width),
-        nn_depth=int(nn_depth),
-        invert=True,
-    )
-
-
 def _fit_flow(
     key: Array,
     flow: AbstractDistribution,
@@ -207,35 +161,6 @@ def _fit_flow(
     ):
         raise FloatingPointError("Flow training produced a nonfinite loss.")
     return trained, training_loss, validation_loss
-
-
-def _validate_flow(
-    flow: AbstractDistribution,
-    data: Array,
-    key: Array,
-    /,
-) -> None:
-    samples = jnp.asarray(data)
-    expected_shape = (int(samples.shape[-1]),)
-    if flow.shape != expected_shape:
-        raise ValueError(
-            f"Flow event shape {flow.shape} does not match {expected_shape}."
-        )
-    if flow.cond_shape is not None:
-        raise ValueError("Flow proposal must be unconditional.")
-    data_log_density = flow.log_prob(samples)
-    proposed, proposed_log_density = flow.sample_and_log_prob(
-        key,
-        sample_shape=(min(8, int(samples.shape[0])),),
-    )
-    if proposed.shape[1:] != expected_shape:
-        raise ValueError("Flow proposal samples have an incompatible event shape.")
-    if not bool(jnp.all(jnp.isfinite(data_log_density))):
-        raise FloatingPointError("Flow density is nonfinite on its training data.")
-    if not bool(jnp.all(jnp.isfinite(proposed))) or not bool(
-        jnp.all(jnp.isfinite(proposed_log_density))
-    ):
-        raise FloatingPointError("Flow proposal produced a nonfinite sample or density.")
 
 
 def _independence_mh_scan(

--- a/phydrax/uq/_flow_variational.py
+++ b/phydrax/uq/_flow_variational.py
@@ -1,0 +1,323 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from math import prod
+from pathlib import Path
+from typing import Any, cast
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+from flowjax.distributions import AbstractDistribution
+from jax.flatten_util import ravel_pytree
+from jaxtyping import Array, PyTree
+
+from .._strict import StrictModule
+from ._flow_family import build_default_flow, validate_flow
+from ._posterior import PosteriorProblem
+from ._variational import (
+    AbstractVariationalFamily,
+    fit_variational,
+    MeanFieldGaussianFamily,
+    VariationalConfig,
+    VariationalResult,
+)
+
+
+_MEAN_FIELD_TAG = 0
+_FLOW_INITIALIZATION_TAG = 1
+_FLOW_OPTIMIZATION_TAG = 2
+
+
+class FlowVariationalFamily(AbstractVariationalFamily):
+    """FlowJAX distribution adapted to an unconstrained parameter PyTree."""
+
+    flow: AbstractDistribution
+    unravel: Callable[[Array], PyTree[Array]] = eqx.field(static=True)
+    tree_definition: Any = eqx.field(static=True)
+    event_shapes: tuple[tuple[int, ...], ...] = eqx.field(static=True)
+    event_sizes: tuple[int, ...] = eqx.field(static=True)
+    dimension: int = eqx.field(static=True)
+
+    def __init__(
+        self,
+        flow: AbstractDistribution,
+        reference: PyTree[Any],
+        /,
+    ):
+        if not isinstance(flow, AbstractDistribution):
+            raise TypeError("flow must be a FlowJAX AbstractDistribution.")
+        flat_reference, unravel = ravel_pytree(reference)
+        if flat_reference.size < 1:
+            raise ValueError("Flow variational coordinates cannot be empty.")
+        if flow.shape != (int(flat_reference.size),) or flow.cond_shape is not None:
+            raise ValueError(
+                "Flow event shape must match unconditional parameter coordinates."
+            )
+        leaves, tree_definition = jax.tree.flatten(reference)
+        self.flow = flow
+        self.unravel = unravel
+        self.tree_definition = tree_definition
+        self.event_shapes = tuple(tuple(jnp.asarray(leaf).shape) for leaf in leaves)
+        self.event_sizes = tuple(int(jnp.asarray(leaf).size) for leaf in leaves)
+        self.dimension = int(flat_reference.size)
+
+    @property
+    def family_id(self) -> str:
+        return "flowjax-spline"
+
+    def _unflatten_samples(
+        self,
+        values: Array,
+        sample_shape: tuple[int, ...],
+        /,
+    ) -> PyTree[Array]:
+        count = prod(sample_shape) if sample_shape else 1
+        matrix = jnp.asarray(values).reshape((count, self.dimension))
+        tree = jax.vmap(self.unravel)(matrix)
+        if not sample_shape:
+            return jax.tree.map(lambda leaf: leaf[0], tree)
+        return jax.tree.map(
+            lambda leaf: leaf.reshape(sample_shape + leaf.shape[1:]),
+            tree,
+        )
+
+    def _flatten_samples(self, value: PyTree[Any], /) -> tuple[Array, tuple[int, ...]]:
+        if jax.tree.structure(value) != self.tree_definition:
+            raise ValueError("value has an incompatible flow parameter PyTree.")
+        leaves = jax.tree.leaves(value)
+        sample_shape = None
+        matrices = []
+        for leaf, event_shape, event_size in zip(
+            leaves,
+            self.event_shapes,
+            self.event_sizes,
+            strict=True,
+        ):
+            array = jnp.asarray(leaf)
+            if event_shape and (
+                array.ndim < len(event_shape)
+                or array.shape[-len(event_shape) :] != event_shape
+            ):
+                raise ValueError("A flow value leaf has an invalid trailing shape.")
+            prefix = (
+                array.shape[: array.ndim - len(event_shape)]
+                if event_shape
+                else array.shape
+            )
+            if sample_shape is None:
+                sample_shape = prefix
+            elif prefix != sample_shape:
+                raise ValueError("Every flow value leaf must share its sample shape.")
+            count = prod(prefix) if prefix else 1
+            matrices.append(array.reshape((count, event_size)))
+        resolved_shape = () if sample_shape is None else tuple(sample_shape)
+        return jnp.concatenate(matrices, axis=-1), resolved_shape
+
+    def sample_and_log_prob(
+        self,
+        key: Array,
+        /,
+        *,
+        sample_shape: tuple[int, ...] = (),
+    ) -> tuple[PyTree[Array], Array]:
+        shape = tuple(int(size) for size in sample_shape)
+        if any(size <= 0 for size in shape):
+            raise ValueError("sample_shape dimensions must be positive.")
+        values, log_prob = self.flow.sample_and_log_prob(key, sample_shape=shape)
+        return self._unflatten_samples(values, shape), log_prob
+
+    def log_prob(self, value: PyTree[Any], /) -> Array:
+        matrix, sample_shape = self._flatten_samples(value)
+        log_prob = self.flow.log_prob(matrix)
+        return log_prob.reshape(sample_shape) if sample_shape else log_prob.reshape(())
+
+
+class FlowVariationalConfig(StrictModule):
+    """Mean-field initialization, flow architecture, and reverse-KL controls."""
+
+    initialization: VariationalConfig
+    optimization: VariationalConfig
+    initialization_samples: int = eqx.field(static=True)
+    flow_layers: int = eqx.field(static=True)
+    num_knots: int = eqx.field(static=True)
+    nn_width: int = eqx.field(static=True)
+    nn_depth: int = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        initialization: VariationalConfig | None = None,
+        optimization: VariationalConfig | None = None,
+        initialization_samples: int = 512,
+        flow_layers: int = 6,
+        num_knots: int = 8,
+        nn_width: int = 64,
+        nn_depth: int = 2,
+    ):
+        initialization_ = (
+            VariationalConfig(num_steps=500) if initialization is None else initialization
+        )
+        optimization_ = VariationalConfig() if optimization is None else optimization
+        if not isinstance(initialization_, VariationalConfig) or not isinstance(
+            optimization_, VariationalConfig
+        ):
+            raise TypeError("initialization and optimization must be VariationalConfig.")
+        counts = tuple(
+            int(value)
+            for value in (
+                initialization_samples,
+                flow_layers,
+                num_knots,
+                nn_width,
+                nn_depth,
+            )
+        )
+        if any(value < 1 for value in counts):
+            raise ValueError("Flow variational architecture counts must be positive.")
+        self.initialization = initialization_
+        self.optimization = optimization_
+        (
+            self.initialization_samples,
+            self.flow_layers,
+            self.num_knots,
+            self.nn_width,
+            self.nn_depth,
+        ) = counts
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "initialization": self.initialization.as_dict(),
+            "optimization": self.optimization.as_dict(),
+            "initialization_samples": self.initialization_samples,
+            "flow_layers": self.flow_layers,
+            "num_knots": self.num_knots,
+            "nn_width": self.nn_width,
+            "nn_depth": self.nn_depth,
+        }
+
+
+class FlowVariationalResult(StrictModule):
+    """Flow posterior and the mean-field approximation used to initialize it."""
+
+    variational: VariationalResult
+    initialization: VariationalResult
+    config: FlowVariationalConfig
+    approximation_id: str = eqx.field(static=True)
+
+    @property
+    def family(self) -> FlowVariationalFamily:
+        return cast(FlowVariationalFamily, self.variational.family)
+
+    @property
+    def samples(self) -> PyTree[Array]:
+        return self.variational.samples
+
+    @property
+    def unconstrained_samples(self) -> PyTree[Array]:
+        return self.variational.unconstrained_samples
+
+    @property
+    def log_target(self) -> Array:
+        return self.variational.log_target
+
+    @property
+    def log_variational(self) -> Array:
+        return self.variational.log_variational
+
+    @property
+    def diagnostics(self):
+        return self.variational.diagnostics
+
+    @property
+    def num_draws(self) -> int:
+        return self.variational.num_draws
+
+
+def fit_flow_variational(
+    problem: PosteriorProblem,
+    /,
+    *,
+    key: Array,
+    config: FlowVariationalConfig | None = None,
+    num_samples: int = 1000,
+    initialization: VariationalResult | None = None,
+    checkpoint_path: str | Path | None = None,
+    checkpoint_every: int | None = None,
+    checkpoint_id: str | None = None,
+    resume_from: str | Path | None = None,
+) -> FlowVariationalResult:
+    """Fit an unconditional FlowJAX posterior by reverse KL."""
+
+    if not isinstance(problem, PosteriorProblem):
+        raise TypeError("problem must be a PosteriorProblem.")
+    config_ = FlowVariationalConfig() if config is None else config
+    if not isinstance(config_, FlowVariationalConfig):
+        raise TypeError("config must be FlowVariationalConfig or None.")
+    if initialization is None:
+        initialized = fit_variational(
+            problem,
+            key=jr.fold_in(key, _MEAN_FIELD_TAG),
+            family=MeanFieldGaussianFamily.from_position(problem.initial_position),
+            config=config_.initialization,
+            num_samples=config_.initialization_samples,
+        )
+    else:
+        if not isinstance(initialization, VariationalResult):
+            raise TypeError("initialization must be VariationalResult or None.")
+        initialized = initialization
+    flat_reference, _ = ravel_pytree(problem.initial_position)
+    flat_initialization = jax.vmap(lambda value: ravel_pytree(value)[0])(
+        initialized.unconstrained_samples
+    )
+    if flat_initialization.shape != (
+        config_.initialization_samples,
+        int(flat_reference.size),
+    ):
+        raise ValueError(
+            "Flow initialization draws do not match initialization_samples and parameter dimension."
+        )
+    flow = build_default_flow(
+        jr.fold_in(key, _FLOW_INITIALIZATION_TAG),
+        flat_initialization,
+        flow_layers=config_.flow_layers,
+        num_knots=config_.num_knots,
+        nn_width=config_.nn_width,
+        nn_depth=config_.nn_depth,
+    )
+    validate_flow(
+        flow,
+        flat_initialization,
+        jr.fold_in(key, _FLOW_INITIALIZATION_TAG + 1),
+    )
+    family = FlowVariationalFamily(flow, problem.initial_position)
+    fitted = fit_variational(
+        problem,
+        key=jr.fold_in(key, _FLOW_OPTIMIZATION_TAG),
+        family=family,
+        config=config_.optimization,
+        num_samples=num_samples,
+        checkpoint_path=checkpoint_path,
+        checkpoint_every=checkpoint_every,
+        checkpoint_id=checkpoint_id,
+        resume_from=resume_from,
+    )
+    return FlowVariationalResult(
+        variational=fitted,
+        initialization=initialized,
+        config=config_,
+        approximation_id="reverse-kl/flowjax-spline",
+    )
+
+
+__all__ = [
+    "fit_flow_variational",
+    "FlowVariationalConfig",
+    "FlowVariationalFamily",
+    "FlowVariationalResult",
+]

--- a/phydrax/uq/_kalman.py
+++ b/phydrax/uq/_kalman.py
@@ -15,6 +15,12 @@ import opt_einsum as oe
 from jaxtyping import Array, Key
 
 from .._strict import StrictModule
+from ..linalg._gaussian_chain import (
+    associative_affine_values,
+    associative_freeze,
+    associative_gaussian_filter,
+    associative_gaussian_smoother,
+)
 from ..stochastic._state_space import (
     GaussianStatePrior,
     LinearGaussianObservationModel,
@@ -23,12 +29,6 @@ from ..stochastic._state_space import (
     StateSpaceProblem,
 )
 from ._covariance import _factor_and_solve_covariance_system
-from ._gaussian_chain import (
-    associative_affine_values,
-    associative_freeze,
-    associative_gaussian_filter,
-    associative_gaussian_smoother,
-)
 
 
 KalmanExecutionMethod: TypeAlias = Literal["sequential", "parallel", "auto"]

--- a/phydrax/uq/_mcmc.py
+++ b/phydrax/uq/_mcmc.py
@@ -17,6 +17,11 @@ from jaxtyping import Array, PyTree
 
 from .._frozendict import frozendict
 from .._strict import StrictModule
+from ._causal_hmc import (
+    build_causal_hmc_kernel,
+    CausalHMCConfig,
+    CausalHMCDiagnostics,
+)
 from ._chain import (
     _prepare_chain_positions,
     _split_chain_keys,
@@ -93,11 +98,14 @@ class MCMCResult(StrictModule):
     diagnostics: MCMCDiagnostics
     root_key: Array
     chain_keys: Array
+    causal_diagnostics: CausalHMCDiagnostics | None
+    causal_config: CausalHMCConfig | None
     algorithm: str = eqx.field(static=True)
     duration_seconds: float = eqx.field(static=True)
     sample_memory_bytes: int = eqx.field(static=True)
     max_num_doublings: int | None = eqx.field(static=True)
     chain_method: NUTSChainMethod = eqx.field(static=True)
+    trajectory_method: Literal["sequential", "causal"] = eqx.field(static=True)
     adaptation_duration_seconds: float = eqx.field(static=True)
     sampling_duration_seconds: float = eqx.field(static=True)
     samples_per_second: float = eqx.field(static=True)
@@ -125,6 +133,9 @@ class MCMCResult(StrictModule):
         chain_method: NUTSChainMethod,
         adaptation_duration_seconds: float,
         sampling_duration_seconds: float,
+        trajectory_method: Literal["sequential", "causal"] = "sequential",
+        causal_diagnostics: CausalHMCDiagnostics | None = None,
+        causal_config: CausalHMCConfig | None = None,
     ):
         self.problem = problem
         self.samples = samples
@@ -140,6 +151,25 @@ class MCMCResult(StrictModule):
         self.diagnostics = diagnostics
         self.root_key = root_key
         self.chain_keys = chain_keys
+        if trajectory_method not in ("sequential", "causal"):
+            raise ValueError("Unknown HMC trajectory method.")
+        if causal_diagnostics is not None and not isinstance(
+            causal_diagnostics, CausalHMCDiagnostics
+        ):
+            raise TypeError("causal_diagnostics must be CausalHMCDiagnostics or None.")
+        if causal_config is not None and not isinstance(causal_config, CausalHMCConfig):
+            raise TypeError("causal_config must be CausalHMCConfig or None.")
+        if trajectory_method == "causal" and (
+            causal_diagnostics is None or causal_config is None
+        ):
+            raise ValueError("Causal trajectory results require config and diagnostics.")
+        if trajectory_method == "sequential" and (
+            causal_diagnostics is not None or causal_config is not None
+        ):
+            raise ValueError("Sequential trajectory results cannot carry causal state.")
+        self.trajectory_method = trajectory_method
+        self.causal_diagnostics = causal_diagnostics
+        self.causal_config = causal_config
         self.algorithm = str(algorithm)
         self.duration_seconds = float(duration_seconds)
         self.sample_memory_bytes = _tree_nbytes(samples) + _tree_nbytes(
@@ -287,6 +317,8 @@ def sample_nuts(
         is_mass_matrix_diagonal=is_mass_matrix_diagonal,
         extra_parameters={"max_num_doublings": int(max_num_doublings)},
         chain_method=chain_method,
+        trajectory_method="sequential",
+        causal_config=None,
         checkpoint_path=checkpoint_path,
         checkpoint_every=checkpoint_every,
         checkpoint_id=checkpoint_id,
@@ -309,6 +341,8 @@ def sample_hmc(
     initial_step_size: float = 1.0,
     is_mass_matrix_diagonal: bool = True,
     chain_method: ChainMethod = "sequential",
+    trajectory_method: Literal["sequential", "causal"] = "sequential",
+    causal_config: CausalHMCConfig | None = None,
     checkpoint_path: str | Path | None = None,
     checkpoint_every: int | None = None,
     checkpoint_id: str | None = None,
@@ -317,6 +351,18 @@ def sample_hmc(
     """Run independently adapted fixed-trajectory BlackJAX HMC chains."""
     if int(num_integration_steps) <= 0:
         raise ValueError("num_integration_steps must be positive.")
+    if trajectory_method not in ("sequential", "causal"):
+        raise ValueError("trajectory_method must be 'sequential' or 'causal'.")
+    if trajectory_method == "causal":
+        if not is_mass_matrix_diagonal:
+            raise ValueError("Causal HMC requires a diagonal inverse mass matrix.")
+        causal = CausalHMCConfig() if causal_config is None else causal_config
+        if not isinstance(causal, CausalHMCConfig):
+            raise TypeError("causal_config must be CausalHMCConfig or None.")
+    else:
+        if causal_config is not None:
+            raise ValueError("causal_config requires trajectory_method='causal'.")
+        causal = None
     return _sample_mcmc(
         problem,
         key=key,
@@ -331,6 +377,8 @@ def sample_hmc(
         is_mass_matrix_diagonal=is_mass_matrix_diagonal,
         extra_parameters={"num_integration_steps": int(num_integration_steps)},
         chain_method=chain_method,
+        trajectory_method=trajectory_method,
+        causal_config=causal,
         checkpoint_path=checkpoint_path,
         checkpoint_every=checkpoint_every,
         checkpoint_id=checkpoint_id,
@@ -354,6 +402,8 @@ def _sample_mcmc(
     is_mass_matrix_diagonal: bool,
     extra_parameters: dict[str, Any],
     chain_method: NUTSChainMethod,
+    trajectory_method: Literal["sequential", "causal"],
+    causal_config: CausalHMCConfig | None,
     checkpoint_path: str | Path | None,
     checkpoint_every: int | None,
     checkpoint_id: str | None,
@@ -381,6 +431,11 @@ def _sample_mcmc(
         if algorithm == "nuts"
         else _validate_chain_method(cast(ChainMethod, chain_method))
     )
+    if trajectory_method == "causal":
+        if algorithm != "hmc" or causal_config is None:
+            raise ValueError("Causal trajectories require HMC and CausalHMCConfig.")
+    elif causal_config is not None:
+        raise ValueError("causal_config requires causal trajectory execution.")
     if resume_from is not None and (
         initial_position is not None or initial_positions is not None
     ):
@@ -435,6 +490,8 @@ def _sample_mcmc(
         "is_mass_matrix_diagonal": bool(is_mass_matrix_diagonal),
         "chain_method": method,
         "extra_parameters": extra_parameters,
+        "trajectory_method": trajectory_method,
+        "causal_config": (None if causal_config is None else causal_config.as_dict()),
         "root_key": [int(value) for value in jr.key_data(root_key).reshape(-1)],
     }
     compatibility = (
@@ -454,6 +511,8 @@ def _sample_mcmc(
         algorithm=algorithm,
         extra_parameters=extra_parameters,
         chain_method=method,
+        trajectory_method=trajectory_method,
+        causal_config=causal_config,
     )
     started = time.perf_counter()
 
@@ -485,6 +544,13 @@ def _sample_mcmc(
         energy = jnp.empty((chains, 0), dtype=float)
         num_integration_steps_array = jnp.empty((chains, 0), dtype=jnp.int32)
         num_trajectory_expansions_array = jnp.empty((chains, 0), dtype=jnp.int32)
+        causal_converged = jnp.empty((chains, 0), dtype=bool)
+        causal_fallback_used = jnp.empty((chains, 0), dtype=bool)
+        causal_outer_iterations = jnp.empty((chains, 0), dtype=jnp.int32)
+        causal_maximum_residual = jnp.empty((chains, 0), dtype=float)
+        causal_accepted_steps = jnp.empty((chains, 0), dtype=jnp.int32)
+        causal_rejected_steps = jnp.empty((chains, 0), dtype=jnp.int32)
+        causal_transition_evaluations = jnp.empty((chains, 0), dtype=jnp.int32)
         sampling_duration = 0.0
         previous_duration = 0.0
         if destination is not None and compatibility is not None:
@@ -504,6 +570,13 @@ def _sample_mcmc(
                 energy=energy,
                 num_integration_steps=num_integration_steps_array,
                 num_trajectory_expansions=num_trajectory_expansions_array,
+                causal_converged=causal_converged,
+                causal_fallback_used=causal_fallback_used,
+                causal_outer_iterations=causal_outer_iterations,
+                causal_maximum_residual=causal_maximum_residual,
+                causal_accepted_steps=causal_accepted_steps,
+                causal_rejected_steps=causal_rejected_steps,
+                causal_transition_evaluations=causal_transition_evaluations,
                 adaptation_duration=adaptation_duration,
                 sampling_duration=sampling_duration,
                 duration_seconds=time.perf_counter() - started,
@@ -525,6 +598,13 @@ def _sample_mcmc(
             energy,
             num_integration_steps_array,
             num_trajectory_expansions_array,
+            causal_converged,
+            causal_fallback_used,
+            causal_outer_iterations,
+            causal_maximum_residual,
+            causal_accepted_steps,
+            causal_rejected_steps,
+            causal_transition_evaluations,
             adaptation_duration,
             sampling_duration,
             previous_duration,
@@ -579,6 +659,33 @@ def _sample_mcmc(
             ),
             axis=1,
         )
+        causal_converged = jnp.concatenate(
+            (causal_converged, chunk_metrics["causal_converged"]), axis=1
+        )
+        causal_fallback_used = jnp.concatenate(
+            (causal_fallback_used, chunk_metrics["causal_fallback_used"]), axis=1
+        )
+        causal_outer_iterations = jnp.concatenate(
+            (causal_outer_iterations, chunk_metrics["causal_outer_iterations"]),
+            axis=1,
+        )
+        causal_maximum_residual = jnp.concatenate(
+            (causal_maximum_residual, chunk_metrics["causal_maximum_residual"]),
+            axis=1,
+        )
+        causal_accepted_steps = jnp.concatenate(
+            (causal_accepted_steps, chunk_metrics["causal_accepted_steps"]), axis=1
+        )
+        causal_rejected_steps = jnp.concatenate(
+            (causal_rejected_steps, chunk_metrics["causal_rejected_steps"]), axis=1
+        )
+        causal_transition_evaluations = jnp.concatenate(
+            (
+                causal_transition_evaluations,
+                chunk_metrics["causal_transition_evaluations"],
+            ),
+            axis=1,
+        )
         completed += chunk
         if destination is not None and compatibility is not None:
             _write_mcmc_checkpoint(
@@ -597,6 +704,13 @@ def _sample_mcmc(
                 energy=energy,
                 num_integration_steps=num_integration_steps_array,
                 num_trajectory_expansions=num_trajectory_expansions_array,
+                causal_converged=causal_converged,
+                causal_fallback_used=causal_fallback_used,
+                causal_outer_iterations=causal_outer_iterations,
+                causal_maximum_residual=causal_maximum_residual,
+                causal_accepted_steps=causal_accepted_steps,
+                causal_rejected_steps=causal_rejected_steps,
+                causal_transition_evaluations=causal_transition_evaluations,
                 adaptation_duration=adaptation_duration,
                 sampling_duration=sampling_duration,
                 duration_seconds=previous_duration + time.perf_counter() - started,
@@ -625,6 +739,19 @@ def _sample_mcmc(
         )
         for index in range(chains)
     )
+    causal_diagnostics = (
+        CausalHMCDiagnostics(
+            converged=causal_converged,
+            fallback_used=causal_fallback_used,
+            outer_iterations=causal_outer_iterations,
+            maximum_residual=causal_maximum_residual,
+            accepted_nonlinear_steps=causal_accepted_steps,
+            rejected_nonlinear_steps=causal_rejected_steps,
+            transition_evaluations=causal_transition_evaluations,
+        )
+        if trajectory_method == "causal"
+        else None
+    )
     duration = previous_duration + time.perf_counter() - started
     return MCMCResult(
         problem=problem,
@@ -649,6 +776,9 @@ def _sample_mcmc(
         adaptation_duration_seconds=adaptation_duration,
         sampling_duration_seconds=sampling_duration,
         chain_method=method,
+        trajectory_method=trajectory_method,
+        causal_diagnostics=causal_diagnostics,
+        causal_config=causal_config,
     )
 
 
@@ -734,6 +864,8 @@ def _build_mcmc_advancer(
     algorithm,
     extra_parameters,
     chain_method,
+    trajectory_method,
+    causal_config,
 ):
     if algorithm == "nuts" and chain_method == "interleaved":
         compiled = build_interleaved_nuts_advancer(
@@ -757,11 +889,29 @@ def _build_mcmc_advancer(
                 inverse_mass_matrices,
                 draw_keys,
             )
-            return final_states, samples, metrics
+            zero = jnp.zeros_like(metrics["num_integration_steps"])
+            return (
+                final_states,
+                samples,
+                {
+                    **metrics,
+                    "causal_converged": jnp.zeros_like(zero, dtype=bool),
+                    "causal_fallback_used": jnp.zeros_like(zero, dtype=bool),
+                    "causal_outer_iterations": zero,
+                    "causal_maximum_residual": zero.astype(metrics["log_density"].dtype),
+                    "causal_accepted_steps": zero,
+                    "causal_rejected_steps": zero,
+                    "causal_transition_evaluations": zero,
+                },
+            )
 
         return advance_interleaved
 
-    kernel = algorithm_factory.build_kernel()
+    kernel = (
+        build_causal_hmc_kernel(causal_config)
+        if trajectory_method == "causal" and causal_config is not None
+        else algorithm_factory.build_kernel()
+    )
     if algorithm == "nuts":
         max_num_doublings = int(extra_parameters["max_num_doublings"])
 
@@ -850,6 +1000,27 @@ def _build_mcmc_advancer(
             if algorithm == "nuts"
             else jnp.zeros_like(infos.num_integration_steps)
         )
+        if trajectory_method == "causal":
+            causal_metrics = {
+                "causal_converged": infos.causal_converged,
+                "causal_fallback_used": infos.causal_fallback_used,
+                "causal_outer_iterations": infos.causal_outer_iterations,
+                "causal_maximum_residual": infos.causal_maximum_residual,
+                "causal_accepted_steps": infos.causal_accepted_steps,
+                "causal_rejected_steps": infos.causal_rejected_steps,
+                "causal_transition_evaluations": (infos.causal_transition_evaluations),
+            }
+        else:
+            zero = jnp.zeros_like(infos.num_integration_steps)
+            causal_metrics = {
+                "causal_converged": jnp.zeros_like(zero, dtype=bool),
+                "causal_fallback_used": jnp.zeros_like(zero, dtype=bool),
+                "causal_outer_iterations": zero,
+                "causal_maximum_residual": zero.astype(states.logdensity.dtype),
+                "causal_accepted_steps": zero,
+                "causal_rejected_steps": zero,
+                "causal_transition_evaluations": zero,
+            }
         return (
             final_states,
             states.position,
@@ -860,6 +1031,7 @@ def _build_mcmc_advancer(
                 "energy": infos.energy,
                 "num_integration_steps": infos.num_integration_steps,
                 "num_trajectory_expansions": trajectory_expansions,
+                **causal_metrics,
             },
         )
 
@@ -890,6 +1062,13 @@ def _write_mcmc_checkpoint(
     energy,
     num_integration_steps,
     num_trajectory_expansions,
+    causal_converged,
+    causal_fallback_used,
+    causal_outer_iterations,
+    causal_maximum_residual,
+    causal_accepted_steps,
+    causal_rejected_steps,
+    causal_transition_evaluations,
     adaptation_duration,
     sampling_duration,
     duration_seconds,
@@ -904,6 +1083,13 @@ def _write_mcmc_checkpoint(
         "energy": energy,
         "num_integration_steps": num_integration_steps,
         "num_trajectory_expansions": num_trajectory_expansions,
+        "causal_converged": causal_converged,
+        "causal_fallback_used": causal_fallback_used,
+        "causal_outer_iterations": causal_outer_iterations,
+        "causal_maximum_residual": causal_maximum_residual,
+        "causal_accepted_steps": causal_accepted_steps,
+        "causal_rejected_steps": causal_rejected_steps,
+        "causal_transition_evaluations": causal_transition_evaluations,
     }
     state = {
         "completed_draws": int(completed),
@@ -976,6 +1162,27 @@ def _read_mcmc_checkpoint(
     trajectory_expansions = _checkpoint_array(
         arrays, "num_trajectory_expansions", shape=expected_draw_shape
     )
+    causal_converged = _checkpoint_array(
+        arrays, "causal_converged", shape=expected_draw_shape
+    )
+    causal_fallback_used = _checkpoint_array(
+        arrays, "causal_fallback_used", shape=expected_draw_shape
+    )
+    causal_outer_iterations = _checkpoint_array(
+        arrays, "causal_outer_iterations", shape=expected_draw_shape
+    )
+    causal_maximum_residual = _checkpoint_array(
+        arrays, "causal_maximum_residual", shape=expected_draw_shape
+    )
+    causal_accepted_steps = _checkpoint_array(
+        arrays, "causal_accepted_steps", shape=expected_draw_shape
+    )
+    causal_rejected_steps = _checkpoint_array(
+        arrays, "causal_rejected_steps", shape=expected_draw_shape
+    )
+    causal_transition_evaluations = _checkpoint_array(
+        arrays, "causal_transition_evaluations", shape=expected_draw_shape
+    )
     return (
         completed,
         current_states,
@@ -990,6 +1197,13 @@ def _read_mcmc_checkpoint(
         energy,
         integration_steps,
         trajectory_expansions,
+        causal_converged,
+        causal_fallback_used,
+        causal_outer_iterations,
+        causal_maximum_residual,
+        causal_accepted_steps,
+        causal_rejected_steps,
+        causal_transition_evaluations,
         float(state["adaptation_duration_seconds"]),
         float(state["sampling_duration_seconds"]),
         float(state["duration_seconds"]),

--- a/phydrax/uq/_parameterized_state_space.py
+++ b/phydrax/uq/_parameterized_state_space.py
@@ -1,0 +1,138 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import equinox as eqx
+import jax.numpy as jnp
+from jaxtyping import Array, PyTree
+
+from .._strict import StrictModule
+from ..stochastic import StateSpaceProblem
+from ._posterior import ParameterSpace
+from ._state_space_path_density import state_space_path_log_density
+
+
+class ParameterizedStateSpacePathLogDensity(StrictModule):
+    """Global-parameter and latent-path normalized density decomposition."""
+
+    parameter_prior: Array
+    parameter_log_abs_det_jacobian: Array
+    initial: Array
+    transition: Array
+    observation: Array
+    case_log_density: Array
+    log_density: Array
+    valid: Array
+    bound_problem: StateSpaceProblem
+    approximation_id: str = eqx.field(static=True)
+
+
+class ParameterizedStateSpaceProblem(StrictModule):
+    """Bind unconstrained global parameters into an existing state-space schedule.
+
+    Transition and observation implementations receive the output of ``bind_args``
+    through ``StateSpaceStepContext.args``. The existing state-space model remains
+    the sole simulation and likelihood hierarchy.
+    """
+
+    problem: StateSpaceProblem
+    parameter_space: ParameterSpace
+    bind_args_function: Callable[[PyTree[Any], Any], Any]
+    initial_log_prob_function: Callable[[PyTree[Any], Array], Array] | None
+    parameterization_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        problem: StateSpaceProblem,
+        parameter_space: ParameterSpace,
+        bind_args: Callable[[PyTree[Any], Any], Any],
+        /,
+        *,
+        initial_log_prob: Callable[[PyTree[Any], Array], Array] | None = None,
+        parameterization_id: str = "parameterized-state-space",
+    ):
+        if not isinstance(problem, StateSpaceProblem):
+            raise TypeError("problem must be a StateSpaceProblem.")
+        if not isinstance(parameter_space, ParameterSpace):
+            raise TypeError("parameter_space must be a ParameterSpace.")
+        if not callable(bind_args):
+            raise TypeError("bind_args must be callable.")
+        if initial_log_prob is not None and not callable(initial_log_prob):
+            raise TypeError("initial_log_prob must be callable or None.")
+        identifier = str(parameterization_id)
+        if not identifier:
+            raise ValueError("parameterization_id must be non-empty.")
+        self.problem = problem
+        self.parameter_space = parameter_space
+        self.bind_args_function = bind_args
+        self.initial_log_prob_function = initial_log_prob
+        self.parameterization_id = identifier
+
+    @property
+    def initial_position(self) -> PyTree[Any]:
+        return self.parameter_space.initial
+
+    def bind_physical(self, physical_parameters: PyTree[Any], /) -> StateSpaceProblem:
+        bound_args = self.bind_args_function(physical_parameters, self.problem.args)
+        return eqx.tree_at(lambda problem: problem.args, self.problem, bound_args)
+
+    def bind(self, position: PyTree[Any], /) -> StateSpaceProblem:
+        return self.bind_physical(self.parameter_space.constrain(position))
+
+    def path_log_density(
+        self,
+        position: PyTree[Any],
+        states: Array,
+        /,
+    ) -> ParameterizedStateSpacePathLogDensity:
+        physical = self.parameter_space.constrain(position)
+        bound_problem = self.bind_physical(physical)
+        path = state_space_path_log_density(bound_problem, states)
+        if self.initial_log_prob_function is None:
+            initial = path.prior
+        else:
+            initial_states = jnp.take(
+                jnp.asarray(states),
+                0,
+                axis=len(bound_problem.observations.case_shape),
+            )
+            initial = jnp.asarray(
+                self.initial_log_prob_function(physical, initial_states)
+            )
+            if initial.shape != bound_problem.observations.case_shape:
+                raise ValueError(
+                    "initial_log_prob must return one scalar per physical case."
+                )
+        finite_initial = jnp.isfinite(initial)
+        valid = path.valid & finite_initial
+        case_log_density = jnp.where(
+            valid,
+            initial + jnp.sum(path.transition + path.observation, axis=-1),
+            -jnp.inf,
+        )
+        parameter_prior = self.parameter_space.log_prior(physical)
+        parameter_jacobian = self.parameter_space.log_abs_det_jacobian(position)
+        log_density = parameter_prior + parameter_jacobian + jnp.sum(case_log_density)
+        return ParameterizedStateSpacePathLogDensity(
+            parameter_prior=parameter_prior,
+            parameter_log_abs_det_jacobian=parameter_jacobian,
+            initial=initial,
+            transition=path.transition,
+            observation=path.observation,
+            case_log_density=case_log_density,
+            log_density=log_density,
+            valid=valid,
+            bound_problem=bound_problem,
+            approximation_id=self.parameterization_id,
+        )
+
+
+__all__ = [
+    "ParameterizedStateSpacePathLogDensity",
+    "ParameterizedStateSpaceProblem",
+]

--- a/phydrax/uq/_particle.py
+++ b/phydrax/uq/_particle.py
@@ -184,7 +184,7 @@ class ParticleFilterState(StrictModule):
     valid: Array
     status: Array
     root_key: Array
-    step_index: int = eqx.field(static=True)
+    step_index: Array
     num_particles: int = eqx.field(static=True)
     problem_id: str = eqx.field(static=True)
     resampling_method: ResamplingMethod = eqx.field(static=True)
@@ -213,6 +213,9 @@ class ParticleFilterStep(StrictModule):
 class ParticleFilterResult(StrictModule):
     """Fixed-shape particle history with genealogy and complete run provenance."""
 
+    initial_particles: Array
+    initial_log_weights: Array
+    initial_valid: Array
     predicted_particles: Array
     posterior_log_weights: Array
     particles: Array
@@ -403,7 +406,7 @@ def initialize_particle_filter(
         valid=valid,
         status=status,
         root_key=jnp.asarray(key),
-        step_index=0,
+        step_index=jnp.asarray(0, dtype=jnp.int32),
         num_particles=count,
         problem_id=problem.problem_id,
         resampling_method=method,
@@ -425,44 +428,53 @@ def _propagate_particles(
     starts = state.time.reshape((case_count,))
     ends = target_time.reshape((case_count,))
     active_flat = active.reshape((case_count,))
+    state_valid = state.valid.reshape((case_count,))
     propagated_cases = []
     valid_cases = []
+    particle_indices = jnp.arange(count, dtype=jnp.int32)
     for case_index, case_id in enumerate(problem.observations.case_ids):
         context = problem.step_context(case_index, state.step_index)
-        propagated = []
-        particle_valid = []
-        for particle_index in range(count):
-            if bool(active_flat[case_index]) and bool(
-                state.valid.reshape((-1,))[case_index]
-            ):
-                transition_key = state_space_key(
-                    state.root_key,
-                    "particle-filter-transition",
-                    case_id,
-                    state.step_index,
-                    member=particle_index,
-                )
+        transition_keys = jax.vmap(
+            lambda particle_index: state_space_key(
+                state.root_key,
+                "particle-filter-transition",
+                case_id,
+                state.step_index,
+                member=particle_index,
+            )
+        )(particle_indices)
+        case_active = active_flat[case_index] & state_valid[case_index]
+
+        def propagate_one(transition_key, previous_particle):
+            def propagate(_):
                 sample = problem.model.transition.sample(
                     transition_key,
-                    previous[case_index, particle_index],
+                    previous_particle,
                     starts[case_index],
                     ends[case_index],
                     context,
                 )
                 sample_valid = jnp.all(sample.valid) & jnp.all(sample.status == 0)
-                propagated.append(
-                    jnp.where(
-                        sample_valid,
-                        sample.values,
-                        previous[case_index, particle_index],
-                    )
+                values = jnp.where(
+                    sample_valid,
+                    sample.values,
+                    previous_particle,
                 )
-                particle_valid.append(sample_valid)
-            else:
-                propagated.append(previous[case_index, particle_index])
-                particle_valid.append(jnp.asarray(True))
-        propagated_cases.append(jnp.stack(propagated, axis=0))
-        valid_cases.append(jnp.stack(particle_valid, axis=0))
+                return values, sample_valid
+
+            return jax.lax.cond(
+                case_active,
+                propagate,
+                lambda _: (previous_particle, jnp.asarray(True)),
+                operand=None,
+            )
+
+        propagated, particle_valid = jax.vmap(propagate_one)(
+            transition_keys,
+            previous[case_index],
+        )
+        propagated_cases.append(propagated)
+        valid_cases.append(particle_valid)
     return (
         jnp.stack(propagated_cases, axis=0).reshape(
             case_shape + (count,) + problem.model.state_shape
@@ -493,20 +505,24 @@ def _observation_log_likelihoods(
     likelihoods = []
     for case_index in range(case_count):
         context = problem.step_context(case_index, state.step_index)
-        case_likelihoods = []
-        for particle_index in range(count):
-            if bool(active_flat[case_index]):
-                value = problem.model.observation.log_prob(
-                    flat_values[case_index],
-                    particles[case_index, particle_index],
-                    flat_times[case_index],
-                    flat_mask[case_index],
-                    context,
-                )
-                case_likelihoods.append(jnp.asarray(value).reshape(()))
-            else:
-                case_likelihoods.append(jnp.asarray(0.0))
-        likelihoods.append(jnp.stack(case_likelihoods, axis=0))
+
+        def evaluate(particle):
+            return jax.lax.cond(
+                active_flat[case_index],
+                lambda _: jnp.asarray(
+                    problem.model.observation.log_prob(
+                        flat_values[case_index],
+                        particle,
+                        flat_times[case_index],
+                        flat_mask[case_index],
+                        context,
+                    )
+                ).reshape(()),
+                lambda _: jnp.zeros((), dtype=predicted_particles.dtype),
+                operand=None,
+            )
+
+        likelihoods.append(jax.vmap(evaluate)(particles[case_index]))
     return jnp.stack(likelihoods, axis=0).reshape(case_shape + (count,))
 
 
@@ -515,22 +531,26 @@ def particle_filter_step(
     state: ParticleFilterState,
     /,
 ) -> tuple[ParticleFilterState, ParticleFilterStep]:
-    """Run one bootstrap-filter step with stable case/step/particle key derivation."""
+    """Run one JAX-safe bootstrap-filter step with semantic key derivation."""
     if not isinstance(problem, StateSpaceProblem):
         raise TypeError("problem must be a StateSpaceProblem.")
     if not isinstance(state, ParticleFilterState):
         raise TypeError("state must be a ParticleFilterState.")
     if state.problem_id != problem.problem_id:
         raise ValueError("Particle-filter state and problem IDs do not match.")
-    index = state.step_index
     sequence = problem.observations
-    if index >= sequence.num_steps:
-        raise ValueError("The particle-filter state has consumed every observation step.")
+    index = jnp.asarray(state.step_index, dtype=jnp.int32)
+    checked_particles = eqx.error_if(
+        state.particles,
+        (index < 0) | (index >= sequence.num_steps),
+        "The particle-filter state has consumed every observation step.",
+    )
+    state = eqx.tree_at(lambda value: value.particles, state, checked_particles)
     case_shape = sequence.case_shape
     case_count = _case_count(problem)
     count = state.num_particles
-    active = sequence.step_valid[..., index]
-    target_time = sequence.times[..., index]
+    active = jnp.take(sequence.step_valid, index, axis=-1)
+    target_time = jnp.take(sequence.times, index, axis=-1)
     step_axis = len(case_shape)
     values = jnp.take(sequence.values, index, axis=step_axis)
     mask = jnp.take(sequence.observation_mask, index, axis=step_axis)
@@ -561,44 +581,76 @@ def particle_filter_step(
     )
     flat_previous_weights = state.log_weights.reshape((case_count, count))
     flat_ess = ess.reshape((case_count,))
-    flat_active = active.reshape((case_count,))
     flat_accepted = accepted.reshape((case_count,))
     output_particles = []
     output_weights = []
     ancestor_indices = []
     resampled_values = []
     for case_index, case_id in enumerate(sequence.case_ids):
-        should_resample = state.resampling_policy == "always" or (
-            state.resampling_policy == "ess"
-            and float(flat_ess[case_index]) < state.resampling_threshold * count
-        )
-        do_resample = bool(flat_accepted[case_index]) and should_resample
-        if do_resample:
-            resampling_key = state_space_key(
-                state.root_key,
-                "particle-filter-resampling",
-                case_id,
-                index,
-            )
-            ancestors = resample_indices(
-                resampling_key,
-                flat_posterior[case_index],
-                method=state.resampling_method,
-            )
-            output_particles.append(flat_predicted[case_index, ancestors])
-            output_weights.append(
-                jnp.full((count,), -jnp.log(float(count)), dtype=predicted.dtype)
-            )
-        elif bool(flat_accepted[case_index]):
-            ancestors = identity
-            output_particles.append(flat_predicted[case_index])
-            output_weights.append(flat_posterior[case_index])
+        if state.resampling_policy == "always":
+            should_resample = jnp.asarray(True)
+        elif state.resampling_policy == "ess":
+            should_resample = flat_ess[case_index] < state.resampling_threshold * count
         else:
-            ancestors = identity
-            output_particles.append(flat_previous_particles[case_index])
-            output_weights.append(flat_previous_weights[case_index])
-        ancestor_indices.append(ancestors)
-        resampled_values.append(jnp.asarray(do_resample))
+            should_resample = jnp.asarray(False)
+        resampling_key = state_space_key(
+            state.root_key,
+            "particle-filter-resampling",
+            case_id,
+            index,
+        )
+
+        def accepted_case(_):
+            def resampled_case(_):
+                selected = resample_indices(
+                    resampling_key,
+                    flat_posterior[case_index],
+                    method=state.resampling_method,
+                )
+                return (
+                    flat_predicted[case_index, selected],
+                    jnp.full(
+                        (count,),
+                        -jnp.log(float(count)),
+                        dtype=predicted.dtype,
+                    ),
+                    selected,
+                    jnp.asarray(True),
+                )
+
+            def retained_case(_):
+                return (
+                    flat_predicted[case_index],
+                    flat_posterior[case_index],
+                    identity,
+                    jnp.asarray(False),
+                )
+
+            return jax.lax.cond(
+                should_resample,
+                resampled_case,
+                retained_case,
+                operand=None,
+            )
+
+        def rejected_case(_):
+            return (
+                flat_previous_particles[case_index],
+                flat_previous_weights[case_index],
+                identity,
+                jnp.asarray(False),
+            )
+
+        case_particles, case_weights, case_ancestors, case_resampled = jax.lax.cond(
+            flat_accepted[case_index],
+            accepted_case,
+            rejected_case,
+            operand=None,
+        )
+        output_particles.append(case_particles)
+        output_weights.append(case_weights)
+        ancestor_indices.append(case_ancestors)
+        resampled_values.append(case_resampled)
     next_particles = jnp.stack(output_particles, axis=0).reshape(
         case_shape + (count,) + problem.model.state_shape
     )
@@ -664,10 +716,6 @@ def particle_filter_step(
     return next_state, record
 
 
-def _stack(values: list[Array], case_rank: int, /) -> Array:
-    return jnp.stack(values, axis=case_rank)
-
-
 def bootstrap_particle_filter(
     key: Key[Array, ""],
     problem: StateSpaceProblem,
@@ -679,7 +727,7 @@ def bootstrap_particle_filter(
     resampling_threshold: float = 0.5,
     raise_on_failure: bool = False,
 ) -> ParticleFilterResult:
-    """Run a bootstrap particle filter without assuming a transition density."""
+    """Run a bootstrap filter as one JAX-compatible temporal scan."""
     state = initialize_particle_filter(
         key,
         problem,
@@ -688,35 +736,40 @@ def bootstrap_particle_filter(
         resampling_policy=resampling_policy,
         resampling_threshold=resampling_threshold,
     )
-    records: list[ParticleFilterStep] = []
-    for _ in range(problem.observations.num_steps):
-        state, record = particle_filter_step(problem, state)
-        records.append(record)
+    initial_state = state
+
+    def scan_step(current_state, _):
+        next_state, record = particle_filter_step(problem, current_state)
+        return next_state, record
+
+    state, time_major_records = jax.lax.scan(
+        scan_step,
+        state,
+        xs=None,
+        length=problem.observations.num_steps,
+    )
     rank = len(problem.observations.case_shape)
+    records = jax.tree.map(
+        lambda leaf: jnp.moveaxis(leaf, 0, rank),
+        time_major_records,
+    )
     result = ParticleFilterResult(
-        predicted_particles=_stack(
-            [record.predicted_particles for record in records], rank
-        ),
-        posterior_log_weights=_stack(
-            [record.posterior_log_weights for record in records], rank
-        ),
-        particles=_stack([record.particles for record in records], rank),
-        log_weights=_stack([record.log_weights for record in records], rank),
-        ancestor_indices=_stack([record.ancestor_indices for record in records], rank),
-        transition_valid=_stack([record.transition_valid for record in records], rank),
-        effective_sample_sizes=_stack(
-            [record.effective_sample_size for record in records], rank
-        ),
-        resampled=_stack([record.resampled for record in records], rank),
-        incremental_log_likelihood=_stack(
-            [record.incremental_log_likelihood for record in records], rank
-        ),
-        cumulative_log_likelihood=_stack(
-            [record.cumulative_log_likelihood for record in records], rank
-        ),
+        initial_particles=initial_state.particles,
+        initial_log_weights=initial_state.log_weights,
+        initial_valid=initial_state.valid,
+        predicted_particles=records.predicted_particles,
+        posterior_log_weights=records.posterior_log_weights,
+        particles=records.particles,
+        log_weights=records.log_weights,
+        ancestor_indices=records.ancestor_indices,
+        transition_valid=records.transition_valid,
+        effective_sample_sizes=records.effective_sample_size,
+        resampled=records.resampled,
+        incremental_log_likelihood=records.incremental_log_likelihood,
+        cumulative_log_likelihood=records.cumulative_log_likelihood,
         step_valid=problem.observations.step_valid,
-        valid=_stack([record.valid for record in records], rank),
-        status=_stack([record.status for record in records], rank),
+        valid=records.valid,
+        status=records.status,
         times=problem.observations.times,
         final_state=state,
         problem=problem,
@@ -736,8 +789,17 @@ def bootstrap_particle_filter(
         resampling_policy=state.resampling_policy,
         resampling_threshold=state.resampling_threshold,
     )
-    if raise_on_failure and not bool(jnp.all(result.successful)):
-        raise RuntimeError("Particle filtering failed for at least one physical case.")
+    if raise_on_failure:
+        checked = eqx.error_if(
+            result.final_state.particles,
+            ~jnp.all(result.successful),
+            "Particle filtering failed for at least one physical case.",
+        )
+        result = eqx.tree_at(
+            lambda value: value.final_state.particles,
+            result,
+            checked,
+        )
     return result
 
 
@@ -1518,7 +1580,7 @@ def write_particle_filter_checkpoint(
         path,
         kind="particle-filter-state-v1",
         compatibility=compatibility,
-        state={"step_index": state.step_index},
+        state={"step_index": int(state.step_index)},
         arrays={
             "particles": state.particles,
             "log_weights": state.log_weights,

--- a/phydrax/uq/_particle_genealogical_score.py
+++ b/phydrax/uq/_particle_genealogical_score.py
@@ -1,0 +1,314 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from math import prod
+from typing import Any
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jax.flatten_util import ravel_pytree
+from jaxtyping import Array
+
+from .._strict import StrictModule
+from ._particle import ParticleFilterResult
+
+
+class StateSpaceModelScore(StrictModule):
+    """Differentiable prior, transition, and observation score PyTrees."""
+
+    prior: Any
+    transition: Any
+    observation: Any
+
+
+class ParticleGenealogicalScoreResult(StrictModule):
+    """Complete-model `O(TN)` Fisher score propagated through realized ancestry."""
+
+    score: StateSpaceModelScore
+    flat_score: Array
+    case_scores: Array
+    valid: Array
+    filter_result: ParticleFilterResult
+    parameter_paths: tuple[str, ...] = eqx.field(static=True)
+    parameter_size: int = eqx.field(static=True)
+    method_id: str = eqx.field(static=True)
+    ancestry_gradient: str = eqx.field(static=True)
+    model_id: str = eqx.field(static=True)
+    problem_id: str = eqx.field(static=True)
+    sequence_id: str = eqx.field(static=True)
+    input_id: str | None = eqx.field(static=True)
+
+
+def _filtered_ravel(tree: Any, /):
+    return ravel_pytree(eqx.filter(tree, eqx.is_inexact_array))
+
+
+def _prior_gradient(prior, particle):
+    return eqx.filter_grad(lambda current: jnp.sum(current.log_prob(particle)))(prior)
+
+
+def _transition_gradient(
+    transition,
+    next_state,
+    previous_state,
+    start_time,
+    end_time,
+    context,
+):
+    return eqx.filter_grad(
+        lambda current: jnp.asarray(
+            current.log_prob(
+                next_state,
+                previous_state,
+                start_time,
+                end_time,
+                context,
+            )
+        ).reshape(())
+    )(transition)
+
+
+def _observation_gradient(
+    observation,
+    value,
+    state,
+    time,
+    mask,
+    context,
+):
+    return eqx.filter_grad(
+        lambda current: jnp.asarray(
+            current.log_prob(value, state, time, mask, context)
+        ).reshape(())
+    )(observation)
+
+
+def particle_genealogical_score(
+    result: ParticleFilterResult,
+    /,
+) -> ParticleGenealogicalScoreResult:
+    """Estimate the complete stored-model score with linear particle complexity."""
+
+    if not isinstance(result, ParticleFilterResult):
+        raise TypeError("result must be a ParticleFilterResult.")
+    problem = result.problem
+    if not problem.model.prior.has_log_density:
+        raise ValueError("A genealogical score requires a normalized state prior.")
+    if not problem.model.transition.has_log_density:
+        raise ValueError("A genealogical score requires normalized transitions.")
+    case_count = prod(result.case_shape) if result.case_shape else 1
+    num_steps = problem.observations.num_steps
+    count = result.num_particles
+    state_shape = result.state_shape
+    observation_shape = result.observation_shape
+    initial_particles = jax.lax.stop_gradient(
+        result.initial_particles.reshape((case_count, count) + state_shape)
+    )
+    initial_log_weights = jax.lax.stop_gradient(
+        result.initial_log_weights.reshape((case_count, count))
+    )
+    particles = jax.lax.stop_gradient(
+        result.particles.reshape((case_count, num_steps, count) + state_shape)
+    )
+    predicted = jax.lax.stop_gradient(
+        result.predicted_particles.reshape((case_count, num_steps, count) + state_shape)
+    )
+    posterior_log_weights = jax.lax.stop_gradient(
+        result.posterior_log_weights.reshape((case_count, num_steps, count))
+    )
+    ancestors = jax.lax.stop_gradient(
+        result.ancestor_indices.reshape((case_count, num_steps, count))
+    )
+    active = jax.lax.stop_gradient(result.step_valid.reshape((case_count, num_steps)))
+    times = problem.observations.times.reshape((case_count, num_steps))
+    initial_times = problem.initial_time.reshape((case_count,))
+    observations = problem.observations.values.reshape(
+        (case_count, num_steps) + observation_shape
+    )
+    observation_masks = problem.observations.observation_mask.reshape(
+        (case_count, num_steps) + observation_shape
+    )
+
+    prior_template = _prior_gradient(problem.model.prior, initial_particles[0, 0])
+    first_context = problem.step_context(0, 0)
+    transition_template = _transition_gradient(
+        problem.model.transition,
+        predicted[0, 0, 0],
+        initial_particles[0, 0],
+        initial_times[0],
+        times[0, 0],
+        first_context,
+    )
+    observation_template = _observation_gradient(
+        problem.model.observation,
+        observations[0, 0],
+        predicted[0, 0, 0],
+        times[0, 0],
+        observation_masks[0, 0],
+        first_context,
+    )
+    prior_reference, unravel_prior = _filtered_ravel(prior_template)
+    transition_reference, unravel_transition = _filtered_ravel(transition_template)
+    observation_reference, unravel_observation = _filtered_ravel(observation_template)
+    prior_size = int(prior_reference.size)
+    transition_size = int(transition_reference.size)
+    observation_size = int(observation_reference.size)
+    parameter_size = prior_size + transition_size + observation_size
+    if parameter_size < 1:
+        raise ValueError("The stored state-space model has no differentiable parameters.")
+
+    def prior_vector(particle):
+        gradient = _prior_gradient(problem.model.prior, particle)
+        vector, _ = _filtered_ravel(gradient)
+        return vector
+
+    initial_scores = []
+    for case_index in range(case_count):
+        case_scores = []
+        for particle_index in range(count):
+            prior_score = prior_vector(initial_particles[case_index, particle_index])
+            case_scores.append(
+                jnp.concatenate(
+                    (
+                        prior_score,
+                        jnp.zeros(
+                            (transition_size + observation_size,),
+                            dtype=prior_score.dtype,
+                        ),
+                    )
+                )
+            )
+        initial_scores.append(jnp.stack(case_scores))
+    cumulative = jnp.stack(initial_scores)
+    terminal_scores = cumulative
+    terminal_log_weights = initial_log_weights
+
+    for step_index in range(num_steps):
+        pre_resampling_cases = []
+        post_resampling_cases = []
+        for case_index in range(case_count):
+            context = problem.step_context(case_index, step_index)
+            start_time = (
+                initial_times[case_index]
+                if step_index == 0
+                else times[case_index, step_index - 1]
+            )
+            end_time = times[case_index, step_index]
+            previous_particles = (
+                initial_particles[case_index]
+                if step_index == 0
+                else particles[case_index, step_index - 1]
+            )
+            local_scores = []
+            for particle_index in range(count):
+                next_state = predicted[case_index, step_index, particle_index]
+                previous_state = previous_particles[particle_index]
+
+                def active_score(_):
+                    transition_gradient = _transition_gradient(
+                        problem.model.transition,
+                        next_state,
+                        previous_state,
+                        start_time,
+                        end_time,
+                        context,
+                    )
+                    observation_gradient = _observation_gradient(
+                        problem.model.observation,
+                        observations[case_index, step_index],
+                        next_state,
+                        end_time,
+                        observation_masks[case_index, step_index],
+                        context,
+                    )
+                    transition_vector, _ = _filtered_ravel(transition_gradient)
+                    observation_vector, _ = _filtered_ravel(observation_gradient)
+                    return jnp.concatenate(
+                        (
+                            jnp.zeros((prior_size,), dtype=transition_vector.dtype),
+                            transition_vector,
+                            observation_vector,
+                        )
+                    )
+
+                local_scores.append(
+                    jax.lax.cond(
+                        active[case_index, step_index],
+                        active_score,
+                        lambda _: jnp.zeros((parameter_size,), dtype=cumulative.dtype),
+                        operand=None,
+                    )
+                )
+            pre_resampling = cumulative[case_index] + jnp.stack(local_scores)
+            pre_resampling_cases.append(pre_resampling)
+            post_resampling_cases.append(
+                pre_resampling[ancestors[case_index, step_index]]
+            )
+        pre_resampling_scores = jnp.stack(pre_resampling_cases)
+        post_resampling_scores = jnp.stack(post_resampling_cases)
+        step_active = active[:, step_index]
+        terminal_scores = jnp.where(
+            step_active[:, None, None],
+            pre_resampling_scores,
+            terminal_scores,
+        )
+        terminal_log_weights = jnp.where(
+            step_active[:, None],
+            posterior_log_weights[:, step_index],
+            terminal_log_weights,
+        )
+        cumulative = jnp.where(
+            step_active[:, None, None],
+            post_resampling_scores,
+            cumulative,
+        )
+
+    normalized_weights = jnp.exp(terminal_log_weights)
+    case_scores = jnp.sum(normalized_weights[..., None] * terminal_scores, axis=1)
+    valid = result.successful.reshape((case_count,)) & result.initial_valid.reshape(
+        (case_count,)
+    )
+    case_scores = jnp.where(valid[:, None], case_scores, 0.0)
+    flat_score = jnp.sum(case_scores, axis=0)
+    prior_score = unravel_prior(flat_score[:prior_size])
+    transition_score = unravel_transition(
+        flat_score[prior_size : prior_size + transition_size]
+    )
+    observation_score = unravel_observation(flat_score[prior_size + transition_size :])
+    score = StateSpaceModelScore(
+        prior=prior_score,
+        transition=transition_score,
+        observation=observation_score,
+    )
+    path_leaves = jax.tree_util.tree_flatten_with_path(score)[0]
+    parameter_paths = tuple(
+        jax.tree_util.keystr(path) or "<root>"
+        for path, leaf in path_leaves
+        if eqx.is_inexact_array(leaf)
+    )
+    return ParticleGenealogicalScoreResult(
+        score=score,
+        flat_score=flat_score,
+        case_scores=case_scores.reshape(result.case_shape + (parameter_size,)),
+        valid=valid.reshape(result.case_shape),
+        filter_result=result,
+        parameter_paths=parameter_paths,
+        parameter_size=parameter_size,
+        method_id="particle-complete-model-genealogical-score",
+        ancestry_gradient="stopped-realized-ancestry",
+        model_id=result.model_id,
+        problem_id=result.problem_id,
+        sequence_id=result.sequence_id,
+        input_id=result.input_id,
+    )
+
+
+__all__ = [
+    "particle_genealogical_score",
+    "ParticleGenealogicalScoreResult",
+    "StateSpaceModelScore",
+]

--- a/phydrax/uq/_particle_parameter_score.py
+++ b/phydrax/uq/_particle_parameter_score.py
@@ -1,0 +1,219 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from math import prod
+from typing import Any
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jax.flatten_util import ravel_pytree
+from jaxtyping import Array, PyTree
+
+from .._strict import StrictModule
+from ._parameterized_state_space import ParameterizedStateSpaceProblem
+from ._particle import ParticleFilterResult
+
+
+class ParameterizedParticleGenealogicalScoreResult(StrictModule):
+    """`O(TN)` likelihood score in unconstrained global-parameter coordinates."""
+
+    gradient: PyTree[Array]
+    flat_score: Array
+    case_scores: Array
+    valid: Array
+    filter_result: ParticleFilterResult
+    parameter_paths: tuple[str, ...] = eqx.field(static=True)
+    parameter_size: int = eqx.field(static=True)
+    method_id: str = eqx.field(static=True)
+    ancestry_gradient: str = eqx.field(static=True)
+    parameterization_id: str = eqx.field(static=True)
+
+
+def parameterized_particle_genealogical_score(
+    parameterized: ParameterizedStateSpaceProblem,
+    position: PyTree[Any],
+    result: ParticleFilterResult,
+    /,
+) -> ParameterizedParticleGenealogicalScoreResult:
+    """Propagate complete-model local scores in global parameter coordinates."""
+
+    if not isinstance(parameterized, ParameterizedStateSpaceProblem):
+        raise TypeError("parameterized must be a ParameterizedStateSpaceProblem.")
+    if not isinstance(result, ParticleFilterResult):
+        raise TypeError("result must be a ParticleFilterResult.")
+    if result.problem_id != parameterized.problem.problem_id:
+        raise ValueError("Particle result and parameterized problem IDs do not match.")
+    flat_position, unravel = ravel_pytree(position)
+    parameter_size = int(flat_position.size)
+    if parameter_size < 1:
+        raise ValueError("Parameterized particle scores require nonempty coordinates.")
+    case_count = prod(result.case_shape) if result.case_shape else 1
+    num_steps = result.problem.observations.num_steps
+    count = result.num_particles
+    state_shape = result.state_shape
+    observation_shape = result.observation_shape
+    initial_particles = jax.lax.stop_gradient(
+        result.initial_particles.reshape((case_count, count) + state_shape)
+    )
+    initial_log_weights = jax.lax.stop_gradient(
+        result.initial_log_weights.reshape((case_count, count))
+    )
+    particles = jax.lax.stop_gradient(
+        result.particles.reshape((case_count, num_steps, count) + state_shape)
+    )
+    predicted = jax.lax.stop_gradient(
+        result.predicted_particles.reshape((case_count, num_steps, count) + state_shape)
+    )
+    posterior_log_weights = jax.lax.stop_gradient(
+        result.posterior_log_weights.reshape((case_count, num_steps, count))
+    )
+    ancestors = jax.lax.stop_gradient(
+        result.ancestor_indices.reshape((case_count, num_steps, count))
+    )
+    active = jax.lax.stop_gradient(result.step_valid.reshape((case_count, num_steps)))
+    times = result.problem.observations.times.reshape((case_count, num_steps))
+    initial_times = result.problem.initial_time.reshape((case_count,))
+    observations = result.problem.observations.values.reshape(
+        (case_count, num_steps) + observation_shape
+    )
+    observation_masks = result.problem.observations.observation_mask.reshape(
+        (case_count, num_steps) + observation_shape
+    )
+    initial_log_prob_function = parameterized.initial_log_prob_function
+
+    def initial_vector(particle):
+        if initial_log_prob_function is None:
+            return jnp.zeros_like(flat_position)
+
+        def initial_log_density(current_position):
+            physical = parameterized.parameter_space.constrain(current_position)
+            return jnp.sum(initial_log_prob_function(physical, particle))
+
+        gradient = jax.grad(initial_log_density)(position)
+        return ravel_pytree(gradient)[0]
+
+    initial_scores = []
+    for case_index in range(case_count):
+        initial_scores.append(
+            jnp.stack(
+                [
+                    initial_vector(initial_particles[case_index, particle_index])
+                    for particle_index in range(count)
+                ]
+            )
+        )
+    cumulative = jnp.stack(initial_scores)
+    terminal_scores = cumulative
+    terminal_log_weights = initial_log_weights
+
+    for step_index in range(num_steps):
+        pre_resampling_cases = []
+        post_resampling_cases = []
+        for case_index in range(case_count):
+            start_time = (
+                initial_times[case_index]
+                if step_index == 0
+                else times[case_index, step_index - 1]
+            )
+            end_time = times[case_index, step_index]
+            previous_particles = (
+                initial_particles[case_index]
+                if step_index == 0
+                else particles[case_index, step_index - 1]
+            )
+            local_scores = []
+            for particle_index in range(count):
+                next_state = predicted[case_index, step_index, particle_index]
+                previous_state = previous_particles[particle_index]
+
+                def active_score(_):
+                    def local_log_density(current_position):
+                        physical = parameterized.parameter_space.constrain(
+                            current_position
+                        )
+                        bound = parameterized.bind_physical(physical)
+                        context = bound.step_context(case_index, step_index)
+                        transition = bound.model.transition.log_prob(
+                            next_state,
+                            previous_state,
+                            start_time,
+                            end_time,
+                            context,
+                        )
+                        observation = bound.model.observation.log_prob(
+                            observations[case_index, step_index],
+                            next_state,
+                            end_time,
+                            observation_masks[case_index, step_index],
+                            context,
+                        )
+                        return jnp.asarray(transition + observation).reshape(())
+
+                    gradient = jax.grad(local_log_density)(position)
+                    return ravel_pytree(gradient)[0]
+
+                local_scores.append(
+                    jax.lax.cond(
+                        active[case_index, step_index],
+                        active_score,
+                        lambda _: jnp.zeros_like(flat_position),
+                        operand=None,
+                    )
+                )
+            pre_resampling = cumulative[case_index] + jnp.stack(local_scores)
+            pre_resampling_cases.append(pre_resampling)
+            post_resampling_cases.append(
+                pre_resampling[ancestors[case_index, step_index]]
+            )
+        pre_resampling_scores = jnp.stack(pre_resampling_cases)
+        post_resampling_scores = jnp.stack(post_resampling_cases)
+        step_active = active[:, step_index]
+        terminal_scores = jnp.where(
+            step_active[:, None, None],
+            pre_resampling_scores,
+            terminal_scores,
+        )
+        terminal_log_weights = jnp.where(
+            step_active[:, None],
+            posterior_log_weights[:, step_index],
+            terminal_log_weights,
+        )
+        cumulative = jnp.where(
+            step_active[:, None, None],
+            post_resampling_scores,
+            cumulative,
+        )
+
+    weights = jnp.exp(terminal_log_weights)
+    case_scores = jnp.sum(weights[..., None] * terminal_scores, axis=1)
+    valid = result.successful.reshape((case_count,)) & result.initial_valid.reshape(
+        (case_count,)
+    )
+    case_scores = jnp.where(valid[:, None], case_scores, 0.0)
+    flat_score = jnp.sum(case_scores, axis=0)
+    path_leaves = jax.tree_util.tree_flatten_with_path(position)[0]
+    parameter_paths = tuple(
+        jax.tree_util.keystr(path) or "<root>" for path, _ in path_leaves
+    )
+    return ParameterizedParticleGenealogicalScoreResult(
+        gradient=unravel(flat_score),
+        flat_score=flat_score,
+        case_scores=case_scores.reshape(result.case_shape + (parameter_size,)),
+        valid=valid.reshape(result.case_shape),
+        filter_result=result,
+        parameter_paths=parameter_paths,
+        parameter_size=parameter_size,
+        method_id="particle-parameter-genealogical-score",
+        ancestry_gradient="stopped-realized-ancestry",
+        parameterization_id=parameterized.parameterization_id,
+    )
+
+
+__all__ = [
+    "parameterized_particle_genealogical_score",
+    "ParameterizedParticleGenealogicalScoreResult",
+]

--- a/phydrax/uq/_result_export.py
+++ b/phydrax/uq/_result_export.py
@@ -32,6 +32,7 @@ from ._discrepancy_diagnostics import DiscrepancyIdentifiabilityReport
 from ._eki import EnsembleKalmanResult
 from ._ensemble_filter import EnsembleFilterResult, EnsembleSmootherResult
 from ._flow_mcmc import FlowNUTSResult
+from ._flow_variational import FlowVariationalResult
 from ._kalman import KalmanFilterResult, KalmanSmootherResult
 from ._laplace import LaplaceResult
 from ._laplax_backend import StructuredLaplaceResult
@@ -47,6 +48,7 @@ from ._particle import (
     ParticleFisherScoreResult,
     ParticleSmootherResult,
 )
+from ._particle_genealogical_score import ParticleGenealogicalScoreResult
 from ._pathfinder import PathfinderResult
 from ._rao_blackwellized import RaoBlackwellizedFilterResult
 from ._rao_blackwellized_smoothing import (
@@ -57,6 +59,10 @@ from ._sgmcmc import SGMCMCResult
 from ._sgmcmc_diagnostics import SGMCMCMixingReport
 from ._sing import SINGResult
 from ._smc import TemperedSMCResult
+from ._state_space_amortized import AmortizedStateSpaceVariationalResult
+from ._state_space_buffered import BufferedStateSpaceVariationalResult
+from ._state_space_variational import StateSpaceVariationalResult
+from ._variational import VariationalResult
 
 
 _RESULT_FORMAT = "phydrax-uq-result"
@@ -561,6 +567,36 @@ def _adapt_result(result, arrays, fields, trees):
             ("backward_simulation.filter_result.problem",),
         )
 
+    if isinstance(result, ParticleGenealogicalScoreResult):
+        _put_field(fields, arrays, "flat_score", result.flat_score)
+        _put_field(fields, arrays, "case_scores", result.case_scores)
+        _put_field(fields, arrays, "valid", result.valid)
+        _put_flat_inexact_tree(
+            trees,
+            arrays,
+            "model_score",
+            result.score,
+            expected_size=result.parameter_size,
+        )
+        metadata = {
+            "method_id": result.method_id,
+            "ancestry_gradient": result.ancestry_gradient,
+            "parameter_size": result.parameter_size,
+            "parameter_paths": list(result.parameter_paths),
+            "model_id": result.model_id,
+            "problem_id": result.problem_id,
+            "sequence_id": result.sequence_id,
+            "input_id": result.input_id,
+            "case_shape": list(result.filter_result.case_shape),
+            "case_axes": list(result.filter_result.case_axes),
+            "case_ids": list(result.filter_result.case_ids),
+        }
+        return (
+            "particle_genealogical_score",
+            metadata,
+            ("model_score", "filter_result"),
+        )
+
     if isinstance(result, ParticleFisherScoreResult):
         _put_field(fields, arrays, "flat_score", result.flat_score)
         _put_field(fields, arrays, "case_scores", result.case_scores)
@@ -764,6 +800,7 @@ def _adapt_result(result, arrays, fields, trees):
             "algorithm": result.algorithm,
             "approximation": result.approximation,
             "chain_method": result.chain_method,
+            "gradient_estimator_id": result.gradient_estimator_id,
             "num_chains": result.num_chains,
             "num_draws": result.num_draws,
             "num_burnin": result.num_burnin,
@@ -791,6 +828,189 @@ def _adapt_result(result, arrays, fields, trees):
             "max_update_gradient_norm": result.max_update_gradient_norm,
         }
         return "sgmcmc", metadata, ("problem",)
+
+    if isinstance(result, AmortizedStateSpaceVariationalResult):
+        _put_tree(trees, arrays, "states", result.states)
+        _put_array_leaves(trees, arrays, "family_parameters", result.family)
+        for name, value in (
+            ("log_model", result.log_model),
+            ("log_variational", result.log_variational),
+            ("diagnostics.steps", result.diagnostics.steps),
+            ("diagnostics.elbo", result.diagnostics.elbo),
+            ("diagnostics.gradient_norm", result.diagnostics.gradient_norm),
+            ("diagnostics.finite", result.diagnostics.finite),
+        ):
+            _put_field(fields, arrays, name, value)
+        _put_field(fields, arrays, "root_key", jr.key_data(result.root_key))
+        metadata = {
+            "algorithm": "amortized-state-space-reverse-kl",
+            "family_id": result.family.family_id,
+            "num_draws": result.num_draws,
+            "completed_steps": result.diagnostics.completed_steps,
+            "duration_seconds": result.duration_seconds,
+            "approximation_id": result.approximation_id,
+            "hidden_size": result.config.hidden_size,
+            "scale_floor": result.config.scale_floor,
+            "optimization": result.config.optimization.as_dict(),
+        }
+        return (
+            "amortized_state_space_variational",
+            metadata,
+            ("problem", "family.static"),
+        )
+
+    if isinstance(result, BufferedStateSpaceVariationalResult):
+        _put_tree(trees, arrays, "states", result.states)
+        _put_array_leaves(trees, arrays, "family_parameters", result.family)
+        for name, value in (
+            ("log_model", result.log_model),
+            ("log_variational", result.log_variational),
+            ("diagnostics.steps", result.diagnostics.steps),
+            ("diagnostics.target_start", result.diagnostics.target_start),
+            ("diagnostics.context_start", result.diagnostics.context_start),
+            ("diagnostics.context_end", result.diagnostics.context_end),
+            ("diagnostics.elbo", result.diagnostics.elbo),
+            ("diagnostics.gradient_norm", result.diagnostics.gradient_norm),
+            ("diagnostics.finite", result.diagnostics.finite),
+            (
+                "window.inclusion_probability",
+                result.window_plan.inclusion_probability,
+            ),
+        ):
+            _put_field(fields, arrays, name, value)
+        _put_field(fields, arrays, "root_key", jr.key_data(result.root_key))
+        metadata = {
+            "algorithm": "buffered-state-space-reverse-kl",
+            "family_id": result.family.family_id,
+            "num_draws": result.num_draws,
+            "duration_seconds": result.duration_seconds,
+            "approximation_id": result.approximation_id,
+            "target_length": result.config.target_length,
+            "left_buffer": result.config.left_buffer,
+            "right_buffer": result.config.right_buffer,
+            "hidden_size": result.config.hidden_size,
+            "scale_floor": result.config.scale_floor,
+            "optimization": result.config.optimization.as_dict(),
+        }
+        return (
+            "buffered_state_space_variational",
+            metadata,
+            ("problem", "family.static"),
+        )
+
+    if isinstance(result, StateSpaceVariationalResult):
+        _put_tree(trees, arrays, "states", result.states)
+        _put_array_leaves(
+            trees,
+            arrays,
+            "family_parameters",
+            result.family,
+        )
+        for name, value in (
+            ("log_model", result.log_model),
+            ("log_variational", result.log_variational),
+            ("diagnostics.steps", result.diagnostics.steps),
+            ("diagnostics.elbo", result.diagnostics.elbo),
+            ("diagnostics.gradient_norm", result.diagnostics.gradient_norm),
+            ("diagnostics.finite", result.diagnostics.finite),
+        ):
+            _put_field(fields, arrays, name, value)
+        _put_field(fields, arrays, "root_key", jr.key_data(result.root_key))
+        metadata = {
+            "algorithm": "state-space-reverse-kl",
+            "family_id": result.family.family_id,
+            "num_draws": result.num_draws,
+            "completed_steps": result.diagnostics.completed_steps,
+            "duration_seconds": result.duration_seconds,
+            "approximation_id": result.approximation_id,
+            "initial_scale": result.config.initial_scale,
+            "scale_floor": result.config.scale_floor,
+            "optimization": result.config.optimization.as_dict(),
+        }
+        return (
+            "state_space_variational",
+            metadata,
+            ("problem", "family.static"),
+        )
+
+    if isinstance(result, FlowVariationalResult):
+        fitted = result.variational
+        _put_tree(trees, arrays, "samples", fitted.samples)
+        _put_tree(
+            trees,
+            arrays,
+            "unconstrained_samples",
+            fitted.unconstrained_samples,
+        )
+        _put_array_leaves(
+            trees,
+            arrays,
+            "family_parameters",
+            fitted.family,
+        )
+        _put_field(fields, arrays, "log_target", fitted.log_target)
+        _put_field(fields, arrays, "log_variational", fitted.log_variational)
+        _put_field(fields, arrays, "diagnostics.elbo", fitted.diagnostics.elbo)
+        _put_field(
+            fields,
+            arrays,
+            "initialization.elbo",
+            result.initialization.diagnostics.elbo,
+        )
+        metadata = {
+            "algorithm": "flow-reverse-kl-variational",
+            "family_id": fitted.family.family_id,
+            "num_draws": fitted.num_draws,
+            "approximation_id": result.approximation_id,
+            "duration_seconds": fitted.duration_seconds,
+            "sample_memory_bytes": fitted.sample_memory_bytes,
+            "family_memory_bytes": fitted.family_memory_bytes,
+            "config": result.config.as_dict(),
+        }
+        return (
+            "flow_variational",
+            metadata,
+            ("variational.problem", "initialization.problem", "family.static"),
+        )
+
+    if isinstance(result, VariationalResult):
+        _put_tree(trees, arrays, "samples", result.samples)
+        _put_tree(
+            trees,
+            arrays,
+            "unconstrained_samples",
+            result.unconstrained_samples,
+        )
+        _put_array_leaves(
+            trees,
+            arrays,
+            "family_parameters",
+            result.family,
+        )
+        for name, value in (
+            ("log_target", result.log_target),
+            ("log_variational", result.log_variational),
+            ("diagnostics.steps", result.diagnostics.steps),
+            ("diagnostics.elbo", result.diagnostics.elbo),
+            ("diagnostics.gradient_norm", result.diagnostics.gradient_norm),
+            ("diagnostics.finite", result.diagnostics.finite),
+        ):
+            _put_field(fields, arrays, name, value)
+        _put_field(fields, arrays, "root_key", jr.key_data(result.root_key))
+        metadata = {
+            "algorithm": "reverse-kl-variational",
+            "family_id": result.family.family_id,
+            "num_draws": result.num_draws,
+            "completed_steps": result.diagnostics.completed_steps,
+            "duration_seconds": result.duration_seconds,
+            "optimization_duration_seconds": (result.optimization_duration_seconds),
+            "sampling_duration_seconds": result.sampling_duration_seconds,
+            "sample_memory_bytes": result.sample_memory_bytes,
+            "family_memory_bytes": result.family_memory_bytes,
+            "approximation_id": result.approximation_id,
+            "config": result.config.as_dict(),
+        }
+        return "variational", metadata, ("problem", "family.static")
 
     if isinstance(result, FlowNUTSResult):
         mcmc = result.mcmc
@@ -897,9 +1117,56 @@ def _adapt_result(result, arrays, fields, trees):
             "warmup.inverse_mass_matrix",
             jnp.stack([item.inverse_mass_matrix for item in result.warmup]),
         )
+        if result.causal_diagnostics is not None:
+            _put_field(
+                fields,
+                arrays,
+                "causal.converged",
+                result.causal_diagnostics.converged,
+            )
+            _put_field(
+                fields,
+                arrays,
+                "causal.fallback_used",
+                result.causal_diagnostics.fallback_used,
+            )
+            _put_field(
+                fields,
+                arrays,
+                "causal.outer_iterations",
+                result.causal_diagnostics.outer_iterations,
+            )
+            _put_field(
+                fields,
+                arrays,
+                "causal.maximum_residual",
+                result.causal_diagnostics.maximum_residual,
+            )
+            _put_field(
+                fields,
+                arrays,
+                "causal.accepted_nonlinear_steps",
+                result.causal_diagnostics.accepted_nonlinear_steps,
+            )
+            _put_field(
+                fields,
+                arrays,
+                "causal.rejected_nonlinear_steps",
+                result.causal_diagnostics.rejected_nonlinear_steps,
+            )
+            _put_field(
+                fields,
+                arrays,
+                "causal.transition_evaluations",
+                result.causal_diagnostics.transition_evaluations,
+            )
         metadata = {
             "algorithm": result.algorithm,
             "chain_method": result.chain_method,
+            "trajectory_method": result.trajectory_method,
+            "causal_config": (
+                None if result.causal_config is None else result.causal_config.as_dict()
+            ),
             "num_chains": result.num_chains,
             "num_draws": result.num_draws,
             "duration_seconds": result.duration_seconds,
@@ -1360,6 +1627,9 @@ def _put_kalman_filter_result(result, arrays, fields, *, prefix):
 
 def _put_particle_filter_result(result, arrays, fields, *, prefix):
     for name, value in (
+        ("initial_particles", result.initial_particles),
+        ("initial_log_weights", result.initial_log_weights),
+        ("initial_valid", result.initial_valid),
         ("predicted_particles", result.predicted_particles),
         ("posterior_log_weights", result.posterior_log_weights),
         ("particles", result.particles),

--- a/phydrax/uq/_sgmcmc.py
+++ b/phydrax/uq/_sgmcmc.py
@@ -54,6 +54,11 @@ from ._sgmcmc_diagnostics import (
     SGMCMCMixingReport,
     SGMCMCMixingThresholds,
 )
+from ._stochastic_gradient import (
+    AbstractStochasticGradientEstimator,
+    AutodiffStochasticGradientEstimator,
+    StochasticGradientEstimate,
+)
 
 
 SGMCMCAlgorithm = Literal["sgld", "sgnht"]
@@ -131,6 +136,7 @@ class SGMCMCResult(StrictModule):
     source_fingerprint: str = eqx.field(static=True)
     _source_configuration_json: str = eqx.field(static=True)
     chain_method: ChainMethod = eqx.field(static=True)
+    gradient_estimator_id: str = eqx.field(static=True)
     compilation_duration_seconds: float = eqx.field(static=True)
     burnin_duration_seconds: float = eqx.field(static=True)
     sampling_duration_seconds: float = eqx.field(static=True)
@@ -172,6 +178,7 @@ class SGMCMCResult(StrictModule):
         source_fingerprint: str,
         source_configuration_json: str,
         chain_method: ChainMethod,
+        gradient_estimator_id: str,
         compilation_duration_seconds: float,
         burnin_duration_seconds: float,
         sampling_duration_seconds: float,
@@ -220,6 +227,7 @@ class SGMCMCResult(StrictModule):
         self.batch_capacity = int(batch_capacity)
         self.source_fingerprint = str(source_fingerprint)
         self._source_configuration_json = str(source_configuration_json)
+        self.gradient_estimator_id = str(gradient_estimator_id)
         self.chain_method = chain_method
         self.compilation_duration_seconds = float(compilation_duration_seconds)
         self.burnin_duration_seconds = float(burnin_duration_seconds)
@@ -401,6 +409,7 @@ def sample_sgld(
     initial_positions: PyTree[Any] | None = None,
     chain_method: ChainMethod = "vectorized",
     control_variate: SGMCMCControlVariate | None = None,
+    gradient_estimator: AbstractStochasticGradientEstimator | None = None,
     checkpoint_path: str | Path | None = None,
     checkpoint_every: int | None = None,
     checkpoint_id: str | None = None,
@@ -423,6 +432,7 @@ def sample_sgld(
         initial_positions=initial_positions,
         chain_method=chain_method,
         control_variate=control_variate,
+        gradient_estimator=gradient_estimator,
         checkpoint_path=checkpoint_path,
         checkpoint_every=checkpoint_every,
         checkpoint_id=checkpoint_id,
@@ -447,6 +457,7 @@ def sample_sgnht(
     initial_positions: PyTree[Any] | None = None,
     chain_method: ChainMethod = "vectorized",
     control_variate: SGMCMCControlVariate | None = None,
+    gradient_estimator: AbstractStochasticGradientEstimator | None = None,
     checkpoint_path: str | Path | None = None,
     checkpoint_every: int | None = None,
     checkpoint_id: str | None = None,
@@ -473,6 +484,7 @@ def sample_sgnht(
         initial_positions=initial_positions,
         chain_method=chain_method,
         control_variate=control_variate,
+        gradient_estimator=gradient_estimator,
         checkpoint_path=checkpoint_path,
         checkpoint_every=checkpoint_every,
         checkpoint_id=checkpoint_id,
@@ -498,6 +510,7 @@ def _sample_sgmcmc(
     initial_positions: PyTree[Any] | None,
     chain_method: ChainMethod,
     control_variate: SGMCMCControlVariate | None,
+    gradient_estimator: AbstractStochasticGradientEstimator | None,
     checkpoint_path: str | Path | None,
     checkpoint_every: int | None,
     checkpoint_id: str | None,
@@ -529,6 +542,20 @@ def _sample_sgmcmc(
         control_variate, SGMCMCControlVariate
     ):
         raise TypeError("control_variate must be an SGMCMCControlVariate or None.")
+    estimator = (
+        AutodiffStochasticGradientEstimator()
+        if gradient_estimator is None
+        else gradient_estimator
+    )
+    if not isinstance(estimator, AbstractStochasticGradientEstimator):
+        raise TypeError(
+            "gradient_estimator must implement AbstractStochasticGradientEstimator."
+        )
+    if control_variate is not None and not estimator.supports_control_variate:
+        raise ValueError(
+            "The selected stochastic-gradient estimator does not support "
+            "SGMCMCControlVariate."
+        )
     if resume_from is not None and (
         initial_position is not None or initial_positions is not None
     ):
@@ -584,6 +611,7 @@ def _sample_sgmcmc(
         "control_variate_fingerprint": (
             None if control_variate is None else control_variate.fingerprint
         ),
+        "gradient_estimator": estimator.configuration(),
         "root_key": [int(value) for value in jr.key_data(root_key).reshape(-1)],
     }
     compatibility = (
@@ -600,7 +628,7 @@ def _sample_sgmcmc(
         if destination is not None
         else None
     )
-    gradient_fn = _gradient_estimator(problem, control_variate)
+    gradient_fn = _gradient_estimator(problem, control_variate, estimator)
     state_template = _initialize_states(
         algorithm,
         chain_positions,
@@ -610,14 +638,23 @@ def _sample_sgmcmc(
     )
 
     if resume_from is None:
-        values = jax.vmap(
-            lambda current: problem.log_density_estimate(current, initial_batches[0])
-        )(chain_positions)
-        gradients = jax.vmap(lambda current: gradient_fn(current, initial_batches[0]))(
-            chain_positions
-        )
+        initial_estimator_keys = jax.vmap(
+            lambda chain_key: jr.fold_in(chain_key, _INITIALIZATION_TAG + 1)
+        )(chain_keys)
+        estimates = jax.vmap(
+            lambda current, estimator_key: gradient_fn(
+                current,
+                initial_batches[0],
+                estimator_key,
+            )
+        )(chain_positions, initial_estimator_keys)
+        values = estimates.log_density
+        gradients = estimates.gradient
         invalid_value_chains = tuple(
-            int(index) for index in jnp.argwhere(~jnp.isfinite(values)).reshape(-1)
+            int(index)
+            for index in jnp.argwhere(~jnp.isfinite(values) | ~estimates.valid).reshape(
+                -1
+            )
         )
         invalid_gradient_locations = _invalid_chain_locations(gradients, chains)
         if invalid_value_chains or invalid_gradient_locations:
@@ -693,6 +730,7 @@ def _sample_sgmcmc(
         algorithm,
         problem,
         control_variate,
+        estimator,
         step_size=step,
         diffusion=diffusion,
         chain_method=method,
@@ -717,13 +755,17 @@ def _sample_sgmcmc(
         batch = epoch_batches[update % int(source.batches_per_epoch)]
         transition_keys = _transition_keys(chain_keys, update)
         update_started = time.perf_counter()
-        new_states, gradient_norm = advance(current_states, transition_keys, batch)
+        new_states, gradient_norm, gradient_valid = advance(
+            current_states, transition_keys, batch
+        )
         jax.block_until_ready(new_states)
         update_duration = time.perf_counter() - update_started
         invalid_state_locations = _invalid_chain_locations(new_states, chains)
         invalid_gradient_locations = tuple(
             f"chain[{int(index)}].gradient_norm"
-            for index in jnp.argwhere(~jnp.isfinite(gradient_norm)).reshape(-1)
+            for index in jnp.argwhere(
+                ~jnp.isfinite(gradient_norm) | ~gradient_valid
+            ).reshape(-1)
         )
         if invalid_state_locations or invalid_gradient_locations:
             raise FloatingPointError(
@@ -856,6 +898,7 @@ def _sample_sgmcmc(
         source_fingerprint=source.fingerprint,
         source_configuration_json=source_configuration_json,
         chain_method=method,
+        gradient_estimator_id=estimator.estimator_id,
         compilation_duration_seconds=compilation_duration,
         burnin_duration_seconds=burnin_duration,
         sampling_duration_seconds=sampling_duration,
@@ -867,28 +910,69 @@ def _sample_sgmcmc(
 def _gradient_estimator(
     problem: MinibatchPosteriorProblem,
     control_variate: SGMCMCControlVariate | None,
+    estimator: AbstractStochasticGradientEstimator | None = None,
 ):
-    ordinary_gradient = jax.grad(problem.log_density_estimate)
-    if control_variate is None:
-        return ordinary_gradient
+    if estimator is None:
+        ordinary_gradient = jax.grad(problem.log_density_estimate)
+        if control_variate is None:
+            return ordinary_gradient
 
-    def control_variate_gradient(position, batch):
-        gradient = ordinary_gradient(position, batch)
-        center_gradient = ordinary_gradient(control_variate.center, batch)
-        return jax.tree_util.tree_map(
-            lambda full, current, center: full + current - center,
+        def legacy_control_variate_gradient(position, batch):
+            gradient = ordinary_gradient(position, batch)
+            center_gradient = ordinary_gradient(control_variate.center, batch)
+            return jax.tree_util.tree_map(
+                lambda full, value, reference: full + value - reference,
+                control_variate.full_gradient,
+                gradient,
+                center_gradient,
+            )
+
+        return legacy_control_variate_gradient
+
+    def ordinary_estimate(position, batch, key):
+        return estimator.estimate(problem, position, batch, key)
+
+    if control_variate is None:
+        return ordinary_estimate
+
+    def control_variate_estimate(position, batch, key):
+        current = ordinary_estimate(position, batch, key)
+        center = ordinary_estimate(control_variate.center, batch, key)
+        gradient = jax.tree_util.tree_map(
+            lambda full, value, reference: full + value - reference,
             control_variate.full_gradient,
-            gradient,
-            center_gradient,
+            current.gradient,
+            center.gradient,
+        )
+        gradient_norm = _tree_norm(gradient)
+        finite = (
+            current.valid
+            & center.valid
+            & jnp.isfinite(gradient_norm)
+            & jnp.all(
+                jnp.stack(
+                    [jnp.all(jnp.isfinite(leaf)) for leaf in jax.tree.leaves(gradient)]
+                )
+            )
+        )
+        return StochasticGradientEstimate(
+            gradient=gradient,
+            log_density=current.log_density,
+            gradient_norm=gradient_norm,
+            valid=finite,
+            status=jnp.where(finite, 0, 1).astype(jnp.int32),
+            likelihood_estimate=current.likelihood_estimate,
+            estimator_id=current.estimator_id,
         )
 
-    return control_variate_gradient
+    return control_variate_estimate
 
 
 def _compile_transition(
     algorithm: SGMCMCAlgorithm,
     problem: MinibatchPosteriorProblem,
     control_variate: SGMCMCControlVariate | None,
+    estimator: AbstractStochasticGradientEstimator,
     *,
     step_size: float,
     diffusion: float | None,
@@ -897,15 +981,23 @@ def _compile_transition(
     chain_keys: Array,
     batch: LikelihoodBatch,
 ):
-    gradient_fn = _gradient_estimator(problem, control_variate)
+    gradient_fn = _gradient_estimator(problem, control_variate, estimator)
     if algorithm == "sgld":
         integrator = diffusions.overdamped_langevin()
 
         def one_step(step_key, state, minibatch):
-            gradient = gradient_fn(state, minibatch)
+            estimator_key = jr.fold_in(step_key, 0x65726164)
+            estimate = gradient_fn(state, minibatch, estimator_key)
             return (
-                integrator(step_key, state, gradient, step_size, 1.0),
-                _tree_norm(gradient),
+                integrator(
+                    step_key,
+                    state,
+                    estimate.gradient,
+                    step_size,
+                    1.0,
+                ),
+                estimate.gradient_norm,
+                estimate.valid,
             )
 
     else:
@@ -914,17 +1006,22 @@ def _compile_transition(
         integrator = diffusions.sgnht(float(diffusion), 0.0)
 
         def one_step(step_key, state, minibatch):
-            gradient = gradient_fn(state.position, minibatch)
+            estimator_key = jr.fold_in(step_key, 0x65726164)
+            estimate = gradient_fn(state.position, minibatch, estimator_key)
             position, momentum, xi = integrator(
                 step_key,
                 state.position,
                 state.momentum,
                 state.xi,
-                gradient,
+                estimate.gradient,
                 step_size,
                 1.0,
             )
-            return SGNHTState(position, momentum, xi), _tree_norm(gradient)
+            return (
+                SGNHTState(position, momentum, xi),
+                estimate.gradient_norm,
+                estimate.valid,
+            )
 
     compile_started = time.perf_counter()
     if chain_method == "vectorized":
@@ -952,11 +1049,19 @@ def _compile_transition(
             current_values = _unstack_tree(current_states, int(keys.shape[0]))
             next_states = []
             gradient_norms = []
+            gradient_validity = []
             for state, step_key in zip(current_values, keys, strict=True):
-                next_state, gradient_norm = compiled(step_key, state, minibatch)
+                next_state, gradient_norm, gradient_valid = compiled(
+                    step_key, state, minibatch
+                )
                 next_states.append(next_state)
                 gradient_norms.append(gradient_norm)
-            return _stack_trees(next_states), jnp.stack(gradient_norms)
+                gradient_validity.append(gradient_valid)
+            return (
+                _stack_trees(next_states),
+                jnp.stack(gradient_norms),
+                jnp.stack(gradient_validity),
+            )
 
     compilation_duration = time.perf_counter() - compile_started
     return advance, compilation_duration

--- a/phydrax/uq/_sing.py
+++ b/phydrax/uq/_sing.py
@@ -16,13 +16,7 @@ import jax.random as jr
 from jaxtyping import Array, ArrayLike
 
 from .._strict import StrictModule
-from ..stochastic._euler_maruyama import EulerMaruyamaTransitionKernel
-from ..stochastic._state_space import (
-    GaussianStatePrior,
-    state_space_key,
-    StateSpaceProblem,
-)
-from ._gaussian_chain import (
+from ..linalg._gaussian_chain import (
     gaussian_markov_information_from_moments,
     gaussian_markov_moments,
     gaussian_markov_moments_from_marginals,
@@ -30,6 +24,12 @@ from ._gaussian_chain import (
     GaussianMarkovInformation,
     GaussianMarkovMoments,
     sample_gaussian_markov,
+)
+from ..stochastic._euler_maruyama import EulerMaruyamaTransitionKernel
+from ..stochastic._state_space import (
+    GaussianStatePrior,
+    state_space_key,
+    StateSpaceProblem,
 )
 from ._gaussian_factor import GaussianFactor
 from ._nonlinear_gaussian import (

--- a/phydrax/uq/_state_space_amortized.py
+++ b/phydrax/uq/_state_space_amortized.py
@@ -1,0 +1,413 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from math import isfinite, prod, sqrt
+from pathlib import Path
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+from jax.typing import DTypeLike
+from jaxtyping import Array
+
+from .._strict import StrictModule
+from ..stochastic import StateSpaceProblem
+from ._posterior import ParameterSpace, PosteriorProblem
+from ._state_space_path_density import state_space_path_log_density
+from ._state_space_variational import GaussianMarkovVariationalFamily
+from ._variational import (
+    AbstractVariationalFamily,
+    fit_variational,
+    VariationalConfig,
+    VariationalDiagnostics,
+)
+
+
+def _sequence_features(problem: StateSpaceProblem, /) -> Array:
+    observations = problem.observations
+    case_count = prod(observations.case_shape) if observations.case_shape else 1
+    steps = observations.num_steps
+    observation_size = prod(observations.observation_shape)
+    values = observations.values.reshape((case_count, steps, observation_size))
+    masks = observations.observation_mask.reshape((case_count, steps, observation_size))
+    valid = observations.step_valid.reshape((case_count, steps))
+    times = observations.times.reshape((case_count, steps))
+    initial = problem.initial_time.reshape((case_count,))
+    valid_count = jnp.sum(valid, axis=-1, dtype=jnp.int32)
+    final_time = jnp.take_along_axis(
+        times,
+        (valid_count - 1)[:, None],
+        axis=1,
+    )[:, 0]
+    duration = jnp.maximum(final_time - initial, jnp.finfo(times.dtype).eps)
+    normalized_time = (times - initial[:, None]) / duration[:, None]
+    return jnp.concatenate(
+        (
+            jnp.where(masks, values, 0.0),
+            masks.astype(values.dtype),
+            normalized_time[..., None],
+        ),
+        axis=-1,
+    )
+
+
+class AmortizedGaussianMarkovEncoder(StrictModule):
+    """Shared observation encoder producing one Gaussian Markov path family."""
+
+    hidden_weight: Array
+    hidden_bias: Array
+    temporal_weight: Array
+    temporal_bias: Array
+    initial_weight: Array
+    initial_bias: Array
+    input_size: int = eqx.field(static=True)
+    hidden_size: int = eqx.field(static=True)
+    state_size: int = eqx.field(static=True)
+
+    def __init__(
+        self,
+        input_size: int,
+        hidden_size: int,
+        state_size: int,
+        /,
+        *,
+        key: Array,
+        dtype: DTypeLike = jnp.float32,
+    ):
+        inputs = int(input_size)
+        hidden = int(hidden_size)
+        state = int(state_size)
+        if inputs < 1 or hidden < 1 or state < 1:
+            raise ValueError("Amortized encoder dimensions must be positive.")
+        hidden_key, temporal_key, initial_key = jr.split(key, 3)
+        hidden_scale = 1.0 / sqrt(float(inputs))
+        head_scale = 1.0 / sqrt(float(hidden))
+        self.hidden_weight = hidden_scale * jr.normal(
+            hidden_key, (hidden, inputs), dtype=dtype
+        )
+        self.hidden_bias = jnp.zeros((hidden,), dtype=dtype)
+        self.temporal_weight = (
+            0.05 * head_scale * jr.normal(temporal_key, (3 * state, hidden), dtype=dtype)
+        )
+        self.temporal_bias = jnp.zeros((3 * state,), dtype=dtype)
+        self.initial_weight = (
+            0.05 * head_scale * jr.normal(initial_key, (2 * state, hidden), dtype=dtype)
+        )
+        self.initial_bias = jnp.zeros((2 * state,), dtype=dtype)
+        self.input_size = inputs
+        self.hidden_size = hidden
+        self.state_size = state
+
+    def family(
+        self,
+        features: Array,
+        step_valid: Array,
+        prior_location: Array,
+        /,
+        *,
+        case_shape: tuple[int, ...],
+        state_shape: tuple[int, ...],
+        scale_floor: float,
+        context_valid: Array | None = None,
+    ) -> GaussianMarkovVariationalFamily:
+        feature_values = jax.lax.stop_gradient(jnp.asarray(features))
+        valid = jax.lax.stop_gradient(jnp.asarray(step_valid, dtype=bool))
+        context = (
+            valid
+            if context_valid is None
+            else jax.lax.stop_gradient(jnp.asarray(context_valid, dtype=bool))
+        )
+        if context.shape != valid.shape:
+            raise ValueError("context_valid must match step_valid.")
+        prior = jax.lax.stop_gradient(jnp.asarray(prior_location))
+        case_count, steps, feature_size = feature_values.shape
+        if feature_size != self.input_size:
+            raise ValueError("Amortized feature size does not match the encoder.")
+        local_hidden = jnp.tanh(
+            jnp.einsum("hi,cti->cth", self.hidden_weight, feature_values)
+            + self.hidden_bias
+        )
+        context_float = context.astype(local_hidden.dtype)
+        masked_hidden = local_hidden * context_float[..., None]
+        prefix_count = jnp.cumsum(context_float, axis=1)
+        prefix = jnp.cumsum(masked_hidden, axis=1) / jnp.maximum(
+            prefix_count[..., None], 1.0
+        )
+        suffix_count = jnp.cumsum(context_float[:, ::-1], axis=1)[:, ::-1]
+        suffix = jnp.cumsum(masked_hidden[:, ::-1], axis=1)[:, ::-1] / jnp.maximum(
+            suffix_count[..., None], 1.0
+        )
+        hidden = jnp.tanh(local_hidden + 0.5 * (prefix + suffix))
+        temporal = (
+            jnp.einsum("oh,cth->cto", self.temporal_weight, hidden) + self.temporal_bias
+        )
+        transition_raw, offsets, raw_scale = jnp.split(temporal, 3, axis=-1)
+        transition_diagonal = 0.95 * jnp.tanh(transition_raw)
+        transitions = jax.vmap(jax.vmap(jnp.diag))(transition_diagonal)
+        pooled = jnp.sum(hidden * context_float[..., None], axis=1) / jnp.maximum(
+            jnp.sum(context_float, axis=1, keepdims=True),
+            1.0,
+        )
+        initial = jnp.einsum("oh,ch->co", self.initial_weight, pooled) + self.initial_bias
+        initial_offset, initial_raw_scale = jnp.split(initial, 2, axis=-1)
+        flat_prior = prior.reshape((case_count, self.state_size))
+        initial_location = flat_prior + initial_offset
+        offsets = flat_prior[:, None, :] + offsets
+        return GaussianMarkovVariationalFamily(
+            initial_location.reshape(case_shape + state_shape),
+            initial_raw_scale.reshape(case_shape + state_shape),
+            transitions.reshape(case_shape + (steps, self.state_size, self.state_size)),
+            offsets.reshape(case_shape + (steps,) + state_shape),
+            raw_scale.reshape(case_shape + (steps,) + state_shape),
+            valid.reshape(case_shape + (steps,)),
+            case_shape=case_shape,
+            state_shape=state_shape,
+            scale_floor=scale_floor,
+        )
+
+
+class AmortizedGaussianMarkovFamily(AbstractVariationalFamily):
+    """Observation-conditioned Gaussian Markov family with shared encoder arrays."""
+
+    encoder: AmortizedGaussianMarkovEncoder
+    features: Array
+    step_valid: Array
+    context_mask: Array
+    prior_location: Array
+    case_shape: tuple[int, ...] = eqx.field(static=True)
+    state_shape: tuple[int, ...] = eqx.field(static=True)
+    scale_floor: float = eqx.field(static=True)
+
+    def __init__(
+        self,
+        encoder: AmortizedGaussianMarkovEncoder,
+        problem: StateSpaceProblem,
+        /,
+        *,
+        scale_floor: float = 1e-6,
+        context_mask: Array | None = None,
+    ):
+        if not isinstance(encoder, AmortizedGaussianMarkovEncoder):
+            raise TypeError("encoder must be AmortizedGaussianMarkovEncoder.")
+        if not isinstance(problem, StateSpaceProblem):
+            raise TypeError("problem must be StateSpaceProblem.")
+        floor = float(scale_floor)
+        if not isfinite(floor) or floor <= 0.0:
+            raise ValueError("scale_floor must be positive and finite.")
+        features = _sequence_features(problem)
+        if features.shape[-1] != encoder.input_size:
+            raise ValueError("Problem observations do not match the encoder input size.")
+        state_size = prod(problem.model.state_shape) if problem.model.state_shape else 1
+        if state_size != encoder.state_size:
+            raise ValueError("Problem state size does not match the encoder.")
+        self.encoder = encoder
+        self.features = features
+        self.step_valid = problem.observations.step_valid
+        context = (
+            problem.observations.step_valid
+            if context_mask is None
+            else jnp.asarray(context_mask, dtype=bool)
+        )
+        if context.shape != problem.observations.step_valid.shape:
+            raise ValueError("context_mask must match the observation step mask.")
+        self.context_mask = context
+        self.prior_location = problem.model.prior.location
+        self.case_shape = problem.observations.case_shape
+        self.state_shape = problem.model.state_shape
+        self.scale_floor = floor
+
+    @classmethod
+    def from_problem(
+        cls,
+        problem: StateSpaceProblem,
+        /,
+        *,
+        hidden_size: int = 64,
+        scale_floor: float = 1e-6,
+        key: Array,
+    ) -> "AmortizedGaussianMarkovFamily":
+        features = _sequence_features(problem)
+        state_size = prod(problem.model.state_shape) if problem.model.state_shape else 1
+        encoder = AmortizedGaussianMarkovEncoder(
+            int(features.shape[-1]),
+            hidden_size,
+            state_size,
+            key=key,
+            dtype=features.dtype,
+        )
+        return cls(encoder, problem, scale_floor=scale_floor)
+
+    @property
+    def family_id(self) -> str:
+        return "amortized-gaussian-markov-path"
+
+    @property
+    def conditional_family(self) -> GaussianMarkovVariationalFamily:
+        case_count = prod(self.case_shape) if self.case_shape else 1
+        return self.encoder.family(
+            self.features.reshape(
+                (case_count, self.step_valid.shape[-1], self.encoder.input_size)
+            ),
+            self.step_valid.reshape((case_count, self.step_valid.shape[-1])),
+            self.prior_location,
+            context_valid=self.context_mask.reshape(
+                (case_count, self.step_valid.shape[-1])
+            ),
+            case_shape=self.case_shape,
+            state_shape=self.state_shape,
+            scale_floor=self.scale_floor,
+        )
+
+    def condition(
+        self,
+        problem: StateSpaceProblem,
+        /,
+    ) -> "AmortizedGaussianMarkovFamily":
+        return AmortizedGaussianMarkovFamily(
+            self.encoder,
+            problem,
+            scale_floor=self.scale_floor,
+        )
+
+    def sample_and_log_prob(
+        self,
+        key: Array,
+        /,
+        *,
+        sample_shape: tuple[int, ...] = (),
+    ):
+        return self.conditional_family.sample_and_log_prob(
+            key,
+            sample_shape=sample_shape,
+        )
+
+    def log_prob(self, value: Array, /) -> Array:
+        return self.conditional_family.log_prob(value)
+
+
+class AmortizedStateSpaceVariationalConfig(StrictModule):
+    """Shared encoder shape and full-path reverse-KL controls."""
+
+    optimization: VariationalConfig
+    hidden_size: int = eqx.field(static=True)
+    scale_floor: float = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        optimization: VariationalConfig | None = None,
+        hidden_size: int = 64,
+        scale_floor: float = 1e-6,
+    ):
+        optimization_ = VariationalConfig() if optimization is None else optimization
+        if not isinstance(optimization_, VariationalConfig):
+            raise TypeError("optimization must be VariationalConfig or None.")
+        hidden = int(hidden_size)
+        floor = float(scale_floor)
+        if hidden < 1:
+            raise ValueError("hidden_size must be positive.")
+        if not isfinite(floor) or floor <= 0.0:
+            raise ValueError("scale_floor must be positive and finite.")
+        self.optimization = optimization_
+        self.hidden_size = hidden
+        self.scale_floor = floor
+
+
+class AmortizedStateSpaceVariationalResult(StrictModule):
+    """Fitted reusable encoder and full latent-path posterior draws."""
+
+    problem: StateSpaceProblem
+    family: AmortizedGaussianMarkovFamily
+    states: Array
+    log_model: Array
+    log_variational: Array
+    diagnostics: VariationalDiagnostics
+    root_key: Array
+    config: AmortizedStateSpaceVariationalConfig
+    duration_seconds: float = eqx.field(static=True)
+    approximation_id: str = eqx.field(static=True)
+
+    @property
+    def num_draws(self) -> int:
+        return int(self.log_model.shape[0])
+
+
+def fit_amortized_state_space_variational(
+    problem: StateSpaceProblem,
+    /,
+    *,
+    key: Array,
+    family: AmortizedGaussianMarkovFamily | None = None,
+    config: AmortizedStateSpaceVariationalConfig | None = None,
+    num_samples: int = 1000,
+    checkpoint_path: str | Path | None = None,
+    checkpoint_every: int | None = None,
+    checkpoint_id: str | None = None,
+    resume_from: str | Path | None = None,
+) -> AmortizedStateSpaceVariationalResult:
+    """Fit one observation-conditioned full-path posterior encoder."""
+
+    if not isinstance(problem, StateSpaceProblem):
+        raise TypeError("problem must be StateSpaceProblem.")
+    config_ = AmortizedStateSpaceVariationalConfig() if config is None else config
+    if not isinstance(config_, AmortizedStateSpaceVariationalConfig):
+        raise TypeError("config must be AmortizedStateSpaceVariationalConfig or None.")
+    family_ = (
+        AmortizedGaussianMarkovFamily.from_problem(
+            problem,
+            hidden_size=config_.hidden_size,
+            scale_floor=config_.scale_floor,
+            key=jr.fold_in(key, 0xA60B),
+        )
+        if family is None
+        else family
+    )
+    if not isinstance(family_, AmortizedGaussianMarkovFamily):
+        raise TypeError("family must be AmortizedGaussianMarkovFamily or None.")
+    initial_path, _ = family_.sample_and_log_prob(jr.fold_in(key, 0x1A17))
+    path_problem = PosteriorProblem(
+        ParameterSpace(
+            initial_path,
+            log_prior=lambda _: jnp.zeros((), dtype=initial_path.dtype),
+        ),
+        lambda path: state_space_path_log_density(problem, path).log_density,
+    )
+    fitted = fit_variational(
+        path_problem,
+        key=key,
+        family=family_,
+        config=config_.optimization,
+        num_samples=num_samples,
+        checkpoint_path=checkpoint_path,
+        checkpoint_every=checkpoint_every,
+        checkpoint_id=checkpoint_id,
+        resume_from=resume_from,
+    )
+    log_model = jax.vmap(
+        lambda path: state_space_path_log_density(problem, path).log_density
+    )(fitted.unconstrained_samples)
+    return AmortizedStateSpaceVariationalResult(
+        problem=problem,
+        family=fitted.family,
+        states=fitted.unconstrained_samples,
+        log_model=log_model,
+        log_variational=fitted.log_variational,
+        diagnostics=fitted.diagnostics,
+        root_key=fitted.root_key,
+        config=config_,
+        duration_seconds=fitted.duration_seconds,
+        approximation_id="reverse-kl/amortized-gaussian-markov-path",
+    )
+
+
+__all__ = [
+    "AmortizedGaussianMarkovEncoder",
+    "AmortizedGaussianMarkovFamily",
+    "AmortizedStateSpaceVariationalConfig",
+    "AmortizedStateSpaceVariationalResult",
+    "fit_amortized_state_space_variational",
+]

--- a/phydrax/uq/_state_space_buffered.py
+++ b/phydrax/uq/_state_space_buffered.py
@@ -1,0 +1,352 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from math import isfinite
+from time import perf_counter
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import optax
+from jaxtyping import Array
+
+from .._strict import StrictModule
+from ..stochastic import StateSpaceProblem
+from ._state_space_amortized import AmortizedGaussianMarkovFamily
+from ._state_space_path_density import state_space_path_log_density
+from ._variational import _tree_all_finite, VariationalConfig
+
+
+class StateSpaceWindowBatch(StrictModule):
+    """One target interval, conditioning context, and inclusion probabilities."""
+
+    target_start: Array
+    context_start: Array
+    context_end: Array
+    target_mask: Array
+    context_mask: Array
+    inclusion_probability: Array
+
+
+class StateSpaceWindowPlan(StrictModule):
+    """Uniform fixed-length target windows with explicit edge probabilities."""
+
+    inclusion_probability: Array
+    num_steps: int = eqx.field(static=True)
+    target_length: int = eqx.field(static=True)
+    left_buffer: int = eqx.field(static=True)
+    right_buffer: int = eqx.field(static=True)
+    num_starts: int = eqx.field(static=True)
+
+    def __init__(
+        self,
+        num_steps: int,
+        /,
+        *,
+        target_length: int,
+        left_buffer: int = 0,
+        right_buffer: int = 0,
+    ):
+        steps = int(num_steps)
+        target = int(target_length)
+        left = int(left_buffer)
+        right = int(right_buffer)
+        if steps < 1 or target < 1:
+            raise ValueError("num_steps and target_length must be positive.")
+        if target > steps:
+            raise ValueError("target_length cannot exceed num_steps.")
+        if left < 0 or right < 0:
+            raise ValueError("Window buffer lengths cannot be negative.")
+        starts = steps - target + 1
+        indices = jnp.arange(steps)
+        lower = jnp.maximum(0, indices - target + 1)
+        upper = jnp.minimum(indices, starts - 1)
+        counts = jnp.maximum(0, upper - lower + 1)
+        inclusion = counts.astype(float) / float(starts)
+        self.inclusion_probability = inclusion
+        self.num_steps = steps
+        self.target_length = target
+        self.left_buffer = left
+        self.right_buffer = right
+        self.num_starts = starts
+
+    def sample(self, key: Array, /) -> StateSpaceWindowBatch:
+        start = jr.randint(
+            key,
+            (),
+            minval=0,
+            maxval=self.num_starts,
+            dtype=jnp.int32,
+        )
+        indices = jnp.arange(self.num_steps, dtype=jnp.int32)
+        target_end = start + self.target_length
+        context_start = jnp.maximum(0, start - self.left_buffer)
+        context_end = jnp.minimum(
+            self.num_steps,
+            target_end + self.right_buffer,
+        )
+        return StateSpaceWindowBatch(
+            target_start=start,
+            context_start=context_start,
+            context_end=context_end,
+            target_mask=(indices >= start) & (indices < target_end),
+            context_mask=(indices >= context_start) & (indices < context_end),
+            inclusion_probability=self.inclusion_probability,
+        )
+
+
+class BufferedStateSpaceVariationalConfig(StrictModule):
+    """Buffered target/context geometry and amortized optimization controls."""
+
+    optimization: VariationalConfig
+    target_length: int = eqx.field(static=True)
+    left_buffer: int = eqx.field(static=True)
+    right_buffer: int = eqx.field(static=True)
+    hidden_size: int = eqx.field(static=True)
+    scale_floor: float = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        target_length: int,
+        left_buffer: int = 0,
+        right_buffer: int = 0,
+        hidden_size: int = 64,
+        scale_floor: float = 1e-6,
+        optimization: VariationalConfig | None = None,
+    ):
+        optimization_ = VariationalConfig() if optimization is None else optimization
+        if not isinstance(optimization_, VariationalConfig):
+            raise TypeError("optimization must be VariationalConfig or None.")
+        target = int(target_length)
+        left = int(left_buffer)
+        right = int(right_buffer)
+        hidden = int(hidden_size)
+        floor = float(scale_floor)
+        if target < 1 or hidden < 1:
+            raise ValueError("target_length and hidden_size must be positive.")
+        if left < 0 or right < 0:
+            raise ValueError("Window buffer lengths cannot be negative.")
+        if not isfinite(floor) or floor <= 0.0:
+            raise ValueError("scale_floor must be positive and finite.")
+        self.optimization = optimization_
+        self.target_length = target
+        self.left_buffer = left
+        self.right_buffer = right
+        self.hidden_size = hidden
+        self.scale_floor = floor
+
+
+class BufferedStateSpaceVariationalDiagnostics(StrictModule):
+    """Window starts, context bounds, ELBO estimates, and gradient norms."""
+
+    steps: Array
+    target_start: Array
+    context_start: Array
+    context_end: Array
+    elbo: Array
+    gradient_norm: Array
+    finite: Array
+
+
+class BufferedStateSpaceVariationalResult(StrictModule):
+    """Buffered-trained reusable encoder with full-context posterior draws."""
+
+    problem: StateSpaceProblem
+    family: AmortizedGaussianMarkovFamily
+    states: Array
+    log_model: Array
+    log_variational: Array
+    diagnostics: BufferedStateSpaceVariationalDiagnostics
+    window_plan: StateSpaceWindowPlan
+    root_key: Array
+    config: BufferedStateSpaceVariationalConfig
+    duration_seconds: float = eqx.field(static=True)
+    approximation_id: str = eqx.field(static=True)
+
+    @property
+    def num_draws(self) -> int:
+        return int(self.log_model.shape[0])
+
+
+def fit_buffered_state_space_variational(
+    problem: StateSpaceProblem,
+    /,
+    *,
+    key: Array,
+    config: BufferedStateSpaceVariationalConfig,
+    family: AmortizedGaussianMarkovFamily | None = None,
+    num_samples: int = 1000,
+) -> BufferedStateSpaceVariationalResult:
+    """Fit an inverse-inclusion-weighted buffered path ELBO approximation."""
+
+    if not isinstance(problem, StateSpaceProblem):
+        raise TypeError("problem must be StateSpaceProblem.")
+    if not isinstance(config, BufferedStateSpaceVariationalConfig):
+        raise TypeError("config must be BufferedStateSpaceVariationalConfig.")
+    draws = int(num_samples)
+    if draws < 1:
+        raise ValueError("num_samples must be positive.")
+    plan = StateSpaceWindowPlan(
+        problem.observations.num_steps,
+        target_length=config.target_length,
+        left_buffer=config.left_buffer,
+        right_buffer=config.right_buffer,
+    )
+    family_ = (
+        AmortizedGaussianMarkovFamily.from_problem(
+            problem,
+            hidden_size=config.hidden_size,
+            scale_floor=config.scale_floor,
+            key=jr.fold_in(key, 0xB0FFE2),
+        )
+        if family is None
+        else family
+    )
+    if not isinstance(family_, AmortizedGaussianMarkovFamily):
+        raise TypeError("family must be AmortizedGaussianMarkovFamily or None.")
+    optimizer = optax.chain(
+        optax.clip_by_global_norm(config.optimization.gradient_clip),
+        optax.adam(config.optimization.learning_rate),
+    )
+    dynamic_family, static_family = eqx.partition(family_, eqx.is_inexact_array)
+    optimizer_state = optimizer.init(dynamic_family)
+    case_shape = problem.observations.case_shape
+    step_valid = problem.observations.step_valid
+
+    def loss_function(current_dynamic, sample_key, window):
+        current_family = eqx.combine(current_dynamic, static_family)
+        context_mask = (
+            jnp.broadcast_to(
+                window.context_mask,
+                case_shape + (plan.num_steps,),
+            )
+            & step_valid
+        )
+        window_family = eqx.tree_at(
+            lambda value: value.context_mask,
+            current_family,
+            context_mask,
+        )
+        conditional = window_family.conditional_family
+        paths, _ = conditional.sample_and_log_prob(
+            sample_key,
+            sample_shape=(config.optimization.samples_per_step,),
+        )
+        q_initial, q_transition = conditional.log_prob_terms(paths)
+        model = jax.vmap(lambda path: state_space_path_log_density(problem, path))(paths)
+        target_weight = (
+            window.target_mask.astype(paths.dtype) / window.inclusion_probability
+        )
+        target_weight = jnp.broadcast_to(
+            target_weight,
+            case_shape + (plan.num_steps,),
+        )
+        step_terms = (model.transition + model.observation - q_transition) * target_weight
+        initial_weight = target_weight[..., 0]
+        initial_terms = (model.prior - q_initial) * initial_weight
+        elbo_samples = initial_terms.reshape((paths.shape[0], -1)).sum(axis=-1)
+        elbo_samples = elbo_samples + step_terms.reshape((paths.shape[0], -1)).sum(
+            axis=-1
+        )
+        loss = -jnp.mean(elbo_samples)
+        finite = jnp.isfinite(loss) & jnp.all(model.valid) & _tree_all_finite(paths)
+        return loss, finite
+
+    @eqx.filter_jit
+    def update(current_dynamic, current_optimizer_state, sample_key, window):
+        (loss, finite), gradient = eqx.filter_value_and_grad(
+            loss_function,
+            has_aux=True,
+        )(current_dynamic, sample_key, window)
+        gradient_norm = optax.tree.norm(gradient)
+        updates, next_optimizer_state = optimizer.update(
+            gradient,
+            current_optimizer_state,
+            current_dynamic,
+        )
+        next_dynamic = eqx.apply_updates(current_dynamic, updates)
+        finite = finite & jnp.isfinite(gradient_norm) & _tree_all_finite(next_dynamic)
+        return next_dynamic, next_optimizer_state, loss, gradient_norm, finite
+
+    recorded_steps = []
+    starts = []
+    context_starts = []
+    context_ends = []
+    elbo_history = []
+    gradient_history = []
+    finite_history = []
+    started = perf_counter()
+    for step in range(config.optimization.num_steps):
+        window_key = jr.fold_in(jr.fold_in(key, 0x710D0), step)
+        sample_key = jr.fold_in(jr.fold_in(key, 0x5A4F1E), step)
+        window = plan.sample(window_key)
+        dynamic_family, optimizer_state, loss, gradient_norm, finite = update(
+            dynamic_family,
+            optimizer_state,
+            sample_key,
+            window,
+        )
+        jax.block_until_ready(loss)
+        if not bool(finite):
+            raise FloatingPointError(
+                f"Buffered variational optimization became nonfinite at step {step + 1}."
+            )
+        completed = step + 1
+        if (
+            completed % config.optimization.record_every == 0
+            or completed == config.optimization.num_steps
+        ):
+            recorded_steps.append(completed)
+            starts.append(window.target_start)
+            context_starts.append(window.context_start)
+            context_ends.append(window.context_end)
+            elbo_history.append(-loss)
+            gradient_history.append(gradient_norm)
+            finite_history.append(finite)
+
+    fitted_family = eqx.combine(dynamic_family, static_family)
+    states, log_variational = fitted_family.sample_and_log_prob(
+        jr.fold_in(key, 0xF17A1),
+        sample_shape=(draws,),
+    )
+    log_model = jax.vmap(
+        lambda path: state_space_path_log_density(problem, path).log_density
+    )(states)
+    jax.block_until_ready(log_model)
+    diagnostics = BufferedStateSpaceVariationalDiagnostics(
+        steps=jnp.asarray(recorded_steps, dtype=jnp.int32),
+        target_start=jnp.asarray(starts, dtype=jnp.int32),
+        context_start=jnp.asarray(context_starts, dtype=jnp.int32),
+        context_end=jnp.asarray(context_ends, dtype=jnp.int32),
+        elbo=jnp.asarray(elbo_history),
+        gradient_norm=jnp.asarray(gradient_history),
+        finite=jnp.asarray(finite_history, dtype=bool),
+    )
+    return BufferedStateSpaceVariationalResult(
+        problem=problem,
+        family=fitted_family,
+        states=states,
+        log_model=log_model,
+        log_variational=log_variational,
+        diagnostics=diagnostics,
+        window_plan=plan,
+        root_key=jnp.asarray(key),
+        config=config,
+        duration_seconds=perf_counter() - started,
+        approximation_id="buffered-amortized-gaussian-markov-path",
+    )
+
+
+__all__ = [
+    "BufferedStateSpaceVariationalConfig",
+    "BufferedStateSpaceVariationalDiagnostics",
+    "BufferedStateSpaceVariationalResult",
+    "fit_buffered_state_space_variational",
+    "StateSpaceWindowBatch",
+    "StateSpaceWindowPlan",
+]

--- a/phydrax/uq/_state_space_path_density.py
+++ b/phydrax/uq/_state_space_path_density.py
@@ -1,0 +1,175 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from math import prod
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array
+
+from .._strict import StrictModule
+from ..stochastic import StateSpaceProblem
+
+
+class StateSpacePathLogDensity(StrictModule):
+    """Normalized initial, transition, and observation path-density terms."""
+
+    problem: StateSpaceProblem
+    states: Array
+    prior: Array
+    transition: Array
+    observation: Array
+    case_log_density: Array
+    log_density: Array
+    valid: Array
+    approximation_id: str = eqx.field(static=True)
+
+
+def _event_all(value: Array, event_shape: tuple[int, ...], /) -> Array:
+    if not event_shape:
+        return value
+    axes = tuple(range(value.ndim - len(event_shape), value.ndim))
+    return jnp.all(value, axis=axes)
+
+
+def state_space_path_log_density(
+    problem: StateSpaceProblem,
+    states: Array,
+    /,
+) -> StateSpacePathLogDensity:
+    """Evaluate one complete latent path under a bound state-space problem.
+
+    The path contains the initial state followed by one state per observation
+    step. Inactive padded steps must preserve their predecessor exactly.
+    """
+
+    if not isinstance(problem, StateSpaceProblem):
+        raise TypeError("problem must be a StateSpaceProblem.")
+    if not problem.model.prior.has_log_density:
+        raise ValueError("State-space path density requires a normalized state prior.")
+    if not problem.model.transition.has_log_density:
+        raise ValueError("State-space path density requires normalized transitions.")
+    values = jnp.asarray(states)
+    case_shape = problem.observations.case_shape
+    state_shape = problem.model.state_shape
+    num_steps = problem.observations.num_steps
+    expected = case_shape + (num_steps + 1,) + state_shape
+    if values.shape != expected:
+        raise ValueError(f"states must have shape {expected}; got {values.shape}.")
+    if not jnp.issubdtype(values.dtype, jnp.floating):
+        raise TypeError("State-space latent paths must be real floating arrays.")
+
+    case_count = prod(case_shape) if case_shape else 1
+    state_size_shape = state_shape
+    flat_states = values.reshape((case_count, num_steps + 1) + state_size_shape)
+    times = problem.observations.times.reshape((case_count, num_steps))
+    active = problem.observations.step_valid.reshape((case_count, num_steps))
+    observation_values = problem.observations.values.reshape(
+        (case_count, num_steps) + problem.model.observation_shape
+    )
+    observation_masks = problem.observations.observation_mask.reshape(
+        (case_count, num_steps) + problem.model.observation_shape
+    )
+    initial_times = problem.initial_time.reshape((case_count,))
+
+    sequence_axis = len(case_shape)
+    initial_states = jnp.take(values, 0, axis=sequence_axis)
+    prior_values = jnp.asarray(problem.model.prior.log_prob(initial_states))
+    prior_terms = prior_values.reshape((case_count,))
+    transition_cases = []
+    observation_cases = []
+    for case_index in range(case_count):
+        transition_terms = []
+        observation_terms = []
+        for step_index in range(num_steps):
+            step_active = active[case_index, step_index]
+            previous_state = flat_states[case_index, step_index]
+            next_state = flat_states[case_index, step_index + 1]
+            start_time = (
+                initial_times[case_index]
+                if step_index == 0
+                else times[case_index, step_index - 1]
+            )
+            end_time = times[case_index, step_index]
+            context = problem.step_context(case_index, step_index)
+
+            def transition_term(_):
+                return jnp.asarray(
+                    problem.model.transition.log_prob(
+                        next_state,
+                        previous_state,
+                        start_time,
+                        end_time,
+                        context,
+                    )
+                ).reshape(())
+
+            def observation_term(_):
+                return jnp.asarray(
+                    problem.model.observation.log_prob(
+                        observation_values[case_index, step_index],
+                        next_state,
+                        end_time,
+                        observation_masks[case_index, step_index],
+                        context,
+                    )
+                ).reshape(())
+
+            transition_terms.append(
+                jax.lax.cond(
+                    step_active,
+                    transition_term,
+                    lambda _: jnp.zeros((), dtype=values.dtype),
+                    operand=None,
+                )
+            )
+            observation_terms.append(
+                jax.lax.cond(
+                    step_active,
+                    observation_term,
+                    lambda _: jnp.zeros((), dtype=values.dtype),
+                    operand=None,
+                )
+            )
+        transition_cases.append(jnp.stack(transition_terms))
+        observation_cases.append(jnp.stack(observation_terms))
+
+    transition = jnp.stack(transition_cases).reshape(case_shape + (num_steps,))
+    observation = jnp.stack(observation_cases).reshape(case_shape + (num_steps,))
+    prior = prior_terms.reshape(case_shape)
+    finite_states = _event_all(jnp.isfinite(values), state_shape)
+    active_with_initial = jnp.concatenate(
+        (jnp.ones(case_shape + (1,), dtype=bool), problem.observations.step_valid),
+        axis=-1,
+    )
+    path_finite = jnp.all(finite_states | ~active_with_initial, axis=-1)
+    later_states = jnp.take(values, jnp.arange(1, num_steps + 1), axis=sequence_axis)
+    earlier_states = jnp.take(values, jnp.arange(num_steps), axis=sequence_axis)
+    frozen = _event_all(later_states == earlier_states, state_shape)
+    padding_frozen = jnp.all(problem.observations.step_valid | frozen, axis=-1)
+    component_finite = (
+        jnp.isfinite(prior)
+        & jnp.all(jnp.isfinite(transition), axis=-1)
+        & jnp.all(jnp.isfinite(observation), axis=-1)
+    )
+    valid = path_finite & padding_frozen & component_finite
+    raw_case_log_density = prior + jnp.sum(transition + observation, axis=-1)
+    case_log_density = jnp.where(valid, raw_case_log_density, -jnp.inf)
+    return StateSpacePathLogDensity(
+        problem=problem,
+        states=values,
+        prior=prior,
+        transition=transition,
+        observation=observation,
+        case_log_density=case_log_density,
+        log_density=jnp.sum(case_log_density),
+        valid=valid,
+        approximation_id="normalized-state-space-path-density",
+    )
+
+
+__all__ = ["state_space_path_log_density", "StateSpacePathLogDensity"]

--- a/phydrax/uq/_state_space_variational.py
+++ b/phydrax/uq/_state_space_variational.py
@@ -1,0 +1,466 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from math import isfinite, prod
+from pathlib import Path
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+from jaxtyping import Array
+
+from .._strict import StrictModule
+from ..linalg._causal_linear import associative_affine_solve
+from ..stochastic import StateSpaceProblem
+from ._posterior import ParameterSpace, PosteriorProblem
+from ._state_space_path_density import state_space_path_log_density
+from ._variational import (
+    AbstractVariationalFamily,
+    fit_variational,
+    VariationalConfig,
+    VariationalDiagnostics,
+)
+
+
+def _inverse_softplus(value: float, /) -> Array:
+    return jnp.log(jnp.expm1(jnp.asarray(value)))
+
+
+class GaussianMarkovVariationalFamily(AbstractVariationalFamily):
+    """Directed Gaussian Markov path with dense affine dynamics and diagonal noise."""
+
+    initial_location: Array
+    initial_raw_scale: Array
+    transitions: Array
+    offsets: Array
+    innovation_raw_scale: Array
+    step_valid: Array
+    case_shape: tuple[int, ...] = eqx.field(static=True)
+    state_shape: tuple[int, ...] = eqx.field(static=True)
+    num_steps: int = eqx.field(static=True)
+    state_size: int = eqx.field(static=True)
+    scale_floor: float = eqx.field(static=True)
+
+    def __init__(
+        self,
+        initial_location: Array,
+        initial_raw_scale: Array,
+        transitions: Array,
+        offsets: Array,
+        innovation_raw_scale: Array,
+        step_valid: Array,
+        /,
+        *,
+        case_shape: tuple[int, ...],
+        state_shape: tuple[int, ...],
+        scale_floor: float = 1e-6,
+    ):
+        cases = tuple(int(size) for size in case_shape)
+        state = tuple(int(size) for size in state_shape)
+        state_size = prod(state) if state else 1
+        initial = jnp.asarray(initial_location)
+        initial_scale = jnp.asarray(initial_raw_scale)
+        matrices = jnp.asarray(transitions)
+        additions = jnp.asarray(offsets)
+        innovation_scale = jnp.asarray(innovation_raw_scale)
+        valid = jnp.asarray(step_valid, dtype=bool)
+        if initial.shape != cases + state or initial_scale.shape != initial.shape:
+            raise ValueError("Initial Gaussian Markov parameters have invalid shapes.")
+        if valid.ndim != len(cases) + 1 or valid.shape[: len(cases)] != cases:
+            raise ValueError("step_valid must have shape case_shape + (time,).")
+        steps = int(valid.shape[-1])
+        if steps < 1:
+            raise ValueError("Gaussian Markov paths require at least one transition.")
+        if matrices.shape != cases + (steps, state_size, state_size):
+            raise ValueError("transitions have an invalid Gaussian Markov shape.")
+        if additions.shape != cases + (steps,) + state:
+            raise ValueError("offsets have an invalid Gaussian Markov shape.")
+        if innovation_scale.shape != additions.shape:
+            raise ValueError("innovation_raw_scale must match offsets.")
+        arrays = (initial, initial_scale, matrices, additions, innovation_scale)
+        if any(not jnp.issubdtype(array.dtype, jnp.floating) for array in arrays):
+            raise TypeError("Gaussian Markov parameters must be real floating arrays.")
+        floor = float(scale_floor)
+        if not isfinite(floor) or floor <= 0.0:
+            raise ValueError("scale_floor must be positive and finite.")
+        self.initial_location = initial
+        self.initial_raw_scale = initial_scale
+        self.transitions = matrices
+        self.offsets = additions
+        self.innovation_raw_scale = innovation_scale
+        self.step_valid = valid
+        self.case_shape = cases
+        self.state_shape = state
+        self.num_steps = steps
+        self.state_size = state_size
+        self.scale_floor = floor
+
+    @classmethod
+    def from_problem(
+        cls,
+        problem: StateSpaceProblem,
+        /,
+        *,
+        initial_scale: float = 0.5,
+        scale_floor: float = 1e-6,
+    ) -> "GaussianMarkovVariationalFamily":
+        if not isinstance(problem, StateSpaceProblem):
+            raise TypeError("problem must be a StateSpaceProblem.")
+        scale = float(initial_scale)
+        floor = float(scale_floor)
+        if not isfinite(scale) or scale <= floor:
+            raise ValueError("initial_scale must be finite and exceed scale_floor.")
+        case_shape = problem.observations.case_shape
+        state_shape = problem.model.state_shape
+        state_size = prod(state_shape) if state_shape else 1
+        steps = problem.observations.num_steps
+        location = jnp.asarray(problem.model.prior.location)
+        dtype = location.dtype
+        raw = _inverse_softplus(scale - floor).astype(dtype)
+        return cls(
+            location,
+            jnp.full_like(location, raw),
+            jnp.zeros(
+                case_shape + (steps, state_size, state_size),
+                dtype=dtype,
+            ),
+            jnp.broadcast_to(
+                jnp.expand_dims(location, axis=len(case_shape)),
+                case_shape + (steps,) + state_shape,
+            ),
+            jnp.full(case_shape + (steps,) + state_shape, raw, dtype=dtype),
+            problem.observations.step_valid,
+            case_shape=case_shape,
+            state_shape=state_shape,
+            scale_floor=floor,
+        )
+
+    @property
+    def family_id(self) -> str:
+        return "gaussian-markov-path"
+
+    @property
+    def initial_scale(self) -> Array:
+        return jax.nn.softplus(self.initial_raw_scale) + self.scale_floor
+
+    @property
+    def innovation_scale(self) -> Array:
+        return jax.nn.softplus(self.innovation_raw_scale) + self.scale_floor
+
+    def _flat_parameters(self):
+        case_count = prod(self.case_shape) if self.case_shape else 1
+        return (
+            self.initial_location.reshape((case_count, self.state_size)),
+            self.initial_scale.reshape((case_count, self.state_size)),
+            self.transitions.reshape(
+                (case_count, self.num_steps, self.state_size, self.state_size)
+            ),
+            self.offsets.reshape((case_count, self.num_steps, self.state_size)),
+            self.innovation_scale.reshape((case_count, self.num_steps, self.state_size)),
+            self.step_valid.reshape((case_count, self.num_steps)),
+        )
+
+    def sample_and_log_prob(
+        self,
+        key: Array,
+        /,
+        *,
+        sample_shape: tuple[int, ...] = (),
+    ) -> tuple[Array, Array]:
+        shape = tuple(int(size) for size in sample_shape)
+        if any(size <= 0 for size in shape):
+            raise ValueError("sample_shape dimensions must be positive.")
+        sample_count = prod(shape) if shape else 1
+        (
+            initial_location,
+            initial_scale,
+            transitions,
+            offsets,
+            innovation_scale,
+            valid,
+        ) = self._flat_parameters()
+        case_count = initial_location.shape[0]
+        initial_key, innovation_key = jr.split(key)
+        initial_noise = jr.normal(
+            initial_key,
+            (sample_count, case_count, self.state_size),
+            dtype=initial_location.dtype,
+        )
+        innovation_noise = jr.normal(
+            innovation_key,
+            (sample_count, case_count, self.num_steps, self.state_size),
+            dtype=initial_location.dtype,
+        )
+        initial_states = (
+            initial_location[None, ...] + initial_scale[None, ...] * initial_noise
+        )
+        identity = jnp.eye(self.state_size, dtype=initial_location.dtype)
+        effective_transitions = jnp.where(
+            valid[..., None, None],
+            transitions,
+            identity,
+        )
+        effective_offsets = jnp.where(
+            valid[..., None],
+            offsets[None, ...] + innovation_scale[None, ...] * innovation_noise,
+            0.0,
+        )
+        effective_transitions = jnp.broadcast_to(
+            effective_transitions,
+            (sample_count,) + effective_transitions.shape,
+        )
+        first_values = (
+            jnp.einsum(
+                "nctij,ncj->ncti",
+                effective_transitions[:, :, :1],
+                initial_states,
+            )[:, :, 0]
+            + effective_offsets[:, :, 0]
+        )
+        scan_transitions = effective_transitions.at[:, :, 0].set(
+            jnp.zeros_like(effective_transitions[:, :, 0])
+        )
+        scan_offsets = effective_offsets.at[:, :, 0].set(first_values)
+
+        def one_path(path_transitions, path_offsets):
+            return associative_affine_solve(path_transitions, path_offsets)
+
+        later_states = jax.vmap(
+            jax.vmap(one_path, in_axes=(0, 0)),
+            in_axes=(0, 0),
+        )(scan_transitions, scan_offsets)
+        flat_path = jnp.concatenate((initial_states[:, :, None, :], later_states), axis=2)
+        path = flat_path.reshape(
+            shape + self.case_shape + (self.num_steps + 1,) + self.state_shape
+        )
+        if not shape:
+            path = path.reshape(
+                self.case_shape + (self.num_steps + 1,) + self.state_shape
+            )
+        return path, self.log_prob(path)
+
+    def log_prob(self, value: Array, /) -> Array:
+        path = jnp.asarray(value)
+        event_shape = self.case_shape + (self.num_steps + 1,) + self.state_shape
+        if path.ndim < len(event_shape) or path.shape[-len(event_shape) :] != event_shape:
+            raise ValueError("value has an incompatible Gaussian Markov path shape.")
+        sample_shape = path.shape[: path.ndim - len(event_shape)]
+        sample_count = prod(sample_shape) if sample_shape else 1
+        case_count = prod(self.case_shape) if self.case_shape else 1
+        flat_path = path.reshape(
+            (sample_count, case_count, self.num_steps + 1, self.state_size)
+        )
+        (
+            initial_location,
+            initial_scale,
+            transitions,
+            offsets,
+            innovation_scale,
+            valid,
+        ) = self._flat_parameters()
+        log_two_pi = jnp.log(jnp.asarray(2.0 * jnp.pi, dtype=path.dtype))
+        initial_standardized = (
+            flat_path[:, :, 0] - initial_location[None, ...]
+        ) / initial_scale[None, ...]
+        initial_log_prob = -0.5 * jnp.sum(
+            jnp.square(initial_standardized)
+            + log_two_pi
+            + 2.0 * jnp.log(initial_scale[None, ...]),
+            axis=-1,
+        )
+        means = (
+            jnp.einsum(
+                "ctij,nctj->ncti",
+                transitions,
+                flat_path[:, :, :-1],
+            )
+            + offsets[None, ...]
+        )
+        standardized = (flat_path[:, :, 1:] - means) / innovation_scale[None, ...]
+        transition_log_prob = -0.5 * jnp.sum(
+            jnp.square(standardized)
+            + log_two_pi
+            + 2.0 * jnp.log(innovation_scale[None, ...]),
+            axis=-1,
+        )
+        transition_log_prob = jnp.where(valid[None, ...], transition_log_prob, 0.0)
+        total = jnp.sum(initial_log_prob, axis=-1) + jnp.sum(
+            transition_log_prob,
+            axis=(-2, -1),
+        )
+        return total.reshape(sample_shape) if sample_shape else total.reshape(())
+
+    def log_prob_terms(self, value: Array, /) -> tuple[Array, Array]:
+        """Return normalized initial and per-transition log-density terms."""
+        path = jnp.asarray(value)
+        event_shape = self.case_shape + (self.num_steps + 1,) + self.state_shape
+        if path.ndim < len(event_shape) or path.shape[-len(event_shape) :] != event_shape:
+            raise ValueError("value has an incompatible Gaussian Markov path shape.")
+        sample_shape = path.shape[: path.ndim - len(event_shape)]
+        sample_count = prod(sample_shape) if sample_shape else 1
+        case_count = prod(self.case_shape) if self.case_shape else 1
+        flat_path = path.reshape(
+            (sample_count, case_count, self.num_steps + 1, self.state_size)
+        )
+        (
+            initial_location,
+            initial_scale,
+            transitions,
+            offsets,
+            innovation_scale,
+            valid,
+        ) = self._flat_parameters()
+        log_two_pi = jnp.log(jnp.asarray(2.0 * jnp.pi, dtype=path.dtype))
+        initial_standardized = (
+            flat_path[:, :, 0] - initial_location[None, ...]
+        ) / initial_scale[None, ...]
+        initial = -0.5 * jnp.sum(
+            jnp.square(initial_standardized)
+            + log_two_pi
+            + 2.0 * jnp.log(initial_scale[None, ...]),
+            axis=-1,
+        )
+        means = (
+            jnp.einsum(
+                "ctij,nctj->ncti",
+                transitions,
+                flat_path[:, :, :-1],
+            )
+            + offsets[None, ...]
+        )
+        standardized = (flat_path[:, :, 1:] - means) / innovation_scale[None, ...]
+        transition = -0.5 * jnp.sum(
+            jnp.square(standardized)
+            + log_two_pi
+            + 2.0 * jnp.log(innovation_scale[None, ...]),
+            axis=-1,
+        )
+        transition = jnp.where(valid[None, ...], transition, 0.0)
+        initial_shape = sample_shape + self.case_shape
+        transition_shape = sample_shape + self.case_shape + (self.num_steps,)
+        return initial.reshape(initial_shape), transition.reshape(transition_shape)
+
+
+class StateSpaceVariationalConfig(StrictModule):
+    """Full-path Gaussian Markov initialization and optimization controls."""
+
+    optimization: VariationalConfig
+    initial_scale: float = eqx.field(static=True)
+    scale_floor: float = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        optimization: VariationalConfig | None = None,
+        initial_scale: float = 0.5,
+        scale_floor: float = 1e-6,
+    ):
+        optimization_ = VariationalConfig() if optimization is None else optimization
+        if not isinstance(optimization_, VariationalConfig):
+            raise TypeError("optimization must be VariationalConfig or None.")
+        scale = float(initial_scale)
+        floor = float(scale_floor)
+        if not isfinite(scale) or not isfinite(floor) or scale <= floor or floor <= 0.0:
+            raise ValueError("initial_scale must be finite and exceed a positive floor.")
+        self.optimization = optimization_
+        self.initial_scale = scale
+        self.scale_floor = floor
+
+
+class StateSpaceVariationalResult(StrictModule):
+    """Fitted full latent paths and normalized model/family densities."""
+
+    problem: StateSpaceProblem
+    family: GaussianMarkovVariationalFamily
+    states: Array
+    log_model: Array
+    log_variational: Array
+    diagnostics: VariationalDiagnostics
+    root_key: Array
+    config: StateSpaceVariationalConfig
+    duration_seconds: float = eqx.field(static=True)
+    approximation_id: str = eqx.field(static=True)
+
+    @property
+    def num_draws(self) -> int:
+        return int(self.log_model.shape[0])
+
+
+def fit_state_space_variational(
+    problem: StateSpaceProblem,
+    /,
+    *,
+    key: Array,
+    family: GaussianMarkovVariationalFamily | None = None,
+    config: StateSpaceVariationalConfig | None = None,
+    num_samples: int = 1000,
+    checkpoint_path: str | Path | None = None,
+    checkpoint_every: int | None = None,
+    checkpoint_id: str | None = None,
+    resume_from: str | Path | None = None,
+) -> StateSpaceVariationalResult:
+    """Fit a normalized full-path Gaussian Markov posterior approximation."""
+
+    if not isinstance(problem, StateSpaceProblem):
+        raise TypeError("problem must be a StateSpaceProblem.")
+    config_ = StateSpaceVariationalConfig() if config is None else config
+    if not isinstance(config_, StateSpaceVariationalConfig):
+        raise TypeError("config must be StateSpaceVariationalConfig or None.")
+    family_ = (
+        GaussianMarkovVariationalFamily.from_problem(
+            problem,
+            initial_scale=config_.initial_scale,
+            scale_floor=config_.scale_floor,
+        )
+        if family is None
+        else family
+    )
+    if not isinstance(family_, GaussianMarkovVariationalFamily):
+        raise TypeError("family must be GaussianMarkovVariationalFamily or None.")
+    initial_path, _ = family_.sample_and_log_prob(jr.fold_in(key, 0x51A7E))
+    path_space = ParameterSpace(
+        initial_path,
+        log_prior=lambda _: jnp.zeros((), dtype=initial_path.dtype),
+    )
+    path_problem = PosteriorProblem(
+        path_space,
+        lambda path: state_space_path_log_density(problem, path).log_density,
+    )
+    fitted = fit_variational(
+        path_problem,
+        key=key,
+        family=family_,
+        config=config_.optimization,
+        num_samples=num_samples,
+        checkpoint_path=checkpoint_path,
+        checkpoint_every=checkpoint_every,
+        checkpoint_id=checkpoint_id,
+        resume_from=resume_from,
+    )
+    log_model = jax.vmap(
+        lambda path: state_space_path_log_density(problem, path).log_density
+    )(fitted.unconstrained_samples)
+    return StateSpaceVariationalResult(
+        problem=problem,
+        family=fitted.family,
+        states=fitted.unconstrained_samples,
+        log_model=log_model,
+        log_variational=fitted.log_variational,
+        diagnostics=fitted.diagnostics,
+        root_key=fitted.root_key,
+        config=config_,
+        duration_seconds=fitted.duration_seconds,
+        approximation_id="reverse-kl/gaussian-markov-state-space-path",
+    )
+
+
+__all__ = [
+    "fit_state_space_variational",
+    "GaussianMarkovVariationalFamily",
+    "StateSpaceVariationalConfig",
+    "StateSpaceVariationalResult",
+]

--- a/phydrax/uq/_stochastic_gradient.py
+++ b/phydrax/uq/_stochastic_gradient.py
@@ -1,0 +1,264 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import Any
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import optax
+from jaxtyping import Array, PyTree
+
+from .._fingerprint import array_tree_fingerprint
+from .._strict import StrictModule
+from ._minibatch_posterior import LikelihoodBatch, MinibatchPosteriorProblem
+from ._parameterized_state_space import ParameterizedStateSpaceProblem
+from ._particle import (
+    bootstrap_particle_filter,
+    ResamplingMethod,
+    ResamplingPolicy,
+)
+from ._particle_parameter_score import parameterized_particle_genealogical_score
+
+
+STOCHASTIC_GRADIENT_SUCCESS = 0
+STOCHASTIC_GRADIENT_INVALID = 1
+
+
+class StochasticGradientEstimate(StrictModule):
+    """One stochastic log-density gradient with explicit numerical validity."""
+
+    gradient: PyTree[Array]
+    log_density: Array
+    gradient_norm: Array
+    valid: Array
+    status: Array
+    likelihood_estimate: Array
+    estimator_id: str = eqx.field(static=True)
+
+
+class AbstractStochasticGradientEstimator(StrictModule):
+    """Replaceable gradient source for fixed-step stochastic-gradient MCMC."""
+
+    @property
+    @abstractmethod
+    def estimator_id(self) -> str:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def supports_control_variate(self) -> bool:
+        raise NotImplementedError
+
+    @abstractmethod
+    def configuration(self) -> dict[str, Any]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def estimate(
+        self,
+        problem: MinibatchPosteriorProblem,
+        position: PyTree[Any],
+        batch: LikelihoodBatch,
+        key: Array,
+        /,
+    ) -> StochasticGradientEstimate:
+        raise NotImplementedError
+
+
+class AutodiffStochasticGradientEstimator(AbstractStochasticGradientEstimator):
+    """Current unbiased factor-minibatch gradient implemented by autodiff."""
+
+    @property
+    def estimator_id(self) -> str:
+        return "autodiff-factor-minibatch"
+
+    @property
+    def supports_control_variate(self) -> bool:
+        return True
+
+    def configuration(self) -> dict[str, Any]:
+        return {"estimator_id": self.estimator_id}
+
+    def estimate(
+        self,
+        problem: MinibatchPosteriorProblem,
+        position: PyTree[Any],
+        batch: LikelihoodBatch,
+        key: Array,
+        /,
+    ) -> StochasticGradientEstimate:
+        del key
+        value, gradient = jax.value_and_grad(problem.log_density_estimate)(
+            position,
+            batch,
+        )
+        gradient_norm = optax.tree.norm(gradient)
+        finite = (
+            jnp.isfinite(value)
+            & jnp.isfinite(gradient_norm)
+            & jnp.all(
+                jnp.stack(
+                    [jnp.all(jnp.isfinite(leaf)) for leaf in jax.tree.leaves(gradient)]
+                )
+            )
+        )
+        physical = problem.parameter_space.constrain(position)
+        likelihood = problem.log_likelihood_estimate(physical, batch)
+        return StochasticGradientEstimate(
+            gradient=gradient,
+            log_density=value,
+            gradient_norm=gradient_norm,
+            valid=finite,
+            status=jnp.where(
+                finite,
+                STOCHASTIC_GRADIENT_SUCCESS,
+                STOCHASTIC_GRADIENT_INVALID,
+            ).astype(jnp.int32),
+            likelihood_estimate=likelihood,
+            estimator_id=self.estimator_id,
+        )
+
+
+class ParticleGenealogicalGradientEstimator(AbstractStochasticGradientEstimator):
+    """Complete-sequence particle likelihood score plus exact parameter prior."""
+
+    parameterized: ParameterizedStateSpaceProblem
+    num_particles: int = eqx.field(static=True)
+    resampling_method: ResamplingMethod = eqx.field(static=True)
+    resampling_policy: ResamplingPolicy = eqx.field(static=True)
+    resampling_threshold: float = eqx.field(static=True)
+
+    def __init__(
+        self,
+        parameterized: ParameterizedStateSpaceProblem,
+        /,
+        *,
+        num_particles: int,
+        resampling_method: ResamplingMethod = "systematic",
+        resampling_policy: ResamplingPolicy = "ess",
+        resampling_threshold: float = 0.5,
+    ):
+        if not isinstance(parameterized, ParameterizedStateSpaceProblem):
+            raise TypeError("parameterized must be ParameterizedStateSpaceProblem.")
+        count = int(num_particles)
+        if count < 1:
+            raise ValueError("num_particles must be positive.")
+        if resampling_method not in (
+            "systematic",
+            "stratified",
+            "multinomial",
+            "residual",
+        ):
+            raise ValueError("Unknown particle resampling method.")
+        if resampling_policy not in ("ess", "always", "never"):
+            raise ValueError("Unknown particle resampling policy.")
+        threshold = float(resampling_threshold)
+        if not 0.0 < threshold <= 1.0:
+            raise ValueError("resampling_threshold must lie in (0, 1].")
+        self.parameterized = parameterized
+        self.num_particles = count
+        self.resampling_method = resampling_method
+        self.resampling_policy = resampling_policy
+        self.resampling_threshold = threshold
+
+    @property
+    def estimator_id(self) -> str:
+        return "particle-complete-sequence-genealogical"
+
+    @property
+    def supports_control_variate(self) -> bool:
+        return False
+
+    def configuration(self) -> dict[str, Any]:
+        return {
+            "estimator_id": self.estimator_id,
+            "parameterization_id": self.parameterized.parameterization_id,
+            "parameterized_digest": array_tree_fingerprint(self.parameterized)["sha256"],
+            "num_particles": self.num_particles,
+            "resampling_method": self.resampling_method,
+            "resampling_policy": self.resampling_policy,
+            "resampling_threshold": self.resampling_threshold,
+        }
+
+    def estimate(
+        self,
+        problem: MinibatchPosteriorProblem,
+        position: PyTree[Any],
+        batch: LikelihoodBatch,
+        key: Array,
+        /,
+    ) -> StochasticGradientEstimate:
+        del batch
+        if (
+            problem.parameter_space.raw_shapes
+            != self.parameterized.parameter_space.raw_shapes
+        ):
+            raise ValueError(
+                "SG-MCMC and parameterized state-space coordinates do not match."
+            )
+        bound_problem = self.parameterized.bind(position)
+        filtered = bootstrap_particle_filter(
+            key,
+            bound_problem,
+            num_particles=self.num_particles,
+            resampling_method=self.resampling_method,
+            resampling_policy=self.resampling_policy,
+            resampling_threshold=self.resampling_threshold,
+        )
+        likelihood_score = parameterized_particle_genealogical_score(
+            self.parameterized,
+            position,
+            filtered,
+        )
+        prior_gradient = jax.grad(problem.parameter_space.unconstrained_log_prior)(
+            position
+        )
+        gradient = jax.tree.map(
+            jnp.add,
+            prior_gradient,
+            likelihood_score.gradient,
+        )
+        gradient_norm = optax.tree.norm(gradient)
+        likelihood_estimate = jnp.sum(filtered.final_state.log_likelihood)
+        log_density = (
+            likelihood_estimate
+            + problem.parameter_space.unconstrained_log_prior(position)
+        )
+        finite = (
+            jnp.all(likelihood_score.valid)
+            & jnp.isfinite(log_density)
+            & jnp.isfinite(gradient_norm)
+            & jnp.all(
+                jnp.stack(
+                    [jnp.all(jnp.isfinite(leaf)) for leaf in jax.tree.leaves(gradient)]
+                )
+            )
+        )
+        return StochasticGradientEstimate(
+            gradient=gradient,
+            log_density=log_density,
+            gradient_norm=gradient_norm,
+            valid=finite,
+            status=jnp.where(
+                finite,
+                STOCHASTIC_GRADIENT_SUCCESS,
+                STOCHASTIC_GRADIENT_INVALID,
+            ).astype(jnp.int32),
+            likelihood_estimate=likelihood_estimate,
+            estimator_id=self.estimator_id,
+        )
+
+
+__all__ = [
+    "AbstractStochasticGradientEstimator",
+    "AutodiffStochasticGradientEstimator",
+    "ParticleGenealogicalGradientEstimator",
+    "STOCHASTIC_GRADIENT_INVALID",
+    "STOCHASTIC_GRADIENT_SUCCESS",
+    "StochasticGradientEstimate",
+]

--- a/phydrax/uq/_variational.py
+++ b/phydrax/uq/_variational.py
@@ -1,0 +1,646 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from math import isfinite
+from pathlib import Path
+from time import perf_counter
+from typing import Any, Literal
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import optax
+from jaxtyping import Array, PyTree
+
+from .._frozendict import frozendict
+from .._strict import StrictModule
+from ._checkpoint import (
+    checkpoint_compatibility,
+    CheckpointCorruptionError,
+    pack_array_tree,
+    read_checkpoint_archive,
+    unpack_array_tree,
+    write_checkpoint_archive,
+)
+from ._posterior import PosteriorProblem
+from ._posterior_predictive import (
+    predict_from_position_samples,
+    sample_observations_from_position_samples,
+)
+from ._predictive import PredictiveField
+
+
+_TRAINING_TAG = 0
+_FINAL_SAMPLING_TAG = 1
+
+
+def _tree_nbytes(tree: Any, /) -> int:
+    return sum(int(leaf.nbytes) for leaf in jax.tree.leaves(tree) if eqx.is_array(leaf))
+
+
+def _tree_all_finite(tree: Any, /) -> Array:
+    leaves = [leaf for leaf in jax.tree.leaves(tree) if eqx.is_array(leaf)]
+    if not leaves:
+        return jnp.asarray(False)
+    return jnp.all(jnp.stack([jnp.all(jnp.isfinite(leaf)) for leaf in leaves]))
+
+
+class AbstractVariationalFamily(StrictModule):
+    """Normalized distribution over unconstrained posterior coordinates."""
+
+    @property
+    @abstractmethod
+    def family_id(self) -> str:
+        raise NotImplementedError
+
+    @abstractmethod
+    def sample_and_log_prob(
+        self,
+        key: Array,
+        /,
+        *,
+        sample_shape: tuple[int, ...] = (),
+    ) -> tuple[PyTree[Array], Array]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def log_prob(self, value: PyTree[Any], /) -> Array:
+        raise NotImplementedError
+
+
+class MeanFieldGaussianFamily(AbstractVariationalFamily):
+    """Reparameterized diagonal Gaussian over an arbitrary array PyTree."""
+
+    location: PyTree[Array]
+    raw_scale: PyTree[Array]
+    scale_floor: float = eqx.field(static=True)
+
+    def __init__(
+        self,
+        location: PyTree[Any],
+        raw_scale: PyTree[Any],
+        /,
+        *,
+        scale_floor: float = 1e-6,
+    ):
+        location_tree = jax.tree.map(jnp.asarray, location)
+        raw_scale_tree = jax.tree.map(jnp.asarray, raw_scale)
+        if jax.tree.structure(location_tree) != jax.tree.structure(raw_scale_tree):
+            raise ValueError("location and raw_scale must share one PyTree structure.")
+        locations = jax.tree.leaves(location_tree)
+        raw_scales = jax.tree.leaves(raw_scale_tree)
+        if not locations:
+            raise ValueError("A variational family requires at least one array leaf.")
+        for location_leaf, raw_scale_leaf in zip(
+            locations,
+            raw_scales,
+            strict=True,
+        ):
+            if location_leaf.shape != raw_scale_leaf.shape:
+                raise ValueError("location and raw_scale leaf shapes must agree.")
+            if not jnp.issubdtype(location_leaf.dtype, jnp.floating):
+                raise TypeError("Variational locations must be real floating arrays.")
+            if not jnp.issubdtype(raw_scale_leaf.dtype, jnp.floating):
+                raise TypeError("Variational scales must be real floating arrays.")
+        floor = float(scale_floor)
+        if not isfinite(floor) or floor <= 0.0:
+            raise ValueError("scale_floor must be positive and finite.")
+        self.location = location_tree
+        self.raw_scale = raw_scale_tree
+        self.scale_floor = floor
+
+    @classmethod
+    def from_position(
+        cls,
+        position: PyTree[Any],
+        /,
+        *,
+        initial_scale: float = 0.1,
+        scale_floor: float = 1e-6,
+    ) -> "MeanFieldGaussianFamily":
+        scale = float(initial_scale)
+        floor = float(scale_floor)
+        if not isfinite(scale) or scale <= floor:
+            raise ValueError("initial_scale must be finite and exceed scale_floor.")
+        location = jax.tree.map(jnp.asarray, position)
+        raw_value = jnp.log(jnp.expm1(jnp.asarray(scale - floor)))
+        raw_scale = jax.tree.map(
+            lambda leaf: jnp.full_like(leaf, raw_value),
+            location,
+        )
+        return cls(location, raw_scale, scale_floor=floor)
+
+    @property
+    def family_id(self) -> str:
+        return "mean-field-gaussian"
+
+    @property
+    def scale(self) -> PyTree[Array]:
+        return jax.tree.map(
+            lambda value: jax.nn.softplus(value) + self.scale_floor,
+            self.raw_scale,
+        )
+
+    def sample_and_log_prob(
+        self,
+        key: Array,
+        /,
+        *,
+        sample_shape: tuple[int, ...] = (),
+    ) -> tuple[PyTree[Array], Array]:
+        shape = tuple(int(size) for size in sample_shape)
+        if any(size <= 0 for size in shape):
+            raise ValueError("sample_shape dimensions must be positive.")
+        locations, treedef = jax.tree.flatten(self.location)
+        scales = jax.tree.leaves(self.scale)
+        keys = jr.split(key, len(locations))
+        samples = treedef.unflatten(
+            [
+                location
+                + scale
+                * jr.normal(
+                    sample_key,
+                    shape + location.shape,
+                    dtype=location.dtype,
+                )
+                for sample_key, location, scale in zip(
+                    keys,
+                    locations,
+                    scales,
+                    strict=True,
+                )
+            ]
+        )
+        return samples, self.log_prob(samples)
+
+    def log_prob(self, value: PyTree[Any], /) -> Array:
+        if jax.tree.structure(value) != jax.tree.structure(self.location):
+            raise ValueError("value has an incompatible variational PyTree structure.")
+        terms = []
+        log_two_pi = jnp.log(jnp.asarray(2.0 * jnp.pi))
+        for sample, location, scale in zip(
+            jax.tree.leaves(value),
+            jax.tree.leaves(self.location),
+            jax.tree.leaves(self.scale),
+            strict=True,
+        ):
+            sample_array = jnp.asarray(sample)
+            if location.shape and (
+                sample_array.ndim < location.ndim
+                or sample_array.shape[-location.ndim :] != location.shape
+            ):
+                raise ValueError(
+                    "A variational value leaf has an invalid trailing shape."
+                )
+            standardized = (sample_array - location) / scale
+            element = -0.5 * (
+                jnp.square(standardized) + log_two_pi + 2.0 * jnp.log(scale)
+            )
+            axes = tuple(range(element.ndim - location.ndim, element.ndim))
+            terms.append(jnp.sum(element, axis=axes) if axes else element)
+        total = terms[0]
+        for term in terms[1:]:
+            total = total + term
+        return total
+
+
+class VariationalConfig(StrictModule):
+    """Static reverse-KL optimization and recording controls."""
+
+    num_steps: int = eqx.field(static=True)
+    samples_per_step: int = eqx.field(static=True)
+    learning_rate: float = eqx.field(static=True)
+    gradient_clip: float = eqx.field(static=True)
+    record_every: int = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        num_steps: int = 1000,
+        samples_per_step: int = 16,
+        learning_rate: float = 1e-3,
+        gradient_clip: float = 100.0,
+        record_every: int = 10,
+    ):
+        steps = int(num_steps)
+        samples = int(samples_per_step)
+        interval = int(record_every)
+        rate = float(learning_rate)
+        clipping = float(gradient_clip)
+        if steps < 1 or samples < 1 or interval < 1:
+            raise ValueError(
+                "Variational step, sample, and record counts must be positive."
+            )
+        if not isfinite(rate) or rate <= 0.0:
+            raise ValueError("learning_rate must be positive and finite.")
+        if not isfinite(clipping) or clipping <= 0.0:
+            raise ValueError("gradient_clip must be positive and finite.")
+        self.num_steps = steps
+        self.samples_per_step = samples
+        self.learning_rate = rate
+        self.gradient_clip = clipping
+        self.record_every = interval
+
+    def as_dict(self) -> dict[str, int | float]:
+        return {
+            "num_steps": self.num_steps,
+            "samples_per_step": self.samples_per_step,
+            "learning_rate": self.learning_rate,
+            "gradient_clip": self.gradient_clip,
+            "record_every": self.record_every,
+        }
+
+
+class VariationalDiagnostics(StrictModule):
+    """Recorded ELBO, gradient norms, and finite optimization state."""
+
+    steps: Array
+    elbo: Array
+    gradient_norm: Array
+    finite: Array
+    completed_steps: int = eqx.field(static=True)
+
+
+class VariationalResult(StrictModule):
+    """Fitted normalized posterior approximation and unconstrained draws."""
+
+    problem: PosteriorProblem
+    family: AbstractVariationalFamily
+    samples: PyTree[Array]
+    unconstrained_samples: PyTree[Array]
+    log_target: Array
+    log_variational: Array
+    diagnostics: VariationalDiagnostics
+    root_key: Array
+    config: VariationalConfig
+    duration_seconds: float = eqx.field(static=True)
+    optimization_duration_seconds: float = eqx.field(static=True)
+    sampling_duration_seconds: float = eqx.field(static=True)
+    sample_memory_bytes: int = eqx.field(static=True)
+    family_memory_bytes: int = eqx.field(static=True)
+    approximation_id: str = eqx.field(static=True)
+
+    @property
+    def num_draws(self) -> int:
+        return int(self.log_target.shape[0])
+
+    def predict(
+        self,
+        *args: Any,
+        batch_size: int | None = None,
+        valid_policy: Literal["record", "raise"] = "record",
+        draw_dim: str = "__phydra_uq_draw",
+        **kwargs: Any,
+    ) -> PredictiveField | frozendict[str, PredictiveField]:
+        return predict_from_position_samples(
+            self.problem,
+            self.unconstrained_samples,
+            *args,
+            sample_dims=(draw_dim,),
+            sample_sources=("epistemic",),
+            batch_size=batch_size,
+            valid_policy=valid_policy,
+            **kwargs,
+        )
+
+    def sample_observations(
+        self,
+        key: Array,
+        *args: Any,
+        batch_size: int | None = None,
+        valid_policy: Literal["record", "raise"] = "record",
+        draw_dim: str = "__phydra_uq_draw",
+        observation_dim: str = "__phydra_uq_observation",
+        **kwargs: Any,
+    ) -> PredictiveField | frozendict[str, PredictiveField]:
+        return sample_observations_from_position_samples(
+            self.problem,
+            self.unconstrained_samples,
+            key,
+            *args,
+            sample_dims=(draw_dim,),
+            sample_sources=("epistemic",),
+            observation_dim=observation_dim,
+            batch_size=batch_size,
+            valid_policy=valid_policy,
+            **kwargs,
+        )
+
+
+def _write_variational_checkpoint(
+    destination: Path,
+    *,
+    compatibility,
+    completed: int,
+    family,
+    optimizer_state,
+    recorded_steps,
+    elbo_history,
+    gradient_history,
+    finite_history,
+    duration_seconds: float,
+) -> None:
+    arrays = {
+        "recorded_steps": jnp.asarray(recorded_steps, dtype=jnp.int32),
+        "elbo_history": jnp.asarray(elbo_history),
+        "gradient_history": jnp.asarray(gradient_history),
+        "finite_history": jnp.asarray(finite_history, dtype=bool),
+    }
+    state = {
+        "completed_steps": int(completed),
+        "duration_seconds": float(duration_seconds),
+        "family_tree": pack_array_tree("family", family, arrays),
+        "optimizer_tree": pack_array_tree("optimizer", optimizer_state, arrays),
+    }
+    write_checkpoint_archive(
+        destination,
+        kind="variational",
+        compatibility=compatibility,
+        state=state,
+        arrays=arrays,
+    )
+
+
+def _read_variational_checkpoint(
+    source: Path,
+    *,
+    compatibility,
+    family_template,
+    optimizer_template,
+):
+    state, arrays = read_checkpoint_archive(
+        source,
+        kind="variational",
+        compatibility=compatibility,
+    )
+    completed = int(state.get("completed_steps", -1))
+    if completed < 0:
+        raise CheckpointCorruptionError("Variational completed step count is invalid.")
+    family = unpack_array_tree(state["family_tree"], arrays, family_template)
+    optimizer_state = unpack_array_tree(
+        state["optimizer_tree"], arrays, optimizer_template
+    )
+    required = (
+        "recorded_steps",
+        "elbo_history",
+        "gradient_history",
+        "finite_history",
+    )
+    if any(name not in arrays for name in required):
+        raise CheckpointCorruptionError("Variational history arrays are incomplete.")
+    recorded_steps = jnp.asarray(arrays["recorded_steps"], dtype=jnp.int32)
+    elbo_history = jnp.asarray(arrays["elbo_history"])
+    gradient_history = jnp.asarray(arrays["gradient_history"])
+    finite_history = jnp.asarray(arrays["finite_history"], dtype=bool)
+    if not (
+        recorded_steps.ndim == 1
+        and elbo_history.shape == recorded_steps.shape
+        and gradient_history.shape == recorded_steps.shape
+        and finite_history.shape == recorded_steps.shape
+    ):
+        raise CheckpointCorruptionError("Variational history shapes are incompatible.")
+    return (
+        completed,
+        family,
+        optimizer_state,
+        list(recorded_steps),
+        list(elbo_history),
+        list(gradient_history),
+        list(finite_history),
+        float(state.get("duration_seconds", 0.0)),
+    )
+
+
+def fit_variational(
+    problem: PosteriorProblem,
+    /,
+    *,
+    key: Array,
+    family: AbstractVariationalFamily | None = None,
+    config: VariationalConfig | None = None,
+    num_samples: int = 1000,
+    checkpoint_path: str | Path | None = None,
+    checkpoint_every: int | None = None,
+    checkpoint_id: str | None = None,
+    resume_from: str | Path | None = None,
+) -> VariationalResult:
+    """Fit a normalized reverse-KL posterior in unconstrained coordinates."""
+
+    if not isinstance(problem, PosteriorProblem):
+        raise TypeError("problem must be a PosteriorProblem.")
+    family_ = (
+        MeanFieldGaussianFamily.from_position(problem.initial_position)
+        if family is None
+        else family
+    )
+    if not isinstance(family_, AbstractVariationalFamily):
+        raise TypeError("family must implement AbstractVariationalFamily or be None.")
+    config_ = VariationalConfig() if config is None else config
+    if not isinstance(config_, VariationalConfig):
+        raise TypeError("config must be VariationalConfig or None.")
+    draws = int(num_samples)
+    if draws < 1:
+        raise ValueError("num_samples must be positive.")
+    destination = (
+        Path(checkpoint_path)
+        if checkpoint_path is not None
+        else (Path(resume_from) if resume_from is not None else None)
+    )
+    if checkpoint_every is not None and destination is None:
+        raise ValueError("checkpoint_every requires checkpoint_path or resume_from.")
+    checkpoint_interval = (
+        min(100, config_.num_steps) if checkpoint_every is None else int(checkpoint_every)
+    )
+    if checkpoint_interval < 1:
+        raise ValueError("checkpoint_every must be positive.")
+    if destination is not None and (checkpoint_id is None or not str(checkpoint_id)):
+        raise ValueError("checkpoint_id is required for variational checkpointing.")
+
+    settings = {
+        "algorithm": "reverse-kl-variational",
+        "family_id": family_.family_id,
+        "config": {
+            name: value
+            for name, value in config_.as_dict().items()
+            if name != "num_steps"
+        },
+        "num_samples": draws,
+        "root_key": [int(value) for value in jr.key_data(key).reshape(-1)],
+    }
+    compatibility = (
+        checkpoint_compatibility(
+            problem,
+            checkpoint_id=str(checkpoint_id),
+            settings=settings,
+        )
+        if destination is not None
+        else None
+    )
+    optimizer = optax.chain(
+        optax.clip_by_global_norm(config_.gradient_clip),
+        optax.adam(config_.learning_rate),
+    )
+    dynamic_family, static_family = eqx.partition(family_, eqx.is_inexact_array)
+    optimizer_state = optimizer.init(dynamic_family)
+    started = perf_counter()
+
+    if resume_from is None:
+        completed = 0
+        recorded_steps: list[Any] = []
+        elbo_history: list[Any] = []
+        gradient_history: list[Any] = []
+        finite_history: list[Any] = []
+        previous_duration = 0.0
+    else:
+        if compatibility is None:
+            raise RuntimeError("Variational resume compatibility was not initialized.")
+        (
+            completed,
+            restored_family,
+            optimizer_state,
+            recorded_steps,
+            elbo_history,
+            gradient_history,
+            finite_history,
+            previous_duration,
+        ) = _read_variational_checkpoint(
+            Path(resume_from),
+            compatibility=compatibility,
+            family_template=family_,
+            optimizer_template=optimizer_state,
+        )
+        if completed > config_.num_steps:
+            raise ValueError("Checkpoint exceeds the configured variational steps.")
+        dynamic_family, static_family = eqx.partition(
+            restored_family, eqx.is_inexact_array
+        )
+
+    def loss_function(current_dynamic, step_key):
+        current_family = eqx.combine(current_dynamic, static_family)
+        positions, log_variational = current_family.sample_and_log_prob(
+            step_key,
+            sample_shape=(config_.samples_per_step,),
+        )
+        log_target = jax.vmap(problem.log_density)(positions)
+        loss = jnp.mean(log_variational - log_target)
+        finite = (
+            jnp.isfinite(loss)
+            & jnp.all(jnp.isfinite(log_variational))
+            & jnp.all(jnp.isfinite(log_target))
+            & _tree_all_finite(positions)
+        )
+        return loss, finite
+
+    @eqx.filter_jit
+    def update(current_dynamic, current_optimizer_state, step_key):
+        (loss, finite), gradient = eqx.filter_value_and_grad(
+            loss_function,
+            has_aux=True,
+        )(current_dynamic, step_key)
+        gradient_norm = optax.tree.norm(gradient)
+        updates, next_optimizer_state = optimizer.update(
+            gradient,
+            current_optimizer_state,
+            current_dynamic,
+        )
+        next_dynamic = eqx.apply_updates(current_dynamic, updates)
+        finite = finite & jnp.isfinite(gradient_norm) & _tree_all_finite(next_dynamic)
+        return next_dynamic, next_optimizer_state, loss, gradient_norm, finite
+
+    optimization_started = perf_counter()
+    while completed < config_.num_steps:
+        step_key = jr.fold_in(
+            jr.fold_in(key, _TRAINING_TAG),
+            jnp.asarray(completed, dtype=jnp.uint32),
+        )
+        (
+            dynamic_family,
+            optimizer_state,
+            loss,
+            gradient_norm,
+            finite,
+        ) = update(dynamic_family, optimizer_state, step_key)
+        jax.block_until_ready(loss)
+        completed += 1
+        if not bool(finite):
+            raise FloatingPointError(
+                f"Variational optimization became nonfinite at step {completed}."
+            )
+        if completed % config_.record_every == 0 or completed == config_.num_steps:
+            recorded_steps.append(jnp.asarray(completed, dtype=jnp.int32))
+            elbo_history.append(-loss)
+            gradient_history.append(gradient_norm)
+            finite_history.append(finite)
+        if (
+            destination is not None
+            and compatibility is not None
+            and (completed % checkpoint_interval == 0 or completed == config_.num_steps)
+        ):
+            _write_variational_checkpoint(
+                destination,
+                compatibility=compatibility,
+                completed=completed,
+                family=eqx.combine(dynamic_family, static_family),
+                optimizer_state=optimizer_state,
+                recorded_steps=recorded_steps,
+                elbo_history=elbo_history,
+                gradient_history=gradient_history,
+                finite_history=finite_history,
+                duration_seconds=(previous_duration + perf_counter() - started),
+            )
+    optimization_duration = perf_counter() - optimization_started
+    fitted_family = eqx.combine(dynamic_family, static_family)
+    sampling_started = perf_counter()
+    unconstrained_samples, log_variational = fitted_family.sample_and_log_prob(
+        jr.fold_in(key, _FINAL_SAMPLING_TAG),
+        sample_shape=(draws,),
+    )
+    log_target = jax.vmap(problem.log_density)(unconstrained_samples)
+    samples = problem.parameter_space.constrain(unconstrained_samples)
+    jax.block_until_ready(log_target)
+    sampling_duration = perf_counter() - sampling_started
+    diagnostics = VariationalDiagnostics(
+        steps=jnp.asarray(recorded_steps, dtype=jnp.int32),
+        elbo=jnp.asarray(elbo_history),
+        gradient_norm=jnp.asarray(gradient_history),
+        finite=jnp.asarray(finite_history, dtype=bool),
+        completed_steps=completed,
+    )
+    duration = previous_duration + perf_counter() - started
+    return VariationalResult(
+        problem=problem,
+        family=fitted_family,
+        samples=samples,
+        unconstrained_samples=unconstrained_samples,
+        log_target=log_target,
+        log_variational=log_variational,
+        diagnostics=diagnostics,
+        root_key=jnp.asarray(key),
+        config=config_,
+        duration_seconds=duration,
+        optimization_duration_seconds=optimization_duration,
+        sampling_duration_seconds=sampling_duration,
+        sample_memory_bytes=(
+            _tree_nbytes(samples)
+            + _tree_nbytes(unconstrained_samples)
+            + int(log_target.nbytes)
+            + int(log_variational.nbytes)
+        ),
+        family_memory_bytes=_tree_nbytes(fitted_family),
+        approximation_id=f"reverse-kl/{fitted_family.family_id}",
+    )
+
+
+__all__ = [
+    "AbstractVariationalFamily",
+    "fit_variational",
+    "MeanFieldGaussianFamily",
+    "VariationalConfig",
+    "VariationalDiagnostics",
+    "VariationalResult",
+]

--- a/tests/integration/test_uq_particle_score_sgmcmc.py
+++ b/tests/integration/test_uq_particle_score_sgmcmc.py
@@ -1,0 +1,149 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+import phydrax as phx
+
+
+def _parameterized_problem():
+    observations = phx.stochastic.ObservationSequence(
+        jnp.asarray([0.5, 1.0]),
+        jnp.asarray([[0.4], [0.8]]),
+        case_ids=("only",),
+        sequence_id="particle-sgmcmc",
+    )
+    prior = phx.stochastic.GaussianStatePrior(
+        jnp.asarray([0.0]),
+        jnp.asarray([[1.0]]),
+        state_shape=(1,),
+        prior_id="state-prior",
+    )
+
+    def offset(t0, t1, context):
+        del t0, t1
+        return jnp.asarray([context.args["drift"]])
+
+    transition = phx.stochastic.LinearGaussianTransitionKernel(
+        jnp.asarray([[1.0]]),
+        jnp.asarray([[0.1]]),
+        state_shape=(1,),
+        offset=offset,
+        process_id="drifting-transition",
+    )
+    observation = phx.stochastic.LinearGaussianObservationModel(
+        jnp.asarray([[1.0]]),
+        jnp.asarray([[0.2]]),
+        state_shape=(1,),
+        observation_shape=(1,),
+    )
+    state_problem = phx.stochastic.StateSpaceProblem(
+        phx.stochastic.StateSpaceModel(
+            prior,
+            transition,
+            observation,
+            model_id="particle-sgmcmc-model",
+        ),
+        observations,
+        initial_time=0.0,
+        problem_id="particle-sgmcmc-problem",
+        args={"drift": jnp.asarray(0.0)},
+    )
+    parameter_space = phx.uq.ParameterSpace(
+        {"drift": jnp.asarray(0.0)},
+        priors={"drift": phx.uq.Normal(0.0, 1.0)},
+    )
+    parameterized = phx.uq.ParameterizedStateSpaceProblem(
+        state_problem,
+        parameter_space,
+        lambda physical, _: {"drift": physical["drift"]},
+        parameterization_id="drift",
+    )
+    stochastic_problem = phx.uq.MinibatchPosteriorProblem(
+        parameter_space,
+        lambda physical, batch: jnp.zeros(batch.factor_mask.shape),
+        num_factors=1,
+    )
+    source = phx.uq.ArrayMinibatchSource(jnp.zeros((1, 1)), batch_size=1)
+    return stochastic_problem, source, parameterized
+
+
+def test_particle_genealogical_estimator_drives_jitted_sgld_end_to_end():
+    problem, source, parameterized = _parameterized_problem()
+    estimator = phx.uq.ParticleGenealogicalGradientEstimator(
+        parameterized,
+        num_particles=8,
+        resampling_policy="never",
+    )
+    result = phx.uq.sample_sgld(
+        problem,
+        source,
+        key=jax.random.key(1),
+        step_size=1e-4,
+        num_chains=2,
+        num_burnin=2,
+        num_samples=4,
+        gradient_estimator=estimator,
+    )
+
+    assert result.gradient_estimator_id == estimator.estimator_id
+    assert result.samples["drift"].shape == (2, 4)
+    assert jnp.all(jnp.isfinite(result.samples["drift"]))
+    assert jnp.all(jnp.isfinite(result.gradient_norm))
+
+
+def test_explicit_autodiff_estimator_preserves_default_sgld_replay():
+    inputs = jnp.linspace(-1.0, 1.0, 6)
+    source = phx.uq.ArrayMinibatchSource(inputs, batch_size=3, seed=2)
+    space = phx.uq.ParameterSpace(jnp.asarray(0.0), priors=phx.uq.Normal(0.0, 1.0))
+    problem = phx.uq.MinibatchPosteriorProblem(
+        space,
+        lambda parameter, batch: -0.5 * jnp.square(batch.data - parameter),
+        num_factors=source.num_factors,
+    )
+    settings = dict(
+        key=jax.random.key(2),
+        step_size=1e-4,
+        num_chains=2,
+        num_burnin=2,
+        num_samples=4,
+    )
+    default = phx.uq.sample_sgld(problem, source, **settings)
+    explicit = phx.uq.sample_sgld(
+        problem,
+        source,
+        **settings,
+        gradient_estimator=phx.uq.AutodiffStochasticGradientEstimator(),
+    )
+
+    assert jnp.array_equal(default.unconstrained_samples, explicit.unconstrained_samples)
+    assert jnp.array_equal(default.gradient_norm, explicit.gradient_norm)
+
+
+def test_particle_gradient_estimator_rejects_existing_control_variate():
+    problem, source, parameterized = _parameterized_problem()
+    control = phx.uq.build_sgmcmc_control_variate(
+        problem,
+        source,
+        problem.initial_position,
+    )
+    estimator = phx.uq.ParticleGenealogicalGradientEstimator(
+        parameterized,
+        num_particles=4,
+    )
+
+    with pytest.raises(ValueError, match="does not support"):
+        phx.uq.sample_sgld(
+            problem,
+            source,
+            key=jax.random.key(3),
+            step_size=1e-4,
+            num_chains=2,
+            num_burnin=1,
+            num_samples=4,
+            control_variate=control,
+            gradient_estimator=estimator,
+        )

--- a/tests/unit/nn/test_causal_recurrent.py
+++ b/tests/unit/nn/test_causal_recurrent.py
@@ -1,0 +1,158 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+import phydrax as phx
+
+
+layers = phx.nn.layers
+nl = phx.nonlinear
+
+
+def _config(*, steps=24, failure_policy="raise"):
+    return layers.CausalRecurrentConfig(
+        method=nl.CausalNewton(),
+        termination=nl.NonlinearTermination(
+            absolute_residual=1e-10,
+            relative_residual=1e-10,
+            maximum_steps=steps,
+        ),
+        failure_policy=failure_policy,
+    )
+
+
+@pytest.mark.parametrize(
+    "cell",
+    (
+        layers.RNNCell(3, 4, dtype=jnp.float64, key=jax.random.key(1)),
+        layers.GRUCell(3, 4, dtype=jnp.float64, key=jax.random.key(2)),
+        layers.LSTMCell(3, 4, dtype=jnp.float64, key=jax.random.key(3)),
+    ),
+)
+def test_causal_recurrent_matches_serial_masks_resets_and_gradients(cell):
+    inputs = jax.random.normal(jax.random.key(4), (2, 10, 3), dtype=jnp.float64)
+    valid = jnp.asarray([[True] * 8 + [False] * 2, [True] * 10])
+    reset = jnp.zeros_like(valid).at[0, 4].set(True).at[1, 6].set(True)
+    batch = layers.RecurrentBatch(inputs, valid, reset=reset)
+
+    serial = layers.run_recurrent(cell, batch)
+    causal = jax.jit(
+        lambda current: layers.run_causal_recurrent(
+            current,
+            batch,
+            config=_config(),
+        )
+    )(cell)
+
+    assert jnp.all(causal.successful)
+    assert jax.tree.all(
+        jax.tree.map(
+            lambda left, right: jnp.allclose(left, right, atol=1e-9, rtol=1e-9),
+            causal.states,
+            serial.states,
+        )
+    )
+    assert jax.tree.all(
+        jax.tree.map(
+            lambda left, right: jnp.allclose(left, right, atol=1e-9, rtol=1e-9),
+            causal.outputs,
+            serial.outputs,
+        )
+    )
+    assert jax.tree.all(
+        jax.tree.map(
+            lambda left, right: jnp.allclose(left, right, atol=1e-9, rtol=1e-9),
+            causal.final_state,
+            serial.final_state,
+        )
+    )
+
+    serial_gradient = jax.grad(
+        lambda current: sum(
+            jnp.sum(leaf)
+            for leaf in jax.tree.leaves(layers.run_recurrent(current, batch).outputs)
+        )
+    )(cell)
+    causal_gradient = jax.grad(
+        lambda current: sum(
+            jnp.sum(leaf)
+            for leaf in jax.tree.leaves(
+                layers.run_causal_recurrent(current, batch, config=_config()).outputs
+            )
+        )
+    )(cell)
+    assert jax.tree.all(
+        jax.tree.map(
+            lambda left, right: jnp.allclose(left, right, atol=2e-8, rtol=2e-8),
+            causal_gradient,
+            serial_gradient,
+        )
+    )
+
+
+def test_causal_recurrent_supports_multidimensional_cases_and_explicit_states():
+    cell = layers.RNNCell(2, 3, dtype=jnp.float64, key=jax.random.key(5))
+    inputs = jax.random.normal(jax.random.key(6), (2, 3, 7, 2), dtype=jnp.float64)
+    valid = jnp.ones((2, 3, 7), dtype=bool)
+    reset = jnp.zeros_like(valid).at[:, :, 4].set(True)
+    batch = layers.RecurrentBatch(inputs, valid, reset=reset)
+    initial = jnp.full((2, 3, 3), 0.1)
+    restart = jnp.full((2, 3, 3), -0.2)
+
+    serial = layers.run_recurrent(
+        cell,
+        batch,
+        initial_state=initial,
+        reset_state=restart,
+    )
+    causal = layers.run_causal_recurrent(
+        cell,
+        batch,
+        initial_state=initial,
+        reset_state=restart,
+        config=_config(),
+    )
+
+    assert causal.states.shape == (2, 3, 7, 3)
+    assert jnp.allclose(causal.states, serial.states, atol=1e-9)
+    assert jnp.allclose(causal.final_output, serial.final_output, atol=1e-9)
+
+
+def test_causal_recurrent_explicit_serial_fallback_is_recorded():
+    cell = layers.RNNCell(1, 1, key=jax.random.key(7))
+    batch = layers.RecurrentBatch(jnp.ones((6, 1)), jnp.ones((6,), dtype=bool))
+    serial = layers.run_recurrent(cell, batch)
+    causal = layers.run_causal_recurrent(
+        cell,
+        batch,
+        config=layers.CausalRecurrentConfig(
+            method=nl.CausalNewton(),
+            termination=nl.NonlinearTermination(
+                absolute_residual=0.0,
+                relative_residual=0.0,
+                maximum_steps=1,
+            ),
+            failure_policy="serial",
+        ),
+    )
+
+    assert bool(causal.diagnostics.fallback_used)
+    assert jnp.array_equal(causal.states, serial.states)
+    assert jnp.array_equal(causal.outputs, serial.outputs)
+
+
+def test_hutchinson_recurrent_requires_explicit_probe_key():
+    cell = layers.RNNCell(1, 1, key=jax.random.key(8))
+    batch = layers.RecurrentBatch(jnp.ones((4, 1)), jnp.ones((4,), dtype=bool))
+    config = layers.CausalRecurrentConfig(
+        method=nl.CausalNewton(
+            linearization=nl.CausalLinearizationPolicy("diagonal-hutchinson")
+        )
+    )
+
+    with pytest.raises(ValueError, match="probe_key"):
+        layers.run_causal_recurrent(cell, batch, config=config)

--- a/tests/unit/nonlinear/test_causal.py
+++ b/tests/unit/nonlinear/test_causal.py
@@ -1,0 +1,233 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+import phydrax as phx
+
+
+nl = phx.nonlinear
+
+
+def _transition(parameter, previous, driver):
+    return jnp.tanh(parameter * previous + driver)
+
+
+def _serial(parameter, initial, drivers):
+    def step(state, driver):
+        next_state = _transition(parameter, state, driver)
+        return next_state, next_state
+
+    return jax.lax.scan(step, initial, drivers)[1]
+
+
+def _termination(steps=24):
+    return nl.NonlinearTermination(
+        absolute_residual=1e-11,
+        relative_residual=1e-11,
+        maximum_steps=steps,
+    )
+
+
+@pytest.mark.parametrize(
+    "method",
+    (
+        nl.CausalNewton(),
+        nl.CausalNewton(linearization=nl.CausalLinearizationPolicy("diagonal-exact")),
+        nl.CausalLevenbergMarquardt(),
+    ),
+)
+def test_causal_solver_matches_serial_recurrence_and_jit(method):
+    drivers = jnp.linspace(-0.2, 0.3, 16, dtype=jnp.float64)
+    parameter = jnp.asarray(0.7, dtype=jnp.float64)
+    initial = jnp.asarray(0.1, dtype=jnp.float64)
+    problem = nl.CausalRecurrenceProblem(
+        _transition,
+        initial,
+        drivers,
+        parameters=parameter,
+        problem_id="tanh-recurrence",
+    )
+
+    result = jax.jit(
+        lambda current: nl.solve_causal_recurrence(
+            current,
+            method=method,
+            termination=_termination(),
+        )
+    )(problem)
+
+    assert bool(result.successful)
+    assert jnp.allclose(result.states, _serial(parameter, initial, drivers), atol=1e-10)
+    assert float(jnp.max(jnp.abs(result.flat_residuals))) < 1e-10
+    assert int(result.diagnostics.iteration_count) <= problem.num_steps
+
+
+def test_hutchinson_quasi_solver_replays_fixed_probes():
+    drivers = jnp.stack(
+        (
+            jnp.linspace(-0.1, 0.2, 12),
+            jnp.linspace(0.2, -0.1, 12),
+        ),
+        axis=-1,
+    )
+
+    def transition(matrix, previous, driver):
+        return jnp.tanh(matrix @ previous + driver)
+
+    problem = nl.CausalRecurrenceProblem(
+        transition,
+        jnp.zeros((2,)),
+        drivers,
+        parameters=jnp.asarray([[0.4, 0.1], [-0.15, 0.3]]),
+    )
+    method = nl.CausalLevenbergMarquardt(
+        linearization=nl.CausalLinearizationPolicy(
+            "diagonal-hutchinson",
+            probe_count=4,
+        )
+    )
+
+    first = nl.solve_causal_recurrence(
+        problem,
+        method=method,
+        termination=_termination(steps=30),
+        probe_key=jax.random.key(7),
+    )
+    second = nl.solve_causal_recurrence(
+        problem,
+        method=method,
+        termination=_termination(steps=30),
+        probe_key=jax.random.key(7),
+    )
+
+    assert bool(first.successful)
+    assert jnp.array_equal(first.flat_states, second.flat_states)
+    assert jnp.array_equal(
+        first.diagnostics.residual_norm,
+        second.diagnostics.residual_norm,
+        equal_nan=True,
+    )
+
+
+def test_causal_implicit_derivative_matches_serial_reverse_mode():
+    drivers = jnp.linspace(-0.2, 0.3, 16, dtype=jnp.float64)
+
+    def causal_objective(parameter, initial, forcing):
+        problem = nl.CausalRecurrenceProblem(
+            _transition,
+            initial,
+            forcing,
+            parameters=parameter,
+        )
+        result = nl.solve_causal_recurrence(
+            problem,
+            method=nl.CausalNewton(
+                linearization=nl.CausalLinearizationPolicy("diagonal-exact")
+            ),
+            termination=_termination(),
+        )
+        return jnp.sum(jnp.square(result.states))
+
+    def serial_objective(parameter, initial, forcing):
+        return jnp.sum(jnp.square(_serial(parameter, initial, forcing)))
+
+    arguments = (
+        jnp.asarray(0.7, dtype=jnp.float64),
+        jnp.asarray(0.1, dtype=jnp.float64),
+        drivers,
+    )
+    causal_gradient = jax.jit(jax.grad(causal_objective, argnums=(0, 1, 2)))(*arguments)
+    serial_gradient = jax.grad(serial_objective, argnums=(0, 1, 2))(*arguments)
+
+    assert jnp.allclose(causal_gradient[0], serial_gradient[0], atol=1e-10)
+    assert jnp.allclose(causal_gradient[1], serial_gradient[1], atol=1e-10)
+    assert jnp.allclose(causal_gradient[2], serial_gradient[2], atol=1e-10)
+
+
+def test_causal_solver_supports_pytree_states_and_fixed_block_linearization():
+    initial = {
+        "position": jnp.asarray([0.0, 0.1]),
+        "memory": jnp.asarray(0.2),
+    }
+    drivers = {
+        "forcing": jnp.linspace(-0.1, 0.2, 9),
+    }
+
+    def transition(parameters, previous, driver):
+        forcing = driver["forcing"]
+        position = jnp.tanh(
+            parameters["matrix"] @ previous["position"] + forcing + previous["memory"]
+        )
+        memory = 0.25 * previous["memory"] + 0.1 * jnp.sum(position)
+        return {"position": position, "memory": memory}
+
+    problem = nl.CausalRecurrenceProblem(
+        transition,
+        initial,
+        drivers,
+        parameters={"matrix": jnp.asarray([[0.3, 0.1], [-0.1, 0.25]])},
+    )
+
+    def block_builder(parameters, previous, driver):
+        del parameters, previous, driver
+        return jnp.zeros((3, 3))
+
+    result = nl.solve_causal_recurrence(
+        problem,
+        method=nl.CausalNewton(
+            linearization=nl.CausalLinearizationPolicy(
+                "fixed-block",
+                block_builder=block_builder,
+                linearization_id="zero-block",
+            )
+        ),
+        termination=_termination(steps=problem.num_steps + 2),
+    )
+
+    assert bool(result.successful)
+    assert result.states["position"].shape == (problem.num_steps, 2)
+    assert result.states["memory"].shape == (problem.num_steps,)
+
+
+def test_nonconverged_causal_result_is_observable_and_not_differentiable():
+    drivers = jnp.linspace(-0.2, 0.3, 8)
+
+    def objective(parameter):
+        result = nl.solve_causal_recurrence(
+            nl.CausalRecurrenceProblem(
+                _transition,
+                jnp.asarray(0.1),
+                drivers,
+                parameters=parameter,
+            ),
+            method=nl.CausalNewton(),
+            termination=nl.NonlinearTermination(
+                absolute_residual=0.0,
+                relative_residual=0.0,
+                maximum_steps=1,
+            ),
+        )
+        return jnp.sum(result.states)
+
+    result = nl.solve_causal_recurrence(
+        nl.CausalRecurrenceProblem(
+            _transition,
+            jnp.asarray(0.1),
+            drivers,
+            parameters=jnp.asarray(0.7),
+        ),
+        method=nl.CausalNewton(),
+        termination=nl.NonlinearTermination(
+            absolute_residual=0.0,
+            relative_residual=0.0,
+            maximum_steps=1,
+        ),
+    )
+    assert not bool(result.successful)
+    assert int(result.status) == int(nl.NonlinearStatus.MAXIMUM_STEPS_REACHED)
+    with pytest.raises(Exception, match="successfully converged"):
+        jax.grad(objective)(jnp.asarray(0.7))

--- a/tests/unit/test_linalg_causal_linear.py
+++ b/tests/unit/test_linalg_causal_linear.py
@@ -1,0 +1,107 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+from phydrax.linalg._causal_linear import (
+    associative_affine_solve,
+    associative_transpose_solve,
+    causal_linearized_residual,
+    solve_causal_least_squares,
+)
+
+
+def _dense_operator(transitions):
+    num_steps, state_size, _ = transitions.shape
+    rows = []
+    for time in range(num_steps):
+        blocks = []
+        for source in range(num_steps):
+            if source == time:
+                block = jnp.eye(state_size, dtype=transitions.dtype)
+            elif source == time - 1:
+                block = -transitions[time]
+            else:
+                block = jnp.zeros((state_size, state_size), dtype=transitions.dtype)
+            blocks.append(block)
+        rows.append(jnp.concatenate(blocks, axis=1))
+    return jnp.concatenate(rows, axis=0)
+
+
+def _problem(dtype=jnp.float64):
+    transitions = jnp.asarray(
+        [
+            [[0.0, 0.0], [0.0, 0.0]],
+            [[0.2, -0.1], [0.05, 0.3]],
+            [[-0.15, 0.08], [0.1, 0.25]],
+            [[0.12, 0.03], [-0.05, 0.18]],
+        ],
+        dtype=dtype,
+    )
+    residuals = jnp.linspace(-0.4, 0.5, 8, dtype=dtype).reshape((4, 2))
+    return transitions, residuals
+
+
+@pytest.mark.parametrize("damping", (0.0, 0.3))
+def test_causal_least_squares_matches_dense_normal_equations(damping):
+    transitions, residuals = _problem()
+    operator = _dense_operator(transitions)
+    expected = jnp.linalg.solve(
+        operator.T @ operator + damping * jnp.eye(operator.shape[1]),
+        -operator.T @ residuals.reshape((-1,)),
+    ).reshape(residuals.shape)
+
+    actual = jax.jit(solve_causal_least_squares)(
+        transitions,
+        residuals,
+        jnp.asarray(damping),
+    )
+
+    assert jnp.allclose(actual, expected, atol=1e-11, rtol=1e-11)
+    assert jnp.allclose(
+        causal_linearized_residual(transitions, residuals, actual).reshape((-1,)),
+        residuals.reshape((-1,)) + operator @ actual.reshape((-1,)),
+    )
+
+
+def test_affine_and_transpose_scans_match_dense_triangular_solves():
+    transitions, right = _problem()
+    operator = _dense_operator(transitions)
+
+    forward = associative_affine_solve(transitions, right)
+    transpose = associative_transpose_solve(transitions, right)
+
+    assert jnp.allclose(
+        forward.reshape((-1,)),
+        jnp.linalg.solve(operator, right.reshape((-1,))),
+    )
+    assert jnp.allclose(
+        transpose.reshape((-1,)),
+        jnp.linalg.solve(operator.T, right.reshape((-1,))),
+    )
+
+
+def test_causal_linear_solves_have_correct_reverse_derivatives():
+    transitions, right = _problem()
+    operator = _dense_operator(transitions)
+    weights = jnp.arange(right.size, dtype=right.dtype).reshape(right.shape)
+
+    gradient = jax.grad(
+        lambda rhs: jnp.sum(associative_affine_solve(transitions, rhs) * weights)
+    )(right)
+    expected = jnp.linalg.solve(operator.T, weights.reshape((-1,))).reshape(right.shape)
+
+    assert jnp.allclose(gradient, expected)
+
+
+def test_causal_linear_contract_rejects_invalid_shapes_and_damping():
+    transitions, residuals = _problem()
+    with pytest.raises(ValueError, match="transitions"):
+        associative_affine_solve(transitions[:, 0], residuals)
+    with pytest.raises(ValueError, match="offsets"):
+        associative_affine_solve(transitions, residuals[:, :1])
+    with pytest.raises(Exception, match="nonnegative"):
+        solve_causal_least_squares(transitions, residuals, jnp.asarray(-1.0))

--- a/tests/unit/uq/test_causal_hmc.py
+++ b/tests/unit/uq/test_causal_hmc.py
@@ -1,0 +1,185 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import blackjax
+import jax
+import jax.numpy as jnp
+import pytest
+
+import phydrax as phx
+from phydrax.uq._causal_hmc import build_causal_hmc_kernel
+
+
+def _logdensity(position):
+    precision = jnp.asarray([[4.0, 1.2], [1.2, 2.5]], dtype=position.dtype)
+    center = jnp.asarray([0.4, -0.7], dtype=position.dtype)
+    residual = position - center
+    return -0.5 * residual @ precision @ residual
+
+
+def _posterior_problem():
+    return phx.uq.PosteriorProblem(
+        phx.uq.ParameterSpace(
+            jnp.zeros((2,)),
+            priors=phx.uq.Normal(0.0, 3.0),
+        ),
+        _logdensity,
+    )
+
+
+@pytest.mark.parametrize("block_size", (3, 8))
+def test_dense_causal_hmc_matches_blackjax_endpoint_energy_and_decision(block_size):
+    state = blackjax.hmc.init(jnp.asarray([0.3, -0.2]), _logdensity)
+    key = jax.random.key(11)
+    step_size = jnp.asarray(0.1)
+    inverse_mass = jnp.asarray([1.0, 0.8])
+    steps = 8
+    sequential_state, sequential_info = blackjax.hmc.build_kernel()(
+        key,
+        state,
+        _logdensity,
+        step_size,
+        inverse_mass,
+        steps,
+    )
+    config = phx.uq.CausalHMCConfig(
+        linearization="dense-exact",
+        trajectory_block_size=block_size,
+        absolute_residual=1e-11,
+        relative_residual=1e-11,
+        maximum_outer_iterations=12,
+    )
+    kernel = build_causal_hmc_kernel(config)
+    causal_state, causal_info = jax.jit(
+        lambda current_key, current_state: kernel(
+            current_key,
+            current_state,
+            _logdensity,
+            step_size,
+            inverse_mass,
+            steps,
+        )
+    )(key, state)
+
+    assert bool(causal_info.causal_converged)
+    assert not bool(causal_info.causal_fallback_used)
+    assert jnp.allclose(
+        causal_info.proposal.position,
+        sequential_info.proposal.position,
+        atol=2e-11,
+        rtol=2e-11,
+    )
+    assert jnp.allclose(
+        causal_info.proposal.momentum,
+        sequential_info.proposal.momentum,
+        atol=2e-11,
+        rtol=2e-11,
+    )
+    assert jnp.allclose(causal_info.energy, sequential_info.energy, atol=2e-11)
+    assert jnp.allclose(
+        causal_info.acceptance_rate,
+        sequential_info.acceptance_rate,
+        atol=2e-11,
+    )
+    assert bool(causal_info.is_accepted) == bool(sequential_info.is_accepted)
+    assert jnp.allclose(causal_state.position, sequential_state.position, atol=2e-11)
+
+
+def test_pair_hutchinson_causal_hmc_converges_to_sequential_trace():
+    state = blackjax.hmc.init(jnp.asarray([0.3, -0.2]), _logdensity)
+    key = jax.random.key(12)
+    step_size = jnp.asarray(0.08)
+    inverse_mass = jnp.asarray([1.0, 0.8])
+    steps = 10
+    _, sequential_info = blackjax.hmc.build_kernel()(
+        key,
+        state,
+        _logdensity,
+        step_size,
+        inverse_mass,
+        steps,
+    )
+    config = phx.uq.CausalHMCConfig(
+        linearization="pair-hutchinson",
+        probe_count=4,
+        trajectory_block_size=6,
+        absolute_residual=1e-9,
+        relative_residual=1e-9,
+        maximum_outer_iterations=20,
+    )
+    _, causal_info = build_causal_hmc_kernel(config)(
+        key,
+        state,
+        _logdensity,
+        step_size,
+        inverse_mass,
+        steps,
+    )
+
+    assert bool(causal_info.causal_converged)
+    assert float(causal_info.causal_maximum_residual) < 1e-8
+    assert jnp.allclose(
+        causal_info.proposal.position,
+        sequential_info.proposal.position,
+        atol=2e-8,
+        rtol=2e-8,
+    )
+    assert bool(causal_info.is_accepted) == bool(sequential_info.is_accepted)
+
+
+def test_sample_hmc_causal_result_preserves_standard_contract():
+    problem = _posterior_problem()
+    settings = dict(
+        key=jax.random.key(13),
+        num_integration_steps=4,
+        num_chains=2,
+        num_warmup=8,
+        num_samples=4,
+        initial_step_size=0.1,
+        chain_method="vectorized",
+    )
+    sequential = phx.uq.sample_hmc(problem, **settings)
+    causal = phx.uq.sample_hmc(
+        problem,
+        **settings,
+        trajectory_method="causal",
+        causal_config=phx.uq.CausalHMCConfig(
+            linearization="dense-exact",
+            trajectory_block_size=4,
+            absolute_residual=1e-9,
+            relative_residual=1e-9,
+            maximum_outer_iterations=8,
+        ),
+    )
+
+    assert causal.trajectory_method == "causal"
+    assert causal.causal_config is not None
+    assert causal.causal_diagnostics is not None
+    assert jnp.all(causal.causal_diagnostics.converged)
+    assert jnp.allclose(causal.samples, sequential.samples, atol=2e-8, rtol=2e-8)
+    assert jnp.array_equal(causal.divergent, sequential.divergent)
+
+
+def test_causal_hmc_configuration_rejects_unsupported_combinations():
+    problem = _posterior_problem()
+    settings = dict(
+        key=jax.random.key(14),
+        num_integration_steps=3,
+        num_chains=2,
+        num_warmup=4,
+        num_samples=4,
+    )
+    with pytest.raises(ValueError, match="diagonal"):
+        phx.uq.sample_hmc(
+            problem,
+            **settings,
+            is_mass_matrix_diagonal=False,
+            trajectory_method="causal",
+        )
+    with pytest.raises(ValueError, match="requires trajectory_method"):
+        phx.uq.sample_hmc(
+            problem,
+            **settings,
+            causal_config=phx.uq.CausalHMCConfig(),
+        )

--- a/tests/unit/uq/test_flow_proposal.py
+++ b/tests/unit/uq/test_flow_proposal.py
@@ -6,8 +6,8 @@ import jax
 import jax.numpy as jnp
 import jax.random as jr
 
+from phydrax.uq._flow_family import build_default_flow as _build_default_flow
 from phydrax.uq._flow_proposal import (
-    _build_default_flow,
     _fit_flow,
     _FlowProposalState,
     _independence_mh_scan,

--- a/tests/unit/uq/test_flow_variational.py
+++ b/tests/unit/uq/test_flow_variational.py
@@ -1,0 +1,83 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax
+import jax.numpy as jnp
+
+import phydrax as phx
+
+
+def _problem():
+    prior = phx.uq.Normal(0.0, 1.0)
+    likelihood = phx.uq.Normal(1.5, 0.5)
+    return phx.uq.PosteriorProblem(
+        phx.uq.ParameterSpace(jnp.asarray(0.0), priors=prior),
+        lambda value: likelihood.log_prob(value),
+    )
+
+
+def _config():
+    return phx.uq.FlowVariationalConfig(
+        initialization=phx.uq.VariationalConfig(
+            num_steps=30,
+            samples_per_step=8,
+            learning_rate=0.03,
+            record_every=5,
+        ),
+        optimization=phx.uq.VariationalConfig(
+            num_steps=30,
+            samples_per_step=8,
+            learning_rate=0.005,
+            record_every=5,
+        ),
+        initialization_samples=64,
+        flow_layers=2,
+        num_knots=4,
+        nn_width=8,
+        nn_depth=1,
+    )
+
+
+def test_flow_variational_family_preserves_pytree_sample_density_contract():
+    problem = _problem()
+    result = phx.uq.fit_flow_variational(
+        problem,
+        key=jax.random.key(1),
+        config=_config(),
+        num_samples=32,
+    )
+    samples, sampled_log_prob = result.family.sample_and_log_prob(
+        jax.random.key(2),
+        sample_shape=(16,),
+    )
+
+    assert result.family.family_id == "flowjax-spline"
+    assert samples.shape == (16,)
+    assert sampled_log_prob.shape == (16,)
+    assert jnp.allclose(sampled_log_prob, result.family.log_prob(samples))
+    assert result.samples.shape == (32,)
+    assert jnp.all(jnp.isfinite(result.log_target))
+    assert jnp.all(jnp.isfinite(result.log_variational))
+
+
+def test_flow_variational_reuses_explicit_mean_field_initialization():
+    problem = _problem()
+    config = _config()
+    initialization = phx.uq.fit_variational(
+        problem,
+        key=jax.random.key(3),
+        config=config.initialization,
+        num_samples=config.initialization_samples,
+    )
+    result = phx.uq.fit_flow_variational(
+        problem,
+        key=jax.random.key(4),
+        config=config,
+        num_samples=16,
+        initialization=initialization,
+    )
+
+    assert result.initialization is initialization
+    assert result.approximation_id == "reverse-kl/flowjax-spline"
+    assert jnp.all(result.diagnostics.finite)

--- a/tests/unit/uq/test_parameterized_state_space.py
+++ b/tests/unit/uq/test_parameterized_state_space.py
@@ -1,0 +1,107 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax
+import jax.numpy as jnp
+
+import phydrax as phx
+
+
+def _problem():
+    observations = phx.stochastic.ObservationSequence(
+        jnp.asarray([0.5, 1.0]),
+        jnp.asarray([[0.4], [0.8]]),
+        case_ids=("only",),
+        sequence_id="parameterized",
+    )
+    prior = phx.stochastic.GaussianStatePrior(
+        jnp.asarray([0.0]),
+        jnp.asarray([[1.0]]),
+        state_shape=(1,),
+        prior_id="prior",
+    )
+
+    def offset(t0, t1, context):
+        del t0, t1
+        return jnp.asarray([context.args["drift"]])
+
+    transition = phx.stochastic.LinearGaussianTransitionKernel(
+        jnp.asarray([[1.0]]),
+        jnp.asarray([[0.1]]),
+        state_shape=(1,),
+        offset=offset,
+        process_id="drifting",
+    )
+    observation = phx.stochastic.LinearGaussianObservationModel(
+        jnp.asarray([[1.0]]),
+        jnp.asarray([[0.2]]),
+        state_shape=(1,),
+        observation_shape=(1,),
+    )
+    return phx.stochastic.StateSpaceProblem(
+        phx.stochastic.StateSpaceModel(
+            prior,
+            transition,
+            observation,
+            model_id="parameterized-model",
+        ),
+        observations,
+        initial_time=0.0,
+        problem_id="parameterized-problem",
+        args={"fixed": jnp.asarray(2.0)},
+    )
+
+
+def test_parameterized_state_space_binds_physical_parameters_into_context():
+    problem = _problem()
+    parameterized = phx.uq.ParameterizedStateSpaceProblem(
+        problem,
+        phx.uq.ParameterSpace(
+            {"drift": jnp.asarray(0.0)},
+            priors={"drift": phx.uq.Normal(0.0, 1.0)},
+        ),
+        lambda physical, fixed: {
+            "drift": physical["drift"],
+            "fixed": fixed["fixed"],
+        },
+        parameterization_id="drift-parameterization",
+    )
+    bound = parameterized.bind({"drift": jnp.asarray(0.3)})
+
+    assert jnp.allclose(bound.args["drift"], 0.3)
+    assert jnp.allclose(bound.args["fixed"], 2.0)
+    context = bound.step_context(0, 0)
+    assert jnp.allclose(
+        bound.model.transition.parameters(0.0, 0.5, context).offset,
+        jnp.asarray([0.3]),
+    )
+
+
+def test_parameterized_path_density_has_finite_parameter_gradient():
+    parameterized = phx.uq.ParameterizedStateSpaceProblem(
+        _problem(),
+        phx.uq.ParameterSpace(
+            {"drift": jnp.asarray(0.0)},
+            priors={"drift": phx.uq.Normal(0.0, 1.0)},
+        ),
+        lambda physical, _: {"drift": physical["drift"]},
+    )
+    states = jnp.asarray([[0.0], [0.3], [0.7]])
+
+    def log_density(drift):
+        return parameterized.path_log_density(
+            {"drift": drift},
+            states,
+        ).log_density
+
+    result = parameterized.path_log_density(
+        {"drift": jnp.asarray(0.2)},
+        states,
+    )
+    gradient = jax.jit(jax.grad(log_density))(jnp.asarray(0.2))
+
+    assert bool(result.valid)
+    assert jnp.isfinite(result.log_density)
+    assert jnp.isfinite(gradient)
+    assert result.approximation_id == "parameterized-state-space"

--- a/tests/unit/uq/test_particle_genealogical_score.py
+++ b/tests/unit/uq/test_particle_genealogical_score.py
@@ -1,0 +1,119 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+import phydrax as phx
+
+
+def _problem():
+    observations = phx.stochastic.ObservationSequence(
+        jnp.asarray([0.5, 1.0, 1.5]),
+        jnp.asarray([[1.0], [2.0], [1.5]]),
+        case_ids=("only",),
+        sequence_id="genealogical-score",
+    )
+    prior = phx.stochastic.GaussianStatePrior(
+        jnp.asarray([0.0]),
+        jnp.asarray([[1.0]]),
+        state_shape=(1,),
+        prior_id="prior",
+    )
+    transition = phx.stochastic.LinearGaussianTransitionKernel(
+        jnp.asarray([[0.8]]),
+        jnp.asarray([[0.2]]),
+        state_shape=(1,),
+        offset=jnp.asarray([0.1]),
+        process_id="latent",
+    )
+    observation = phx.stochastic.LinearGaussianObservationModel(
+        jnp.asarray([[1.0]]),
+        jnp.asarray([[0.3]]),
+        state_shape=(1,),
+        observation_shape=(1,),
+    )
+    return phx.stochastic.StateSpaceProblem(
+        phx.stochastic.StateSpaceModel(
+            prior,
+            transition,
+            observation,
+            model_id="linear-score-model",
+        ),
+        observations,
+        initial_time=0.0,
+        problem_id="linear-score-problem",
+    )
+
+
+@pytest.mark.parametrize("resampling_policy", ("never", "always", "ess"))
+def test_genealogical_score_covers_complete_model_and_resampling(resampling_policy):
+    filtered = phx.uq.bootstrap_particle_filter(
+        jax.random.key(1),
+        _problem(),
+        num_particles=32,
+        resampling_policy=resampling_policy,
+        resampling_threshold=0.8,
+    )
+    score = phx.uq.particle_genealogical_score(filtered)
+
+    assert bool(score.valid)
+    assert score.flat_score.shape == (score.parameter_size,)
+    assert score.case_scores.shape == (score.parameter_size,)
+    assert jnp.all(jnp.isfinite(score.flat_score))
+    assert any(path.startswith(".prior") for path in score.parameter_paths)
+    assert any(path.startswith(".transition") for path in score.parameter_paths)
+    assert any(path.startswith(".observation") for path in score.parameter_paths)
+    assert score.method_id == "particle-complete-model-genealogical-score"
+    assert score.ancestry_gradient == "stopped-realized-ancestry"
+
+
+def test_genealogical_score_replays_exactly_with_semantic_particle_keys():
+    problem = _problem()
+    first_filter = phx.uq.bootstrap_particle_filter(
+        jax.random.key(2),
+        problem,
+        num_particles=24,
+        resampling_policy="always",
+    )
+    second_filter = phx.uq.bootstrap_particle_filter(
+        jax.random.key(2),
+        problem,
+        num_particles=24,
+        resampling_policy="always",
+    )
+    first = phx.uq.particle_genealogical_score(first_filter)
+    second = phx.uq.particle_genealogical_score(second_filter)
+
+    assert jnp.array_equal(
+        first_filter.initial_particles, second_filter.initial_particles
+    )
+    assert jnp.array_equal(first_filter.ancestor_indices, second_filter.ancestor_indices)
+    assert jnp.array_equal(first.flat_score, second.flat_score)
+
+
+def test_genealogical_score_cost_state_has_linear_particle_shape():
+    problem = _problem()
+    small = phx.uq.particle_genealogical_score(
+        phx.uq.bootstrap_particle_filter(
+            jax.random.key(3),
+            problem,
+            num_particles=8,
+            resampling_policy="never",
+        )
+    )
+    large = phx.uq.particle_genealogical_score(
+        phx.uq.bootstrap_particle_filter(
+            jax.random.key(3),
+            problem,
+            num_particles=16,
+            resampling_policy="never",
+        )
+    )
+
+    assert small.case_scores.shape == large.case_scores.shape
+    assert small.parameter_size == large.parameter_size
+    assert small.filter_result.initial_particles.shape[-2] == 8
+    assert large.filter_result.initial_particles.shape[-2] == 16

--- a/tests/unit/uq/test_particle_jit.py
+++ b/tests/unit/uq/test_particle_jit.py
@@ -1,0 +1,102 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax
+import jax.numpy as jnp
+
+import phydrax as phx
+
+
+def _problem():
+    observations = phx.stochastic.ObservationSequence(
+        jnp.asarray([[0.5, 1.0], [0.5, 1.0]]),
+        jnp.asarray([[[1.0], [2.0]], [[-1.0], [-2.0]]]),
+        case_axes=("case",),
+        case_shape=(2,),
+        case_ids=("positive", "negative"),
+        sequence_id="particle-jit",
+    )
+    prior = phx.stochastic.GaussianStatePrior(
+        jnp.zeros((2, 1)),
+        jnp.asarray([[1.0]]),
+        state_shape=(1,),
+        prior_id="prior",
+    )
+    transition = phx.stochastic.LinearGaussianTransitionKernel(
+        jnp.asarray([[0.9]]),
+        jnp.asarray([[0.2]]),
+        state_shape=(1,),
+        process_id="latent",
+    )
+    observation = phx.stochastic.LinearGaussianObservationModel(
+        jnp.asarray([[1.0]]),
+        jnp.asarray([[0.3]]),
+        state_shape=(1,),
+        observation_shape=(1,),
+    )
+    return phx.stochastic.StateSpaceProblem(
+        phx.stochastic.StateSpaceModel(
+            prior,
+            transition,
+            observation,
+            model_id="particle-jit-model",
+        ),
+        observations,
+        initial_time=0.0,
+        problem_id="particle-jit-problem",
+    )
+
+
+def test_bootstrap_particle_filter_runs_as_one_jitted_scan():
+    problem = _problem()
+    compiled = jax.jit(
+        lambda key: phx.uq.bootstrap_particle_filter(
+            key,
+            problem,
+            num_particles=16,
+            resampling_policy="ess",
+            resampling_threshold=0.8,
+        )
+    )
+    result = compiled(jax.random.key(1))
+    replay = compiled(jax.random.key(1))
+
+    assert result.particles.shape == (2, 2, 16, 1)
+    assert int(result.final_state.step_index) == 2
+    assert jnp.array_equal(result.initial_particles, replay.initial_particles)
+    assert jnp.array_equal(result.particles, replay.particles)
+    assert jnp.array_equal(result.ancestor_indices, replay.ancestor_indices)
+    assert jnp.array_equal(result.resampled, replay.resampled)
+
+
+def test_jitted_scan_matches_streaming_particle_steps_exactly():
+    problem = _problem()
+    key = jax.random.key(2)
+    scan = phx.uq.bootstrap_particle_filter(
+        key,
+        problem,
+        num_particles=12,
+        resampling_policy="always",
+    )
+    state = phx.uq.initialize_particle_filter(
+        key,
+        problem,
+        num_particles=12,
+        resampling_policy="always",
+    )
+    records = []
+    for _ in range(problem.observations.num_steps):
+        state, record = jax.jit(phx.uq.particle_filter_step)(problem, state)
+        records.append(record)
+
+    assert jnp.array_equal(scan.final_state.particles, state.particles)
+    assert jnp.array_equal(scan.final_state.log_weights, state.log_weights)
+    assert jnp.array_equal(
+        scan.ancestor_indices,
+        jnp.stack([record.ancestor_indices for record in records], axis=1),
+    )
+    assert jnp.array_equal(
+        scan.cumulative_log_likelihood,
+        jnp.stack([record.cumulative_log_likelihood for record in records], axis=1),
+    )

--- a/tests/unit/uq/test_state_space_amortized.py
+++ b/tests/unit/uq/test_state_space_amortized.py
@@ -1,0 +1,101 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax
+import jax.numpy as jnp
+
+import phydrax as phx
+
+
+def _problem(values, *, problem_id):
+    observations = phx.stochastic.ObservationSequence(
+        jnp.asarray([0.5, 1.0]),
+        jnp.asarray(values).reshape((2, 1)),
+        case_ids=("only",),
+        sequence_id=problem_id,
+    )
+    prior = phx.stochastic.GaussianStatePrior(
+        jnp.asarray([0.0]),
+        jnp.asarray([[1.0]]),
+        state_shape=(1,),
+        prior_id="prior",
+    )
+    transition = phx.stochastic.LinearGaussianTransitionKernel(
+        jnp.asarray([[1.0]]),
+        jnp.asarray([[0.1]]),
+        state_shape=(1,),
+        process_id="latent",
+    )
+    observation = phx.stochastic.LinearGaussianObservationModel(
+        jnp.asarray([[1.0]]),
+        jnp.asarray([[0.2]]),
+        state_shape=(1,),
+        observation_shape=(1,),
+    )
+    return phx.stochastic.StateSpaceProblem(
+        phx.stochastic.StateSpaceModel(
+            prior,
+            transition,
+            observation,
+            model_id="amortized-model",
+        ),
+        observations,
+        initial_time=0.0,
+        problem_id=problem_id,
+    )
+
+
+def test_amortized_family_is_normalized_and_conditions_on_observations():
+    first_problem = _problem([1.0, 2.0], problem_id="first")
+    second_problem = _problem([-1.0, -2.0], problem_id="second")
+    family = phx.uq.AmortizedGaussianMarkovFamily.from_problem(
+        first_problem,
+        hidden_size=8,
+        key=jax.random.key(1),
+    )
+    conditioned = family.condition(second_problem)
+    first_states, first_log_prob = family.sample_and_log_prob(
+        jax.random.key(2), sample_shape=(16,)
+    )
+    second_states, second_log_prob = conditioned.sample_and_log_prob(
+        jax.random.key(2), sample_shape=(16,)
+    )
+
+    assert first_states.shape == second_states.shape == (16, 3, 1)
+    assert jnp.array_equal(first_log_prob, family.log_prob(first_states))
+    assert jnp.array_equal(second_log_prob, conditioned.log_prob(second_states))
+    assert not jnp.array_equal(
+        family.conditional_family.offsets,
+        conditioned.conditional_family.offsets,
+    )
+    assert jax.tree.structure(family.encoder) == jax.tree.structure(conditioned.encoder)
+
+
+def test_amortized_full_path_training_returns_reusable_encoder():
+    problem = _problem([1.0, 2.0], problem_id="training")
+    result = phx.uq.fit_amortized_state_space_variational(
+        problem,
+        key=jax.random.key(3),
+        config=phx.uq.AmortizedStateSpaceVariationalConfig(
+            optimization=phx.uq.VariationalConfig(
+                num_steps=80,
+                samples_per_step=8,
+                learning_rate=0.01,
+                record_every=10,
+            ),
+            hidden_size=8,
+        ),
+        num_samples=32,
+    )
+    new_family = result.family.condition(_problem([0.0, 0.5], problem_id="deployment"))
+    new_states, new_log_prob = new_family.sample_and_log_prob(
+        jax.random.key(4),
+        sample_shape=(8,),
+    )
+
+    assert result.states.shape == (32, 3, 1)
+    assert result.family.family_id == "amortized-gaussian-markov-path"
+    assert jnp.all(result.diagnostics.finite)
+    assert new_states.shape == (8, 3, 1)
+    assert jnp.all(jnp.isfinite(new_log_prob))

--- a/tests/unit/uq/test_state_space_buffered.py
+++ b/tests/unit/uq/test_state_space_buffered.py
@@ -1,0 +1,146 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+
+import phydrax as phx
+
+
+def _problem():
+    observations = phx.stochastic.ObservationSequence(
+        jnp.asarray([0.5, 1.0, 1.5, 2.0]),
+        jnp.asarray([[1.0], [2.0], [1.5], [1.8]]),
+        case_ids=("only",),
+        sequence_id="buffered",
+    )
+    prior = phx.stochastic.GaussianStatePrior(
+        jnp.asarray([0.0]),
+        jnp.asarray([[1.0]]),
+        state_shape=(1,),
+        prior_id="prior",
+    )
+    transition = phx.stochastic.LinearGaussianTransitionKernel(
+        jnp.asarray([[1.0]]),
+        jnp.asarray([[0.1]]),
+        state_shape=(1,),
+        process_id="latent",
+    )
+    observation = phx.stochastic.LinearGaussianObservationModel(
+        jnp.asarray([[1.0]]),
+        jnp.asarray([[0.2]]),
+        state_shape=(1,),
+        observation_shape=(1,),
+    )
+    return phx.stochastic.StateSpaceProblem(
+        phx.stochastic.StateSpaceModel(
+            prior,
+            transition,
+            observation,
+            model_id="buffered-model",
+        ),
+        observations,
+        initial_time=0.0,
+        problem_id="buffered-problem",
+    )
+
+
+def test_window_inclusion_weights_reconstruct_every_full_path_factor():
+    plan = phx.uq.StateSpaceWindowPlan(
+        6,
+        target_length=3,
+        left_buffer=2,
+        right_buffer=1,
+    )
+    masks = []
+    for start in range(plan.num_starts):
+        indices = jnp.arange(plan.num_steps)
+        masks.append((indices >= start) & (indices < start + plan.target_length))
+    target_masks = jnp.stack(masks)
+    weighted_average = jnp.mean(
+        target_masks / plan.inclusion_probability[None, :],
+        axis=0,
+    )
+
+    assert jnp.allclose(weighted_average, jnp.ones((plan.num_steps,)))
+    assert jnp.all(plan.inclusion_probability > 0.0)
+
+
+def test_buffer_context_changes_bidirectional_amortized_conditioning():
+    problem = _problem()
+    family = phx.uq.AmortizedGaussianMarkovFamily.from_problem(
+        problem,
+        hidden_size=8,
+        key=jax.random.key(1),
+    )
+    short_context = jnp.asarray([True, True, False, False])
+    long_context = jnp.asarray([True, True, True, True])
+    short = eqx.tree_at(
+        lambda value: value.context_mask,
+        family,
+        short_context,
+    )
+    long = eqx.tree_at(
+        lambda value: value.context_mask,
+        family,
+        long_context,
+    )
+
+    assert not jnp.array_equal(
+        short.conditional_family.offsets,
+        long.conditional_family.offsets,
+    )
+
+
+def test_buffered_variational_training_replays_and_returns_full_context_family():
+    problem = _problem()
+    config = phx.uq.BufferedStateSpaceVariationalConfig(
+        target_length=2,
+        left_buffer=1,
+        right_buffer=1,
+        hidden_size=8,
+        optimization=phx.uq.VariationalConfig(
+            num_steps=30,
+            samples_per_step=4,
+            learning_rate=0.01,
+            record_every=5,
+        ),
+    )
+    first = phx.uq.fit_buffered_state_space_variational(
+        problem,
+        key=jax.random.key(2),
+        config=config,
+        num_samples=16,
+    )
+    replay = phx.uq.fit_buffered_state_space_variational(
+        problem,
+        key=jax.random.key(2),
+        config=config,
+        num_samples=16,
+    )
+
+    assert jnp.array_equal(first.states, replay.states)
+    assert jnp.array_equal(
+        first.diagnostics.target_start,
+        replay.diagnostics.target_start,
+    )
+    assert jnp.all(first.diagnostics.finite)
+    assert first.approximation_id == "buffered-amortized-gaussian-markov-path"
+    assert jnp.array_equal(first.family.context_mask, problem.observations.step_valid)
+
+
+def test_full_length_target_has_unit_inclusion_and_full_context():
+    plan = phx.uq.StateSpaceWindowPlan(
+        4,
+        target_length=4,
+        left_buffer=0,
+        right_buffer=0,
+    )
+    window = plan.sample(jax.random.key(3))
+
+    assert int(window.target_start) == 0
+    assert jnp.all(window.target_mask)
+    assert jnp.all(window.context_mask)
+    assert jnp.all(plan.inclusion_probability == 1.0)

--- a/tests/unit/uq/test_state_space_variational.py
+++ b/tests/unit/uq/test_state_space_variational.py
@@ -1,0 +1,119 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax
+import jax.numpy as jnp
+
+import phydrax as phx
+
+
+def _problem(*, step_valid=None):
+    observations = phx.stochastic.ObservationSequence(
+        jnp.asarray([0.5, 1.0, 1.5]),
+        jnp.asarray([[1.0], [2.0], [2.0]]),
+        step_valid=step_valid,
+        case_ids=("only",),
+        sequence_id="state-space-vi",
+    )
+    prior = phx.stochastic.GaussianStatePrior(
+        jnp.asarray([0.0]),
+        jnp.asarray([[1.0]]),
+        state_shape=(1,),
+        prior_id="prior",
+    )
+    transition = phx.stochastic.LinearGaussianTransitionKernel(
+        jnp.asarray([[1.0]]),
+        jnp.asarray([[0.1]]),
+        state_shape=(1,),
+        process_id="latent",
+    )
+    observation = phx.stochastic.LinearGaussianObservationModel(
+        jnp.asarray([[1.0]]),
+        jnp.asarray([[0.2]]),
+        state_shape=(1,),
+        observation_shape=(1,),
+    )
+    return phx.stochastic.StateSpaceProblem(
+        phx.stochastic.StateSpaceModel(
+            prior,
+            transition,
+            observation,
+            model_id="linear",
+        ),
+        observations,
+        initial_time=0.0,
+        problem_id="linear-state-space-vi",
+    )
+
+
+def test_state_space_path_density_decomposes_normalized_model_terms():
+    problem = _problem()
+    states = jnp.asarray([[0.0], [0.5], [1.0], [1.5]])
+    result = jax.jit(phx.uq.state_space_path_log_density)(problem, states)
+
+    assert bool(result.valid)
+    assert result.prior.shape == ()
+    assert result.transition.shape == (3,)
+    assert result.observation.shape == (3,)
+    assert jnp.allclose(
+        result.log_density,
+        result.prior + jnp.sum(result.transition) + jnp.sum(result.observation),
+    )
+
+
+def test_state_space_path_density_requires_frozen_padding():
+    problem = _problem(step_valid=jnp.asarray([True, True, False]))
+    frozen = phx.uq.state_space_path_log_density(
+        problem,
+        jnp.asarray([[0.0], [0.5], [1.0], [1.0]]),
+    )
+    changed = phx.uq.state_space_path_log_density(
+        problem,
+        jnp.asarray([[0.0], [0.5], [1.0], [1.2]]),
+    )
+
+    assert bool(frozen.valid)
+    assert not bool(changed.valid)
+    assert jnp.isneginf(changed.log_density)
+    assert frozen.transition[-1] == 0.0
+    assert frozen.observation[-1] == 0.0
+
+
+def test_gaussian_markov_family_sampling_and_density_are_consistent():
+    problem = _problem(step_valid=jnp.asarray([True, True, False]))
+    family = phx.uq.GaussianMarkovVariationalFamily.from_problem(problem)
+    states, sampled_log_prob = family.sample_and_log_prob(
+        jax.random.key(1),
+        sample_shape=(32,),
+    )
+
+    assert states.shape == (32, 4, 1)
+    assert sampled_log_prob.shape == (32,)
+    assert jnp.array_equal(sampled_log_prob, family.log_prob(states))
+    assert jnp.array_equal(states[:, -1], states[:, -2])
+
+
+def test_full_path_variational_matches_linear_gaussian_smoother_means():
+    problem = _problem()
+    exact = phx.uq.rts_smoother(phx.uq.kalman_filter(problem))
+    result = phx.uq.fit_state_space_variational(
+        problem,
+        key=jax.random.key(2),
+        config=phx.uq.StateSpaceVariationalConfig(
+            optimization=phx.uq.VariationalConfig(
+                num_steps=500,
+                samples_per_step=32,
+                learning_rate=0.02,
+                record_every=25,
+            ),
+            initial_scale=0.5,
+        ),
+        num_samples=2000,
+    )
+    variational_means = jnp.mean(result.states[:, 1:], axis=0)
+
+    assert jnp.all(result.diagnostics.finite)
+    assert jnp.allclose(variational_means, exact.means, atol=0.15, rtol=0.1)
+    assert jnp.all(jnp.isfinite(result.log_model))
+    assert jnp.all(jnp.isfinite(result.log_variational))

--- a/tests/unit/uq/test_variational.py
+++ b/tests/unit/uq/test_variational.py
@@ -1,0 +1,137 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax
+import jax.numpy as jnp
+
+import phydrax as phx
+
+
+def _gaussian_problem():
+    prior = phx.uq.Normal(0.0, 1.0)
+    likelihood = phx.uq.Normal(1.5, 0.5)
+    return phx.uq.PosteriorProblem(
+        phx.uq.ParameterSpace(jnp.asarray(0.0), priors=prior),
+        lambda value: likelihood.log_prob(value),
+    )
+
+
+def test_mean_field_samples_and_normalized_log_density_are_consistent():
+    family = phx.uq.MeanFieldGaussianFamily.from_position(
+        {"a": jnp.asarray([0.2, -0.1]), "b": jnp.asarray(0.3)},
+        initial_scale=0.4,
+    )
+    samples, sampled_log_prob = family.sample_and_log_prob(
+        jax.random.key(1),
+        sample_shape=(16,),
+    )
+
+    assert samples["a"].shape == (16, 2)
+    assert samples["b"].shape == (16,)
+    assert sampled_log_prob.shape == (16,)
+    assert jnp.array_equal(sampled_log_prob, family.log_prob(samples))
+    assert all(
+        bool(jnp.all(leaf))
+        for leaf in jax.tree.leaves(jax.tree.map(jnp.isfinite, family.scale))
+    )
+
+
+def test_mean_field_vi_recovers_analytic_gaussian_posterior():
+    problem = _gaussian_problem()
+    result = phx.uq.fit_variational(
+        problem,
+        key=jax.random.key(2),
+        config=phx.uq.VariationalConfig(
+            num_steps=300,
+            samples_per_step=32,
+            learning_rate=0.03,
+            record_every=20,
+        ),
+        num_samples=1000,
+    )
+    expected_mean = 1.2
+    expected_scale = jnp.sqrt(0.2)
+
+    assert abs(float(result.family.location) - expected_mean) < 0.08
+    assert abs(float(result.family.scale) - float(expected_scale)) < 0.08
+    assert abs(float(jnp.mean(result.samples)) - expected_mean) < 0.1
+    assert abs(float(jnp.std(result.samples)) - float(expected_scale)) < 0.1
+    assert jnp.all(result.diagnostics.finite)
+    assert result.num_draws == 1000
+    assert result.approximation_id == "reverse-kl/mean-field-gaussian"
+
+
+def test_variational_checkpoint_resume_matches_uninterrupted_training(tmp_path):
+    problem = _gaussian_problem()
+    root_key = jax.random.key(3)
+    common = dict(
+        samples_per_step=16,
+        learning_rate=0.02,
+        record_every=5,
+    )
+    checkpoint = tmp_path / "variational.npz"
+    phx.uq.fit_variational(
+        problem,
+        key=root_key,
+        config=phx.uq.VariationalConfig(num_steps=20, **common),
+        num_samples=32,
+        checkpoint_path=checkpoint,
+        checkpoint_every=5,
+        checkpoint_id="gaussian-vi",
+    )
+    resumed = phx.uq.fit_variational(
+        problem,
+        key=root_key,
+        config=phx.uq.VariationalConfig(num_steps=40, **common),
+        num_samples=32,
+        resume_from=checkpoint,
+        checkpoint_every=5,
+        checkpoint_id="gaussian-vi",
+    )
+    uninterrupted = phx.uq.fit_variational(
+        problem,
+        key=root_key,
+        config=phx.uq.VariationalConfig(num_steps=40, **common),
+        num_samples=32,
+    )
+
+    assert jax.tree.all(
+        jax.tree.map(
+            jnp.array_equal,
+            resumed.unconstrained_samples,
+            uninterrupted.unconstrained_samples,
+        )
+    )
+    assert jax.tree.all(
+        jax.tree.map(jnp.array_equal, resumed.family, uninterrupted.family)
+    )
+    assert jnp.array_equal(resumed.diagnostics.elbo, uninterrupted.diagnostics.elbo)
+
+
+def test_variational_family_preserves_constrained_parameter_coordinates():
+    likelihood = phx.uq.Normal(2.0, 0.3)
+    space = phx.uq.ParameterSpace(
+        jnp.asarray(0.0),
+        priors=phx.uq.LogNormal(0.0, 0.5),
+        bijectors=phx.uq.ExpBijector(),
+    )
+    problem = phx.uq.PosteriorProblem(
+        space,
+        lambda value: likelihood.log_prob(value),
+    )
+    result = phx.uq.fit_variational(
+        problem,
+        key=jax.random.key(4),
+        config=phx.uq.VariationalConfig(
+            num_steps=150,
+            samples_per_step=16,
+            learning_rate=0.02,
+            record_every=10,
+        ),
+        num_samples=128,
+    )
+
+    assert jnp.all(result.samples > 0.0)
+    assert jnp.all(jnp.isfinite(result.log_target))
+    assert jnp.all(jnp.isfinite(result.log_variational))

--- a/tools/causal_hmc_benchmarks.py
+++ b/tools/causal_hmc_benchmarks.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+"""Deterministic sequential-versus-causal fixed-trajectory HMC benchmarks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import time
+from pathlib import Path
+from typing import Any
+
+import blackjax
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+
+import phydrax as phx
+from phydrax.uq._causal_hmc import build_causal_hmc_kernel
+
+
+def _ready(value: Any) -> Any:
+    return jax.block_until_ready(value)
+
+
+def _timings(function, arguments, *, repetitions: int):
+    compiled = jax.jit(function)
+    started = time.perf_counter()
+    result = compiled(*arguments)
+    _ready(result)
+    cold = time.perf_counter() - started
+    warm = []
+    for _ in range(int(repetitions)):
+        started = time.perf_counter()
+        value = compiled(*arguments)
+        _ready(value)
+        warm.append(time.perf_counter() - started)
+    execution = statistics.median(warm)
+    return result, {
+        "cold_seconds": cold,
+        "compile_seconds": max(0.0, cold - execution),
+        "execute_seconds": execution,
+    }
+
+
+def _target(name: str, dimension: int):
+    scales = jnp.linspace(1.0, 4.0, dimension)
+    if name == "gaussian":
+        return lambda value: -0.5 * jnp.sum(scales * value * value)
+    if name == "curved":
+
+        def logdensity(value):
+            leading = value[:-1]
+            trailing = value[1:]
+            rosenbrock = jnp.sum(
+                100.0 * jnp.square(trailing - jnp.square(leading))
+                + jnp.square(1.0 - leading)
+            )
+            return -0.02 * rosenbrock - 0.01 * jnp.sum(value * value)
+
+        return logdensity
+    raise ValueError(f"Unknown HMC benchmark target {name!r}.")
+
+
+def benchmark_case(
+    *,
+    target_name: str,
+    dimension: int,
+    leapfrog_steps: int,
+    linearization: str,
+    repetitions: int,
+    seed: int,
+) -> dict[str, Any]:
+    logdensity = _target(target_name, dimension)
+    position = jnp.linspace(-0.2, 0.3, dimension)
+    state = blackjax.hmc.init(position, logdensity)
+    key = jr.key(seed)
+    step_size = jnp.asarray(0.02 if target_name == "curved" else 0.08)
+    inverse_mass = jnp.ones((dimension,))
+    sequential_kernel = blackjax.hmc.build_kernel()
+    config = phx.uq.CausalHMCConfig(
+        trajectory_block_size=min(128, leapfrog_steps),
+        linearization=linearization,
+        probe_count=4,
+        absolute_residual=2e-6,
+        relative_residual=2e-6,
+        maximum_outer_iterations=min(160, max(16, leapfrog_steps)),
+    )
+    causal_kernel = build_causal_hmc_kernel(config)
+
+    def sequential(current_key, current_state):
+        return sequential_kernel(
+            current_key,
+            current_state,
+            logdensity,
+            step_size,
+            inverse_mass,
+            leapfrog_steps,
+        )
+
+    def causal(current_key, current_state):
+        return causal_kernel(
+            current_key,
+            current_state,
+            logdensity,
+            step_size,
+            inverse_mass,
+            leapfrog_steps,
+        )
+
+    sequential_result, sequential_timing = _timings(
+        sequential,
+        (key, state),
+        repetitions=repetitions,
+    )
+    causal_result, causal_timing = _timings(
+        causal,
+        (key, state),
+        repetitions=repetitions,
+    )
+    sequential_state, sequential_info = sequential_result
+    causal_state, causal_info = causal_result
+    return {
+        "target": target_name,
+        "dimension": dimension,
+        "leapfrog_steps": leapfrog_steps,
+        "linearization": linearization,
+        "sequential": sequential_timing,
+        "causal": causal_timing,
+        "warm_speedup": (
+            sequential_timing["execute_seconds"] / causal_timing["execute_seconds"]
+        ),
+        "maximum_endpoint_error": float(
+            jnp.max(
+                jnp.abs(sequential_info.proposal.position - causal_info.proposal.position)
+            )
+        ),
+        "energy_error": float(jnp.abs(sequential_info.energy - causal_info.energy)),
+        "acceptance_rate_error": float(
+            jnp.abs(sequential_info.acceptance_rate - causal_info.acceptance_rate)
+        ),
+        "acceptance_decision_matches": bool(
+            sequential_info.is_accepted == causal_info.is_accepted
+        ),
+        "returned_state_error": float(
+            jnp.max(jnp.abs(sequential_state.position - causal_state.position))
+        ),
+        "converged": bool(causal_info.causal_converged),
+        "fallback_used": bool(causal_info.causal_fallback_used),
+        "outer_iterations": int(causal_info.causal_outer_iterations),
+        "maximum_direct_residual": float(causal_info.causal_maximum_residual),
+        "transition_evaluations": int(causal_info.causal_transition_evaluations),
+    }
+
+
+def run_causal_hmc_benchmarks(*, quick: bool = False) -> dict[str, Any]:
+    dimensions = (2,) if quick else (2, 16, 64)
+    steps = (8,) if quick else (8, 32, 128)
+    targets = ("gaussian",) if quick else ("gaussian", "curved")
+    linearizations = (
+        ("dense-exact",)
+        if quick
+        else (
+            "dense-exact",
+            "pair-hutchinson",
+        )
+    )
+    repetitions = 2 if quick else 5
+    cases = []
+    index = 0
+    for target_name in targets:
+        for dimension in dimensions:
+            for leapfrog_steps in steps:
+                for linearization in linearizations:
+                    if linearization == "dense-exact" and dimension > 16:
+                        continue
+                    index += 1
+                    cases.append(
+                        benchmark_case(
+                            target_name=target_name,
+                            dimension=dimension,
+                            leapfrog_steps=leapfrog_steps,
+                            linearization=linearization,
+                            repetitions=repetitions,
+                            seed=20260821 + index,
+                        )
+                    )
+    return {
+        "schema": "phydrax-causal-hmc-benchmark-v1",
+        "backend": jax.default_backend(),
+        "quick": bool(quick),
+        "cases": cases,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--quick", action="store_true")
+    parser.add_argument("--output", type=Path, default=None)
+    arguments = parser.parse_args()
+    report = run_causal_hmc_benchmarks(quick=arguments.quick)
+    payload = json.dumps(report, indent=2, sort_keys=True)
+    if arguments.output is None:
+        print(payload)
+    else:
+        arguments.output.parent.mkdir(parents=True, exist_ok=True)
+        arguments.output.write_text(payload + "\n")
+        print(arguments.output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/recurrent_benchmarks.py
+++ b/tools/recurrent_benchmarks.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+"""Deterministic serial-versus-causal recurrent execution benchmarks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import time
+from pathlib import Path
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+
+import phydrax as phx
+
+
+def _ready(value: Any) -> Any:
+    return jax.block_until_ready(value)
+
+
+def _timings(function, argument, *, repetitions: int):
+    compiled = jax.jit(function)
+    started = time.perf_counter()
+    first = compiled(argument)
+    _ready(first)
+    cold = time.perf_counter() - started
+    warm = []
+    for _ in range(int(repetitions)):
+        started = time.perf_counter()
+        value = compiled(argument)
+        _ready(value)
+        warm.append(time.perf_counter() - started)
+    execution = statistics.median(warm)
+    return first, {
+        "cold_seconds": cold,
+        "compile_seconds": max(0.0, cold - execution),
+        "execute_seconds": execution,
+    }
+
+
+def _cell(kind: str, width: int, key):
+    if kind == "rnn":
+        return phx.nn.layers.RNNCell(width, width, key=key)
+    if kind == "gru":
+        return phx.nn.layers.GRUCell(width, width, key=key)
+    if kind == "lstm":
+        return phx.nn.layers.LSTMCell(width, width, key=key)
+    raise ValueError(f"Unknown recurrent cell kind {kind!r}.")
+
+
+def benchmark_case(
+    *,
+    cell_kind: str,
+    sequence_length: int,
+    hidden_size: int,
+    repetitions: int,
+    seed: int,
+) -> dict[str, Any]:
+    root = jr.key(seed)
+    cell_key, input_key = jr.split(root)
+    cell = _cell(cell_kind, hidden_size, cell_key)
+    inputs = jr.normal(input_key, (sequence_length, hidden_size))
+    batch = phx.nn.layers.RecurrentBatch(
+        inputs,
+        jnp.ones((sequence_length,), dtype=bool),
+    )
+    termination = phx.nonlinear.NonlinearTermination(
+        absolute_residual=2e-6,
+        relative_residual=2e-6,
+        maximum_steps=64,
+    )
+    causal_config = phx.nn.layers.CausalRecurrentConfig(
+        method=phx.nonlinear.CausalLevenbergMarquardt(
+            linearization=phx.nonlinear.CausalLinearizationPolicy("diagonal-exact")
+        ),
+        termination=termination,
+    )
+
+    def serial_function(current):
+        return phx.nn.layers.run_recurrent(current, batch).outputs
+
+    def causal_function(current):
+        return phx.nn.layers.run_causal_recurrent(
+            current,
+            batch,
+            config=causal_config,
+        ).outputs
+
+    serial, serial_timing = _timings(
+        serial_function,
+        cell,
+        repetitions=repetitions,
+    )
+    causal, causal_timing = _timings(
+        causal_function,
+        cell,
+        repetitions=repetitions,
+    )
+    causal_result = phx.nn.layers.run_causal_recurrent(
+        cell,
+        batch,
+        config=causal_config,
+    )
+    serial_gradient = jax.grad(lambda current: jnp.sum(serial_function(current)))(cell)
+    causal_gradient = jax.grad(lambda current: jnp.sum(causal_function(current)))(cell)
+    gradient_error = max(
+        float(jnp.max(jnp.abs(left - right)))
+        for left, right in zip(
+            jax.tree.leaves(serial_gradient),
+            jax.tree.leaves(causal_gradient),
+            strict=True,
+        )
+    )
+    output_error = float(jnp.max(jnp.abs(serial - causal)))
+    speedup = serial_timing["execute_seconds"] / causal_timing["execute_seconds"]
+    outer_iterations = int(causal_result.diagnostics.causal.iteration_count)
+    final_residual = causal_result.diagnostics.causal.residual_norm[
+        max(outer_iterations - 1, 0)
+    ]
+    return {
+        "cell": cell_kind,
+        "sequence_length": sequence_length,
+        "hidden_size": hidden_size,
+        "dtype": str(inputs.dtype),
+        "serial": serial_timing,
+        "causal": causal_timing,
+        "warm_speedup": speedup,
+        "maximum_output_error": output_error,
+        "maximum_gradient_error": gradient_error,
+        "outer_iterations": outer_iterations,
+        "maximum_direct_residual": float(final_residual),
+        "transition_evaluations": int(
+            causal_result.diagnostics.causal.transition_evaluations
+        ),
+        "jvp_evaluations": int(causal_result.diagnostics.causal.jvp_evaluations),
+        "fallback_used": bool(causal_result.diagnostics.fallback_used),
+    }
+
+
+def run_recurrent_benchmarks(*, quick: bool = False) -> dict[str, Any]:
+    lengths = (128,) if quick else (128, 512, 2048, 8192)
+    widths = (16,) if quick else (16, 64, 256)
+    kinds = ("rnn",) if quick else ("rnn", "gru", "lstm")
+    repetitions = 2 if quick else 5
+    cases = []
+    index = 0
+    for kind in kinds:
+        for length in lengths:
+            for width in widths:
+                index += 1
+                cases.append(
+                    benchmark_case(
+                        cell_kind=kind,
+                        sequence_length=length,
+                        hidden_size=width,
+                        repetitions=repetitions,
+                        seed=20260821 + index,
+                    )
+                )
+    return {
+        "schema": "phydrax-recurrent-causal-benchmark-v1",
+        "backend": jax.default_backend(),
+        "quick": bool(quick),
+        "cases": cases,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--quick", action="store_true")
+    parser.add_argument("--output", type=Path, default=None)
+    arguments = parser.parse_args()
+    report = run_recurrent_benchmarks(quick=arguments.quick)
+    payload = json.dumps(report, indent=2, sort_keys=True)
+    if arguments.output is None:
+        print(payload)
+    else:
+        arguments.output.parent.mkdir(parents=True, exist_ok=True)
+        arguments.output.write_text(payload + "\n")
+        print(arguments.output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/sequence_inference_benchmarks.py
+++ b/tools/sequence_inference_benchmarks.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+"""Deterministic variational and particle sequence-inference benchmarks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+
+import phydrax as phx
+
+
+def _state_problem():
+    observations = phx.stochastic.ObservationSequence(
+        jnp.linspace(0.25, 2.0, 8),
+        jnp.sin(jnp.linspace(0.25, 2.0, 8))[:, None],
+        case_ids=("only",),
+        sequence_id="sequence-benchmark",
+    )
+    prior = phx.stochastic.GaussianStatePrior(
+        jnp.asarray([0.0]),
+        jnp.asarray([[1.0]]),
+        state_shape=(1,),
+        prior_id="prior",
+    )
+    transition = phx.stochastic.LinearGaussianTransitionKernel(
+        jnp.asarray([[0.9]]),
+        jnp.asarray([[0.15]]),
+        state_shape=(1,),
+        process_id="latent",
+    )
+    observation = phx.stochastic.LinearGaussianObservationModel(
+        jnp.asarray([[1.0]]),
+        jnp.asarray([[0.2]]),
+        state_shape=(1,),
+        observation_shape=(1,),
+    )
+    return phx.stochastic.StateSpaceProblem(
+        phx.stochastic.StateSpaceModel(
+            prior,
+            transition,
+            observation,
+            model_id="sequence-benchmark-model",
+        ),
+        observations,
+        initial_time=0.0,
+        problem_id="sequence-benchmark-problem",
+    )
+
+
+def _timed(function):
+    started = time.perf_counter()
+    value = function()
+    jax.block_until_ready(value)
+    return value, time.perf_counter() - started
+
+
+def run_sequence_inference_benchmarks(*, quick: bool = False):
+    optimization_steps = 20 if quick else 200
+    posterior = phx.uq.PosteriorProblem(
+        phx.uq.ParameterSpace(
+            jnp.asarray(0.0),
+            priors=phx.uq.Normal(0.0, 1.0),
+        ),
+        lambda value: -0.5 * jnp.square((value - 1.2) / 0.5),
+    )
+    variational, variational_seconds = _timed(
+        lambda: phx.uq.fit_variational(
+            posterior,
+            key=jr.key(1),
+            config=phx.uq.VariationalConfig(
+                num_steps=optimization_steps,
+                samples_per_step=8,
+                learning_rate=0.02,
+                record_every=max(1, optimization_steps // 4),
+            ),
+            num_samples=64,
+        )
+    )
+    problem = _state_problem()
+    state_variational, state_variational_seconds = _timed(
+        lambda: phx.uq.fit_state_space_variational(
+            problem,
+            key=jr.key(2),
+            config=phx.uq.StateSpaceVariationalConfig(
+                optimization=phx.uq.VariationalConfig(
+                    num_steps=optimization_steps,
+                    samples_per_step=8,
+                    learning_rate=0.02,
+                    record_every=max(1, optimization_steps // 4),
+                )
+            ),
+            num_samples=32,
+        )
+    )
+    buffered, buffered_seconds = _timed(
+        lambda: phx.uq.fit_buffered_state_space_variational(
+            problem,
+            key=jr.key(3),
+            config=phx.uq.BufferedStateSpaceVariationalConfig(
+                target_length=4,
+                left_buffer=2,
+                right_buffer=2,
+                hidden_size=8,
+                optimization=phx.uq.VariationalConfig(
+                    num_steps=optimization_steps,
+                    samples_per_step=4,
+                    learning_rate=0.01,
+                    record_every=max(1, optimization_steps // 4),
+                ),
+            ),
+            num_samples=16,
+        )
+    )
+    particle_cases = []
+    for count in (8, 16) if quick else (8, 16, 32, 64):
+        filtered, filter_seconds = _timed(
+            lambda count=count: phx.uq.bootstrap_particle_filter(
+                jr.key(100 + count),
+                problem,
+                num_particles=count,
+                resampling_policy="always",
+            )
+        )
+        score, score_seconds = _timed(
+            lambda filtered=filtered: phx.uq.particle_genealogical_score(filtered)
+        )
+        particle_cases.append(
+            {
+                "num_particles": count,
+                "filter_seconds": filter_seconds,
+                "score_seconds": score_seconds,
+                "parameter_size": score.parameter_size,
+                "score_norm": float(jnp.linalg.norm(score.flat_score)),
+                "valid": bool(score.valid),
+            }
+        )
+    return {
+        "schema": "phydrax-sequence-inference-benchmark-v1",
+        "backend": jax.default_backend(),
+        "quick": bool(quick),
+        "variational": {
+            "seconds": variational_seconds,
+            "final_elbo": float(variational.diagnostics.elbo[-1]),
+            "mean": float(jnp.mean(variational.samples)),
+            "scale": float(jnp.std(variational.samples)),
+        },
+        "state_space_variational": {
+            "seconds": state_variational_seconds,
+            "final_elbo": float(state_variational.diagnostics.elbo[-1]),
+            "finite": bool(jnp.all(jnp.isfinite(state_variational.log_model))),
+        },
+        "buffered_state_space_variational": {
+            "seconds": buffered_seconds,
+            "final_elbo": float(buffered.diagnostics.elbo[-1]),
+            "finite": bool(jnp.all(jnp.isfinite(buffered.log_model))),
+            "inclusion_probability": [
+                float(value) for value in buffered.window_plan.inclusion_probability
+            ],
+        },
+        "particle_genealogical": particle_cases,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--quick", action="store_true")
+    parser.add_argument("--output", type=Path, default=None)
+    arguments = parser.parse_args()
+    report = run_sequence_inference_benchmarks(quick=arguments.quick)
+    payload = json.dumps(report, indent=2, sort_keys=True)
+    if arguments.output is None:
+        print(payload)
+    else:
+        arguments.output.parent.mkdir(parents=True, exist_ok=True)
+        arguments.output.write_text(payload + "\n")
+        print(arguments.output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR adds a Phydrax-native sequence-inference stack spanning structured temporal numerics, nonlinear recurrence, recurrent neural layers, fixed-trajectory HMC, normalized variational inference, latent state-space paths, particle genealogy, and stochastic-gradient MCMC.

The implementation absorbs the useful mathematical ideas from SeqJAX, ELK, and parallel-mcmc without importing their model hierarchies, registries, CLIs, storage layers, or runtime dependencies. Existing Phydrax contracts remain authoritative for state spaces, parameters, masks, physical time, exogenous inputs, checkpoints, predictions, results, and provenance.

## Motivation

Phydrax already supported exact and approximate filtering, smoothing, particle inference, MCMC, SG-MCMC, Laplace, Pathfinder, flow-assisted NUTS, serial nonlinear recurrence, and associative affine recurrence. It did not have one coherent path for:

- accelerator-parallel evaluation of nonlinear causal recurrences;
- fixed-trajectory HMC with temporal leapfrog parallelism;
- standalone normalized reverse-KL posterior inference;
- learned full-path posteriors for nonlinear state-space systems;
- reusable amortized and buffered sequence inference;
- complete-model particle scores with linear particle complexity;
- particle-derived stochastic gradients for SGLD and SGNHT.

This PR fills those gaps while keeping every approximation and failure mode explicit.

## Architecture

### Structured temporal linear algebra

- Relocates the complete covariance- and information-form Gaussian-chain implementation to `phydrax.linalg._gaussian_chain`.
- Preserves the existing `phydrax.uq` public Gaussian-chain names.
- Updates Kalman and SING consumers to use the lower-level implementation.
- Adds associative forward and transpose affine solves plus damped causal least-squares in `phydrax.linalg._causal_linear`.
- Never materializes a global trajectory Jacobian or normal matrix.

### Causal nonlinear recurrence

Adds `phydrax.nonlinear` contracts for first-order recurrences written as direct temporal residuals:

- `CausalRecurrenceProblem`
- `CausalLinearizationPolicy`
- `CausalNewton`
- `CausalLevenbergMarquardt`
- `CausalRecurrenceDiagnostics`
- `CausalRecurrenceResult`
- `solve_causal_recurrence`

Supported linearizations are dense exact, exact diagonal, fixed-probe Hutchinson diagonal, and caller-defined fixed blocks. Quasi-Newton structure changes only the proposed direction. Convergence is always certified against the direct nonlinear recurrence residual.

ELK-style Levenberg--Marquardt uses actual-versus-predicted reduction, bounded damping retries, explicit rejection, and portable nonlinear statuses. Maximum work never implies success.

The solved trajectory carries an exact implicit derivative. The backward path solves the exact reverse block-bidiagonal recurrence at the converged state and does not differentiate through iteration count, damping choices, accepted/rejected trials, or approximate forward linearizations.

### Recurrent neural layers

Adds opt-in causal execution over the existing `RecurrentBatch` contract:

- `CausalRecurrentConfig`
- `CausalRecurrentResult`
- `run_causal_recurrent`

RNN, GRU, LSTM, stacked cells, custom outputs, multidimensional cases, padding, resets, explicit initial/reset states, and fixed per-step random keys retain the same semantics as `run_recurrent`.

Serial execution remains the default. Affine recurrence continues to use its exact associative monoid. Causal nonlinear execution is never selected automatically and exposes either a hard failure or an explicitly recorded serial fallback.

### Fixed-trajectory causal HMC

Extends `sample_hmc` with the orthogonal `trajectory_method="causal"` option and `CausalHMCConfig`.

BlackJAX continues to own:

- window adaptation;
- momentum generation;
- kinetic energy;
- momentum flipping;
- safe energy differences;
- Metropolis acceptance.

Only the static velocity-Verlet trajectory is evaluated through the causal recurrence. The first release supports diagonal adapted inverse mass matrices, static leapfrog counts, explicit trajectory blocks, dense exact validation, and analytic position--momentum block structure using fixed Hutchinson Hessian probes.

Every block must converge before the endpoint is treated as an ordinary HMC proposal. NUTS is intentionally excluded because dynamic tree construction does not provide a fixed causal layout.

### Generic variational inference

Adds normalized reverse-KL inference in unconstrained `PosteriorProblem` coordinates:

- `AbstractVariationalFamily`
- `MeanFieldGaussianFamily`
- `VariationalConfig`
- `VariationalDiagnostics`
- `VariationalResult`
- `fit_variational`

The target density includes the physical prior and bijector Jacobian exactly once. Results retain unconstrained and physical draws, target and family log densities, ELBO and gradient histories, deterministic key lineage, memory, duration, prediction methods, portable exports, and exact checkpoint continuation.

### Flow variational inference

Extracts reusable FlowJAX family construction from the flow-NUTS proposal path and adds:

- `FlowVariationalFamily`
- `FlowVariationalConfig`
- `FlowVariationalResult`
- `fit_flow_variational`

Flow VI is initialized from a fitted mean-field approximation and optimized by reverse KL. This remains distinct from flow-NUTS proposal training, which fits replay samples by maximum likelihood.

### State-space path inference

Adds a normalized latent-path convention with shape:

`case_shape + (num_steps + 1,) + state_shape`

Index zero is the state at `initial_time`; index `t + 1` aligns with observation step `t`. Initial, transition, and observation terms remain separately observable. Inactive padded steps contribute zero and must preserve their predecessor exactly.

New APIs include:

- `state_space_path_log_density`
- `GaussianMarkovVariationalFamily`
- `fit_state_space_variational`
- `ParameterizedStateSpaceProblem`

`ParameterizedStateSpaceProblem` binds physical global parameters through the existing `StateSpaceStepContext.args` contract rather than introducing parallel prior, transition, or observation interfaces.

### Amortized and buffered sequence inference

Adds a shared bidirectional context encoder and reusable observation-conditioned Gaussian Markov family:

- `AmortizedGaussianMarkovEncoder`
- `AmortizedGaussianMarkovFamily`
- `fit_amortized_state_space_variational`

A fitted encoder can be rebound to a compatible observation sequence without retraining.

Buffered inference adds:

- `StateSpaceWindowPlan`
- `StateSpaceWindowBatch`
- `BufferedStateSpaceVariationalConfig`
- `fit_buffered_state_space_variational`

Target intervals use exact inverse inclusion probabilities, including boundary effects. Left and right buffers control encoder context. The result is explicitly labeled as a buffered amortized approximation; inverse inclusion weighting corrects target frequency but does not claim an exact full-data boundary law.

### JAX particle runtime and genealogical scores

Refactors bootstrap particle filtering into one JAX-compatible temporal scan while preserving semantic case/step/particle key derivation, resampling decisions, genealogy, streaming state, checkpoint behavior, masks, padding, and status handling.

`ParticleFilterResult` now retains initial particles, weights, and validity so complete initial-state score terms are auditable.

Adds `particle_genealogical_score`, which propagates prior, transition, and observation score increments through realized stopped-gradient ancestry using `O(TN)` state. The existing density-based `O(TN²)` smoother score remains available as the lower-variance reference when affordable.

### Pluggable SG-MCMC gradients

Adds:

- `AbstractStochasticGradientEstimator`
- `AutodiffStochasticGradientEstimator`
- `ParticleGenealogicalGradientEstimator`
- `StochasticGradientEstimate`

`sample_sgld` and `sample_sgnht` accept an optional estimator. The default autodiff factor-minibatch path remains replay-compatible. Particle-driven updates use a complete-sequence particle likelihood score plus the exact unconstrained parameter prior.

The existing control variate is rejected for particle estimators because its reference-gradient semantics differ. Buffered particle SG-MCMC is deliberately not exposed until a validated particle boundary correction exists.

## Exactness and approximation boundaries

- Dense causal recurrence is exact up to the declared direct-residual tolerance.
- Quasi-Newton and Hutchinson structure affect convergence speed, not the final success criterion.
- Causal HMC requires converged leapfrog blocks before using the ordinary Metropolis decision.
- Mean-field and flow VI are posterior approximations; ELBO convergence is not a calibration guarantee.
- Full-path Gaussian Markov VI is the reference for amortized and buffered variants.
- Buffered target weighting is exact for inclusion frequency, while the learned boundary law remains approximate.
- Genealogical particle scores trade variance for linear particle complexity.
- SG-MCMC remains an unadjusted fixed-step approximation.

## Compatibility

- Existing serial recurrent APIs and defaults are unchanged.
- Existing affine associative recurrence is unchanged.
- Existing `sample_hmc` behavior is unchanged unless `trajectory_method="causal"` is requested.
- NUTS behavior is unchanged.
- Existing SG-MCMC behavior is unchanged when `gradient_estimator` is omitted.
- Existing Kalman, SING, filtering, smoothing, prediction, and result contracts remain public.
- The Gaussian-chain source move preserves all UQ exports while establishing the correct lower-level ownership.

## Review guide

Recommended review order:

1. `phydrax/linalg/_causal_linear.py` and relocated `_gaussian_chain.py`
2. `phydrax/nonlinear/_causal.py` and `_causal_adjoint.py`
3. `phydrax/nn/layers/_causal_recurrent.py`
4. `phydrax/uq/_causal_hmc.py` and `_mcmc.py`
5. `phydrax/uq/_variational.py`, `_flow_variational.py`, and state-space variational modules
6. `phydrax/uq/_particle.py`, genealogical score modules, and `_stochastic_gradient.py`
7. SG-MCMC integration, result exports, API exports, documentation, and provenance
