### PR TITLE
fix: prevent masked nonfinite gradient contamination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -217,3 +217,9 @@
 - Closure-converted matrix-free SVD, eigensolve, spectral-projector, density-kernel, and spectral-function derivatives now support filtered JVP, reverse mode, and JIT.
 - Named truncated-normal initializers now produce their conventional target variance, while rectangular orthogonal initialization avoids max-dimension square samples.
 - `phydrax.nn.layers.inference_mode` now switches every inference-aware Equinox or Phydrax leaf in mixed model trees.
+
+### Fixed
+
+- Masked BSDE and deep-splitting losses now sanitize inactive residuals before
+  nonlinear reductions, Flower sanitizes masked source and normalization state,
+  and ragged-series pooling selects inactive latent values before reduction.

--- a/docs/api/nn/wrappers.md
+++ b/docs/api/nn/wrappers.md
@@ -133,9 +133,13 @@ Use `RaggedSeriesModel` to wrap a callable that consumes
 `RaggedSeriesDatasetDomain` batch and returns a `coordax.Field` with the case
 axis preserved.
 
-`MaskedSeriesPoolingModel` is a small baseline encoder. It applies a per-step
-model to each valid timestep, masks padded entries, pools over time, then applies
-a readout model.
+`MaskedSeriesPoolingModel` is a small baseline encoder. It evaluates a per-step
+model over the complete fixed-shape padded payload, removes inactive latent values,
+pools over time, then applies a readout model.
+The mask makes the reduction padding-invariant; it does not make `step_model`
+execution lazy. For differentiated use, a custom step model must remain finite and
+differentiable on the padded input representation. Use fixed-width sampled views or
+length buckets when evaluating the padded suffix is unsuitable or too expensive.
 
 ```python
 import jax.numpy as jnp

--- a/phydrax/nn/models/wrappers/_ragged_series.py
+++ b/phydrax/nn/models/wrappers/_ragged_series.py
@@ -190,7 +190,12 @@ class RaggedSeriesModel(StrictModule, BatchEvaluator):
 
 
 class MaskedSeriesPoolingModel(StrictModule):
-    """Encode variable-length series with a per-step model and masked reduction."""
+    """Encode variable-length series with a per-step model and masked reduction.
+
+    The step model evaluates the complete padded array before inactive latent values
+    are removed. Differentiated step models must therefore remain finite on the
+    padded input representation.
+    """
 
     step_model: Callable
     readout_model: Callable
@@ -267,11 +272,18 @@ class MaskedSeriesPoolingModel(StrictModule):
         mask = jnp.asarray(x.mask, dtype=bool)
         if mask.shape != step_input.shape[:2]:
             raise ValueError("mask must have shape (N, Lmax).")
-        mask_f = mask.astype(latent.dtype)[..., None]
-        pooled = jnp.sum(latent * mask_f, axis=1)
+        latent_mask = mask[..., None]
+        safe_latent = jnp.where(
+            latent_mask,
+            latent,
+            jnp.zeros((), dtype=latent.dtype),
+        )
+        pooled = jnp.sum(safe_latent, axis=1)
         if self.reduction == "mean":
+            valid_count = jnp.sum(mask, axis=1, dtype=jnp.int32)
             denom = jnp.maximum(
-                jnp.sum(mask_f, axis=1), jnp.asarray(1.0, dtype=pooled.dtype)
+                valid_count.astype(pooled.dtype)[:, None],
+                jnp.asarray(1.0, dtype=pooled.dtype),
             )
             pooled = pooled / denom
         elif self.scale_sampled_sum and x.sample_scale is not None:

--- a/phydrax/nn/operator/architectures/dynamics/_flower.py
+++ b/phydrax/nn/operator/architectures/dynamics/_flower.py
@@ -95,6 +95,7 @@ class _ChannelLastGroupNorm(StrictModule):
         if mask is None:
             mean = jnp.mean(grouped, axis=reduction_axes, keepdims=True)
             variance = jnp.var(grouped, axis=reduction_axes, keepdims=True)
+            centered = grouped - mean
             valid_mask = None
         else:
             valid_mask = jnp.asarray(mask, dtype=bool)
@@ -114,23 +115,33 @@ class _ChannelLastGroupNorm(StrictModule):
                 "Every masked GroupNorm case must contain a valid sample.",
             )
             count = jnp.maximum(count, 1)
+            safe_grouped = jnp.where(
+                grouped_mask,
+                grouped,
+                jnp.zeros((), dtype=grouped.dtype),
+            )
             mean = (
                 jnp.sum(
-                    grouped * grouped_mask,
+                    safe_grouped,
                     axis=reduction_axes,
                     keepdims=True,
                 )
                 / count
+            )
+            centered = jnp.where(
+                grouped_mask,
+                safe_grouped - mean,
+                jnp.zeros((), dtype=grouped.dtype),
             )
             variance = (
                 jnp.sum(
-                    (grouped - mean) ** 2 * grouped_mask,
+                    centered**2,
                     axis=reduction_axes,
                     keepdims=True,
                 )
                 / count
             )
-        normalized = ((grouped - mean) * jax.lax.rsqrt(variance + self.eps)).reshape(
+        normalized = (centered * jax.lax.rsqrt(variance + self.eps)).reshape(
             array.shape
         )
         affine_shape = (1,) * (array.ndim - 1) + (self.channels,)
@@ -149,7 +160,11 @@ class _ChannelLastGroupNorm(StrictModule):
                 modulation_shift.reshape(broadcast)
             )
         if valid_mask is not None:
-            output = output * valid_mask[..., None].astype(output.dtype)
+            output = jnp.where(
+                valid_mask[..., None],
+                output,
+                jnp.zeros((), dtype=output.dtype),
+            )
         return output
 
 
@@ -1024,6 +1039,11 @@ class Flower(AbstractOperatorModel):
                 ),
                 "Every Flower case must contain at least one valid source sample.",
             )
+        values = jnp.where(
+            mask[..., None],
+            values,
+            jnp.zeros((), dtype=values.dtype),
+        )
         return mask, values
 
     def _tensor_product_weights(

--- a/phydrax/stochastic/_bsde.py
+++ b/phydrax/stochastic/_bsde.py
@@ -604,14 +604,25 @@ def evaluate_bsde(
 def _masked_mean_square(
     values: Array, valid: Array, event_shape: tuple[int, ...], /
 ) -> Array:
-    squared = jnp.abs(values) ** 2
+    event_mask = jnp.broadcast_to(
+        valid.reshape(valid.shape + (1,) * len(event_shape)),
+        values.shape,
+    )
+    safe_values = jnp.where(
+        event_mask,
+        values,
+        jnp.zeros((), dtype=values.dtype),
+    )
+    squared = jnp.abs(safe_values) ** 2
     if event_shape:
         squared = jnp.sum(
             squared,
             axis=tuple(range(squared.ndim - len(event_shape), squared.ndim)),
         )
-    mask = jnp.broadcast_to(valid, squared.shape)
-    return jnp.sum(jnp.where(mask, squared, 0.0)) / jnp.maximum(jnp.sum(mask), 1)
+    reduction_mask = jnp.broadcast_to(valid, squared.shape)
+    return jnp.sum(jnp.where(reduction_mask, squared, 0.0)) / jnp.maximum(
+        jnp.sum(reduction_mask), 1
+    )
 
 
 def bsde_objective_loss(

--- a/phydrax/terms/_deep_bsde.py
+++ b/phydrax/terms/_deep_bsde.py
@@ -65,7 +65,16 @@ def _masked_mean_square(
     event_shape: tuple[int, ...],
     /,
 ) -> Array:
-    squared = jnp.abs(values) ** 2
+    event_mask = jnp.broadcast_to(
+        valid.reshape(valid.shape + (1,) * len(event_shape)),
+        values.shape,
+    )
+    safe_values = jnp.where(
+        event_mask,
+        values,
+        jnp.zeros((), dtype=values.dtype),
+    )
+    squared = jnp.abs(safe_values) ** 2
     event_axes = tuple(range(squared.ndim - len(event_shape), squared.ndim))
     squared = jnp.sum(squared, axis=event_axes)
     count = jnp.sum(valid)

--- a/phydrax/terms/_deep_splitting.py
+++ b/phydrax/terms/_deep_splitting.py
@@ -40,7 +40,16 @@ def _masked_mean_square(
     event_shape: tuple[int, ...],
     /,
 ) -> Array:
-    squared = jnp.abs(values) ** 2
+    event_mask = jnp.broadcast_to(
+        valid.reshape(valid.shape + (1,) * len(event_shape)),
+        values.shape,
+    )
+    safe_values = jnp.where(
+        event_mask,
+        values,
+        jnp.zeros((), dtype=values.dtype),
+    )
+    squared = jnp.abs(safe_values) ** 2
     event_axes = tuple(range(squared.ndim - len(event_shape), squared.ndim))
     squared = jnp.sum(squared, axis=event_axes)
     count = jnp.sum(valid)

--- a/tests/unit/nn/test_flower_generalized.py
+++ b/tests/unit/nn/test_flower_generalized.py
@@ -3,6 +3,7 @@
 #
 
 import equinox as eqx
+import jax
 import jax.numpy as jnp
 import jax.random as jr
 import pytest
@@ -149,6 +150,13 @@ def test_flower_source_holes_are_supported_and_remain_masked(mask_mode):
         phx.nn.operator.FunctionSamples(values=None, axes=(axis,)),
         source_mask=source_mask,
     )
+    nan_values = values.at[1].set(jnp.nan)
+    nan_batch = _batch(
+        nan_values,
+        (axis,),
+        phx.nn.operator.FunctionSamples(values=None, axes=(axis,)),
+        source_mask=source_mask,
+    )
     model = _flower(
         source_key="state",
         source_mask_mode=mask_mode,
@@ -158,11 +166,27 @@ def test_flower_source_holes_are_supported_and_remain_masked(mask_mode):
 
     output = model(batch)
     changed_output = model(changed_batch)
+    nan_output = eqx.filter_jit(lambda current, data: current(data))(model, nan_batch)
+
+    def squared_output(field):
+        data = _batch(
+            field,
+            (axis,),
+            phx.nn.operator.FunctionSamples(values=None, axes=(axis,)),
+            source_mask=source_mask,
+        )
+        return jnp.sum(model(data) ** 2)
+
+    nan_gradient = jax.grad(squared_output)(nan_values)
 
     assert output.shape == values.shape
     assert jnp.all(jnp.isfinite(output))
     assert jnp.array_equal(output[~source_mask], jnp.zeros((1,)))
     assert jnp.allclose(changed_output, output)
+    assert jnp.all(jnp.isfinite(nan_output))
+    assert jnp.allclose(nan_output, output)
+    assert jnp.all(jnp.isfinite(nan_gradient))
+    assert nan_gradient[1] == 0.0
 
 
 @pytest.mark.parametrize("query_kind", ("tensor_grid", "points"))

--- a/tests/unit/nn/test_models/test_ragged_series_models.py
+++ b/tests/unit/nn/test_models/test_ragged_series_models.py
@@ -80,6 +80,37 @@ def test_masked_series_pooling_ignores_padded_tail_values():
     assert jnp.allclose(out_a, jnp.asarray([2.0, 7.0]))
 
 
+def test_masked_series_pooling_selects_nonfinite_padded_latents():
+    payload = phx.nn.models.RaggedSeriesBatchInput(
+        static=None,
+        series=jnp.asarray([[[1.0], [0.0]]]),
+        time=jnp.asarray([[0.0, 1.0]]),
+        mask=jnp.asarray([[True, False]]),
+        length=jnp.asarray([1], dtype=jnp.int32),
+    )
+
+    def step_model(x, *, key=None):
+        del key
+        return jnp.log(x)
+
+    def readout_model(x, *, key=None):
+        del key
+        return x[:, 0]
+
+    model = phx.nn.models.MaskedSeriesPoolingModel(
+        step_model=step_model,
+        readout_model=readout_model,
+        reduction="sum",
+        include_time=False,
+        include_static_in_readout=False,
+    )
+    eager = model(payload)
+    compiled = eqx.filter_jit(lambda current, data: current(data))(model, payload)
+
+    assert jnp.array_equal(eager, jnp.asarray([0.0]))
+    assert jnp.array_equal(compiled, eager)
+
+
 def test_masked_series_pooling_can_scale_sampled_sum():
     payload = phx.nn.models.RaggedSeriesBatchInput(
         static=None,

--- a/tests/unit/solver/test_deep_bsde.py
+++ b/tests/unit/solver/test_deep_bsde.py
@@ -1,3 +1,4 @@
+import jax
 import jax.numpy as jnp
 import optax
 
@@ -70,6 +71,46 @@ def test_deep_bsde_rollout_reproduces_linear_brownian_solution():
     assert objective.diagnostics(
         {"initial": initial, "control": control}, batch=paths
     ).passed
+
+
+def test_deep_bsde_masks_nonfinite_invalid_terminal_gradient():
+    base_paths = _brownian_paths()
+    paths = BSDEPathBatch(
+        base_paths.times,
+        base_paths.states.at[1, -1, 0].set(2.0),
+        base_paths.wiener_increments,
+        sample_shape=base_paths.sample_shape,
+        state_shape=base_paths.state_shape,
+        noise_shape=base_paths.noise_shape,
+        path_id="masked-terminal",
+        process_id=base_paths.process_id,
+    )
+    problem = _problem(
+        paths,
+        terminal=lambda state, args: jnp.where(
+            state[0] > 1.0,
+            jnp.asarray([jnp.nan]),
+            jnp.asarray([0.0]),
+        ),
+    )
+    domain = phx.domain.Interval1d(-1.0, 1.0)
+    control = _constant(domain, [[0.0]])
+    objective = DeepBSDEShootingTerm(
+        problem,
+        initial_value_name="initial",
+        control_name="control",
+        sampling_mode="fixed",
+        fixed_paths=paths,
+    )
+
+    def loss(initial_value):
+        initial = _constant(domain, jnp.reshape(initial_value, (1,)))
+        return objective.loss({"initial": initial, "control": control}, batch=paths)
+
+    value, gradient = jax.jit(jax.value_and_grad(loss))(jnp.asarray(1.5))
+
+    assert value == 2.25
+    assert gradient == 3.0
 
 
 def test_solve_deep_bsde_trains_initial_value_and_removes_temporary_objective():

--- a/tests/unit/solver/test_deep_splitting.py
+++ b/tests/unit/solver/test_deep_splitting.py
@@ -1,3 +1,4 @@
+import equinox as eqx
 import jax
 import jax.numpy as jnp
 import optax
@@ -62,6 +63,40 @@ def test_deep_splitting_labels_use_explicit_right_endpoint_source():
     assert jnp.allclose(labels.source_controls, 0.0)
     assert jnp.allclose(labels.value_targets, 0.5)
     assert jnp.allclose(objective.loss({"value": exact}, batch=labels), 0.0)
+
+
+def test_deep_splitting_masks_nonfinite_invalid_target_gradient():
+    paths = _paths()
+    problem = _problem(paths)
+    labels = deep_splitting_labels(
+        problem,
+        paths,
+        lambda time, state: jnp.asarray([0.0]),
+        1,
+    )
+    valid = jnp.arange(paths.num_paths) < paths.num_paths // 2
+    labels = eqx.tree_at(lambda batch: batch.valid, labels, valid)
+    labels = eqx.tree_at(
+        lambda batch: batch.value_targets,
+        labels,
+        jnp.where(valid[:, None], labels.value_targets, jnp.nan),
+    )
+    domain = phx.domain.Interval1d(-1.0, 1.0)
+    objective = DeepSplittingRegressionTerm(
+        problem,
+        value_name="value",
+        slice_index=1,
+        labels=labels,
+    )
+
+    def loss(value):
+        predictor = domain.Parameter(jnp.reshape(value, (1,)))
+        return objective.loss({"value": predictor}, batch=labels)
+
+    value, gradient = jax.jit(jax.value_and_grad(loss))(jnp.asarray(1.5))
+
+    assert value == 1.0
+    assert gradient == 2.0
 
 
 def test_solve_deep_splitting_trains_distinct_slices_and_interpolates_field():

--- a/tests/unit/stochastic/test_bsde.py
+++ b/tests/unit/stochastic/test_bsde.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 from typing import Any
 
+import jax
 import jax.numpy as jnp
 import jax.random as jr
 import pytest
@@ -83,6 +84,58 @@ def test_exact_linear_bsde_has_zero_local_global_and_terminal_residuals():
             phx.stochastic.bsde_objective_loss(evaluation, mode=mode), 0.0
         )
     assert phx.stochastic.bsde_diagnostics(evaluation).passed
+
+
+def test_bsde_objective_masks_nonfinite_invalid_paths_before_squaring():
+    paths = _brownian_paths(num_paths=2, num_steps=2)
+    terminal = jnp.asarray([[1.0, 2.0], [jnp.nan, jnp.nan]])
+    local = jnp.asarray(
+        [
+            [[1.0, 2.0], [3.0, 4.0]],
+            [[jnp.nan, jnp.nan], [jnp.nan, jnp.nan]],
+        ]
+    )
+    global_residual = jnp.asarray([[2.0, 1.0], [jnp.nan, jnp.nan]])
+
+    def objective(terminal_residual, local_residuals, complete_residual):
+        evaluation = phx.stochastic.BSDEEvaluation(
+            values=jnp.zeros((2, 3, 2)),
+            controls=jnp.zeros((2, 2, 2, 1)),
+            generator_values=jnp.zeros((2, 2, 2)),
+            terminal_residual=terminal_residual,
+            local_residuals=local_residuals,
+            global_residual=complete_residual,
+            martingale_increments=jnp.zeros((2, 2, 2)),
+            valid_paths=jnp.asarray([True, False]),
+            paths=paths,
+            quadrature="left",
+            control_mode="explicit",
+        )
+        return phx.stochastic.bsde_objective_loss(evaluation, mode="joint")
+
+    value, gradients = jax.value_and_grad(objective, argnums=(0, 1, 2))(
+        terminal, local, global_residual
+    )
+    terminal_gradient, local_gradient, global_gradient = gradients
+
+    assert value == 25.0
+    assert jnp.array_equal(
+        terminal_gradient,
+        jnp.asarray([[2.0, 4.0], [0.0, 0.0]]),
+    )
+    assert jnp.array_equal(
+        local_gradient,
+        jnp.asarray(
+            [
+                [[1.0, 2.0], [3.0, 4.0]],
+                [[0.0, 0.0], [0.0, 0.0]],
+            ]
+        ),
+    )
+    assert jnp.array_equal(
+        global_gradient,
+        jnp.asarray([[4.0, 2.0], [0.0, 0.0]]),
+    )
 
 
 def test_autodiff_control_matches_explicit_control_and_heat_pde_residual():


### PR DESCRIPTION
## Summary

Hardens PhydraX masking semantics where inactive payloads can contain nonfinite values. Inactive data is now selected to a typed neutral value before nonlinear reductions, normalization, or pooling rather than being multiplied by zero after a partial computation.

## BSDE and deep-splitting reductions

- Sanitizes inactive residuals before absolute-square evaluation in the stochastic BSDE objective, deep-BSDE shooting, and deep-splitting regression paths.
- Expands validity across declared event dimensions explicitly, preserving scalar, vector, tensor, and complex residual semantics.
- Keeps each existing empty-support policy unchanged: the stochastic objective retains its neutral denominator behavior, while deep-BSDE and deep-splitting terms retain explicit no-valid-sample failures.
- Makes inactive residual adjoints exact zeros instead of allowing undefined residual derivatives to propagate through an outer selection.

## Flower masking

- Sanitizes source holes at the `Flower._source_mask` boundary before lifting, warping, and identity projections.
- Computes masked GroupNorm means and variances from selected finite values.
- Centers and normalizes only safe grouped values, then selects inactive outputs to exact zero after affine and FiLM modulation.
- Preserves source-mask modes, nonempty-support validation, channel/group layouts, parameter trees, and serialized model structure.

## Ragged-series pooling

- Replaces arithmetic latent masking with selection-first mean and sum reductions.
- Counts valid timesteps directly from the Boolean mask while preserving sampled-sum scaling and existing empty-row behavior.
- Documents that the step model still evaluates the complete fixed-shape padded payload: the mask makes pooling padding-invariant but does not make callback execution lazy.

## Numerical and API compatibility

- No public signatures, exports, result types, model parameter shapes, or static execution shapes change.
- Finite active-data results retain their existing formulas.
- Valid nonfinite values are not hidden; sanitization applies only where the explicit validity mask is false.
- Fixed-capacity solver and control-flow architecture remains unchanged.

## Documentation

Updates the ragged model wrapper reference with the dense padded-execution contract and records the corrected mask safety behavior in the unreleased changelog.