### PR TITLE
feat: compose nonlinear solvers and add matrix-free trust regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ### Added
 
+- Prepared finite nonlinear updates with typed application status, hard work
+  controls, refreshable plans, additive/multiplicative/residual-optimal
+  composition, Armijo Richardson and typed NGMRES outer methods, FAS/Picard/Newton
+  updates, nonlinear Schwarz/Gauss--Seidel decomposition, and ASPIN with
+  independently certified physical roots.
+- Strict box-preserving semismooth variational inequalities with prepared
+  topology-preserving refresh; matrix-free Steihaug--Toint quadratic trust
+  regions; large-scale unconstrained and bounded Newton trust-region methods;
+  and bound-aware Gauss--Newton and Levenberg--Marquardt residual optimization.
 - Positive certified Xiao--Gimbutas, Lebedev, periodic, radial, and Duffy
   cubature with content identity and bounded storage; measure-matched fixed
   Gauss--Hermite expectations; geometry-owned native disk, circle, ball,

--- a/benchmarks/advanced_solvers/README.md
+++ b/benchmarks/advanced_solvers/README.md
@@ -46,6 +46,7 @@ contract:
 | `optimization-unconstrained` | nonquadratic Rosenbrock minimization | objective, reference gap, gradient norm, and distance |
 | `optimization-constrained` | Maratos-type equality/inequality problem | objective, feasibility, and independently estimated KKT stationarity |
 | `optimization-proximal` | smooth plus L1 composite objective | proximal-gradient stationarity and reference gap |
+| `optimization-bounded-least-squares` | unit-box residual minimization with active bounds | projected stationarity, exact feasibility, objective/reference gap |
 | `optimization-linear-program` | bounded separable LP | projected KKT stationarity, feasibility, objective/reference gap |
 | `optimization-quadratic-program` | bounded diagonal positive-definite QP | projected KKT stationarity, feasibility, objective/reference gap |
 | `optimization-conic-program` | active Lorentz-cone QP | cone feasibility, estimated KKT stationarity, objective/reference gap |

--- a/benchmarks/advanced_solvers/adapters/phydrax.py
+++ b/benchmarks/advanced_solvers/adapters/phydrax.py
@@ -45,6 +45,7 @@ _CAPABILITIES = frozenset(
         "optimization.unconstrained",
         "optimization.constrained",
         "optimization.proximal",
+        "optimization.bounded-least-squares",
         "optimization.linear-program",
         "optimization.quadratic-program",
     }
@@ -153,7 +154,7 @@ class PhydraxAdapter(BenchmarkAdapter):
             method, preconditioner = methods[spec.solver_mode]
         elif capability == "nonlinear.vi":
             method, preconditioner = (
-                "semismooth-newton-fischer-burmeister",
+                "semismooth-newton-fischer-burmeister-preserve-box",
                 "policy-selected-linear-solver",
             )
         elif capability == "eigen.general":
@@ -164,6 +165,11 @@ class PhydraxAdapter(BenchmarkAdapter):
             method, preconditioner = "sqp-merit", "dense-bfgs-qp"
         elif capability == "optimization.proximal":
             method, preconditioner = "proximal-gradient", "exact-l1-proximal-map"
+        elif capability == "optimization.bounded-least-squares":
+            method, preconditioner = (
+                "bounded-levenberg-marquardt",
+                "active-set-trust-region",
+            )
         elif capability == "optimization.linear-program":
             method, preconditioner = "dense-primal-dual-lp", "none"
         elif capability == "optimization.quadratic-program":
@@ -410,10 +416,11 @@ class PhydraxAdapter(BenchmarkAdapter):
                 )
                 policy = (
                     nonlinear.SemismoothNewton(
+                        feasibility="preserve-box",
                         certification_tolerance=max(
                             spec.tolerances.relative,
                             spec.tolerances.absolute,
-                        )
+                        ),
                     ),
                     termination,
                 )
@@ -467,6 +474,23 @@ class PhydraxAdapter(BenchmarkAdapter):
                 )
                 policy = (optim.SQP(), termination)
                 transferred_bytes = int(problem.initial.nbytes)
+            elif problem.variant == "bounded-least-squares":
+                if problem.target is None:
+                    raise ValueError("bounded least-squares benchmark lacks its target")
+                target = jnp.asarray(problem.target)
+                native_problem = optim.NonlinearLeastSquaresProblem(
+                    lambda value, args: value - target,
+                    bounds=optim.Bounds(0.0, 1.0),
+                    problem_id=(
+                        "benchmark-bounded-least-squares:"
+                        f"{problem.identity()['fingerprint']}"
+                    ),
+                )
+                policy = (
+                    optim.BoundedLevenbergMarquardt(),
+                    termination,
+                )
+                transferred_bytes = int(problem.initial.nbytes + problem.target.nbytes)
             else:
                 if problem.target is None:
                     raise ValueError("proximal benchmark lacks its target")
@@ -668,7 +692,16 @@ class PhydraxAdapter(BenchmarkAdapter):
         elif isinstance(problem, OptimizationProblem):
             jax = import_module("jax")
             method, termination = setup_state.policy
-            if problem.variant == "proximal":
+            if problem.variant == "bounded-least-squares":
+
+                def operation(initial):
+                    return phx.optim.least_squares(
+                        setup_state.native_problem,
+                        initial,
+                        method=method,
+                        termination=termination,
+                    )
+            elif problem.variant == "proximal":
 
                 def operation(initial):
                     return phx.optim.proximal_minimize(
@@ -1304,6 +1337,16 @@ def _required_public_api(capability: str) -> tuple[str, frozenset[str]]:
                     "plan_convex_program",
                     "prepare_convex_program",
                     "solve_convex_program",
+                }
+            )
+        if capability == "optimization.bounded-least-squares":
+            return "phydrax.optim", frozenset(
+                {
+                    "BoundedLevenbergMarquardt",
+                    "Bounds",
+                    "NonlinearLeastSquaresProblem",
+                    "OptimizationTermination",
+                    "least_squares",
                 }
             )
         common = {

--- a/benchmarks/advanced_solvers/adapters/scipy.py
+++ b/benchmarks/advanced_solvers/adapters/scipy.py
@@ -36,6 +36,7 @@ _CAPABILITIES = frozenset(
         "optimization.unconstrained",
         "optimization.constrained",
         "optimization.proximal",
+        "optimization.bounded-least-squares",
     }
 )
 
@@ -318,6 +319,21 @@ class ScipyAdapter(BenchmarkAdapter):
                 method="SLSQP",
                 options=options,
             )
+        elif problem.variant == "bounded-least-squares":
+            options.update(
+                {
+                    "ftol": tolerance.absolute,
+                    "gtol": tolerance.absolute,
+                }
+            )
+            result = optimize.minimize(
+                problem.objective,
+                problem.initial,
+                jac=problem.gradient,
+                bounds=[(0.0, 1.0)] * problem.initial.size,
+                method="L-BFGS-B",
+                options=options,
+            )
         else:
             options.update(
                 {
@@ -365,6 +381,8 @@ def _configuration(spec: CaseSpec) -> tuple[str, str]:
         return "slsqp", "dense-bfgs-qp"
     if capability == "optimization.proximal":
         return "powell-exact-composite-objective", "none"
+    if capability == "optimization.bounded-least-squares":
+        return "l-bfgs-b-bound-least-squares", "none"
     return "unsupported", "none"
 
 

--- a/benchmarks/advanced_solvers/campaign.py
+++ b/benchmarks/advanced_solvers/campaign.py
@@ -34,6 +34,7 @@ DEFAULT_CASES = (
     "optimization-unconstrained",
     "optimization-constrained",
     "optimization-proximal",
+    "optimization-bounded-least-squares",
 )
 MATCHED_ROOT_CASES = (
     "nonlinear-root-dense",

--- a/benchmarks/advanced_solvers/certificates.py
+++ b/benchmarks/advanced_solvers/certificates.py
@@ -285,6 +285,30 @@ def _optimization_certificate(
         }
         scale = 1.0 + float(np.linalg.norm(gradient, ord=np.inf))
         kind = "optimization-kkt"
+    elif problem.variant == "bounded-least-squares":
+        projected = np.clip(value - gradient, 0.0, 1.0)
+        stationarity = value - projected
+        feasibility = max(
+            float(np.max(np.maximum(-value, 0.0))),
+            float(np.max(np.maximum(value - 1.0, 0.0))),
+        )
+        residual_norm = max(
+            feasibility,
+            float(np.linalg.norm(stationarity, ord=np.inf)),
+        )
+        details = {
+            "objective": problem.objective(value),
+            "objective_gap": abs(
+                problem.objective(value) - problem.objective(problem.optimum)
+            ),
+            "distance_to_reference": float(np.linalg.norm(value - problem.optimum)),
+            "projected_stationarity_norm": float(
+                np.linalg.norm(stationarity, ord=np.inf)
+            ),
+            "bound_feasibility": feasibility,
+        }
+        scale = 1.0 + float(np.linalg.norm(value, ord=np.inf))
+        kind = "optimization-bound-stationarity"
     elif problem.variant == "proximal":
         stationarity = problem.proximal_stationarity(value)
         residual_norm = float(np.linalg.norm(stationarity, ord=np.inf))

--- a/benchmarks/advanced_solvers/cli.py
+++ b/benchmarks/advanced_solvers/cli.py
@@ -164,6 +164,7 @@ def _all_capabilities() -> tuple[str, ...]:
         "optimization.unconstrained",
         "optimization.constrained",
         "optimization.proximal",
+        "optimization.bounded-least-squares",
         "optimization.linear-program",
         "optimization.quadratic-program",
         "optimization.conic-program",

--- a/benchmarks/advanced_solvers/harness.py
+++ b/benchmarks/advanced_solvers/harness.py
@@ -514,6 +514,7 @@ def _certificate_kind(capability: str) -> str:
         "optimization.unconstrained": "optimization-stationarity",
         "optimization.constrained": "optimization-kkt",
         "optimization.proximal": "optimization-proximal-stationarity",
+        "optimization.bounded-least-squares": ("optimization-bound-stationarity"),
         "optimization.linear-program": "optimization-program-kkt",
         "optimization.quadratic-program": "optimization-program-kkt",
         "optimization.conic-program": "optimization-program-kkt",

--- a/benchmarks/advanced_solvers/problems.py
+++ b/benchmarks/advanced_solvers/problems.py
@@ -23,6 +23,7 @@ Capability = Literal[
     "optimization.unconstrained",
     "optimization.constrained",
     "optimization.proximal",
+    "optimization.bounded-least-squares",
     "optimization.linear-program",
     "optimization.quadratic-program",
     "optimization.conic-program",
@@ -298,6 +299,8 @@ class OptimizationProblem:
             return "optimization.constrained"
         if self.variant == "proximal":
             return "optimization.proximal"
+        if self.variant == "bounded-least-squares":
+            return "optimization.bounded-least-squares"
         raise ValueError(f"Unsupported optimization variant {self.variant!r}")
 
     def objective(self, value: np.ndarray) -> float:
@@ -308,6 +311,10 @@ class OptimizationProblem:
             return float(np.sum(100.0 * (right - left * left) ** 2 + (1.0 - left) ** 2))
         if self.variant == "constrained":
             return float(2.0 * (point @ point - 1.0) - point[0])
+        if self.variant == "bounded-least-squares":
+            if self.target is None:
+                raise ValueError("bounded least-squares problem is missing its target")
+            return float(0.5 * np.sum((point - self.target) ** 2))
         if self.target is None:
             raise ValueError("proximal problem is missing its target")
         return float(
@@ -328,6 +335,10 @@ class OptimizationProblem:
             gradient = 4.0 * point
             gradient[0] -= 1.0
             return gradient
+        if self.variant == "bounded-least-squares":
+            if self.target is None:
+                raise ValueError("bounded least-squares problem is missing its target")
+            return point - self.target
         if self.target is None:
             raise ValueError("proximal problem is missing its target")
         return point - self.target
@@ -372,6 +383,9 @@ class OptimizationProblem:
                     "unconstrained": "nonquadratic Rosenbrock chain",
                     "constrained": "Maratos-style circle equality with affine inequality",
                     "proximal": "separable quadratic plus L1",
+                    "bounded-least-squares": (
+                        "separable residual with active unit-box solution"
+                    ),
                 }[self.variant],
                 "l1_weight": self.l1_weight,
             },
@@ -693,6 +707,28 @@ def l1_composite_optimization(*, size: int, seed: int) -> OptimizationProblem:
     )
 
 
+def bounded_least_squares_optimization(
+    *,
+    size: int,
+    seed: int,
+) -> OptimizationProblem:
+    if size < 1:
+        raise ValueError("bounded least-squares dimension must be positive")
+    generator = np.random.Generator(np.random.PCG64(seed))
+    target = generator.standard_normal(size)
+    target[::2] += 1.5
+    target[1::2] -= 1.5
+    optimum = np.clip(target, 0.0, 1.0)
+    return OptimizationProblem(
+        name="bounded-separable-residual",
+        variant="bounded-least-squares",
+        seed=seed,
+        initial=np.full(size, 0.5, dtype=np.float64),
+        optimum=optimum,
+        target=target,
+    )
+
+
 def bounded_linear_program(*, size: int, seed: int) -> MathematicalProgramProblem:
     generator = np.random.Generator(np.random.PCG64(seed))
     linear = generator.standard_normal(size)
@@ -806,6 +842,12 @@ def default_problems(*, size: int, seed: int) -> dict[str, BenchmarkProblem]:
             size=size,
             seed=seed + 8,
         ),
+        "optimization-bounded-least-squares": (
+            bounded_least_squares_optimization(
+                size=size,
+                seed=seed + 13,
+            )
+        ),
         "optimization-linear-program": bounded_linear_program(
             size=size,
             seed=seed + 10,
@@ -907,6 +949,7 @@ __all__ = [
     "NonlinearProblem",
     "OptimizationProblem",
     "SparseLinearProblem",
+    "bounded_least_squares_optimization",
     "default_problems",
     "general_eigenproblem",
     "l1_composite_optimization",

--- a/benchmarks/advanced_solvers/schema.py
+++ b/benchmarks/advanced_solvers/schema.py
@@ -541,6 +541,13 @@ def validate_row(row: Mapping[str, Any], /, *, path: str = "row") -> None:
             "estimated_equality_multiplier",
             "dual_stationarity_norm",
         ),
+        "optimization-bound-stationarity": (
+            "objective",
+            "objective_gap",
+            "distance_to_reference",
+            "projected_stationarity_norm",
+            "bound_feasibility",
+        ),
         "optimization-proximal-stationarity": (
             "objective",
             "objective_gap",

--- a/docs/all-of-phydrax.md
+++ b/docs/all-of-phydrax.md
@@ -324,21 +324,24 @@ choices with no automatic fallback or universal differentiability claim.
 General nonlinear optimization lives in `phydrax.optim`. Scalar, residual,
 residual-plus-signed-scalar, proximal-composite, constrained, state/design, and
 stochastic problems share typed termination, status, diagnostics, provenance, and
-PyTree contracts. Native methods cover matrix-free Newton--Krylov, Newton trust
-regions, nonlinear conjugate gradients with strong-Wolfe search, Gauss--Newton,
-Levenberg--Marquardt, deterministic finite-difference least squares, proximal
-gradient/Newton methods, projected box methods, augmented Lagrangian, filter/SOC
-SQP, and primal--dual predictor--corrector KKT solves. Curvature methods prepare
-reusable symbolic linear-solve templates and report numeric refreshes separately
-from setup. Smooth stationarity, least-squares normal-equation, and strictly
-complementary active-set KKT solution maps are differentiated implicitly;
-unsuccessful, singular, or ambiguous solves fail instead of returning fabricated
-sensitivities.
+PyTree contracts. Native methods cover matrix-free Newton--Krylov, operator
+Steihaug--Toint and explicit dense-dogleg trust regions, nonlinear conjugate
+gradients with strong-Wolfe search, Gauss--Newton, Levenberg--Marquardt,
+bound-aware residual trust regions, deterministic finite-difference least
+squares, proximal gradient/Newton methods, projected box methods, augmented
+Lagrangian, filter/SOC SQP, and primal--dual predictor--corrector KKT solves.
+Curvature methods prepare reusable symbolic linear-solve templates and report
+numeric refreshes separately from setup. Smooth stationarity, least-squares
+normal-equation, and strictly complementary active-set KKT solution maps are
+differentiated implicitly; unsuccessful, singular, or ambiguous solves fail
+instead of returning fabricated sensitivities.
 
 Nonlinear algebraic systems live in `phydrax.nonlinear`, not in optimization.
-Newton--Krylov and trust-region roots, nonlinear GMRES, semismooth complementarity
-solves, fixed-point acceleration, nonlinear preconditioners, full-approximation
-multigrid, and implicit root maps share explicit status and work diagnostics.
+Complete solves are separated from prepared finite updates. Static
+additive/multiplicative/residual-optimal graphs compose Newton/Picard/FAS,
+nonlinear Schwarz and Gauss--Seidel, Richardson, NGMRES, and ASPIN while final
+success remains certified by the original physical residual. Semismooth
+complementarity offers explicit infeasible and strict box-preserving execution.
 Domain-invalid evaluations remain distinct from nonfinite trials.
 
 Generic parameterized residual curves and local bifurcation workflows live in

--- a/docs/api/nonlinear.md
+++ b/docs/api/nonlinear.md
@@ -111,6 +111,37 @@ spaces, derivative structure, or unsupported nonlinear methods are rejected rath
 than replanned. Per-call termination overrides may tighten work limits without
 changing the prepared artifact.
 
+## Finite nonlinear updates and composition
+
+A complete solve and a finite update have different contracts. An
+`AbstractNonlinearUpdate` may apply a Newton step, Picard correction, FAS cycle,
+or subdomain sweep without claiming that the resulting state is a root.
+`NonlinearUpdateResult.applied` means that bounded work produced a finite,
+physically valid proposal; only a complete `NonlinearResult` can certify
+convergence.
+
+`plan_nonlinear_update`, `prepare_nonlinear_update`,
+`refresh_nonlinear_update`, and `apply_prepared_nonlinear_update` bind the
+physical state/residual spaces and retain update history or prepared linear
+state. Work controls are checked before an indivisible update. Arbitrary
+callables enter this lifecycle only through `FunctionNonlinearUpdate`.
+
+`CompositeNonlinearUpdate` supports static multiplicative, weighted additive,
+and safeguarded residual-optimal composition. Every child is evaluated from
+the declared base state, its result remains component evidence, and the
+combined candidate is independently evaluated against the original physical
+problem. `NonlinearRichardson` adds physical-residual Armijo globalization.
+`NonlinearGMRES` accepts a typed update rather than an untracked callable.
+
+`NonlinearSubdomain` declares state and residual restrictions, correction
+prolongation, one local residual, and a typed local update.
+`NonlinearAdditiveSchwarz`, `NonlinearMultiplicativeSchwarz`, and
+`NonlinearGaussSeidel` preserve this topology under JIT and certify the global
+residual after local work. `ASPIN` uses additive Schwarz as a left nonlinear
+preconditioner and prepares local dense Jacobian inverses for reuse within each
+outer approximate-Jacobian action. Its nested local work is explicitly marked
+as incompletely countable.
+
 ## Fixed points and nonlinear acceleration
 
 `FixedPointProblem` represents `state = mapping(state, args)`. `PicardIteration` and
@@ -157,14 +188,24 @@ not a linear correction scheme with nonlinear labels.
 ## Variational inequalities and complementarity
 
 `VariationalInequalityProblem` combines a nonlinear map with explicit `Bounds`.
-`SemismoothNewton` solves a Fischer--Burmeister complementarity residual with a
-configurable `GeneralizedDerivativePolicy`. Infinite one-sided bounds are handled
-without invalid arithmetic.
+`SemismoothNewton` solves a natural-map or Fischer--Burmeister residual with a
+configurable `GeneralizedDerivativePolicy`. Infinite one-sided bounds are
+handled without invalid arithmetic.
+
+`feasibility="allow-infeasible"` retains the ordinary semismooth Newton path.
+`feasibility="preserve-box"` projects every trial before operator evaluation,
+so an operator whose mathematical domain is the box never receives an
+out-of-domain state. The accepted and returned state is exactly projected.
+
+`prepare_variational_inequality`, `refresh_variational_inequality`, and
+`solve_prepared_variational_inequality` separate compilation from repeated
+solves. Refresh permits new finite bound values but rejects changed
+unbounded/lower/upper/box/fixed topology.
 
 `ComplementarityCertificate` reports lower/upper feasibility, natural residual,
 Fischer--Burmeister residual, active sets, and finiteness separately. A loose
-nonlinear residual tolerance cannot turn an infeasible point into a successful VI
-result; final success requires the complementarity certificate as well.
+nonlinear residual tolerance cannot turn an infeasible point into a successful
+VI result; final success requires the complementarity certificate as well.
 
 ## Implicit root differentiation
 
@@ -279,6 +320,54 @@ Differentiating a failed solve raises instead of returning an approximate gradie
 ::: phydrax.nonlinear.NewtonTrustRegion
 
 ---
+::: phydrax.nonlinear.AbstractNonlinearUpdate
+
+---
+
+::: phydrax.nonlinear.NonlinearUpdateResult
+
+---
+
+::: phydrax.nonlinear.PreparedNonlinearUpdate
+
+---
+
+::: phydrax.nonlinear.FunctionNonlinearUpdate
+
+---
+
+::: phydrax.nonlinear.NewtonStepUpdate
+
+---
+
+::: phydrax.nonlinear.CompositeNonlinearUpdate
+
+---
+
+::: phydrax.nonlinear.NonlinearRichardson
+
+---
+
+::: phydrax.nonlinear.NonlinearSubdomain
+
+---
+
+::: phydrax.nonlinear.NonlinearAdditiveSchwarz
+
+---
+
+::: phydrax.nonlinear.NonlinearMultiplicativeSchwarz
+
+---
+
+::: phydrax.nonlinear.NonlinearGaussSeidel
+
+---
+
+::: phydrax.nonlinear.ASPIN
+
+---
+
 
 ::: phydrax.nonlinear.FixedPointProblem
 
@@ -311,6 +400,23 @@ Differentiating a failed solve raises instead of returning an approximate gradie
 ::: phydrax.nonlinear.SemismoothNewton
 
 ---
+
+::: phydrax.nonlinear.PreparedVariationalInequalitySolve
+
+---
+
+::: phydrax.nonlinear.prepare_variational_inequality
+
+---
+
+::: phydrax.nonlinear.refresh_variational_inequality
+
+---
+
+::: phydrax.nonlinear.solve_prepared_variational_inequality
+
+---
+
 
 ::: phydrax.nonlinear.NonlinearTransformationEvidence
 

--- a/docs/api/optim.md
+++ b/docs/api/optim.md
@@ -465,8 +465,11 @@ latter returns `NONFINITE_EVALUATION` while preserving the last accepted point.
 matrix-free Hessian-vector products, the shared linear-solve policy layer,
 Eisenstat--Walker style inexact forcing, and frozen-objective Armijo globalization.
 Indefinite or unusable Newton directions fall back to steepest descent and record that
-decision. `NewtonTrustRegion` instead solves a damped Newton model and updates its
-radius from the actual-to-predicted reduction ratio. `NonlinearConjugateGradient`
+decision. `NewtonTrustRegion` builds a matrix-free Hessian action and solves its
+self-adjoint quadratic model with `SteihaugToint`; negative curvature and trust-boundary
+termination are explicit evidence. It has no dense dimension cap. `DenseNewtonDogleg`
+retains the former bounded-dimension dense eigendecomposition and dogleg route as an
+explicit small-system method. `NonlinearConjugateGradient`
 supports Fletcher--Reeves, Polak--Ribière+, Hestenes--Stiefel+, and Dai--Yuan beta
 rules, with periodic, orthogonality, and lost-descent restarts. Its
 `StrongWolfeLineSearch` reports the Armijo and curvature inequalities independently.
@@ -479,13 +482,20 @@ objective-evaluation counts. Adapter diagnostics therefore set
 `counts_complete=False`, and `maximum_evaluations` is rejected rather than silently
 approximated.
 
-`least_squares` accepts `GaussNewton`, `LevenbergMarquardt`, and
-`FiniteDifferenceGaussNewton`. The differentiated methods use matrix-free Jacobian
+`least_squares` accepts `GaussNewton`, `LevenbergMarquardt`,
+`FiniteDifferenceGaussNewton`, `BoundedGaussNewton`, and
+`BoundedLevenbergMarquardt`. The differentiated methods use matrix-free Jacobian
 products over arbitrary real array PyTrees. Levenberg--Marquardt accepts or rejects
 trial steps by the actual-to-predicted reduction ratio and updates damping accordingly;
 rejected steps do not mutate the accepted iterate. The finite-difference method
 constructs a deterministic coordinate Jacobian, accounts for every residual evaluation,
 and does not advertise implicit differentiation.
+
+Bounds on `NonlinearLeastSquaresProblem` are never converted to residual penalties.
+Unbounded methods reject them. The bounded methods mask the active set, solve a
+matrix-free free-variable Gauss--Newton trust model, project every candidate before
+residual evaluation, and recompute predicted reduction for the actual projected
+displacement.
 
 !!! example
     ```python
@@ -535,10 +545,13 @@ root of an already reduced scalar objective.
 
 `Bounds` materializes scalar or PyTree lower and upper values against the parameter tree,
 broadcasts each bound to its corresponding leaf, and rejects incompatible or inverted
-bounds. `ProjectedGradient`, `ProjectedLBFGS`, and `ActiveSetNewton` all preserve the
-closed box at every accepted iterate. Projected L-BFGS stores curvature only from
-accepted projected steps. Active-set Newton solves over free variables and reports
-active-set size, primal feasibility, complementarity, and direction fallbacks.
+bounds. `ProjectedGradient`, `ProjectedLBFGS`, `ActiveSetNewton`, and
+`BoundedNewtonTrustRegion` all preserve the closed box at every accepted iterate.
+Projected L-BFGS stores curvature only from accepted projected steps. Active-set Newton
+solves over free variables and reports active-set size, primal feasibility,
+complementarity, and direction fallbacks. `BoundedNewtonTrustRegion` uses the shared
+Steihaug--Toint kernel over a masked Hessian action, detects negative curvature, and
+recomputes the local model for the displacement after projection.
 
 `NonlinearConstraint` represents any differentiable residual bounded componentwise by
 `lower <= c(x) <= upper`; equal finite bounds are equalities. `AugmentedLagrangian`
@@ -798,6 +811,26 @@ single-process measurements, not backend-independent performance claims.
 
 ---
 
+::: phydrax.optim.DenseNewtonDogleg
+
+---
+
+::: phydrax.optim.SteihaugToint
+
+---
+
+::: phydrax.optim.TrustRegionQuadraticProblem
+
+---
+
+::: phydrax.optim.solve_trust_region_subproblem
+
+---
+
+::: phydrax.optim.BoundedNewtonTrustRegion
+
+---
+
 ::: phydrax.optim.NonlinearConjugateGradient
 
 ---
@@ -821,6 +854,15 @@ single-process measurements, not backend-independent performance claims.
 ::: phydrax.optim.FiniteDifferenceGaussNewton
 
 ---
+
+::: phydrax.optim.BoundedGaussNewton
+
+---
+
+::: phydrax.optim.BoundedLevenbergMarquardt
+
+---
+
 
 ::: phydrax.optim.ProximalProblem
 

--- a/docs/cookbook/advanced_solvers.md
+++ b/docs/cookbook/advanced_solvers.md
@@ -109,6 +109,54 @@ problem remains matrix-free unless the caller selects a resource-bounded explici
 Jacobian policy. Phydrax does not silently switch to a dense direct correction after
 a Krylov failure.
 
+### Compose bounded nonlinear work
+
+Use a typed update when an inner method should propose progress without claiming
+root convergence. The outer method still owns termination and certifies the
+physical residual:
+
+```python
+half_step = phx.nonlinear.FunctionNonlinearUpdate(
+    lambda state, target: jax.tree.map(
+        lambda value, expected: value + 0.5 * (expected - value),
+        state,
+        target,
+    ),
+    update_id="half-correction",
+)
+composite = phx.nonlinear.CompositeNonlinearUpdate(
+    (half_step, half_step),
+    kind="multiplicative",
+)
+accelerated = phx.nonlinear.NonlinearGMRES(composite)
+result = accelerated.solve(
+    phx.nonlinear.NonlinearSystemProblem(
+        lambda state, target: state - target
+    ),
+    jnp.asarray([0.0]),
+    args=jnp.asarray([2.0]),
+    termination=phx.nonlinear.NonlinearTermination(maximum_steps=10),
+)
+assert bool(result.successful)
+```
+
+For a complementarity operator that is undefined outside its declared bounds,
+select strict trial projection explicitly:
+
+```python
+vi = phx.nonlinear.VariationalInequalityProblem(
+    lambda state, _: jnp.where(state < 0.0, jnp.nan, state - 1.0),
+    phx.nonlinear.Bounds(0.0, jnp.inf),
+)
+vi_result = phx.nonlinear.SemismoothNewton(
+    feasibility="preserve-box"
+).solve(
+    vi,
+    jnp.asarray([-1.0]),
+)
+assert bool(vi_result.successful)
+```
+
 ## 3. Select an optimization method by contract
 
 Unconstrained second-order optimization, nonlinear least squares, bounds,

--- a/docs/guides_solver_substrates.md
+++ b/docs/guides_solver_substrates.md
@@ -5,6 +5,34 @@ solution algorithm. A tensor grid does not select finite differences or spectral
 calculus, and an FFT direct solve does not change an FD operator into a spectral
 method.
 
+```python
+import jax.numpy as jnp
+import phydrax as phx
+```
+
+## Nonlinear update graphs
+
+`phydrax.nonlinear` separates finite nonlinear work from complete root
+certification. A prepared `AbstractNonlinearUpdate` graph may contain Newton or
+Picard corrections, FAS cycles, additive/multiplicative Schwarz, or static
+composition. An outer `NonlinearRichardson` or `NonlinearGMRES` method owns
+termination and globalization. The returned `NonlinearResult` always
+re-evaluates the original physical problem.
+
+The lifecycle is:
+
+```text
+physical problem
+  -> plan and prepare a fixed update graph
+  -> apply bounded work and retain component evidence
+  -> outer method accepts or rejects the proposal
+  -> certify the original physical residual
+```
+
+Linear subspace correction and nonlinear Schwarz reuse explicit restriction and
+prolongation ideas, but not one result type: nonlinear local work owns a local
+problem, update status, domain validity, and physical reconstruction.
+
 ## Structured support
 
 `TensorGridPlan.prepare(bounds)` returns `PreparedTensorGrid`: axes, topology,
@@ -35,6 +63,7 @@ request = phx.discretization.DerivativeRequest(
     accuracy_order=4,
 )
 fd = phx.discretization.FiniteDifferencePlan(support, (request,)).prepare()
+u = fd.operator("dx").source.zeros()
 du = fd.operator("dx").mv(u)
 ```
 

--- a/phydrax/nonlinear/__init__.py
+++ b/phydrax/nonlinear/__init__.py
@@ -5,6 +5,7 @@
 """Nonlinear algebraic systems, fixed points, and implicit root calculus."""
 
 from .._bounds import Bounds
+from ._aspin import ASPIN
 from ._causal import (
     CausalLevenbergMarquardt,
     CausalLinearizationMode,
@@ -16,6 +17,14 @@ from ._causal import (
     CausalRecurrenceResult,
     solve_causal_recurrence,
 )
+from ._composition import CompositeNonlinearUpdate, NonlinearCompositionKind
+from ._decomposition import (
+    AbstractNonlinearSchwarz,
+    NonlinearAdditiveSchwarz,
+    NonlinearGaussSeidel,
+    NonlinearMultiplicativeSchwarz,
+    NonlinearSubdomain,
+)
 from ._fas import (
     fas_cycle,
     FASCycleKind,
@@ -26,7 +35,12 @@ from ._fas import (
     FASNonlinearPreconditioner,
     FASResult,
 )
-from ._fixed_point import AndersonAcceleration, FixedPointIteration, PicardIteration
+from ._fixed_point import (
+    AndersonAcceleration,
+    FixedPointIteration,
+    PicardIteration,
+    PicardUpdate,
+)
 from ._implicit import implicit_root, implicit_root_result
 from ._linearization import (
     JacobianMode,
@@ -63,6 +77,7 @@ from ._prepared import (
     refresh_nonlinear,
     solve_prepared_nonlinear,
 )
+from ._richardson import NonlinearRichardson
 from ._types import (
     AbstractNonlinearMethod,
     FixedPointProblem,
@@ -76,12 +91,35 @@ from ._types import (
     NonlinearTermination,
     NonlinearTransformationEvidence,
 )
+from ._updates import (
+    AbstractNonlinearUpdate,
+    apply_prepared_nonlinear_update,
+    FunctionNonlinearUpdate,
+    NewtonStepUpdate,
+    nonlinear_update_status_message,
+    NonlinearUpdateCapabilities,
+    NonlinearUpdateControl,
+    NonlinearUpdateDiagnostics,
+    NonlinearUpdatePlan,
+    NonlinearUpdateProvenance,
+    NonlinearUpdateResult,
+    NonlinearUpdateStatus,
+    plan_nonlinear_update,
+    prepare_nonlinear_update,
+    PreparedNonlinearUpdate,
+    refresh_nonlinear_update,
+)
 from ._vi import (
     complementarity_certificate,
     ComplementarityCertificate,
     ComplementarityFormulation,
     GeneralizedDerivativePolicy,
+    prepare_variational_inequality,
+    PreparedVariationalInequalitySolve,
+    refresh_variational_inequality,
     SemismoothNewton,
+    solve_prepared_variational_inequality,
+    VariationalInequalityFeasibility,
     VariationalInequalityProblem,
     VariationalInequalityResult,
 )
@@ -90,7 +128,10 @@ from ._vi import (
 __all__ = [
     "AbstractNonlinearMethod",
     "AbstractLeftNonlinearPreconditioner",
+    "AbstractNonlinearSchwarz",
     "AbstractNonlinearSystemTransformation",
+    "AbstractNonlinearUpdate",
+    "ASPIN",
     "AndersonAcceleration",
     "AbstractRightNonlinearPreconditioner",
     "Bounds",
@@ -98,6 +139,7 @@ __all__ = [
     "CausalLinearizationMode",
     "CausalLinearizationPolicy",
     "CausalNewton",
+    "CompositeNonlinearUpdate",
     "CausalProbeDistribution",
     "CausalRecurrenceDiagnostics",
     "CausalRecurrenceProblem",
@@ -115,6 +157,7 @@ __all__ = [
     "FixedPointProblem",
     "FunctionLeftNonlinearPreconditioner",
     "FunctionRightNonlinearPreconditioner",
+    "FunctionNonlinearUpdate",
     "GeneralizedDerivativePolicy",
     "JacobianRefreshPolicy",
     "JacobianRefreshStrategy",
@@ -125,35 +168,61 @@ __all__ = [
     "NewtonTrustRegion",
     "NewtonForcingPolicy",
     "NewtonForcingStrategy",
+    "NewtonStepUpdate",
     "NonlinearCapabilities",
     "NonlinearGMRES",
     "NonlinearDiagnostics",
     "NonlinearProvenance",
     "NonlinearTransformationEvidence",
+    "NonlinearAdditiveSchwarz",
+    "NonlinearGaussSeidel",
+    "NonlinearMultiplicativeSchwarz",
+    "NonlinearSubdomain",
+    "NonlinearCompositionKind",
     "NonlinearResult",
+    "NonlinearRichardson",
     "NonlinearStatus",
     "NonlinearSystemProblem",
     "NonlinearTermination",
+    "NonlinearUpdateCapabilities",
+    "NonlinearUpdateControl",
+    "NonlinearUpdateDiagnostics",
+    "NonlinearUpdatePlan",
+    "NonlinearUpdateProvenance",
+    "NonlinearUpdateResult",
+    "NonlinearUpdateStatus",
     "PicardIteration",
+    "PicardUpdate",
     "PreparedJacobian",
     "PreparedNonlinearSolve",
+    "PreparedNonlinearUpdate",
+    "PreparedVariationalInequalitySolve",
     "RightPreconditionedSystem",
     "RootLineSearch",
     "RootTrustRegion",
     "SemismoothNewton",
     "VariationalInequalityProblem",
     "VariationalInequalityResult",
+    "VariationalInequalityFeasibility",
     "complementarity_certificate",
+    "apply_prepared_nonlinear_update",
     "fas_cycle",
     "implicit_root",
     "implicit_root_result",
     "left_precondition",
     "nonlinear_status_message",
+    "nonlinear_update_status_message",
     "prepare_jacobian",
+    "plan_nonlinear_update",
     "prepare_nonlinear",
+    "prepare_nonlinear_update",
+    "prepare_variational_inequality",
     "root",
     "refresh_nonlinear",
+    "refresh_nonlinear_update",
+    "refresh_variational_inequality",
     "right_precondition",
     "solve_prepared_nonlinear",
+    "solve_prepared_variational_inequality",
     "solve_causal_recurrence",
 ]

--- a/phydrax/nonlinear/_aspin.py
+++ b/phydrax/nonlinear/_aspin.py
@@ -1,0 +1,308 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+from jaxtyping import PyTree
+
+from ..linalg import FunctionLinearOperator, OperatorProperties
+from ._decomposition import NonlinearAdditiveSchwarz
+from ._linearization import JacobianPolicy
+from ._newton import NewtonKrylov
+from ._preconditioning import (
+    FunctionLeftNonlinearPreconditioner,
+    LeftPreconditionedSystem,
+)
+from ._types import (
+    AbstractNonlinearMethod,
+    NonlinearCapabilities,
+    NonlinearDiagnostics,
+    NonlinearProvenance,
+    NonlinearResult,
+    NonlinearSystemProblem,
+    NonlinearTermination,
+)
+from ._updates import (
+    apply_prepared_nonlinear_update,
+    prepare_nonlinear_update,
+    PreparedNonlinearUpdate,
+    refresh_nonlinear_update,
+)
+
+
+class ASPIN(AbstractNonlinearMethod):
+    """Additive-Schwarz preconditioned inexact Newton with local Jacobian inverses."""
+
+    schwarz: NonlinearAdditiveSchwarz
+    outer: NewtonKrylov
+
+    def __init__(
+        self,
+        schwarz: NonlinearAdditiveSchwarz,
+        /,
+        *,
+        outer: NewtonKrylov | None = None,
+    ):
+        if not isinstance(schwarz, NonlinearAdditiveSchwarz):
+            raise TypeError("schwarz must be NonlinearAdditiveSchwarz.")
+        outer_ = NewtonKrylov() if outer is None else outer
+        if not isinstance(outer_, NewtonKrylov):
+            raise TypeError("outer must be NewtonKrylov or None.")
+        self.schwarz = schwarz
+        self.outer = outer_
+
+    @property
+    def method_id(self) -> str:
+        return "aspin"
+
+    @property
+    def capabilities(self) -> NonlinearCapabilities:
+        return NonlinearCapabilities(
+            matrix_free=True,
+            prepared_refresh=False,
+            jit=False,
+            implicit_differentiation=True,
+            nonlinear_preconditioning=True,
+        )
+
+    def solve(
+        self,
+        problem: NonlinearSystemProblem,
+        initial_state: PyTree[Any],
+        /,
+        *,
+        termination: NonlinearTermination,
+        args: Any = None,
+    ) -> NonlinearResult:
+        if not isinstance(problem, NonlinearSystemProblem):
+            raise TypeError("problem must be NonlinearSystemProblem.")
+        if not isinstance(termination, NonlinearTermination):
+            raise TypeError("termination must be NonlinearTermination.")
+        if (
+            termination.maximum_evaluations is not None
+            and termination.maximum_evaluations < 2
+        ):
+            raise ValueError(
+                "ASPIN requires at least two residual evaluations to solve and "
+                "certify the physical system."
+            )
+        initial = problem.validate_state(initial_state)
+        initial_residual, _ = problem.evaluate(initial, args)
+        problem_ = problem.bind_spaces(initial, initial_residual)
+        if problem_.state_space is None or problem_.residual_space is None:
+            raise ValueError("ASPIN requires bound physical vector spaces.")
+        if problem_.state_space.size != problem_.residual_space.size:
+            raise ValueError(
+                "ASPIN requires equal physical state and residual dimensions."
+            )
+        prepared = prepare_nonlinear_update(
+            problem_,
+            initial,
+            self.schwarz,
+            args=args,
+        )
+
+        def preconditioned_residual(state, residual, current_args):
+            del residual
+            result, _ = apply_prepared_nonlinear_update(
+                prepared,
+                state,
+                args=current_args,
+            )
+            return jax.tree.map(
+                lambda value, corrected: value - corrected,
+                state,
+                result.state,
+            )
+
+        preconditioner = FunctionLeftNonlinearPreconditioner(
+            preconditioned_residual,
+            state_space=problem_.state_space,
+            source=problem_.residual_space,
+            target=problem_.state_space,
+            preconditioner_id=f"aspin/{self.schwarz.update_id}",
+        )
+        transformed = LeftPreconditionedSystem(problem_, preconditioner)
+
+        def operator(state, current_args):
+            return _aspin_operator(
+                problem_,
+                self.schwarz,
+                prepared,
+                state,
+                current_args,
+            )
+
+        outer = NewtonKrylov(
+            jacobian_policy=JacobianPolicy("explicit", operator=operator),
+            linear_policy=self.outer.linear_policy,
+            forcing_policy=self.outer.forcing_policy,
+            jacobian_refresh=self.outer.jacobian_refresh,
+            line_search=self.outer.line_search,
+        )
+        inner_termination = NonlinearTermination(
+            absolute_residual=0.01 * termination.absolute_residual,
+            relative_residual=0.01 * termination.relative_residual,
+            absolute_step=termination.absolute_step,
+            relative_step=termination.relative_step,
+            maximum_steps=termination.maximum_steps,
+            maximum_evaluations=(
+                None
+                if termination.maximum_evaluations is None
+                else termination.maximum_evaluations - 1
+            ),
+            maximum_linear_iterations=termination.maximum_linear_iterations,
+            divergence_factor=termination.divergence_factor,
+        )
+        transformed_result = outer.solve(
+            transformed.problem,
+            initial,
+            termination=inner_termination,
+            args=args,
+        )
+        result = transformed.finalize_result(
+            transformed_result,
+            initial,
+            termination,
+            args=args,
+        )
+        diagnostics = NonlinearDiagnostics(
+            initial_residual_norm=result.diagnostics.initial_residual_norm,
+            final_residual_norm=result.diagnostics.final_residual_norm,
+            final_step_norm=result.diagnostics.final_step_norm,
+            iterations=result.diagnostics.iterations,
+            residual_evaluations=result.diagnostics.residual_evaluations,
+            jvp_evaluations=result.diagnostics.jvp_evaluations,
+            vjp_evaluations=result.diagnostics.vjp_evaluations,
+            jacobian_preparations=result.diagnostics.jacobian_preparations,
+            linear_solves=result.diagnostics.linear_solves,
+            linear_iterations=result.diagnostics.linear_iterations,
+            accepted_steps=result.diagnostics.accepted_steps,
+            rejected_steps=result.diagnostics.rejected_steps,
+            domain_failures=result.diagnostics.domain_failures,
+            nonfinite_trials=result.diagnostics.nonfinite_trials,
+            acceleration_restarts=result.diagnostics.acceleration_restarts,
+            setup_refreshes=result.diagnostics.setup_refreshes,
+            numeric_refreshes=result.diagnostics.numeric_refreshes,
+            final_forcing=result.diagnostics.final_forcing,
+            final_trust_radius=result.diagnostics.final_trust_radius,
+            final_linear_status=result.diagnostics.final_linear_status,
+            final_linear_rank=result.diagnostics.final_linear_rank,
+            final_linear_condition_estimate=(
+                result.diagnostics.final_linear_condition_estimate
+            ),
+            final_linear_residual_norm=(result.diagnostics.final_linear_residual_norm),
+            final_linear_converged=result.diagnostics.final_linear_converged,
+            counts_complete=False,
+        )
+        provenance = NonlinearProvenance(
+            problem_id=problem_.problem_id,
+            method_id=self.method_id,
+            derivative_id="aspin-local-inverse-jacobians",
+            globalization_id=result.provenance.globalization_id,
+            linear_plan_id=result.provenance.linear_plan_id,
+            notes=(
+                f"subdomains={len(self.schwarz.subdomains)};"
+                "local dense inverses reused within each prepared ASPIN Jacobian"
+            ),
+        )
+        return NonlinearResult(
+            state=result.state,
+            residual=result.residual,
+            auxiliary=result.auxiliary,
+            status=result.status,
+            diagnostics=diagnostics,
+            provenance=provenance,
+            transformation_evidence=result.transformation_evidence,
+        )
+
+
+def _aspin_operator(
+    problem: NonlinearSystemProblem,
+    schwarz: NonlinearAdditiveSchwarz,
+    prepared: PreparedNonlinearUpdate,
+    state: PyTree[Any],
+    args: Any,
+    /,
+) -> FunctionLinearOperator:
+    if problem.state_space is None or problem.residual_space is None:
+        raise ValueError("ASPIN operator requires bound physical spaces.")
+    state_ = problem.state_space.validate(state)
+    local_data = []
+    for child, subdomain in zip(
+        prepared.internal_state,
+        schwarz.subdomains,
+        strict=True,
+    ):
+        local_state = subdomain.state_space.validate(subdomain.restrict_state(state_))
+        local_problem = subdomain.local_problem()
+        refreshed = refresh_nonlinear_update(
+            child,
+            local_problem,
+            local_state,
+            args=(state_, args),
+        )
+        local_result, _ = apply_prepared_nonlinear_update(
+            refreshed,
+            local_state,
+            args=(state_, args),
+        )
+        point = subdomain.state_space.validate(local_result.state)
+        coordinates = subdomain.state_space.flatten(point)
+
+        def local_coordinates_residual(
+            value, *, subdomain=subdomain, local_problem=local_problem
+        ):
+            local_value = subdomain.state_space.unflatten(value)
+            residual = local_problem.residual(local_value, (state_, args))
+            return subdomain.residual_space.flatten(residual)
+
+        matrix = jax.jacfwd(local_coordinates_residual)(coordinates)
+        inverse = jnp.linalg.inv(matrix)
+        inverse = jnp.where(
+            local_result.applied, inverse, jnp.full_like(inverse, jnp.nan)
+        )
+        local_data.append((subdomain, inverse))
+
+    def action(direction):
+        direction_ = problem.state_space.validate(direction)
+        _, global_action = jax.jvp(
+            lambda value: problem.residual(value, args),
+            (state_,),
+            (direction_,),
+        )
+        result = problem.state_space.zeros()
+        for subdomain, inverse in local_data:
+            restricted = subdomain.residual_space.validate(
+                subdomain.restrict_residual(global_action)
+            )
+            local_coordinates = inverse @ subdomain.residual_space.flatten(restricted)
+            local_correction = subdomain.state_space.unflatten(local_coordinates)
+            prolonged = problem.state_space.validate(
+                subdomain.prolong_correction(local_correction)
+            )
+            result = jax.tree.map(
+                lambda value, correction, weight=subdomain.weight: (
+                    value + weight * correction
+                ),
+                result,
+                prolonged,
+            )
+        return result
+
+    return FunctionLinearOperator(
+        action,
+        source=problem.state_space,
+        target=problem.state_space,
+        properties=OperatorProperties(),
+        operator_id=f"aspin-jacobian/{schwarz.update_id}",
+        closure_convert=False,
+    )
+
+
+__all__ = ["ASPIN"]

--- a/phydrax/nonlinear/_composition.py
+++ b/phydrax/nonlinear/_composition.py
@@ -1,0 +1,451 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from math import isfinite
+from typing import Any, Literal, TypeAlias
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array, PyTree
+
+from .._fingerprint import canonical_fingerprint
+from .._tree_math import tree_allfinite
+from ._updates import (
+    AbstractNonlinearUpdate,
+    apply_prepared_nonlinear_update,
+    NonlinearUpdateCapabilities,
+    NonlinearUpdateControl,
+    NonlinearUpdateDiagnostics,
+    NonlinearUpdateProvenance,
+    NonlinearUpdateResult,
+    NonlinearUpdateStatus,
+    prepare_nonlinear_update,
+    PreparedNonlinearUpdate,
+    refresh_nonlinear_update,
+)
+
+
+NonlinearCompositionKind: TypeAlias = Literal[
+    "multiplicative", "additive", "residual-optimal"
+]
+
+
+def _space_norm(space, value, /) -> Array:
+    squared = jnp.real(space.inner(value, value))
+    return jnp.sqrt(jnp.maximum(squared, 0.0))
+
+
+def _component_control(
+    control: NonlinearUpdateControl,
+    count: int,
+    *,
+    residual_reserve: int,
+) -> NonlinearUpdateControl:
+    def share(value: int | None, reserve: int = 0) -> int | None:
+        if value is None:
+            return None
+        return max((value - reserve) // count, 0)
+
+    return NonlinearUpdateControl(
+        maximum_residual_evaluations=share(
+            control.maximum_residual_evaluations,
+            residual_reserve,
+        ),
+        maximum_jacobian_preparations=share(control.maximum_jacobian_preparations),
+        maximum_linear_solves=share(control.maximum_linear_solves),
+        maximum_linear_iterations=share(control.maximum_linear_iterations),
+    )
+
+
+def _sum_component_field(components, name: str, /) -> Array:
+    values = [vars(component.diagnostics)[name] for component in components]
+    return sum(values[1:], values[0])
+
+
+class CompositeNonlinearUpdate(AbstractNonlinearUpdate):
+    """Static additive, multiplicative, or residual-optimal update composition."""
+
+    updates: tuple[AbstractNonlinearUpdate, ...]
+    weights: tuple[float, ...] = eqx.field(static=True)
+    kind: NonlinearCompositionKind = eqx.field(static=True)
+    regularization: float = eqx.field(static=True)
+    safeguard_factor: float = eqx.field(static=True)
+    update_name: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        updates: tuple[AbstractNonlinearUpdate, ...],
+        /,
+        *,
+        kind: NonlinearCompositionKind = "multiplicative",
+        weights: tuple[float, ...] | None = None,
+        regularization: float = 1e-10,
+        safeguard_factor: float = 1.0,
+    ):
+        updates_ = tuple(updates)
+        if not updates_ or not all(
+            isinstance(update, AbstractNonlinearUpdate) for update in updates_
+        ):
+            raise TypeError(
+                "updates must be a nonempty tuple of AbstractNonlinearUpdate values."
+            )
+        if kind not in ("multiplicative", "additive", "residual-optimal"):
+            raise ValueError("Unknown nonlinear composition kind.")
+        weights_ = (
+            tuple(1.0 for _ in updates_)
+            if weights is None
+            else tuple(float(value) for value in weights)
+        )
+        if len(weights_) != len(updates_):
+            raise ValueError("Composition weights must match the child count.")
+        if any(not isfinite(value) for value in weights_):
+            raise ValueError("Composition weights must be finite.")
+        regularization_ = float(regularization)
+        safeguard_ = float(safeguard_factor)
+        if not isfinite(regularization_) or regularization_ < 0.0:
+            raise ValueError("regularization must be finite and non-negative.")
+        if not isfinite(safeguard_) or safeguard_ < 1.0:
+            raise ValueError("safeguard_factor must be finite and at least one.")
+        identifier = canonical_fingerprint(
+            {
+                "kind": "nonlinear-composition",
+                "composition": kind,
+                "updates": [update.update_id for update in updates_],
+                "weights": list(weights_),
+                "regularization": regularization_,
+                "safeguard": safeguard_,
+            }
+        )
+        self.updates = updates_
+        self.weights = weights_
+        self.kind = kind
+        self.regularization = regularization_
+        self.safeguard_factor = safeguard_
+        self.update_name = f"composite-{kind}/{identifier}"
+
+    @property
+    def update_id(self) -> str:
+        return self.update_name
+
+    @property
+    def capabilities(self) -> NonlinearUpdateCapabilities:
+        return NonlinearUpdateCapabilities(
+            jit=all(update.capabilities.jit for update in self.updates),
+            prepared_refresh=all(
+                update.capabilities.prepared_refresh for update in self.updates
+            ),
+            differentiable_action=all(
+                update.capabilities.differentiable_action for update in self.updates
+            ),
+            exposes_linearization=False,
+            counts_complete=all(
+                update.capabilities.counts_complete for update in self.updates
+            ),
+        )
+
+    def _prepare_internal(self, problem, state, args, /):
+        return tuple(
+            prepare_nonlinear_update(problem, state, update, args=args)
+            for update in self.updates
+        )
+
+    def _refresh_internal(self, internal_state, problem, state, args, /):
+        children = tuple(internal_state)
+        if len(children) != len(self.updates) or not all(
+            isinstance(child, PreparedNonlinearUpdate) for child in children
+        ):
+            raise TypeError("Prepared composite child state is invalid.")
+        return tuple(
+            refresh_nonlinear_update(child, problem, state, args=args)
+            for child in children
+        )
+
+    def _apply(
+        self,
+        prepared: PreparedNonlinearUpdate,
+        state: PyTree[Any],
+        args: Any,
+        control: NonlinearUpdateControl,
+        /,
+    ):
+        children = tuple(prepared.internal_state)
+        child_control = _component_control(
+            control,
+            len(children),
+            residual_reserve=(4 if self.kind == "residual-optimal" else 2),
+        )
+        if self.kind == "multiplicative":
+            components, next_children, candidate = self._apply_multiplicative(
+                children,
+                prepared.plan.state_space.validate(state),
+                args,
+                child_control,
+            )
+        else:
+            components, next_children, candidate = self._apply_additive(
+                prepared,
+                children,
+                prepared.plan.state_space.validate(state),
+                args,
+                child_control,
+                residual_optimal=self.kind == "residual-optimal",
+            )
+        return self._package(
+            prepared,
+            state,
+            candidate,
+            args,
+            components,
+        ), next_children
+
+    def _apply_multiplicative(self, children, state, args, control, /):
+        current = state
+        components = []
+        next_children = []
+        active = jnp.asarray(True)
+        for child in children:
+            result, next_child = apply_prepared_nonlinear_update(
+                child,
+                current,
+                args=args,
+                control=control,
+            )
+            take = active & result.applied
+            current = jax.tree.map(
+                lambda proposed, old: jnp.where(take, proposed, old),
+                result.state,
+                current,
+            )
+            active = active & result.applied
+            components.append(result)
+            next_children.append(next_child)
+        return tuple(components), tuple(next_children), current
+
+    def _apply_additive(
+        self,
+        prepared,
+        children,
+        state,
+        args,
+        control,
+        /,
+        *,
+        residual_optimal: bool,
+    ):
+        components = []
+        next_children = []
+        for child in children:
+            result, next_child = apply_prepared_nonlinear_update(
+                child,
+                state,
+                args=args,
+                control=control,
+            )
+            components.append(result)
+            next_children.append(next_child)
+        components_ = tuple(components)
+        if residual_optimal:
+            candidate = self._residual_optimal_candidate(
+                prepared,
+                state,
+                components_,
+                args,
+            )
+        else:
+            candidate = state
+            for weight, component in zip(self.weights, components_, strict=True):
+                candidate = jax.tree.map(
+                    lambda value, proposed, base, scale=weight: (
+                        value + scale * (proposed - base)
+                    ),
+                    candidate,
+                    component.state,
+                    state,
+                )
+        return components_, tuple(next_children), candidate
+
+    def _residual_optimal_candidate(
+        self,
+        prepared,
+        state,
+        components,
+        args,
+        /,
+    ):
+        problem = prepared.problem
+        residual_space = prepared.plan.residual_space
+        base_residual, _ = problem.evaluate(state, args)
+        residual_differences = tuple(
+            jax.tree.map(
+                lambda child, base: child - base,
+                component.residual,
+                base_residual,
+            )
+            for component in components
+        )
+        gram = jnp.stack(
+            [
+                jnp.stack(
+                    [
+                        jnp.real(residual_space.inner(left, right))
+                        for right in residual_differences
+                    ]
+                )
+                for left in residual_differences
+            ]
+        )
+        gram = gram + self.regularization * jnp.eye(
+            len(components),
+            dtype=gram.dtype,
+        )
+        right = -jnp.stack(
+            [
+                jnp.real(residual_space.inner(delta, base_residual))
+                for delta in residual_differences
+            ]
+        )
+        coefficients = jnp.linalg.solve(gram, right)
+        accelerated = state
+        for coefficient, component in zip(coefficients, components, strict=True):
+            accelerated = jax.tree.map(
+                lambda value, proposed, base, scale=coefficient: (
+                    value + scale * (proposed - base)
+                ),
+                accelerated,
+                component.state,
+                state,
+            )
+        accelerated_residual, accelerated_auxiliary = problem.evaluate(
+            accelerated,
+            args,
+        )
+        accelerated_norm = _space_norm(residual_space, accelerated_residual)
+        child_norms = jnp.stack(
+            [_space_norm(residual_space, component.residual) for component in components]
+        )
+        best_index = jnp.argmin(child_norms)
+        best_state = components[0].state
+        for index, component in enumerate(components):
+            best_state = jax.tree.map(
+                lambda selected, proposed, take=best_index == index: jnp.where(
+                    take,
+                    proposed,
+                    selected,
+                ),
+                best_state,
+                component.state,
+            )
+        all_applied = jnp.asarray(True)
+        for component in components:
+            all_applied = all_applied & component.applied
+        base_norm = _space_norm(residual_space, base_residual)
+        finite = (
+            tree_allfinite(accelerated)
+            & tree_allfinite(accelerated_residual)
+            & jnp.all(jnp.isfinite(coefficients))
+        )
+        valid = problem.valid(
+            accelerated,
+            accelerated_residual,
+            accelerated_auxiliary,
+            args,
+        )
+        use_accelerated = (
+            all_applied
+            & finite
+            & valid
+            & (
+                accelerated_norm
+                <= self.safeguard_factor * jnp.minimum(base_norm, jnp.min(child_norms))
+            )
+        )
+        selected = jax.tree.map(
+            lambda accelerated_value, best_value: jnp.where(
+                use_accelerated,
+                accelerated_value,
+                best_value,
+            ),
+            accelerated,
+            best_state,
+        )
+        return jax.tree.map(
+            lambda proposed, base: jnp.where(all_applied, proposed, base),
+            selected,
+            state,
+        )
+
+    def _package(self, prepared, initial_state, candidate, args, components, /):
+        problem = prepared.problem
+        initial_residual, initial_auxiliary = problem.evaluate(initial_state, args)
+        candidate = prepared.plan.state_space.validate(candidate)
+        residual, auxiliary = problem.evaluate(candidate, args)
+        initial_norm = _space_norm(prepared.plan.residual_space, initial_residual)
+        final_norm = _space_norm(prepared.plan.residual_space, residual)
+        finite = tree_allfinite(candidate) & tree_allfinite(residual)
+        valid = problem.valid(candidate, residual, auxiliary, args)
+        children_applied = jnp.asarray(True)
+        for component in components:
+            children_applied = children_applied & component.applied
+        status = jnp.where(
+            ~children_applied,
+            int(NonlinearUpdateStatus.INNER_FAILURE),
+            jnp.where(
+                ~finite,
+                int(NonlinearUpdateStatus.NONFINITE_EVALUATION),
+                jnp.where(
+                    ~valid,
+                    int(NonlinearUpdateStatus.DOMAIN_REJECTED),
+                    int(NonlinearUpdateStatus.APPLIED),
+                ),
+            ),
+        ).astype(jnp.int32)
+        step = jax.tree.map(lambda new, old: new - old, candidate, initial_state)
+        diagnostics = NonlinearUpdateDiagnostics(
+            initial_residual_norm=initial_norm,
+            final_residual_norm=final_norm,
+            step_norm=_space_norm(prepared.plan.state_space, step),
+            residual_evaluations=(
+                _sum_component_field(components, "residual_evaluations")
+                + (4 if self.kind == "residual-optimal" else 2)
+            ),
+            jacobian_preparations=_sum_component_field(
+                components, "jacobian_preparations"
+            ),
+            linear_solves=_sum_component_field(components, "linear_solves"),
+            linear_iterations=_sum_component_field(components, "linear_iterations"),
+            accepted_steps=_sum_component_field(components, "accepted_steps")
+            + (status == int(NonlinearUpdateStatus.APPLIED)).astype(jnp.int32),
+            rejected_steps=_sum_component_field(components, "rejected_steps")
+            + (status != int(NonlinearUpdateStatus.APPLIED)).astype(jnp.int32),
+            domain_failures=_sum_component_field(components, "domain_failures")
+            + (finite & ~valid).astype(jnp.int32),
+            nonfinite_trials=_sum_component_field(components, "nonfinite_trials")
+            + (~finite).astype(jnp.int32),
+            counts_complete=all(
+                component.diagnostics.counts_complete for component in components
+            ),
+        )
+        return NonlinearUpdateResult(
+            state=candidate,
+            residual=residual,
+            auxiliary=auxiliary,
+            status=status,
+            diagnostics=diagnostics,
+            provenance=NonlinearUpdateProvenance(
+                problem_id=problem.problem_id,
+                update_id=self.update_id,
+                plan_id=prepared.plan.plan_id,
+                notes=f"composition={self.kind}",
+            ),
+            components=components,
+        )
+
+
+__all__ = [
+    "CompositeNonlinearUpdate",
+    "NonlinearCompositionKind",
+]

--- a/phydrax/nonlinear/_decomposition.py
+++ b/phydrax/nonlinear/_decomposition.py
@@ -1,0 +1,431 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import abc
+from math import isfinite
+from typing import Any
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jaxtyping import PyTree
+
+from .._fingerprint import canonical_fingerprint
+from .._strict import StrictModule
+from .._tree_math import tree_allfinite
+from ..linalg import AbstractVectorSpace
+from ._types import NonlinearSystemProblem
+from ._updates import (
+    AbstractNonlinearUpdate,
+    apply_prepared_nonlinear_update,
+    NonlinearUpdateCapabilities,
+    NonlinearUpdateControl,
+    NonlinearUpdateDiagnostics,
+    NonlinearUpdateProvenance,
+    NonlinearUpdateResult,
+    NonlinearUpdateStatus,
+    prepare_nonlinear_update,
+    PreparedNonlinearUpdate,
+    refresh_nonlinear_update,
+)
+
+
+def _norm(space, value, /):
+    squared = jnp.real(space.inner(value, value))
+    return jnp.sqrt(jnp.maximum(squared, 0.0))
+
+
+def _sum_field(results, field: str, /):
+    values = [vars(result.diagnostics)[field] for result in results]
+    return sum(values[1:], values[0])
+
+
+def _child_control(
+    control: NonlinearUpdateControl,
+    count: int,
+    /,
+) -> NonlinearUpdateControl:
+    def share(value: int | None, reserve: int = 0) -> int | None:
+        if value is None:
+            return None
+        return max((value - reserve) // count, 0)
+
+    return NonlinearUpdateControl(
+        maximum_residual_evaluations=share(
+            control.maximum_residual_evaluations,
+            2,
+        ),
+        maximum_jacobian_preparations=share(control.maximum_jacobian_preparations),
+        maximum_linear_solves=share(control.maximum_linear_solves),
+        maximum_linear_iterations=share(control.maximum_linear_iterations),
+    )
+
+
+class NonlinearSubdomain(StrictModule):
+    """One explicit nonlinear restriction, local problem, and correction route."""
+
+    restrict_state: Any
+    restrict_residual: Any
+    prolong_correction: Any
+    local_residual: Any
+    update: AbstractNonlinearUpdate
+    state_space: AbstractVectorSpace
+    residual_space: AbstractVectorSpace
+    weight: float = eqx.field(static=True)
+    subdomain_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        restrict_state: Any,
+        restrict_residual: Any,
+        prolong_correction: Any,
+        local_residual: Any,
+        update: AbstractNonlinearUpdate,
+        /,
+        *,
+        state_space: AbstractVectorSpace,
+        residual_space: AbstractVectorSpace,
+        weight: float = 1.0,
+        subdomain_id: str,
+    ):
+        callbacks = (
+            restrict_state,
+            restrict_residual,
+            prolong_correction,
+            local_residual,
+        )
+        if not all(callable(value) for value in callbacks):
+            raise TypeError(
+                "Nonlinear subdomain transfer and residual values must be callable."
+            )
+        if not isinstance(update, AbstractNonlinearUpdate):
+            raise TypeError("update must be AbstractNonlinearUpdate.")
+        if not isinstance(state_space, AbstractVectorSpace) or not isinstance(
+            residual_space, AbstractVectorSpace
+        ):
+            raise TypeError("Subdomain state and residual spaces must be declared.")
+        weight_ = float(weight)
+        if not isfinite(weight_):
+            raise ValueError("Subdomain weight must be finite.")
+        identifier = str(subdomain_id)
+        if not identifier:
+            raise ValueError("subdomain_id must be non-empty.")
+        self.restrict_state = restrict_state
+        self.restrict_residual = restrict_residual
+        self.prolong_correction = prolong_correction
+        self.local_residual = local_residual
+        self.update = update
+        self.state_space = state_space
+        self.residual_space = residual_space
+        self.weight = weight_
+        self.subdomain_id = identifier
+
+    def local_problem(self, /) -> NonlinearSystemProblem:
+        def residual(local_state, context):
+            global_state, user_args = context
+            return self.local_residual(local_state, global_state, user_args)
+
+        return NonlinearSystemProblem(
+            residual,
+            state_space=self.state_space,
+            residual_space=self.residual_space,
+            problem_id=f"nonlinear-subdomain/{self.subdomain_id}",
+        )
+
+
+class AbstractNonlinearSchwarz(AbstractNonlinearUpdate):
+    """Shared static nonlinear subspace-correction update."""
+
+    subdomains: tuple[NonlinearSubdomain, ...]
+    update_name: str = eqx.field(static=True)
+
+    def __init__(self, subdomains: tuple[NonlinearSubdomain, ...], /):
+        subdomains_ = tuple(subdomains)
+        if not subdomains_ or not all(
+            isinstance(subdomain, NonlinearSubdomain) for subdomain in subdomains_
+        ):
+            raise TypeError(
+                "subdomains must be a nonempty tuple of NonlinearSubdomain values."
+            )
+        identifier = canonical_fingerprint(
+            {
+                "kind": self.schwarz_kind,
+                "subdomains": [value.subdomain_id for value in subdomains_],
+                "updates": [value.update.update_id for value in subdomains_],
+                "weights": [value.weight for value in subdomains_],
+            }
+        )
+        self.subdomains = subdomains_
+        self.update_name = f"{self.schwarz_kind}/{identifier}"
+
+    @property
+    @abc.abstractmethod
+    def schwarz_kind(self) -> str:
+        raise NotImplementedError
+
+    @property
+    def update_id(self) -> str:
+        return self.update_name
+
+    @property
+    def capabilities(self) -> NonlinearUpdateCapabilities:
+        return NonlinearUpdateCapabilities(
+            jit=all(value.update.capabilities.jit for value in self.subdomains),
+            prepared_refresh=all(
+                value.update.capabilities.prepared_refresh for value in self.subdomains
+            ),
+            differentiable_action=all(
+                value.update.capabilities.differentiable_action
+                for value in self.subdomains
+            ),
+            counts_complete=all(
+                value.update.capabilities.counts_complete for value in self.subdomains
+            ),
+        )
+
+    def _prepare_internal(self, problem, state, args, /):
+        del problem
+        return tuple(
+            prepare_nonlinear_update(
+                subdomain.local_problem(),
+                subdomain.state_space.validate(subdomain.restrict_state(state)),
+                subdomain.update,
+                args=(state, args),
+            )
+            for subdomain in self.subdomains
+        )
+
+    def _refresh_internal(self, internal_state, problem, state, args, /):
+        del problem
+        children = tuple(internal_state)
+        if len(children) != len(self.subdomains) or not all(
+            isinstance(child, PreparedNonlinearUpdate) for child in children
+        ):
+            raise TypeError("Prepared nonlinear Schwarz child state is invalid.")
+        return tuple(
+            refresh_nonlinear_update(
+                child,
+                subdomain.local_problem(),
+                subdomain.state_space.validate(subdomain.restrict_state(state)),
+                args=(state, args),
+            )
+            for child, subdomain in zip(children, self.subdomains, strict=True)
+        )
+
+    def _apply(
+        self,
+        prepared: PreparedNonlinearUpdate,
+        state: PyTree[Any],
+        args: Any,
+        control: NonlinearUpdateControl,
+        /,
+    ):
+        state_ = prepared.plan.state_space.validate(state)
+        initial_residual, _ = prepared.problem.evaluate(state_, args)
+        child_control = _child_control(control, len(self.subdomains))
+        if self.schwarz_kind == "nonlinear-additive-schwarz":
+            candidate, components, children = self._apply_additive(
+                prepared,
+                state_,
+                args,
+                child_control,
+            )
+        else:
+            candidate, components, children = self._apply_multiplicative(
+                prepared,
+                state_,
+                args,
+                child_control,
+            )
+        all_applied = jnp.asarray(True)
+        for component in components:
+            all_applied = all_applied & component.applied
+        candidate = jax.tree.map(
+            lambda proposed, base: jnp.where(all_applied, proposed, base),
+            candidate,
+            state_,
+        )
+        residual, auxiliary = prepared.problem.evaluate(candidate, args)
+        finite = tree_allfinite(candidate) & tree_allfinite(residual)
+        valid = prepared.problem.valid(candidate, residual, auxiliary, args)
+        status = jnp.where(
+            ~all_applied,
+            int(NonlinearUpdateStatus.INNER_FAILURE),
+            jnp.where(
+                ~finite,
+                int(NonlinearUpdateStatus.NONFINITE_EVALUATION),
+                jnp.where(
+                    ~valid,
+                    int(NonlinearUpdateStatus.DOMAIN_REJECTED),
+                    int(NonlinearUpdateStatus.APPLIED),
+                ),
+            ),
+        ).astype(jnp.int32)
+        step = jax.tree.map(lambda new, old: new - old, candidate, state_)
+        diagnostics = NonlinearUpdateDiagnostics(
+            initial_residual_norm=_norm(
+                prepared.plan.residual_space,
+                initial_residual,
+            ),
+            final_residual_norm=_norm(prepared.plan.residual_space, residual),
+            step_norm=_norm(prepared.plan.state_space, step),
+            residual_evaluations=_sum_field(
+                components,
+                "residual_evaluations",
+            )
+            + 2,
+            jacobian_preparations=_sum_field(
+                components,
+                "jacobian_preparations",
+            ),
+            linear_solves=_sum_field(components, "linear_solves"),
+            linear_iterations=_sum_field(components, "linear_iterations"),
+            accepted_steps=_sum_field(components, "accepted_steps")
+            + (status == int(NonlinearUpdateStatus.APPLIED)).astype(jnp.int32),
+            rejected_steps=_sum_field(components, "rejected_steps")
+            + (status != int(NonlinearUpdateStatus.APPLIED)).astype(jnp.int32),
+            domain_failures=_sum_field(components, "domain_failures")
+            + (finite & ~valid).astype(jnp.int32),
+            nonfinite_trials=_sum_field(components, "nonfinite_trials")
+            + (~finite).astype(jnp.int32),
+            counts_complete=all(
+                component.diagnostics.counts_complete for component in components
+            ),
+        )
+        return (
+            NonlinearUpdateResult(
+                state=candidate,
+                residual=residual,
+                auxiliary=auxiliary,
+                status=status,
+                diagnostics=diagnostics,
+                provenance=NonlinearUpdateProvenance(
+                    problem_id=prepared.problem.problem_id,
+                    update_id=self.update_id,
+                    plan_id=prepared.plan.plan_id,
+                    notes=f"subdomains={len(self.subdomains)}",
+                ),
+                components=components,
+            ),
+            children,
+        )
+
+    def _apply_additive(self, prepared, state, args, control, /):
+        candidate = state
+        components = []
+        children = []
+        for child, subdomain in zip(
+            prepared.internal_state,
+            self.subdomains,
+            strict=True,
+        ):
+            local_state = subdomain.state_space.validate(subdomain.restrict_state(state))
+            refreshed = refresh_nonlinear_update(
+                child,
+                subdomain.local_problem(),
+                local_state,
+                args=(state, args),
+            )
+            result, next_child = apply_prepared_nonlinear_update(
+                refreshed,
+                local_state,
+                args=(state, args),
+                control=control,
+            )
+            correction = jax.tree.map(
+                lambda new, old: new - old,
+                result.state,
+                local_state,
+            )
+            prolonged = prepared.plan.state_space.validate(
+                subdomain.prolong_correction(correction)
+            )
+            candidate = jax.tree.map(
+                lambda value, delta, weight=subdomain.weight: value + weight * delta,
+                candidate,
+                prolonged,
+            )
+            components.append(result)
+            children.append(next_child)
+        return candidate, tuple(components), tuple(children)
+
+    def _apply_multiplicative(self, prepared, state, args, control, /):
+        current = state
+        components = []
+        children = []
+        active = jnp.asarray(True)
+        for child, subdomain in zip(
+            prepared.internal_state,
+            self.subdomains,
+            strict=True,
+        ):
+            local_state = subdomain.state_space.validate(
+                subdomain.restrict_state(current)
+            )
+            refreshed = refresh_nonlinear_update(
+                child,
+                subdomain.local_problem(),
+                local_state,
+                args=(current, args),
+            )
+            result, next_child = apply_prepared_nonlinear_update(
+                refreshed,
+                local_state,
+                args=(current, args),
+                control=control,
+            )
+            correction = jax.tree.map(
+                lambda new, old: new - old,
+                result.state,
+                local_state,
+            )
+            prolonged = prepared.plan.state_space.validate(
+                subdomain.prolong_correction(correction)
+            )
+            proposal = jax.tree.map(
+                lambda value, delta, weight=subdomain.weight: value + weight * delta,
+                current,
+                prolonged,
+            )
+            take = active & result.applied
+            current = jax.tree.map(
+                lambda proposed, old: jnp.where(take, proposed, old),
+                proposal,
+                current,
+            )
+            active = active & result.applied
+            components.append(result)
+            children.append(next_child)
+        return current, tuple(components), tuple(children)
+
+
+class NonlinearAdditiveSchwarz(AbstractNonlinearSchwarz):
+    @property
+    def schwarz_kind(self) -> str:
+        return "nonlinear-additive-schwarz"
+
+
+class NonlinearMultiplicativeSchwarz(AbstractNonlinearSchwarz):
+    @property
+    def schwarz_kind(self) -> str:
+        return "nonlinear-multiplicative-schwarz"
+
+
+class NonlinearGaussSeidel(AbstractNonlinearSchwarz):
+    """Ordered nonlinear block sweep using multiplicative Schwarz semantics."""
+
+    @property
+    def schwarz_kind(self) -> str:
+        return "nonlinear-gauss-seidel"
+
+
+__all__ = [
+    "AbstractNonlinearSchwarz",
+    "NonlinearAdditiveSchwarz",
+    "NonlinearGaussSeidel",
+    "NonlinearMultiplicativeSchwarz",
+    "NonlinearSubdomain",
+]

--- a/phydrax/nonlinear/_fas.py
+++ b/phydrax/nonlinear/_fas.py
@@ -13,9 +13,19 @@ import jax.numpy as jnp
 from jaxtyping import Array, PyTree
 
 from .._strict import StrictModule
-from .._tree_math import tree_add_scaled
+from .._tree_math import tree_add_scaled, tree_allfinite
 from ..linalg import AbstractVectorSpace
 from ._types import NonlinearProvenance, NonlinearStatus
+from ._updates import (
+    AbstractNonlinearUpdate,
+    NonlinearUpdateCapabilities,
+    NonlinearUpdateControl,
+    NonlinearUpdateDiagnostics,
+    NonlinearUpdateProvenance,
+    NonlinearUpdateResult,
+    NonlinearUpdateStatus,
+    PreparedNonlinearUpdate,
+)
 
 
 FASCycleKind: TypeAlias = Literal["v", "w", "f"]
@@ -409,8 +419,8 @@ def fas_cycle(
     )
 
 
-class FASNonlinearPreconditioner(StrictModule):
-    """One FAS cycle exposed as a nonlinear state preconditioner."""
+class FASNonlinearPreconditioner(AbstractNonlinearUpdate):
+    """One prepared FAS cycle exposed as a finite nonlinear update."""
 
     hierarchy: FASHierarchy
     policy: FASCyclePolicy
@@ -430,6 +440,27 @@ class FASNonlinearPreconditioner(StrictModule):
         self.hierarchy = hierarchy
         self.policy = policy_
 
+    @property
+    def update_id(self) -> str:
+        return f"fas-{self.policy.kind}/{self.hierarchy.hierarchy_id}"
+
+    @property
+    def capabilities(self) -> NonlinearUpdateCapabilities:
+        return NonlinearUpdateCapabilities(
+            jit=True,
+            prepared_refresh=True,
+            differentiable_action=True,
+            counts_complete=False,
+        )
+
+    def _prepare_internal(self, problem, state, args, /):
+        del problem, state, args
+        return None
+
+    def _refresh_internal(self, internal_state, problem, state, args, /):
+        del problem, state, args
+        return internal_state
+
     def __call__(self, state: PyTree[Any], args: Any = None, /) -> PyTree[Array]:
         return fas_cycle(
             self.hierarchy,
@@ -437,6 +468,109 @@ class FASNonlinearPreconditioner(StrictModule):
             args=args,
             policy=self.policy,
         ).state
+
+    def _apply(
+        self,
+        prepared: PreparedNonlinearUpdate,
+        state: PyTree[Any],
+        args: Any,
+        control: NonlinearUpdateControl,
+        /,
+    ):
+        problem = prepared.problem
+        state_ = prepared.plan.state_space.validate(state)
+        initial_residual, initial_auxiliary = problem.evaluate(state_, args)
+        initial_norm = _space_norm(prepared.plan.residual_space, initial_residual)
+        hard_budget_requested = any(
+            value is not None
+            for value in (
+                control.maximum_residual_evaluations,
+                control.maximum_jacobian_preparations,
+                control.maximum_linear_solves,
+                control.maximum_linear_iterations,
+            )
+        )
+        if hard_budget_requested:
+            diagnostics = NonlinearUpdateDiagnostics(
+                initial_residual_norm=initial_norm,
+                final_residual_norm=initial_norm,
+                step_norm=0.0,
+                residual_evaluations=1,
+                counts_complete=False,
+            )
+            return (
+                NonlinearUpdateResult(
+                    state=state_,
+                    residual=initial_residual,
+                    auxiliary=initial_auxiliary,
+                    status=NonlinearUpdateStatus.BUDGET_EXHAUSTED,
+                    diagnostics=diagnostics,
+                    provenance=NonlinearUpdateProvenance(
+                        problem_id=problem.problem_id,
+                        update_id=self.update_id,
+                        plan_id=prepared.plan.plan_id,
+                        notes="FAS smoother/coarse work is not fully countable.",
+                    ),
+                ),
+                prepared.internal_state,
+            )
+        cycle = fas_cycle(
+            self.hierarchy,
+            state_,
+            args=args,
+            policy=self.policy,
+        )
+        residual, auxiliary = problem.evaluate(cycle.state, args)
+        final_norm = _space_norm(prepared.plan.residual_space, residual)
+        finite = (
+            tree_allfinite(cycle.state)
+            & tree_allfinite(residual)
+            & cycle.diagnostics.finite
+        )
+        valid = problem.valid(cycle.state, residual, auxiliary, args)
+        status = jnp.where(
+            ~finite,
+            int(NonlinearUpdateStatus.NONFINITE_EVALUATION),
+            jnp.where(
+                ~valid,
+                int(NonlinearUpdateStatus.DOMAIN_REJECTED),
+                int(NonlinearUpdateStatus.APPLIED),
+            ),
+        ).astype(jnp.int32)
+        diagnostics = NonlinearUpdateDiagnostics(
+            initial_residual_norm=initial_norm,
+            final_residual_norm=final_norm,
+            step_norm=_space_norm(
+                prepared.plan.state_space,
+                jax.tree.map(lambda new, old: new - old, cycle.state, state_),
+            ),
+            residual_evaluations=2,
+            accepted_steps=(status == int(NonlinearUpdateStatus.APPLIED)).astype(
+                jnp.int32
+            ),
+            rejected_steps=(status != int(NonlinearUpdateStatus.APPLIED)).astype(
+                jnp.int32
+            ),
+            domain_failures=(finite & ~valid).astype(jnp.int32),
+            nonfinite_trials=(~finite).astype(jnp.int32),
+            counts_complete=False,
+        )
+        return (
+            NonlinearUpdateResult(
+                state=cycle.state,
+                residual=residual,
+                auxiliary=auxiliary,
+                status=status,
+                diagnostics=diagnostics,
+                provenance=NonlinearUpdateProvenance(
+                    problem_id=problem.problem_id,
+                    update_id=self.update_id,
+                    plan_id=prepared.plan.plan_id,
+                    notes=f"cycle={self.policy.kind};hierarchy={self.hierarchy.hierarchy_id}",
+                ),
+            ),
+            prepared.internal_state,
+        )
 
 
 __all__ = [

--- a/phydrax/nonlinear/_fixed_point.py
+++ b/phydrax/nonlinear/_fixed_point.py
@@ -14,7 +14,12 @@ import jax.numpy as jnp
 from jaxtyping import Array, PyTree
 
 from .._strict import StrictModule
-from .._tree_math import tree_add_scaled, tree_norm, validate_inexact_tree
+from .._tree_math import (
+    tree_add_scaled,
+    tree_allfinite,
+    tree_norm,
+    validate_inexact_tree,
+)
 from ..linalg import AbstractPreconditioner, PyTreeSpace
 from ._types import (
     FixedPointProblem,
@@ -25,6 +30,16 @@ from ._types import (
     NonlinearStatus,
     NonlinearSystemProblem,
     NonlinearTermination,
+)
+from ._updates import (
+    AbstractNonlinearUpdate,
+    NonlinearUpdateCapabilities,
+    NonlinearUpdateControl,
+    NonlinearUpdateDiagnostics,
+    NonlinearUpdateProvenance,
+    NonlinearUpdateResult,
+    NonlinearUpdateStatus,
+    PreparedNonlinearUpdate,
 )
 
 
@@ -390,6 +405,176 @@ class FixedPointIteration(StrictModule):
         )
 
 
+def _picard_candidate(
+    inverse_action: Callable[[PyTree[Any]], PyTree[Any]] | AbstractPreconditioner,
+    damping: float,
+    state: PyTree[Any],
+    residual: PyTree[Any],
+    /,
+) -> PyTree[Array]:
+    correction = (
+        inverse_action.apply(residual)
+        if isinstance(inverse_action, AbstractPreconditioner)
+        else inverse_action(residual)
+    )
+    return tree_add_scaled(state, correction, -damping)
+
+
+class PicardUpdate(AbstractNonlinearUpdate):
+    """One preconditioned Picard correction as a finite nonlinear update."""
+
+    inverse_action: Callable[[PyTree[Any]], PyTree[Any]] | AbstractPreconditioner
+    damping: float = eqx.field(static=True)
+
+    def __init__(
+        self,
+        inverse_action: Callable[[PyTree[Any]], PyTree[Any]] | AbstractPreconditioner,
+        /,
+        *,
+        damping: float = 1.0,
+    ):
+        if not callable(inverse_action) and not isinstance(
+            inverse_action, AbstractPreconditioner
+        ):
+            raise TypeError("inverse_action must be callable or AbstractPreconditioner.")
+        damping_ = float(damping)
+        if not isfinite(damping_) or not 0.0 < damping_ <= 1.0:
+            raise ValueError("Picard damping must lie in (0, 1].")
+        self.inverse_action = inverse_action
+        self.damping = damping_
+
+    @property
+    def update_id(self) -> str:
+        return "picard-update"
+
+    @property
+    def capabilities(self) -> NonlinearUpdateCapabilities:
+        return NonlinearUpdateCapabilities(
+            jit=True,
+            prepared_refresh=True,
+            differentiable_action=True,
+        )
+
+    def _prepare_internal(self, problem, state, args, /):
+        del problem, state, args
+        return None
+
+    def _refresh_internal(self, internal_state, problem, state, args, /):
+        del problem, state, args
+        return internal_state
+
+    def _apply(
+        self,
+        prepared: PreparedNonlinearUpdate,
+        state: PyTree[Any],
+        args: Any,
+        control: NonlinearUpdateControl,
+        /,
+    ):
+        problem = prepared.problem
+        state_ = prepared.plan.state_space.validate(state)
+        residual, auxiliary = problem.evaluate(state_, args)
+        initial_norm = jnp.sqrt(
+            jnp.maximum(
+                jnp.real(prepared.plan.residual_space.inner(residual, residual)),
+                0.0,
+            )
+        )
+        if not control.permits(
+            residual_evaluations=2,
+            jacobian_preparations=0,
+            linear_solves=0,
+            linear_iterations=0,
+        ):
+            diagnostics = NonlinearUpdateDiagnostics(
+                initial_residual_norm=initial_norm,
+                final_residual_norm=initial_norm,
+                step_norm=0.0,
+                residual_evaluations=1,
+            )
+            return (
+                NonlinearUpdateResult(
+                    state=state_,
+                    residual=residual,
+                    auxiliary=auxiliary,
+                    status=NonlinearUpdateStatus.BUDGET_EXHAUSTED,
+                    diagnostics=diagnostics,
+                    provenance=NonlinearUpdateProvenance(
+                        problem_id=problem.problem_id,
+                        update_id=self.update_id,
+                        plan_id=prepared.plan.plan_id,
+                    ),
+                ),
+                prepared.internal_state,
+            )
+        candidate = prepared.plan.state_space.validate(
+            _picard_candidate(self.inverse_action, self.damping, state_, residual)
+        )
+        candidate_residual, candidate_auxiliary = problem.evaluate(candidate, args)
+        final_norm = jnp.sqrt(
+            jnp.maximum(
+                jnp.real(
+                    prepared.plan.residual_space.inner(
+                        candidate_residual,
+                        candidate_residual,
+                    )
+                ),
+                0.0,
+            )
+        )
+        finite = tree_allfinite(candidate) & tree_allfinite(candidate_residual)
+        valid = problem.valid(
+            candidate,
+            candidate_residual,
+            candidate_auxiliary,
+            args,
+        )
+        status = jnp.where(
+            ~finite,
+            int(NonlinearUpdateStatus.NONFINITE_EVALUATION),
+            jnp.where(
+                ~valid,
+                int(NonlinearUpdateStatus.DOMAIN_REJECTED),
+                int(NonlinearUpdateStatus.APPLIED),
+            ),
+        ).astype(jnp.int32)
+        step = jax.tree.map(lambda new, old: new - old, candidate, state_)
+        diagnostics = NonlinearUpdateDiagnostics(
+            initial_residual_norm=initial_norm,
+            final_residual_norm=final_norm,
+            step_norm=jnp.sqrt(
+                jnp.maximum(
+                    jnp.real(prepared.plan.state_space.inner(step, step)),
+                    0.0,
+                )
+            ),
+            residual_evaluations=2,
+            accepted_steps=(status == int(NonlinearUpdateStatus.APPLIED)).astype(
+                jnp.int32
+            ),
+            rejected_steps=(status != int(NonlinearUpdateStatus.APPLIED)).astype(
+                jnp.int32
+            ),
+            domain_failures=(finite & ~valid).astype(jnp.int32),
+            nonfinite_trials=(~finite).astype(jnp.int32),
+        )
+        return (
+            NonlinearUpdateResult(
+                state=candidate,
+                residual=candidate_residual,
+                auxiliary=candidate_auxiliary,
+                status=status,
+                diagnostics=diagnostics,
+                provenance=NonlinearUpdateProvenance(
+                    problem_id=problem.problem_id,
+                    update_id=self.update_id,
+                    plan_id=prepared.plan.plan_id,
+                ),
+            ),
+            prepared.internal_state,
+        )
+
+
 class PicardIteration(StrictModule):
     """Preconditioned Picard iteration for a physical nonlinear residual."""
 
@@ -437,12 +622,12 @@ class PicardIteration(StrictModule):
 
         def mapping(state, current_args):
             residual = problem.residual(state, current_args)
-            correction = (
-                self.inverse_action.apply(residual)
-                if isinstance(self.inverse_action, AbstractPreconditioner)
-                else self.inverse_action(residual)
+            return _picard_candidate(
+                self.inverse_action,
+                self.damping,
+                state,
+                residual,
             )
-            return tree_add_scaled(state, correction, -self.damping)
 
         fixed_problem = FixedPointProblem(
             mapping,
@@ -487,4 +672,9 @@ class PicardIteration(StrictModule):
         )
 
 
-__all__ = ["AndersonAcceleration", "FixedPointIteration", "PicardIteration"]
+__all__ = [
+    "AndersonAcceleration",
+    "FixedPointIteration",
+    "PicardIteration",
+    "PicardUpdate",
+]

--- a/phydrax/nonlinear/_ngmres.py
+++ b/phydrax/nonlinear/_ngmres.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from math import isfinite
 from typing import Any
 
+import equinox as eqx
 import jax
 import jax.numpy as jnp
 from jaxtyping import Array, PyTree
@@ -24,6 +24,12 @@ from ._types import (
     NonlinearStatus,
     NonlinearSystemProblem,
     NonlinearTermination,
+)
+from ._updates import (
+    AbstractNonlinearUpdate,
+    apply_prepared_nonlinear_update,
+    prepare_nonlinear_update,
+    PreparedNonlinearUpdate,
 )
 
 
@@ -44,27 +50,33 @@ class _NGMRESRun(StrictModule):
     history_residuals: Array
     history_count: Array
     status: Array
+    prepared_update: PreparedNonlinearUpdate
+    jvp_evaluations: Array
+    vjp_evaluations: Array
+    jacobian_preparations: Array
+    linear_solves: Array
+    linear_iterations: Array
 
 
 class NonlinearGMRES(AbstractNonlinearMethod):
     """Nonlinear-preconditioned residual-minimizing affine acceleration."""
 
-    preconditioner: Callable[[PyTree[Any], Any], PyTree[Any]]
+    update: AbstractNonlinearUpdate
     history: int
     regularization: float
     safeguard_factor: float
 
     def __init__(
         self,
-        preconditioner: Callable[[PyTree[Any], Any], PyTree[Any]],
+        update: AbstractNonlinearUpdate,
         /,
         *,
         history: int = 8,
         regularization: float = 1e-10,
         safeguard_factor: float = 1.0,
     ):
-        if not callable(preconditioner):
-            raise TypeError("preconditioner must be callable.")
+        if not isinstance(update, AbstractNonlinearUpdate):
+            raise TypeError("update must be AbstractNonlinearUpdate.")
         history_ = int(history)
         regularization_ = float(regularization)
         safeguard_ = float(safeguard_factor)
@@ -74,7 +86,7 @@ class NonlinearGMRES(AbstractNonlinearMethod):
             raise ValueError("regularization must be finite and non-negative.")
         if not isfinite(safeguard_) or safeguard_ < 1.0:
             raise ValueError("safeguard_factor must be finite and at least one.")
-        self.preconditioner = preconditioner
+        self.update = update
         self.history = history_
         self.regularization = regularization_
         self.safeguard_factor = safeguard_
@@ -87,7 +99,7 @@ class NonlinearGMRES(AbstractNonlinearMethod):
     def capabilities(self) -> NonlinearCapabilities:
         return NonlinearCapabilities(
             matrix_free=True,
-            prepared_refresh=False,
+            prepared_refresh=True,
             jit=True,
             implicit_differentiation=False,
             nonlinear_preconditioning=True,
@@ -131,6 +143,16 @@ class NonlinearGMRES(AbstractNonlinearMethod):
             & initial_valid
             & (initial_norm <= termination.residual_threshold(initial_norm))
         )
+        prepared_update = prepare_nonlinear_update(
+            problem,
+            initial,
+            self.update,
+            args=args,
+        )
+        prepared_dynamic, prepared_static = eqx.partition(
+            prepared_update,
+            eqx.is_array,
+        )
         run = _NGMRESRun(
             state=initial_coordinates,
             residual=initial_residual,
@@ -147,6 +169,12 @@ class NonlinearGMRES(AbstractNonlinearMethod):
             history_states=history_states,
             history_residuals=history_residuals,
             history_count=jnp.asarray(0, dtype=jnp.int32),
+            prepared_update=prepared_dynamic,
+            jvp_evaluations=jnp.asarray(0, dtype=jnp.int32),
+            vjp_evaluations=jnp.asarray(0, dtype=jnp.int32),
+            jacobian_preparations=jnp.asarray(0, dtype=jnp.int32),
+            linear_solves=jnp.asarray(0, dtype=jnp.int32),
+            linear_iterations=jnp.asarray(0, dtype=jnp.int32),
             status=jnp.where(
                 initial_converged,
                 int(NonlinearStatus.SUCCESS),
@@ -176,16 +204,27 @@ class NonlinearGMRES(AbstractNonlinearMethod):
 
         def body(current):
             state_tree = source.unflatten(current.state)
-            base_tree = self.preconditioner(state_tree, args)
+            combined_prepared = eqx.combine(
+                current.prepared_update,
+                prepared_static,
+            )
+            base_result, next_prepared_update = apply_prepared_nonlinear_update(
+                combined_prepared,
+                state_tree,
+                args=args,
+            )
+            next_prepared_dynamic, _ = eqx.partition(
+                next_prepared_update,
+                eqx.is_array,
+            )
+            base_tree = base_result.state
             base = source.flatten(base_tree)
-            base_residual_tree, base_auxiliary = problem.evaluate(base_tree, args)
+            base_residual_tree = base_result.residual
             base_residual = target.flatten(base_residual_tree)
             base_finite = jnp.all(jnp.isfinite(base)) & jnp.all(
                 jnp.isfinite(base_residual)
             )
-            base_valid = problem.valid(
-                base_tree, base_residual_tree, base_auxiliary, args
-            )
+            base_valid = base_result.applied
 
             indices = jnp.arange(self.history)
             active = indices >= (self.history - current.history_count)
@@ -323,24 +362,39 @@ class NonlinearGMRES(AbstractNonlinearMethod):
                 residual_norm=accepted_norm,
                 step_norm=step_norm,
                 iteration=current.iteration + accepted.astype(jnp.int32),
-                residual_evaluations=current.residual_evaluations + 2,
+                residual_evaluations=(
+                    current.residual_evaluations
+                    + base_result.diagnostics.residual_evaluations
+                    + 1
+                ),
                 accepted_steps=current.accepted_steps + accepted.astype(jnp.int32),
                 rejected_steps=current.rejected_steps
                 + rejected_acceleration.astype(jnp.int32)
                 + (~accepted).astype(jnp.int32),
                 domain_failures=current.domain_failures
-                + (
-                    (base_finite & ~base_valid)
-                    | (accelerated_finite & ~accelerated_valid)
-                ).astype(jnp.int32),
+                + base_result.diagnostics.domain_failures
+                + (accelerated_finite & ~accelerated_valid).astype(jnp.int32),
                 nonfinite_trials=current.nonfinite_trials
-                + (~base_finite).astype(jnp.int32)
+                + base_result.diagnostics.nonfinite_trials
                 + (~accelerated_finite).astype(jnp.int32),
                 restarts=current.restarts + rejected_acceleration.astype(jnp.int32),
                 history_states=next_history_states,
                 history_residuals=next_history_residuals,
                 history_count=next_history_count,
                 status=status,
+                prepared_update=next_prepared_dynamic,
+                jvp_evaluations=current.jvp_evaluations,
+                vjp_evaluations=current.vjp_evaluations,
+                jacobian_preparations=(
+                    current.jacobian_preparations
+                    + base_result.diagnostics.jacobian_preparations
+                ),
+                linear_solves=(
+                    current.linear_solves + base_result.diagnostics.linear_solves
+                ),
+                linear_iterations=(
+                    current.linear_iterations + base_result.diagnostics.linear_iterations
+                ),
             )
 
         run = jax.lax.while_loop(condition, body, run)
@@ -387,6 +441,11 @@ class NonlinearGMRES(AbstractNonlinearMethod):
             final_step_norm=run.step_norm,
             iterations=run.iteration,
             residual_evaluations=run.residual_evaluations + 1,
+            jvp_evaluations=run.jvp_evaluations,
+            vjp_evaluations=run.vjp_evaluations,
+            jacobian_preparations=run.jacobian_preparations,
+            linear_solves=run.linear_solves,
+            linear_iterations=run.linear_iterations,
             accepted_steps=run.accepted_steps,
             rejected_steps=run.rejected_steps,
             domain_failures=run.domain_failures
@@ -395,6 +454,7 @@ class NonlinearGMRES(AbstractNonlinearMethod):
             ),
             nonfinite_trials=run.nonfinite_trials,
             acceleration_restarts=run.restarts,
+            counts_complete=self.update.capabilities.counts_complete,
         )
         return NonlinearResult(
             state=final_state,
@@ -407,6 +467,7 @@ class NonlinearGMRES(AbstractNonlinearMethod):
                 method_id=self.method_id,
                 derivative_id="residual-affine-model",
                 globalization_id="preconditioner-safeguard",
+                notes=f"update={self.update.update_id}",
             ),
         )
 

--- a/phydrax/nonlinear/_richardson.py
+++ b/phydrax/nonlinear/_richardson.py
@@ -1,0 +1,432 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from math import isfinite
+from typing import Any
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array, PyTree
+
+from .._strict import StrictModule
+from .._tree_math import validate_inexact_tree
+from ..linalg import PyTreeSpace
+from ._types import (
+    AbstractNonlinearMethod,
+    NonlinearCapabilities,
+    NonlinearDiagnostics,
+    NonlinearProvenance,
+    NonlinearResult,
+    NonlinearStatus,
+    NonlinearSystemProblem,
+    NonlinearTermination,
+)
+from ._updates import (
+    AbstractNonlinearUpdate,
+    apply_prepared_nonlinear_update,
+    prepare_nonlinear_update,
+    PreparedNonlinearUpdate,
+)
+
+
+class _RichardsonSearch(StrictModule):
+    state: Array
+    residual: Array
+    residual_norm: Array
+    rate: Array
+    steps: Array
+    accepted: Array
+    finite_valid_seen: Array
+    domain_failures: Array
+    nonfinite_trials: Array
+
+
+class _RichardsonRun(StrictModule):
+    state: Array
+    residual: Array
+    initial_residual_norm: Array
+    residual_norm: Array
+    step_norm: Array
+    iteration: Array
+    residual_evaluations: Array
+    jacobian_preparations: Array
+    linear_solves: Array
+    linear_iterations: Array
+    accepted_steps: Array
+    rejected_steps: Array
+    domain_failures: Array
+    nonfinite_trials: Array
+    prepared_update: PreparedNonlinearUpdate
+    status: Array
+
+
+class NonlinearRichardson(AbstractNonlinearMethod):
+    """Armijo-globalized iteration over one typed nonlinear update."""
+
+    update: AbstractNonlinearUpdate
+    sufficient_decrease: float = eqx.field(static=True)
+    contraction: float = eqx.field(static=True)
+    minimum_rate: float = eqx.field(static=True)
+    maximum_search_steps: int = eqx.field(static=True)
+
+    def __init__(
+        self,
+        update: AbstractNonlinearUpdate,
+        /,
+        *,
+        sufficient_decrease: float = 1e-4,
+        contraction: float = 0.5,
+        minimum_rate: float = 1e-8,
+        maximum_search_steps: int = 20,
+    ):
+        if not isinstance(update, AbstractNonlinearUpdate):
+            raise TypeError("update must be AbstractNonlinearUpdate.")
+        decrease = float(sufficient_decrease)
+        contraction_ = float(contraction)
+        minimum = float(minimum_rate)
+        steps = int(maximum_search_steps)
+        if not isfinite(decrease) or not 0.0 < decrease < 1.0:
+            raise ValueError("sufficient_decrease must lie in (0, 1).")
+        if not isfinite(contraction_) or not 0.0 < contraction_ < 1.0:
+            raise ValueError("contraction must lie in (0, 1).")
+        if not isfinite(minimum) or not 0.0 < minimum < 1.0:
+            raise ValueError("minimum_rate must lie in (0, 1).")
+        if steps < 1:
+            raise ValueError("maximum_search_steps must be positive.")
+        self.update = update
+        self.sufficient_decrease = decrease
+        self.contraction = contraction_
+        self.minimum_rate = minimum
+        self.maximum_search_steps = steps
+
+    @property
+    def method_id(self) -> str:
+        return "nonlinear-richardson"
+
+    @property
+    def capabilities(self) -> NonlinearCapabilities:
+        return NonlinearCapabilities(
+            matrix_free=True,
+            prepared_refresh=True,
+            jit=self.update.capabilities.jit,
+            implicit_differentiation=False,
+            fixed_point=True,
+            nonlinear_preconditioning=True,
+        )
+
+    def solve(
+        self,
+        problem: NonlinearSystemProblem,
+        initial_state: PyTree[Any],
+        /,
+        *,
+        termination: NonlinearTermination,
+        args: Any = None,
+    ) -> NonlinearResult:
+        if not isinstance(problem, NonlinearSystemProblem):
+            raise TypeError("problem must be NonlinearSystemProblem.")
+        if not isinstance(termination, NonlinearTermination):
+            raise TypeError("termination must be NonlinearTermination.")
+        initial = validate_inexact_tree(initial_state, name="initial Richardson state")
+        residual, auxiliary = problem.evaluate(initial, args)
+        source = PyTreeSpace(initial)
+        target = PyTreeSpace(residual)
+        state_coordinates = source.flatten(initial)
+        residual_coordinates = target.flatten(residual)
+        initial_norm = jnp.linalg.norm(residual_coordinates)
+        finite = jnp.all(jnp.isfinite(state_coordinates)) & jnp.all(
+            jnp.isfinite(residual_coordinates)
+        )
+        valid = problem.valid(initial, residual, auxiliary, args)
+        converged = (
+            finite
+            & valid
+            & (initial_norm <= termination.residual_threshold(initial_norm))
+        )
+        prepared_update = prepare_nonlinear_update(
+            problem,
+            initial,
+            self.update,
+            args=args,
+        )
+        prepared_dynamic, prepared_static = eqx.partition(
+            prepared_update,
+            eqx.is_array,
+        )
+        run = _RichardsonRun(
+            state=state_coordinates,
+            residual=residual_coordinates,
+            initial_residual_norm=initial_norm,
+            residual_norm=initial_norm,
+            step_norm=jnp.asarray(0.0, dtype=initial_norm.dtype),
+            iteration=jnp.asarray(0, dtype=jnp.int32),
+            residual_evaluations=jnp.asarray(1, dtype=jnp.int32),
+            jacobian_preparations=jnp.asarray(0, dtype=jnp.int32),
+            linear_solves=jnp.asarray(0, dtype=jnp.int32),
+            linear_iterations=jnp.asarray(0, dtype=jnp.int32),
+            accepted_steps=jnp.asarray(0, dtype=jnp.int32),
+            rejected_steps=jnp.asarray(0, dtype=jnp.int32),
+            domain_failures=(finite & ~valid).astype(jnp.int32),
+            nonfinite_trials=(~finite).astype(jnp.int32),
+            prepared_update=prepared_dynamic,
+            status=jnp.where(
+                converged,
+                int(NonlinearStatus.SUCCESS),
+                jnp.where(
+                    finite & valid,
+                    int(NonlinearStatus.ITERATING),
+                    jnp.where(
+                        finite,
+                        int(NonlinearStatus.UNRECOVERABLE_DOMAIN_FAILURE),
+                        int(NonlinearStatus.NONFINITE_INPUT),
+                    ),
+                ),
+            ).astype(jnp.int32),
+        )
+
+        def condition(current):
+            within_evaluations = (
+                jnp.asarray(True)
+                if termination.maximum_evaluations is None
+                else current.residual_evaluations + 1 <= termination.maximum_evaluations
+            )
+            return (
+                (current.status == int(NonlinearStatus.ITERATING))
+                & (current.iteration < termination.maximum_steps)
+                & within_evaluations
+            )
+
+        def body(current):
+            state_tree = source.unflatten(current.state)
+            combined_prepared = eqx.combine(
+                current.prepared_update,
+                prepared_static,
+            )
+            update_result, next_prepared = apply_prepared_nonlinear_update(
+                combined_prepared,
+                state_tree,
+                args=args,
+            )
+            next_prepared_dynamic, _ = eqx.partition(next_prepared, eqx.is_array)
+            proposed_state = source.flatten(update_result.state)
+            proposed_residual = target.flatten(update_result.residual)
+            direction = proposed_state - current.state
+            proposed_norm = jnp.linalg.norm(proposed_residual)
+            proposed_finite = jnp.all(jnp.isfinite(proposed_state)) & jnp.all(
+                jnp.isfinite(proposed_residual)
+            )
+            proposed_valid = update_result.applied
+            proposed_accepted = (
+                proposed_valid
+                & proposed_finite
+                & (
+                    proposed_norm * proposed_norm
+                    <= (1.0 - self.sufficient_decrease)
+                    * current.residual_norm
+                    * current.residual_norm
+                )
+            )
+            search = _RichardsonSearch(
+                state=proposed_state,
+                residual=proposed_residual,
+                residual_norm=proposed_norm,
+                rate=jnp.asarray(1.0, dtype=proposed_norm.dtype),
+                steps=jnp.asarray(0, dtype=jnp.int32),
+                accepted=proposed_accepted,
+                finite_valid_seen=proposed_finite & proposed_valid,
+                domain_failures=update_result.diagnostics.domain_failures,
+                nonfinite_trials=update_result.diagnostics.nonfinite_trials,
+            )
+
+            def search_condition(item):
+                return (
+                    update_result.applied
+                    & ~item.accepted
+                    & (item.steps < self.maximum_search_steps)
+                    & (item.rate > self.minimum_rate)
+                )
+
+            def search_body(item):
+                rate = self.contraction * item.rate
+                trial_coordinates = current.state + rate * direction
+                trial_state = source.unflatten(trial_coordinates)
+                trial_residual_tree, trial_auxiliary = problem.evaluate(trial_state, args)
+                trial_residual = target.flatten(trial_residual_tree)
+                trial_norm = jnp.linalg.norm(trial_residual)
+                trial_finite = jnp.all(jnp.isfinite(trial_coordinates)) & jnp.all(
+                    jnp.isfinite(trial_residual)
+                )
+                trial_valid = problem.valid(
+                    trial_state,
+                    trial_residual_tree,
+                    trial_auxiliary,
+                    args,
+                )
+                accepted = (
+                    trial_finite
+                    & trial_valid
+                    & (
+                        trial_norm * trial_norm
+                        <= (1.0 - self.sufficient_decrease * rate)
+                        * current.residual_norm
+                        * current.residual_norm
+                    )
+                )
+                return _RichardsonSearch(
+                    state=trial_coordinates,
+                    residual=trial_residual,
+                    residual_norm=trial_norm,
+                    rate=rate,
+                    steps=item.steps + 1,
+                    accepted=accepted,
+                    finite_valid_seen=item.finite_valid_seen
+                    | (trial_finite & trial_valid),
+                    domain_failures=item.domain_failures
+                    + (trial_finite & ~trial_valid).astype(jnp.int32),
+                    nonfinite_trials=item.nonfinite_trials
+                    + (~trial_finite).astype(jnp.int32),
+                )
+
+            search = jax.lax.while_loop(search_condition, search_body, search)
+            accepted_state = jnp.where(search.accepted, search.state, current.state)
+            accepted_residual = jnp.where(
+                search.accepted,
+                search.residual,
+                current.residual,
+            )
+            accepted_norm = jnp.where(
+                search.accepted,
+                search.residual_norm,
+                current.residual_norm,
+            )
+            step_norm = jnp.linalg.norm(accepted_state - current.state)
+            converged = search.accepted & (
+                accepted_norm
+                <= termination.residual_threshold(current.initial_residual_norm)
+            )
+            stagnated = (
+                search.accepted
+                & ~converged
+                & (
+                    step_norm
+                    <= termination.step_threshold(jnp.linalg.norm(current.state))
+                )
+            )
+            status = jnp.where(
+                converged,
+                int(NonlinearStatus.SUCCESS),
+                jnp.where(
+                    stagnated,
+                    int(NonlinearStatus.RESIDUAL_STAGNATION),
+                    jnp.where(
+                        search.accepted,
+                        int(NonlinearStatus.ITERATING),
+                        jnp.where(
+                            search.finite_valid_seen,
+                            int(NonlinearStatus.LINE_SEARCH_FAILED),
+                            int(NonlinearStatus.NONFINITE_EVALUATION),
+                        ),
+                    ),
+                ),
+            ).astype(jnp.int32)
+            return _RichardsonRun(
+                state=accepted_state,
+                residual=accepted_residual,
+                initial_residual_norm=current.initial_residual_norm,
+                residual_norm=accepted_norm,
+                step_norm=step_norm,
+                iteration=current.iteration + search.accepted.astype(jnp.int32),
+                residual_evaluations=current.residual_evaluations
+                + update_result.diagnostics.residual_evaluations
+                + search.steps,
+                jacobian_preparations=current.jacobian_preparations
+                + update_result.diagnostics.jacobian_preparations,
+                linear_solves=current.linear_solves
+                + update_result.diagnostics.linear_solves,
+                linear_iterations=current.linear_iterations
+                + update_result.diagnostics.linear_iterations,
+                accepted_steps=current.accepted_steps
+                + update_result.diagnostics.accepted_steps
+                + search.accepted.astype(jnp.int32),
+                rejected_steps=current.rejected_steps
+                + update_result.diagnostics.rejected_steps
+                + (~search.accepted).astype(jnp.int32),
+                domain_failures=current.domain_failures + search.domain_failures,
+                nonfinite_trials=current.nonfinite_trials + search.nonfinite_trials,
+                prepared_update=next_prepared_dynamic,
+                status=status,
+            )
+
+        run = jax.lax.while_loop(condition, body, run)
+        exhausted = (
+            jnp.asarray(False)
+            if termination.maximum_evaluations is None
+            else run.residual_evaluations >= termination.maximum_evaluations
+        )
+        status = jnp.where(
+            run.status == int(NonlinearStatus.ITERATING),
+            jnp.where(
+                exhausted,
+                int(NonlinearStatus.MAXIMUM_EVALUATIONS_REACHED),
+                int(NonlinearStatus.MAXIMUM_STEPS_REACHED),
+            ),
+            run.status,
+        ).astype(jnp.int32)
+        final_state = source.unflatten(run.state)
+        final_residual, final_auxiliary = problem.evaluate(final_state, args)
+        final_coordinates = target.flatten(final_residual)
+        final_norm = jnp.linalg.norm(final_coordinates)
+        final_finite = jnp.all(jnp.isfinite(run.state)) & jnp.all(
+            jnp.isfinite(final_coordinates)
+        )
+        final_valid = problem.valid(
+            final_state,
+            final_residual,
+            final_auxiliary,
+            args,
+        )
+        status = jnp.where(
+            ~final_finite,
+            int(NonlinearStatus.NONFINITE_EVALUATION),
+            jnp.where(
+                ~final_valid,
+                int(NonlinearStatus.UNRECOVERABLE_DOMAIN_FAILURE),
+                status,
+            ),
+        ).astype(jnp.int32)
+        diagnostics = NonlinearDiagnostics(
+            initial_residual_norm=run.initial_residual_norm,
+            final_residual_norm=final_norm,
+            final_step_norm=run.step_norm,
+            iterations=run.iteration,
+            residual_evaluations=run.residual_evaluations + 1,
+            jacobian_preparations=run.jacobian_preparations,
+            linear_solves=run.linear_solves,
+            linear_iterations=run.linear_iterations,
+            accepted_steps=run.accepted_steps,
+            rejected_steps=run.rejected_steps,
+            domain_failures=run.domain_failures,
+            nonfinite_trials=run.nonfinite_trials,
+            counts_complete=self.update.capabilities.counts_complete,
+        )
+        return NonlinearResult(
+            state=final_state,
+            residual=final_residual,
+            auxiliary=final_auxiliary,
+            status=status,
+            diagnostics=diagnostics,
+            provenance=NonlinearProvenance(
+                problem_id=problem.problem_id,
+                method_id=self.method_id,
+                derivative_id="none",
+                globalization_id="physical-residual-armijo",
+                notes=f"update={self.update.update_id}",
+            ),
+        )
+
+
+__all__ = ["NonlinearRichardson"]

--- a/phydrax/nonlinear/_updates.py
+++ b/phydrax/nonlinear/_updates.py
@@ -1,0 +1,876 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import abc
+from enum import IntEnum
+from typing import Any
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array, PyTree
+
+from .._fingerprint import canonical_fingerprint
+from .._strict import StrictModule
+from .._tree_math import tree_allfinite, validate_inexact_tree
+from ..linalg import AbstractVectorSpace
+from ._newton import NewtonKrylov, NewtonTrustRegion
+from ._prepared import (
+    prepare_nonlinear,
+    PreparedNonlinearSolve,
+    refresh_nonlinear,
+    solve_prepared_nonlinear,
+)
+from ._types import (
+    AbstractNonlinearMethod,
+    NonlinearDiagnostics,
+    NonlinearStatus,
+    NonlinearSystemProblem,
+    NonlinearTermination,
+)
+
+
+def _space_norm(space: AbstractVectorSpace, vector: PyTree[Any], /) -> Array:
+    squared = jnp.real(space.inner(vector, vector))
+    return jnp.sqrt(jnp.maximum(squared, 0.0))
+
+
+class NonlinearUpdateStatus(IntEnum):
+    """Terminal status for one bounded nonlinear update application."""
+
+    APPLIED = 0
+    NO_PROGRESS = 1
+    DOMAIN_REJECTED = 2
+    NONFINITE_INPUT = 3
+    NONFINITE_EVALUATION = 4
+    INNER_FAILURE = 5
+    LINEAR_FAILURE = 6
+    BUDGET_EXHAUSTED = 7
+
+
+_UPDATE_STATUS_MESSAGES = {
+    NonlinearUpdateStatus.APPLIED: "nonlinear update applied",
+    NonlinearUpdateStatus.NO_PROGRESS: "nonlinear update made no certified progress",
+    NonlinearUpdateStatus.DOMAIN_REJECTED: "nonlinear update left the physical domain",
+    NonlinearUpdateStatus.NONFINITE_INPUT: "nonlinear update input is non-finite",
+    NonlinearUpdateStatus.NONFINITE_EVALUATION: "nonlinear update evaluation is non-finite",
+    NonlinearUpdateStatus.INNER_FAILURE: "inner nonlinear method failed",
+    NonlinearUpdateStatus.LINEAR_FAILURE: "inner linear solve failed",
+    NonlinearUpdateStatus.BUDGET_EXHAUSTED: "remaining work cannot fund the nonlinear update",
+}
+
+
+def nonlinear_update_status_message(status: int | NonlinearUpdateStatus, /) -> str:
+    return _UPDATE_STATUS_MESSAGES[NonlinearUpdateStatus(int(status))]
+
+
+class NonlinearUpdateCapabilities(StrictModule):
+    """Static execution capabilities of one finite nonlinear update."""
+
+    jit: bool = eqx.field(static=True)
+    prepared_refresh: bool = eqx.field(static=True)
+    differentiable_action: bool = eqx.field(static=True)
+    exposes_linearization: bool = eqx.field(static=True)
+    counts_complete: bool = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        jit: bool,
+        prepared_refresh: bool,
+        differentiable_action: bool,
+        exposes_linearization: bool = False,
+        counts_complete: bool = True,
+    ):
+        self.jit = bool(jit)
+        self.prepared_refresh = bool(prepared_refresh)
+        self.differentiable_action = bool(differentiable_action)
+        self.exposes_linearization = bool(exposes_linearization)
+        self.counts_complete = bool(counts_complete)
+
+
+class NonlinearUpdateControl(StrictModule):
+    """Remaining aggregate work available to one indivisible update."""
+
+    maximum_residual_evaluations: int | None = eqx.field(static=True)
+    maximum_jacobian_preparations: int | None = eqx.field(static=True)
+    maximum_linear_solves: int | None = eqx.field(static=True)
+    maximum_linear_iterations: int | None = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        maximum_residual_evaluations: int | None = None,
+        maximum_jacobian_preparations: int | None = None,
+        maximum_linear_solves: int | None = None,
+        maximum_linear_iterations: int | None = None,
+    ):
+        values = (
+            maximum_residual_evaluations,
+            maximum_jacobian_preparations,
+            maximum_linear_solves,
+            maximum_linear_iterations,
+        )
+        normalized = tuple(None if value is None else int(value) for value in values)
+        if any(value is not None and value < 0 for value in normalized):
+            raise ValueError(
+                "Nonlinear update work allowances must be non-negative or None."
+            )
+        (
+            self.maximum_residual_evaluations,
+            self.maximum_jacobian_preparations,
+            self.maximum_linear_solves,
+            self.maximum_linear_iterations,
+        ) = normalized
+
+    def permits(
+        self,
+        *,
+        residual_evaluations: int,
+        jacobian_preparations: int,
+        linear_solves: int,
+        linear_iterations: int,
+    ) -> bool:
+        requested = (
+            int(residual_evaluations),
+            int(jacobian_preparations),
+            int(linear_solves),
+            int(linear_iterations),
+        )
+        available = (
+            self.maximum_residual_evaluations,
+            self.maximum_jacobian_preparations,
+            self.maximum_linear_solves,
+            self.maximum_linear_iterations,
+        )
+        return all(
+            limit is None or need <= limit
+            for need, limit in zip(requested, available, strict=True)
+        )
+
+
+class NonlinearUpdateDiagnostics(StrictModule):
+    """Physical progress and exact work from one update application."""
+
+    initial_residual_norm: Array
+    final_residual_norm: Array
+    step_norm: Array
+    residual_evaluations: Array
+    jacobian_preparations: Array
+    linear_solves: Array
+    linear_iterations: Array
+    accepted_steps: Array
+    rejected_steps: Array
+    domain_failures: Array
+    nonfinite_trials: Array
+    counts_complete: bool = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        initial_residual_norm: Any,
+        final_residual_norm: Any,
+        step_norm: Any,
+        residual_evaluations: Any = 0,
+        jacobian_preparations: Any = 0,
+        linear_solves: Any = 0,
+        linear_iterations: Any = 0,
+        accepted_steps: Any = 0,
+        rejected_steps: Any = 0,
+        domain_failures: Any = 0,
+        nonfinite_trials: Any = 0,
+        counts_complete: bool = True,
+    ):
+        self.initial_residual_norm = jnp.asarray(initial_residual_norm)
+        self.final_residual_norm = jnp.asarray(final_residual_norm)
+        self.step_norm = jnp.asarray(step_norm)
+        values = tuple(
+            jnp.asarray(value, dtype=jnp.int32)
+            for value in (
+                residual_evaluations,
+                jacobian_preparations,
+                linear_solves,
+                linear_iterations,
+                accepted_steps,
+                rejected_steps,
+                domain_failures,
+                nonfinite_trials,
+            )
+        )
+        (
+            self.residual_evaluations,
+            self.jacobian_preparations,
+            self.linear_solves,
+            self.linear_iterations,
+            self.accepted_steps,
+            self.rejected_steps,
+            self.domain_failures,
+            self.nonfinite_trials,
+        ) = values
+        self.counts_complete = bool(counts_complete)
+
+    @classmethod
+    def from_nonlinear(
+        cls,
+        diagnostics: NonlinearDiagnostics,
+        /,
+        *,
+        step_norm: Any | None = None,
+    ) -> NonlinearUpdateDiagnostics:
+        if not isinstance(diagnostics, NonlinearDiagnostics):
+            raise TypeError("diagnostics must be NonlinearDiagnostics.")
+        return cls(
+            initial_residual_norm=diagnostics.initial_residual_norm,
+            final_residual_norm=diagnostics.final_residual_norm,
+            step_norm=(diagnostics.final_step_norm if step_norm is None else step_norm),
+            residual_evaluations=diagnostics.residual_evaluations,
+            jacobian_preparations=diagnostics.jacobian_preparations,
+            linear_solves=diagnostics.linear_solves,
+            linear_iterations=diagnostics.linear_iterations,
+            accepted_steps=diagnostics.accepted_steps,
+            rejected_steps=diagnostics.rejected_steps,
+            domain_failures=diagnostics.domain_failures,
+            nonfinite_trials=diagnostics.nonfinite_trials,
+            counts_complete=diagnostics.counts_complete,
+        )
+
+
+class NonlinearUpdateProvenance(StrictModule):
+    """Static identity of one update application and its bound plan."""
+
+    problem_id: str = eqx.field(static=True)
+    update_id: str = eqx.field(static=True)
+    plan_id: str = eqx.field(static=True)
+    notes: str = eqx.field(static=True)
+
+    def __init__(self, *, problem_id: str, update_id: str, plan_id: str, notes: str = ""):
+        identifiers = tuple(str(value) for value in (problem_id, update_id, plan_id))
+        if any(not value for value in identifiers):
+            raise ValueError("Nonlinear update provenance identifiers must be non-empty.")
+        self.problem_id, self.update_id, self.plan_id = identifiers
+        self.notes = str(notes)
+
+
+class NonlinearUpdateResult(StrictModule):
+    """One physical state proposal with application-level evidence."""
+
+    state: PyTree[Array]
+    residual: PyTree[Array]
+    auxiliary: Any
+    status: Array
+    inner_status: Array
+    diagnostics: NonlinearUpdateDiagnostics
+    provenance: NonlinearUpdateProvenance
+    components: tuple[NonlinearUpdateResult, ...]
+
+    def __init__(
+        self,
+        *,
+        state: PyTree[Any],
+        residual: PyTree[Any],
+        auxiliary: Any,
+        status: Any,
+        diagnostics: NonlinearUpdateDiagnostics,
+        provenance: NonlinearUpdateProvenance,
+        inner_status: Any = -1,
+        components: tuple[NonlinearUpdateResult, ...] = (),
+    ):
+        if not isinstance(diagnostics, NonlinearUpdateDiagnostics):
+            raise TypeError("diagnostics must be NonlinearUpdateDiagnostics.")
+        if not isinstance(provenance, NonlinearUpdateProvenance):
+            raise TypeError("provenance must be NonlinearUpdateProvenance.")
+        components_ = tuple(components)
+        if not all(isinstance(value, NonlinearUpdateResult) for value in components_):
+            raise TypeError("components must contain NonlinearUpdateResult values.")
+        self.state = validate_inexact_tree(state, name="nonlinear update state")
+        self.residual = validate_inexact_tree(residual, name="nonlinear update residual")
+        self.auxiliary = auxiliary
+        self.status = jnp.asarray(status, dtype=jnp.int32)
+        self.inner_status = jnp.asarray(inner_status, dtype=jnp.int32)
+        self.diagnostics = diagnostics
+        self.provenance = provenance
+        self.components = components_
+
+    @property
+    def applied(self) -> Array:
+        return self.status == int(NonlinearUpdateStatus.APPLIED)
+
+
+class NonlinearUpdatePlan(StrictModule):
+    """Symbolic binding of one update to physical vector spaces."""
+
+    state_space: AbstractVectorSpace
+    residual_space: AbstractVectorSpace
+    problem_id: str = eqx.field(static=True)
+    update_id: str = eqx.field(static=True)
+    plan_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        state_space: AbstractVectorSpace,
+        residual_space: AbstractVectorSpace,
+        /,
+        *,
+        problem_id: str,
+        update_id: str,
+    ):
+        if not isinstance(state_space, AbstractVectorSpace) or not isinstance(
+            residual_space, AbstractVectorSpace
+        ):
+            raise TypeError("Update plans require declared state and residual spaces.")
+        problem_id_ = str(problem_id)
+        update_id_ = str(update_id)
+        if not problem_id_ or not update_id_:
+            raise ValueError("Update plan identifiers must be non-empty.")
+        plan_id = canonical_fingerprint(
+            {
+                "kind": "nonlinear-update-plan",
+                "problem": problem_id_,
+                "update": update_id_,
+                "state_space": state_space.space_id,
+                "residual_space": residual_space.space_id,
+            }
+        )
+        self.state_space = state_space
+        self.residual_space = residual_space
+        self.problem_id = problem_id_
+        self.update_id = update_id_
+        self.plan_id = plan_id
+
+
+class PreparedNonlinearUpdate(StrictModule):
+    """Prepared finite-work update with reusable numerical state."""
+
+    problem: NonlinearSystemProblem
+    update: AbstractNonlinearUpdate
+    plan: NonlinearUpdatePlan
+    internal_state: Any
+    numeric_version: Array
+
+    def __init__(
+        self,
+        problem: NonlinearSystemProblem,
+        update: AbstractNonlinearUpdate,
+        plan: NonlinearUpdatePlan,
+        internal_state: Any,
+        /,
+        *,
+        numeric_version: Any,
+    ):
+        if not isinstance(problem, NonlinearSystemProblem):
+            raise TypeError("problem must be NonlinearSystemProblem.")
+        if not isinstance(update, AbstractNonlinearUpdate):
+            raise TypeError("update must be AbstractNonlinearUpdate.")
+        if not isinstance(plan, NonlinearUpdatePlan):
+            raise TypeError("plan must be NonlinearUpdatePlan.")
+        if plan.problem_id != problem.problem_id or plan.update_id != update.update_id:
+            raise ValueError("Prepared update identity does not match its plan.")
+        version = jnp.asarray(numeric_version, dtype=jnp.int32)
+        if version.ndim != 0:
+            raise ValueError("numeric_version must be scalar.")
+        version = eqx.error_if(
+            version, version < 0, "numeric_version must be non-negative."
+        )
+        self.problem = problem
+        self.update = update
+        self.plan = plan
+        self.internal_state = internal_state
+        self.numeric_version = version
+
+
+class AbstractNonlinearUpdate(StrictModule):
+    """Finite nonlinear work that proposes, but need not solve for, a physical state."""
+
+    @property
+    @abc.abstractmethod
+    def update_id(self) -> str:
+        raise NotImplementedError
+
+    @property
+    @abc.abstractmethod
+    def capabilities(self) -> NonlinearUpdateCapabilities:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def _prepare_internal(
+        self,
+        problem: NonlinearSystemProblem,
+        state: PyTree[Any],
+        args: Any,
+        /,
+    ) -> Any:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def _refresh_internal(
+        self,
+        internal_state: Any,
+        problem: NonlinearSystemProblem,
+        state: PyTree[Any],
+        args: Any,
+        /,
+    ) -> Any:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def _apply(
+        self,
+        prepared: PreparedNonlinearUpdate,
+        state: PyTree[Any],
+        args: Any,
+        control: NonlinearUpdateControl,
+        /,
+    ) -> tuple[NonlinearUpdateResult, Any]:
+        raise NotImplementedError
+
+
+class FunctionNonlinearUpdate(AbstractNonlinearUpdate):
+    """Explicit callable boundary for one physical state proposal."""
+
+    function: Any
+    update_name: str = eqx.field(static=True)
+
+    def __init__(self, function: Any, /, *, update_id: str = "function-update"):
+        if not callable(function):
+            raise TypeError("function must be callable.")
+        identifier = str(update_id)
+        if not identifier:
+            raise ValueError("update_id must be non-empty.")
+        self.function = function
+        self.update_name = identifier
+
+    @property
+    def update_id(self) -> str:
+        return self.update_name
+
+    @property
+    def capabilities(self) -> NonlinearUpdateCapabilities:
+        return NonlinearUpdateCapabilities(
+            jit=True,
+            prepared_refresh=True,
+            differentiable_action=True,
+        )
+
+    def _prepare_internal(
+        self,
+        problem: NonlinearSystemProblem,
+        state: PyTree[Any],
+        args: Any,
+        /,
+    ) -> None:
+        del problem, state, args
+        return None
+
+    def _refresh_internal(
+        self,
+        internal_state: Any,
+        problem: NonlinearSystemProblem,
+        state: PyTree[Any],
+        args: Any,
+        /,
+    ) -> Any:
+        del problem, state, args
+        return internal_state
+
+    def _apply(
+        self,
+        prepared: PreparedNonlinearUpdate,
+        state: PyTree[Any],
+        args: Any,
+        control: NonlinearUpdateControl,
+        /,
+    ) -> tuple[NonlinearUpdateResult, Any]:
+        problem = prepared.problem
+        state_ = prepared.plan.state_space.validate(state)
+        initial_residual, initial_auxiliary = problem.evaluate(state_, args)
+        initial_norm = _space_norm(prepared.plan.residual_space, initial_residual)
+        if not control.permits(
+            residual_evaluations=2,
+            jacobian_preparations=0,
+            linear_solves=0,
+            linear_iterations=0,
+        ):
+            diagnostics = NonlinearUpdateDiagnostics(
+                initial_residual_norm=initial_norm,
+                final_residual_norm=initial_norm,
+                step_norm=0.0,
+                residual_evaluations=1,
+            )
+            return (
+                NonlinearUpdateResult(
+                    state=state_,
+                    residual=initial_residual,
+                    auxiliary=initial_auxiliary,
+                    status=NonlinearUpdateStatus.BUDGET_EXHAUSTED,
+                    diagnostics=diagnostics,
+                    provenance=_provenance(prepared),
+                ),
+                prepared.internal_state,
+            )
+        candidate = prepared.plan.state_space.validate(self.function(state_, args))
+        residual, auxiliary = problem.evaluate(candidate, args)
+        final_norm = _space_norm(prepared.plan.residual_space, residual)
+        finite = tree_allfinite(candidate) & tree_allfinite(residual)
+        valid = problem.valid(candidate, residual, auxiliary, args)
+        status = jnp.where(
+            ~finite,
+            int(NonlinearUpdateStatus.NONFINITE_EVALUATION),
+            jnp.where(
+                ~valid,
+                int(NonlinearUpdateStatus.DOMAIN_REJECTED),
+                int(NonlinearUpdateStatus.APPLIED),
+            ),
+        ).astype(jnp.int32)
+        diagnostics = NonlinearUpdateDiagnostics(
+            initial_residual_norm=initial_norm,
+            final_residual_norm=final_norm,
+            step_norm=_space_norm(
+                prepared.plan.state_space,
+                jax.tree.map(lambda new, old: new - old, candidate, state_),
+            ),
+            residual_evaluations=2,
+            accepted_steps=(status == int(NonlinearUpdateStatus.APPLIED)).astype(
+                jnp.int32
+            ),
+            rejected_steps=(status != int(NonlinearUpdateStatus.APPLIED)).astype(
+                jnp.int32
+            ),
+            domain_failures=(finite & ~valid).astype(jnp.int32),
+            nonfinite_trials=(~finite).astype(jnp.int32),
+        )
+        return (
+            NonlinearUpdateResult(
+                state=candidate,
+                residual=residual,
+                auxiliary=auxiliary,
+                status=status,
+                diagnostics=diagnostics,
+                provenance=_provenance(prepared),
+            ),
+            prepared.internal_state,
+        )
+
+
+class NewtonStepUpdate(AbstractNonlinearUpdate):
+    """One globalized Newton step exposed independently of root convergence."""
+
+    method: NewtonKrylov | NewtonTrustRegion
+    termination: NonlinearTermination
+    require_decrease: bool = eqx.field(static=True)
+
+    def __init__(
+        self,
+        method: AbstractNonlinearMethod | None = None,
+        /,
+        *,
+        termination: NonlinearTermination | None = None,
+        require_decrease: bool = True,
+    ):
+        method_ = NewtonKrylov() if method is None else method
+        termination_ = NonlinearTermination() if termination is None else termination
+        if not isinstance(method_, (NewtonKrylov, NewtonTrustRegion)):
+            raise TypeError(
+                "NewtonStepUpdate requires NewtonKrylov or NewtonTrustRegion."
+            )
+        if not isinstance(termination_, NonlinearTermination):
+            raise TypeError("termination must be NonlinearTermination or None.")
+        self.method = method_
+        self.termination = _single_step_termination(termination_)
+        self.require_decrease = bool(require_decrease)
+
+    @property
+    def update_id(self) -> str:
+        return f"newton-step/{self.method.method_id}"
+
+    @property
+    def capabilities(self) -> NonlinearUpdateCapabilities:
+        return NonlinearUpdateCapabilities(
+            jit=True,
+            prepared_refresh=True,
+            differentiable_action=False,
+            exposes_linearization=True,
+        )
+
+    def _prepare_internal(
+        self,
+        problem: NonlinearSystemProblem,
+        state: PyTree[Any],
+        args: Any,
+        /,
+    ) -> PreparedNonlinearSolve:
+        return prepare_nonlinear(
+            problem,
+            state,
+            method=self.method,
+            termination=self.termination,
+            args=args,
+        )
+
+    def _refresh_internal(
+        self,
+        internal_state: Any,
+        problem: NonlinearSystemProblem,
+        state: PyTree[Any],
+        args: Any,
+        /,
+    ) -> PreparedNonlinearSolve:
+        if not isinstance(internal_state, PreparedNonlinearSolve):
+            raise TypeError("Prepared Newton update state is invalid.")
+        return refresh_nonlinear(internal_state, problem, state, args=args)
+
+    def _apply(
+        self,
+        prepared: PreparedNonlinearUpdate,
+        state: PyTree[Any],
+        args: Any,
+        control: NonlinearUpdateControl,
+        /,
+    ) -> tuple[NonlinearUpdateResult, Any]:
+        internal = self._refresh_internal(
+            prepared.internal_state,
+            prepared.problem,
+            state,
+            args,
+        )
+        initial_norm = internal.run.residual_norm
+        maximum_evaluations = self.termination.maximum_evaluations
+        maximum_linear = self.termination.maximum_linear_iterations
+        if not control.permits(
+            residual_evaluations=(
+                2 if maximum_evaluations is None else maximum_evaluations
+            ),
+            jacobian_preparations=1,
+            linear_solves=1,
+            linear_iterations=(0 if maximum_linear is None else maximum_linear),
+        ):
+            diagnostics = NonlinearUpdateDiagnostics(
+                initial_residual_norm=initial_norm,
+                final_residual_norm=initial_norm,
+                step_norm=0.0,
+                residual_evaluations=internal.run.residual_evaluations,
+                jacobian_preparations=internal.run.jacobian_preparations,
+            )
+            return (
+                NonlinearUpdateResult(
+                    state=internal.state,
+                    residual=internal.run.residual,
+                    auxiliary=internal.run.auxiliary,
+                    status=NonlinearUpdateStatus.BUDGET_EXHAUSTED,
+                    diagnostics=diagnostics,
+                    provenance=_provenance(prepared),
+                ),
+                internal,
+            )
+        result = solve_prepared_nonlinear(internal, termination=self.termination)
+        accepted = result.diagnostics.accepted_steps > 0
+        decreased = result.diagnostics.final_residual_norm < initial_norm
+        finite = tree_allfinite(result.state) & tree_allfinite(result.residual)
+        valid = prepared.problem.valid(
+            result.state, result.residual, result.auxiliary, args
+        )
+        usable = accepted & finite & valid & (decreased | ~self.require_decrease)
+        status = jnp.where(
+            usable,
+            int(NonlinearUpdateStatus.APPLIED),
+            _update_status_from_inner(result.status),
+        ).astype(jnp.int32)
+        diagnostics = NonlinearUpdateDiagnostics.from_nonlinear(result.diagnostics)
+        return (
+            NonlinearUpdateResult(
+                state=result.state,
+                residual=result.residual,
+                auxiliary=result.auxiliary,
+                status=status,
+                inner_status=result.status,
+                diagnostics=diagnostics,
+                provenance=_provenance(prepared),
+            ),
+            internal,
+        )
+
+
+def _single_step_termination(value: NonlinearTermination, /) -> NonlinearTermination:
+    return NonlinearTermination(
+        absolute_residual=value.absolute_residual,
+        relative_residual=value.relative_residual,
+        absolute_step=value.absolute_step,
+        relative_step=value.relative_step,
+        maximum_steps=1,
+        maximum_evaluations=value.maximum_evaluations,
+        maximum_linear_iterations=value.maximum_linear_iterations,
+        divergence_factor=value.divergence_factor,
+    )
+
+
+def _update_status_from_inner(status: Any, /) -> Array:
+    value = jnp.asarray(status, dtype=jnp.int32)
+    return jnp.where(
+        value == int(NonlinearStatus.NONFINITE_INPUT),
+        int(NonlinearUpdateStatus.NONFINITE_INPUT),
+        jnp.where(
+            value == int(NonlinearStatus.NONFINITE_EVALUATION),
+            int(NonlinearUpdateStatus.NONFINITE_EVALUATION),
+            jnp.where(
+                (value == int(NonlinearStatus.RECOVERABLE_DOMAIN_FAILURE))
+                | (value == int(NonlinearStatus.UNRECOVERABLE_DOMAIN_FAILURE)),
+                int(NonlinearUpdateStatus.DOMAIN_REJECTED),
+                jnp.where(
+                    (value == int(NonlinearStatus.LINEAR_SOLVE_FAILED))
+                    | (value == int(NonlinearStatus.SINGULAR_JACOBIAN))
+                    | (value == int(NonlinearStatus.MAXIMUM_LINEAR_ITERATIONS_REACHED)),
+                    int(NonlinearUpdateStatus.LINEAR_FAILURE),
+                    int(NonlinearUpdateStatus.NO_PROGRESS),
+                ),
+            ),
+        ),
+    ).astype(jnp.int32)
+
+
+def _provenance(
+    prepared: PreparedNonlinearUpdate, /, *, notes: str = ""
+) -> NonlinearUpdateProvenance:
+    return NonlinearUpdateProvenance(
+        problem_id=prepared.problem.problem_id,
+        update_id=prepared.update.update_id,
+        plan_id=prepared.plan.plan_id,
+        notes=notes,
+    )
+
+
+def plan_nonlinear_update(
+    problem: NonlinearSystemProblem,
+    initial_state: PyTree[Any],
+    update: AbstractNonlinearUpdate,
+    /,
+    *,
+    args: Any = None,
+) -> tuple[NonlinearSystemProblem, PyTree[Array], NonlinearUpdatePlan]:
+    if not isinstance(problem, NonlinearSystemProblem):
+        raise TypeError("problem must be NonlinearSystemProblem.")
+    if not isinstance(update, AbstractNonlinearUpdate):
+        raise TypeError("update must be AbstractNonlinearUpdate.")
+    state = problem.validate_state(initial_state)
+    residual, _ = problem.evaluate(state, args)
+    problem_ = problem.bind_spaces(state, residual)
+    if problem_.state_space is None or problem_.residual_space is None:
+        raise ValueError("A nonlinear update plan requires bound vector spaces.")
+    return (
+        problem_,
+        state,
+        NonlinearUpdatePlan(
+            problem_.state_space,
+            problem_.residual_space,
+            problem_id=problem_.problem_id,
+            update_id=update.update_id,
+        ),
+    )
+
+
+def prepare_nonlinear_update(
+    problem: NonlinearSystemProblem,
+    initial_state: PyTree[Any],
+    update: AbstractNonlinearUpdate,
+    /,
+    *,
+    args: Any = None,
+) -> PreparedNonlinearUpdate:
+    problem_, state, plan = plan_nonlinear_update(
+        problem,
+        initial_state,
+        update,
+        args=args,
+    )
+    internal = update._prepare_internal(problem_, state, args)
+    return PreparedNonlinearUpdate(
+        problem_,
+        update,
+        plan,
+        internal,
+        numeric_version=0,
+    )
+
+
+def refresh_nonlinear_update(
+    prepared: PreparedNonlinearUpdate,
+    problem: NonlinearSystemProblem,
+    state: PyTree[Any],
+    /,
+    *,
+    args: Any = None,
+) -> PreparedNonlinearUpdate:
+    if not isinstance(prepared, PreparedNonlinearUpdate):
+        raise TypeError("prepared must be PreparedNonlinearUpdate.")
+    if not isinstance(problem, NonlinearSystemProblem):
+        raise TypeError("problem must be NonlinearSystemProblem.")
+    if problem.problem_id != prepared.problem.problem_id:
+        raise ValueError("Nonlinear update refresh must preserve problem_id.")
+    state_ = problem.validate_state(state)
+    residual, _ = problem.evaluate(state_, args)
+    problem_ = problem.bind_spaces(state_, residual)
+    if problem_.state_space is None or problem_.residual_space is None:
+        raise ValueError("Refreshed nonlinear update requires bound spaces.")
+    if not prepared.plan.state_space.compatible(problem_.state_space):
+        raise ValueError("Nonlinear update refresh changed the state space.")
+    if not prepared.plan.residual_space.compatible(problem_.residual_space):
+        raise ValueError("Nonlinear update refresh changed the residual space.")
+    internal = prepared.update._refresh_internal(
+        prepared.internal_state,
+        problem_,
+        state_,
+        args,
+    )
+    return PreparedNonlinearUpdate(
+        problem_,
+        prepared.update,
+        prepared.plan,
+        internal,
+        numeric_version=prepared.numeric_version + 1,
+    )
+
+
+def apply_prepared_nonlinear_update(
+    prepared: PreparedNonlinearUpdate,
+    state: PyTree[Any],
+    /,
+    *,
+    args: Any = None,
+    control: NonlinearUpdateControl | None = None,
+) -> tuple[NonlinearUpdateResult, PreparedNonlinearUpdate]:
+    if not isinstance(prepared, PreparedNonlinearUpdate):
+        raise TypeError("prepared must be PreparedNonlinearUpdate.")
+    control_ = NonlinearUpdateControl() if control is None else control
+    if not isinstance(control_, NonlinearUpdateControl):
+        raise TypeError("control must be NonlinearUpdateControl or None.")
+    state_ = prepared.plan.state_space.validate(state)
+    result, internal = prepared.update._apply(prepared, state_, args, control_)
+    next_prepared = PreparedNonlinearUpdate(
+        prepared.problem,
+        prepared.update,
+        prepared.plan,
+        internal,
+        numeric_version=prepared.numeric_version,
+    )
+    return result, next_prepared
+
+
+__all__ = [
+    "AbstractNonlinearUpdate",
+    "FunctionNonlinearUpdate",
+    "NewtonStepUpdate",
+    "NonlinearUpdateCapabilities",
+    "NonlinearUpdateControl",
+    "NonlinearUpdateDiagnostics",
+    "NonlinearUpdatePlan",
+    "NonlinearUpdateProvenance",
+    "NonlinearUpdateResult",
+    "NonlinearUpdateStatus",
+    "PreparedNonlinearUpdate",
+    "apply_prepared_nonlinear_update",
+    "nonlinear_update_status_message",
+    "plan_nonlinear_update",
+    "prepare_nonlinear_update",
+    "refresh_nonlinear_update",
+]

--- a/phydrax/nonlinear/_vi.py
+++ b/phydrax/nonlinear/_vi.py
@@ -11,13 +11,21 @@ from typing import Any, Literal, TypeAlias
 import equinox as eqx
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jaxtyping import Array, PyTree
 
 from .._bounds import Bounds
+from .._fingerprint import canonical_fingerprint
 from .._strict import StrictModule
 from .._tree_math import tree_allfinite, tree_norm, validate_real_inexact_tree
 from ..linalg import PyTreeSpace
 from ._newton import NewtonKrylov
+from ._prepared import (
+    prepare_nonlinear,
+    PreparedNonlinearSolve,
+    refresh_nonlinear,
+    solve_prepared_nonlinear,
+)
 from ._types import (
     NonlinearDiagnostics,
     NonlinearProvenance,
@@ -29,6 +37,7 @@ from ._types import (
 
 
 ComplementarityFormulation: TypeAlias = Literal["natural", "fischer-burmeister"]
+VariationalInequalityFeasibility: TypeAlias = Literal["allow-infeasible", "preserve-box"]
 
 
 @jax.custom_jvp
@@ -193,6 +202,7 @@ class VariationalInequalityProblem(StrictModule):
         /,
         *,
         derivative_policy: GeneralizedDerivativePolicy | None = None,
+        project_trials: bool = False,
     ) -> NonlinearSystemProblem:
         if formulation not in ("natural", "fischer-burmeister"):
             raise ValueError(f"Unknown complementarity formulation {formulation!r}.")
@@ -207,7 +217,8 @@ class VariationalInequalityProblem(StrictModule):
             )
 
         def residual(state, args):
-            value = validate_real_inexact_tree(state, name="VI state")
+            raw_value = validate_real_inexact_tree(state, name="VI state")
+            value = self.bounds.project(raw_value) if project_trials else raw_value
             physical = self.evaluate(value, args)
             transformed = (
                 _natural_map(value, physical, self.bounds)
@@ -224,7 +235,11 @@ class VariationalInequalityProblem(StrictModule):
         return NonlinearSystemProblem(
             residual,
             has_aux=True,
-            problem_id=f"{self.problem_id}/{formulation}",
+            problem_id=(
+                f"{self.problem_id}/{formulation}/projected"
+                if project_trials
+                else f"{self.problem_id}/{formulation}"
+            ),
         )
 
 
@@ -286,12 +301,14 @@ class SemismoothNewton(StrictModule):
     formulation: ComplementarityFormulation = eqx.field(static=True)
     derivative_policy: GeneralizedDerivativePolicy
     certification_tolerance: float = eqx.field(static=True)
+    feasibility: VariationalInequalityFeasibility = eqx.field(static=True)
 
     def __init__(
         self,
         *,
         newton: NewtonKrylov | None = None,
         formulation: ComplementarityFormulation = "fischer-burmeister",
+        feasibility: VariationalInequalityFeasibility = "allow-infeasible",
         derivative_policy: GeneralizedDerivativePolicy | None = None,
         certification_tolerance: float = 1e-7,
     ):
@@ -306,6 +323,8 @@ class SemismoothNewton(StrictModule):
             raise TypeError("newton must be NewtonKrylov or None.")
         if formulation not in ("natural", "fischer-burmeister"):
             raise ValueError(f"Unknown complementarity formulation {formulation!r}.")
+        if feasibility not in ("allow-infeasible", "preserve-box"):
+            raise ValueError("feasibility must be 'allow-infeasible' or 'preserve-box'.")
         if not isinstance(policy_, GeneralizedDerivativePolicy):
             raise TypeError(
                 "derivative_policy must be GeneralizedDerivativePolicy or None."
@@ -316,6 +335,7 @@ class SemismoothNewton(StrictModule):
         self.formulation = formulation
         self.derivative_policy = policy_
         self.certification_tolerance = tolerance
+        self.feasibility = feasibility
 
     def solve(
         self,
@@ -326,46 +346,265 @@ class SemismoothNewton(StrictModule):
         termination: NonlinearTermination | None = None,
         args: Any = None,
     ) -> VariationalInequalityResult:
-        if not isinstance(problem, VariationalInequalityProblem):
-            raise TypeError("problem must be a VariationalInequalityProblem.")
-        termination_ = NonlinearTermination() if termination is None else termination
-        if not isinstance(termination_, NonlinearTermination):
-            raise TypeError("termination must be NonlinearTermination or None.")
-        initial = problem.bounds.project(initial_state)
-        nonlinear_problem = problem.as_nonlinear_problem(
-            self.formulation,
-            derivative_policy=self.derivative_policy,
-        )
-        result = self.newton.solve(
-            nonlinear_problem,
-            initial,
-            termination=termination_,
-            args=args,
-        )
-        certificate = complementarity_certificate(
+        prepared = prepare_variational_inequality(
             problem,
-            result.state,
+            initial_state,
+            method=self,
+            termination=termination,
             args=args,
-            tolerance=self.certification_tolerance,
-            derivative_policy=self.derivative_policy,
         )
-        certified_status = jnp.where(
-            (result.status == int(NonlinearStatus.SUCCESS)) & ~certificate.certified,
-            int(NonlinearStatus.RESIDUAL_STAGNATION),
-            result.status,
-        ).astype(jnp.int32)
-        certified_result = NonlinearResult(
-            state=result.state,
-            residual=result.residual,
-            auxiliary=result.auxiliary,
-            status=certified_status,
-            diagnostics=result.diagnostics,
-            provenance=result.provenance,
+        return solve_prepared_variational_inequality(prepared)
+
+
+class PreparedVariationalInequalitySolve(StrictModule):
+    """Prepared semismooth VI solve with fixed bound-role topology."""
+
+    problem: VariationalInequalityProblem
+    method: SemismoothNewton
+    termination: NonlinearTermination
+    args: Any
+    nonlinear: PreparedNonlinearSolve
+    numeric_version: Array
+    topology_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        problem: VariationalInequalityProblem,
+        method: SemismoothNewton,
+        termination: NonlinearTermination,
+        args: Any,
+        nonlinear: PreparedNonlinearSolve,
+        /,
+        *,
+        topology_id: str,
+        numeric_version: Any,
+    ):
+        if not isinstance(problem, VariationalInequalityProblem):
+            raise TypeError("problem must be VariationalInequalityProblem.")
+        if not isinstance(method, SemismoothNewton):
+            raise TypeError("method must be SemismoothNewton.")
+        if not isinstance(termination, NonlinearTermination):
+            raise TypeError("termination must be NonlinearTermination.")
+        if not isinstance(nonlinear, PreparedNonlinearSolve):
+            raise TypeError("nonlinear must be PreparedNonlinearSolve.")
+        topology_id_ = str(topology_id)
+        if not topology_id_:
+            raise ValueError("topology_id must be non-empty.")
+        version = jnp.asarray(numeric_version, dtype=jnp.int32)
+        if version.ndim != 0:
+            raise ValueError("numeric_version must be scalar.")
+        version = eqx.error_if(
+            version,
+            version < 0,
+            "numeric_version must be non-negative.",
         )
-        return VariationalInequalityResult(
-            nonlinear_result=certified_result,
-            certificate=certificate,
+        self.problem = problem
+        self.method = method
+        self.termination = termination
+        self.args = args
+        self.nonlinear = nonlinear
+        self.numeric_version = version
+        self.topology_id = topology_id_
+
+
+def _bound_topology_id(problem: VariationalInequalityProblem, state, /) -> str:
+    lower, upper = problem.bounds.materialize(state)
+    roles = []
+    for lower_leaf, upper_leaf in zip(
+        jax.tree.leaves(lower),
+        jax.tree.leaves(upper),
+        strict=True,
+    ):
+        lower_host = np.asarray(lower_leaf)
+        upper_host = np.asarray(upper_leaf)
+        role = (
+            np.isfinite(lower_host).astype(np.int8)
+            + 2 * np.isfinite(upper_host).astype(np.int8)
+            + 4
+            * (
+                np.isfinite(lower_host)
+                & np.isfinite(upper_host)
+                & (lower_host == upper_host)
+            ).astype(np.int8)
         )
+        roles.append(
+            {
+                "shape": list(role.shape),
+                "roles": role.reshape(-1).tolist(),
+            }
+        )
+    return canonical_fingerprint(
+        {
+            "kind": "variational-inequality-bound-topology",
+            "problem": problem.problem_id,
+            "roles": roles,
+        }
+    )
+
+
+def _vi_nonlinear_problem(
+    problem: VariationalInequalityProblem,
+    method: SemismoothNewton,
+    /,
+) -> NonlinearSystemProblem:
+    return problem.as_nonlinear_problem(
+        method.formulation,
+        derivative_policy=method.derivative_policy,
+        project_trials=method.feasibility == "preserve-box",
+    )
+
+
+def prepare_variational_inequality(
+    problem: VariationalInequalityProblem,
+    initial_state: PyTree[Any],
+    /,
+    *,
+    method: SemismoothNewton | None = None,
+    termination: NonlinearTermination | None = None,
+    args: Any = None,
+) -> PreparedVariationalInequalitySolve:
+    if not isinstance(problem, VariationalInequalityProblem):
+        raise TypeError("problem must be VariationalInequalityProblem.")
+    method_ = SemismoothNewton() if method is None else method
+    termination_ = NonlinearTermination() if termination is None else termination
+    if not isinstance(method_, SemismoothNewton):
+        raise TypeError("method must be SemismoothNewton or None.")
+    if not isinstance(termination_, NonlinearTermination):
+        raise TypeError("termination must be NonlinearTermination or None.")
+    initial = problem.bounds.project(initial_state)
+    nonlinear = prepare_nonlinear(
+        _vi_nonlinear_problem(problem, method_),
+        initial,
+        method=method_.newton,
+        termination=termination_,
+        args=args,
+    )
+    return PreparedVariationalInequalitySolve(
+        problem,
+        method_,
+        termination_,
+        args,
+        nonlinear,
+        topology_id=_bound_topology_id(problem, initial),
+        numeric_version=0,
+    )
+
+
+def refresh_variational_inequality(
+    prepared: PreparedVariationalInequalitySolve,
+    problem: VariationalInequalityProblem,
+    initial_state: PyTree[Any],
+    /,
+    *,
+    args: Any = None,
+) -> PreparedVariationalInequalitySolve:
+    if not isinstance(prepared, PreparedVariationalInequalitySolve):
+        raise TypeError("prepared must be PreparedVariationalInequalitySolve.")
+    if not isinstance(problem, VariationalInequalityProblem):
+        raise TypeError("problem must be VariationalInequalityProblem.")
+    if problem.problem_id != prepared.problem.problem_id:
+        raise ValueError("VI refresh must preserve problem_id.")
+    initial = problem.bounds.project(initial_state)
+    topology_id = _bound_topology_id(problem, initial)
+    if topology_id != prepared.topology_id:
+        raise ValueError("VI refresh changed finite/infinite/fixed bound topology.")
+    nonlinear = refresh_nonlinear(
+        prepared.nonlinear,
+        _vi_nonlinear_problem(problem, prepared.method),
+        initial,
+        args=args,
+    )
+    return PreparedVariationalInequalitySolve(
+        problem,
+        prepared.method,
+        prepared.termination,
+        args,
+        nonlinear,
+        topology_id=prepared.topology_id,
+        numeric_version=prepared.numeric_version + 1,
+    )
+
+
+def solve_prepared_variational_inequality(
+    prepared: PreparedVariationalInequalitySolve,
+    /,
+    *,
+    termination: NonlinearTermination | None = None,
+) -> VariationalInequalityResult:
+    if not isinstance(prepared, PreparedVariationalInequalitySolve):
+        raise TypeError("prepared must be PreparedVariationalInequalitySolve.")
+    termination_ = prepared.termination if termination is None else termination
+    if not isinstance(termination_, NonlinearTermination):
+        raise TypeError("termination must be NonlinearTermination or None.")
+    result = solve_prepared_nonlinear(
+        prepared.nonlinear,
+        termination=termination_,
+    )
+    return _certify_variational_inequality_result(
+        prepared.problem,
+        prepared.method,
+        result,
+        prepared.args,
+    )
+
+
+def _certify_variational_inequality_result(
+    problem: VariationalInequalityProblem,
+    method: SemismoothNewton,
+    result: NonlinearResult,
+    args: Any,
+    /,
+) -> VariationalInequalityResult:
+    state = (
+        problem.bounds.project(result.state)
+        if method.feasibility == "preserve-box"
+        else result.state
+    )
+    nonlinear_problem = _vi_nonlinear_problem(problem, method)
+    transformed, physical = nonlinear_problem.evaluate(state, args)
+    certificate = complementarity_certificate(
+        problem,
+        state,
+        args=args,
+        tolerance=method.certification_tolerance,
+        derivative_policy=method.derivative_policy,
+    )
+    certified_status = jnp.where(
+        (result.status == int(NonlinearStatus.SUCCESS)) & ~certificate.certified,
+        int(NonlinearStatus.RESIDUAL_STAGNATION),
+        result.status,
+    ).astype(jnp.int32)
+    diagnostics = eqx.tree_at(
+        lambda value: (
+            value.final_residual_norm,
+            value.residual_evaluations,
+        ),
+        result.diagnostics,
+        (
+            tree_norm(transformed),
+            result.diagnostics.residual_evaluations + 1,
+        ),
+    )
+    provenance = NonlinearProvenance(
+        problem_id=nonlinear_problem.problem_id,
+        method_id=result.provenance.method_id,
+        derivative_id=result.provenance.derivative_id,
+        globalization_id=result.provenance.globalization_id,
+        linear_plan_id=result.provenance.linear_plan_id,
+        notes=(f"vi-formulation={method.formulation};feasibility={method.feasibility}"),
+    )
+    certified_result = NonlinearResult(
+        state=state,
+        residual=transformed,
+        auxiliary=physical,
+        status=certified_status,
+        diagnostics=diagnostics,
+        provenance=provenance,
+    )
+    return VariationalInequalityResult(
+        nonlinear_result=certified_result,
+        certificate=certificate,
+    )
 
 
 def complementarity_certificate(
@@ -445,9 +684,14 @@ def complementarity_certificate(
 __all__ = [
     "ComplementarityCertificate",
     "ComplementarityFormulation",
+    "PreparedVariationalInequalitySolve",
     "GeneralizedDerivativePolicy",
     "SemismoothNewton",
     "VariationalInequalityProblem",
     "VariationalInequalityResult",
+    "VariationalInequalityFeasibility",
     "complementarity_certificate",
+    "prepare_variational_inequality",
+    "refresh_variational_inequality",
+    "solve_prepared_variational_inequality",
 ]

--- a/phydrax/optim/__init__.py
+++ b/phydrax/optim/__init__.py
@@ -5,7 +5,12 @@
 """Phydrax-owned optimization algorithms and workflow configurations."""
 
 from .._model import KFACAffineBlock, KFACLayoutProvider
-from ._bounds import ActiveSetNewton, ProjectedGradient, ProjectedLBFGS
+from ._bounds import (
+    ActiveSetNewton,
+    BoundedNewtonTrustRegion,
+    ProjectedGradient,
+    ProjectedLBFGS,
+)
 from ._composite import (
     composite_least_squares,
     CompositeLeastSquaresProblem,
@@ -45,6 +50,9 @@ from ._iterative import (
 )
 from ._kfac._config import kfac
 from ._least_squares import (
+    AbstractBoundedLeastSquaresMethod,
+    BoundedGaussNewton,
+    BoundedLevenbergMarquardt,
     GaussNewton,
     least_squares,
     LeastSquaresState,
@@ -160,8 +168,18 @@ from ._stochastic import (
     StochasticProblem,
     StochasticResult,
 )
+from ._trust_region import (
+    solve_trust_region_subproblem,
+    SteihaugToint,
+    TrustRegionQuadraticProblem,
+    TrustRegionSubproblemDiagnostics,
+    TrustRegionSubproblemResult,
+    TrustRegionSubproblemStatus,
+)
 from ._unconstrained import (
     BetaMethod,
+    DenseNewtonDogleg,
+    DenseNewtonDoglegState,
     NewtonTrustRegion,
     NewtonTrustRegionState,
     NonlinearConjugateGradient,
@@ -208,6 +226,7 @@ __all__ = [
     "solve_conic_program",
     "solve_prepared_convex_program",
     "solve_linear_program",
+    "AbstractBoundedLeastSquaresMethod",
     "AbstractCompositeLeastSquaresMethod",
     "AbstractProximalFunctional",
     "AbstractProximalMethod",
@@ -225,6 +244,9 @@ __all__ = [
     "AugmentedLagrangian",
     "Bounds",
     "BetaMethod",
+    "BoundedNewtonTrustRegion",
+    "BoundedGaussNewton",
+    "BoundedLevenbergMarquardt",
     "BoxIndicator",
     "CVaRRisk",
     "ChanceConstraint",
@@ -233,6 +255,8 @@ __all__ = [
     "ConsensusADMM",
     "ConstrainedOptimalityCertificate",
     "DifferentialEvolutionSearch",
+    "DenseNewtonDogleg",
+    "DenseNewtonDoglegState",
     "EntropicRisk",
     "ElasticNetFunctional",
     "ExpectationRisk",
@@ -303,9 +327,14 @@ __all__ = [
     "StateDesignProblem",
     "StateDesignResult",
     "StateEquationResult",
+    "SteihaugToint",
     "StochasticAdam",
     "StochasticProblem",
     "StochasticResult",
+    "TrustRegionQuadraticProblem",
+    "TrustRegionSubproblemDiagnostics",
+    "TrustRegionSubproblemResult",
+    "TrustRegionSubproblemStatus",
     "composite_least_squares",
     "proximal_minimize",
     "riemannian_adam",
@@ -316,6 +345,7 @@ __all__ = [
     "solve_quadratic_program",
     "solve_quadratic_program_primal",
     "solve_state_design",
+    "solve_trust_region_subproblem",
     "strong_wolfe_line_search",
     "minimize_stochastic",
 ]

--- a/phydrax/optim/_bounds.py
+++ b/phydrax/optim/_bounds.py
@@ -46,6 +46,11 @@ from ._iterative._types import (
     OptimizationStatus,
     OptimizationTermination,
 )
+from ._trust_region import (
+    solve_trust_region_subproblem,
+    SteihaugToint,
+    TrustRegionQuadraticProblem,
+)
 
 
 def _default_active_set_linear_policy() -> LinearSolvePolicy:
@@ -218,6 +223,105 @@ class ActiveSetNewton(AbstractMinimizationMethod):
     @property
     def method_id(self) -> str:
         return "active-set-newton"
+
+    @property
+    def capabilities(self) -> OptimizationCapabilities:
+        return _bound_capabilities()
+
+    def solve(
+        self,
+        problem: MinimizationProblem,
+        initial_parameters: PyTree[Any],
+        /,
+        *,
+        termination: OptimizationTermination,
+        args: Any,
+    ) -> MinimizationResult:
+        return _solve_bound_constrained(
+            self,
+            problem,
+            initial_parameters,
+            termination=termination,
+            args=args,
+        )
+
+
+class BoundedNewtonTrustRegion(AbstractMinimizationMethod):
+    """Projected active-set Newton method with a matrix-free trust region."""
+
+    subproblem: SteihaugToint
+    initial_radius: float = eqx.field(static=True)
+    maximum_radius: float = eqx.field(static=True)
+    minimum_radius: float = eqx.field(static=True)
+    acceptance_ratio: float = eqx.field(static=True)
+    shrink_ratio: float = eqx.field(static=True)
+    expansion_ratio: float = eqx.field(static=True)
+    shrink_factor: float = eqx.field(static=True)
+    expansion_factor: float = eqx.field(static=True)
+    active_tolerance: float = eqx.field(static=True)
+    project_initial: bool = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        subproblem: SteihaugToint | None = None,
+        initial_radius: float = 1.0,
+        maximum_radius: float = 1e4,
+        minimum_radius: float = 1e-12,
+        acceptance_ratio: float = 1e-4,
+        shrink_ratio: float = 0.25,
+        expansion_ratio: float = 0.75,
+        shrink_factor: float = 0.25,
+        expansion_factor: float = 2.0,
+        active_tolerance: float = 1e-10,
+        project_initial: bool = True,
+    ):
+        subproblem_ = SteihaugToint() if subproblem is None else subproblem
+        if not isinstance(subproblem_, SteihaugToint):
+            raise TypeError("subproblem must be SteihaugToint or None.")
+        values = tuple(
+            float(value)
+            for value in (
+                initial_radius,
+                maximum_radius,
+                minimum_radius,
+                acceptance_ratio,
+                shrink_ratio,
+                expansion_ratio,
+                shrink_factor,
+                expansion_factor,
+                active_tolerance,
+            )
+        )
+        if any(not isfinite(value) or value <= 0.0 for value in values[:-1]):
+            raise ValueError("Bounded trust-region controls must be positive and finite.")
+        if not isfinite(values[-1]) or values[-1] < 0.0:
+            raise ValueError("active_tolerance must be finite and non-negative.")
+        if not values[2] <= values[0] <= values[1]:
+            raise ValueError(
+                "Radii must satisfy minimum_radius <= initial_radius <= maximum_radius."
+            )
+        if not 0.0 < values[3] < values[4] < values[5] < 1.0:
+            raise ValueError("Ratios must satisfy acceptance < shrink < expansion < one.")
+        if not 0.0 < values[6] < 1.0 or values[7] <= 1.0:
+            raise ValueError("Radius factors must shrink below and expand above one.")
+        self.subproblem = subproblem_
+        (
+            self.initial_radius,
+            self.maximum_radius,
+            self.minimum_radius,
+            self.acceptance_ratio,
+            self.shrink_ratio,
+            self.expansion_ratio,
+            self.shrink_factor,
+            self.expansion_factor,
+            self.active_tolerance,
+        ) = values
+        self.project_initial = bool(project_initial)
+
+    @property
+    def method_id(self) -> str:
+        return "bounded-newton-trust-region/steihaug-toint"
 
     @property
     def capabilities(self) -> OptimizationCapabilities:
@@ -452,6 +556,8 @@ class _BoundState(NamedTuple):
     numeric_refreshes: Array
     globalization_evaluations: Array
     direction_fallbacks: Array
+    trust_radius: Array
+    reduction_ratio: Array
 
 
 class _LBFGSState(NamedTuple):
@@ -689,6 +795,8 @@ def _initial_bound_state(
         numeric_refreshes=zero_count,
         globalization_evaluations=zero_count,
         direction_fallbacks=zero_count,
+        trust_radius=jnp.asarray(jnp.nan, dtype=scalar_dtype),
+        reduction_ratio=jnp.asarray(jnp.nan, dtype=scalar_dtype),
     )
 
 
@@ -1022,6 +1130,216 @@ def _run_active_set_newton(
     )
 
 
+def _run_bounded_newton_trust_region(
+    method: BoundedNewtonTrustRegion,
+    value_function,
+    bounds: Bounds,
+    initial_state: _BoundState,
+    termination: OptimizationTermination,
+    /,
+) -> _BoundState:
+    value_and_gradient = jax.value_and_grad(value_function)
+    seeded = initial_state._replace(
+        trust_radius=jnp.asarray(
+            method.initial_radius,
+            dtype=initial_state.final_step_norm.dtype,
+        )
+    )
+
+    def iteration_body(carry):
+        state, method_state = carry
+        (value, gradient), linearized = jax.linearize(
+            value_and_gradient,
+            state.parameters,
+        )
+        evaluated, _, optimality = _evaluate_bound_state(
+            state,
+            value,
+            gradient,
+            bounds,
+            termination,
+        )
+
+        def take_step(_):
+            active = bounds.active_mask(
+                evaluated.parameters,
+                gradient,
+                tolerance=method.active_tolerance,
+            )
+            free_gradient = jax.tree.map(
+                lambda value, mask: jnp.where(mask, 0.0, value),
+                gradient,
+                active,
+            )
+            space = PyTreeSpace(evaluated.parameters)
+
+            def hessian_action(direction):
+                free_direction = jax.tree.map(
+                    lambda value, mask: jnp.where(mask, 0.0, value),
+                    direction,
+                    active,
+                )
+                _, action = linearized(free_direction)
+                return jax.tree.map(
+                    lambda value, mask: jnp.where(mask, 0.0, value),
+                    action,
+                    active,
+                )
+
+            hessian = FunctionLinearOperator(
+                hessian_action,
+                source=space,
+                target=space,
+                properties=OperatorProperties(
+                    self_adjoint=True,
+                    evidence={"self_adjoint": "construction"},
+                ),
+                operator_id="bounded-objective-free-hessian",
+                closure_convert=False,
+            )
+            subproblem = solve_trust_region_subproblem(
+                TrustRegionQuadraticProblem(
+                    hessian,
+                    free_gradient,
+                    evaluated.trust_radius,
+                ),
+                method=method.subproblem,
+            )
+            unprojected = _tree_add_scaled(
+                evaluated.parameters,
+                subproblem.step,
+                1.0,
+            )
+            candidate = bounds.project(unprojected)
+            displacement = jax.tree.map(
+                lambda new, old: new - old,
+                candidate,
+                evaluated.parameters,
+            )
+            hessian_displacement = hessian.mv(displacement)
+            predicted = -(
+                _tree_inner(gradient, displacement)
+                + 0.5 * _tree_inner(displacement, hessian_displacement)
+            )
+            candidate_value, candidate_gradient = value_and_gradient(candidate)
+            actual = value - candidate_value
+            ratio = actual / jnp.maximum(predicted, 1e-30)
+            candidate_finite = (
+                jnp.isfinite(candidate_value)
+                & _tree_allfinite(candidate)
+                & _tree_allfinite(candidate_gradient)
+            )
+            accepted = (
+                subproblem.successful
+                & candidate_finite
+                & jnp.isfinite(predicted)
+                & (predicted > 0.0)
+                & jnp.isfinite(ratio)
+                & (ratio >= method.acceptance_ratio)
+            )
+            step_norm = _tree_norm(displacement)
+            shrink = (
+                ~subproblem.successful
+                | ~candidate_finite
+                | ~jnp.isfinite(ratio)
+                | (ratio < method.shrink_ratio)
+            )
+            expand = (
+                accepted
+                & (ratio > method.expansion_ratio)
+                & subproblem.diagnostics.boundary_hit
+            )
+            next_radius = jnp.where(
+                shrink,
+                jnp.maximum(
+                    method.minimum_radius,
+                    method.shrink_factor * evaluated.trust_radius,
+                ),
+                jnp.where(
+                    expand,
+                    jnp.minimum(
+                        method.maximum_radius,
+                        method.expansion_factor * evaluated.trust_radius,
+                    ),
+                    evaluated.trust_radius,
+                ),
+            )
+            accepted_parameters = _tree_where(
+                accepted,
+                candidate,
+                evaluated.parameters,
+            )
+            accepted_gradient = _tree_where(
+                accepted,
+                candidate_gradient,
+                gradient,
+            )
+            accepted_projected = bounds.projected_gradient(
+                accepted_parameters,
+                accepted_gradient,
+            )
+            accepted_optimality = _tree_norm(accepted_projected)
+            stagnated = (
+                accepted
+                & (
+                    step_norm
+                    <= termination.step_threshold(_tree_norm(accepted_parameters))
+                )
+                & (
+                    accepted_optimality
+                    > termination.optimality_threshold(evaluated.initial_optimality)
+                )
+            )
+            failed = (~accepted) & (next_radius <= method.minimum_radius)
+            status = jnp.where(
+                stagnated,
+                int(OptimizationStatus.STAGNATION),
+                jnp.where(
+                    failed,
+                    int(OptimizationStatus.TRUST_REGION_FAILED),
+                    int(OptimizationStatus.ITERATING),
+                ),
+            ).astype(jnp.int32)
+            return evaluated._replace(
+                parameters=accepted_parameters,
+                status=status,
+                iterations=evaluated.iterations + 1,
+                final_step_norm=step_norm,
+                accepted_rate=jnp.where(accepted, 1.0, 0.0),
+                accepted_steps=evaluated.accepted_steps + accepted.astype(jnp.int32),
+                rejected_steps=evaluated.rejected_steps + (~accepted).astype(jnp.int32),
+                objective_evaluations=evaluated.objective_evaluations + 1,
+                gradient_evaluations=evaluated.gradient_evaluations + 1,
+                hvp_evaluations=(
+                    evaluated.hvp_evaluations + subproblem.diagnostics.hessian_actions + 1
+                ),
+                linear_solves=evaluated.linear_solves + 1,
+                linear_iterations=(
+                    evaluated.linear_iterations + subproblem.diagnostics.iterations
+                ),
+                setup_refreshes=evaluated.setup_refreshes + 1,
+                numeric_refreshes=evaluated.numeric_refreshes + 1,
+                globalization_evaluations=evaluated.globalization_evaluations + 1,
+                trust_radius=next_radius,
+                reduction_ratio=ratio,
+            )
+
+        next_state = jax.lax.cond(
+            evaluated.status == int(OptimizationStatus.ITERATING),
+            take_step,
+            lambda _: evaluated,
+            None,
+        )
+        return next_state, method_state
+
+    return _run_bound_iterations(
+        seeded,
+        (),
+        iteration_body,
+        termination,
+    )
+
+
 def _initial_lbfgs_state(
     parameters: PyTree[Any],
     history_size: int,
@@ -1200,7 +1518,9 @@ def _run_projected_lbfgs(
 
 
 def _solve_bound_constrained(
-    method: ProjectedGradient | ActiveSetNewton | ProjectedLBFGS,
+    method: (
+        ProjectedGradient | ActiveSetNewton | BoundedNewtonTrustRegion | ProjectedLBFGS
+    ),
     problem: MinimizationProblem,
     initial_parameters: PyTree[Any],
     /,
@@ -1276,6 +1596,15 @@ def _solve_bound_constrained(
             termination,
         )
         active_tolerance = method.active_tolerance
+    elif isinstance(method, BoundedNewtonTrustRegion):
+        state = _run_bounded_newton_trust_region(
+            method,
+            value_function,
+            bounds,
+            initial_state,
+            termination,
+        )
+        active_tolerance = method.active_tolerance
     elif isinstance(method, ProjectedLBFGS):
         state = _run_projected_lbfgs(
             method,
@@ -1334,6 +1663,8 @@ def _solve_bound_constrained(
         final_optimality_norm=final_optimality,
         final_step_norm=state.final_step_norm,
         accepted_step_size=state.accepted_rate,
+        damping=state.trust_radius,
+        reduction_ratio=state.reduction_ratio,
         direction_fallbacks=state.direction_fallbacks,
         primal_feasibility=bounds.violation(state.parameters),
         dual_feasibility=final_optimality,
@@ -1349,7 +1680,11 @@ def _solve_bound_constrained(
         problem_id=problem.problem_id,
         method=method.method_id,
         backend="phydrax",
-        globalization="projected-armijo",
+        globalization=(
+            "projected-trust-region"
+            if isinstance(method, BoundedNewtonTrustRegion)
+            else "projected-armijo"
+        ),
         matrix_free=True,
         implicit_differentiation=True,
         notes="Feasible iterates maintained by projection.",
@@ -1404,4 +1739,9 @@ def _infeasible_result(
     )
 
 
-__all__ = ["ActiveSetNewton", "ProjectedGradient", "ProjectedLBFGS"]
+__all__ = [
+    "ActiveSetNewton",
+    "BoundedNewtonTrustRegion",
+    "ProjectedGradient",
+    "ProjectedLBFGS",
+]

--- a/phydrax/optim/_derivative_free_least_squares.py
+++ b/phydrax/optim/_derivative_free_least_squares.py
@@ -435,6 +435,11 @@ class FiniteDifferenceGaussNewton(AbstractLeastSquaresMethod):
     ) -> LeastSquaresResult:
         if not isinstance(problem, NonlinearLeastSquaresProblem):
             raise TypeError("problem must be a NonlinearLeastSquaresProblem.")
+        if problem.bounds is not None:
+            raise ValueError(
+                "FiniteDifferenceGaussNewton does not silently ignore bounds; "
+                "use a bounded least-squares method."
+            )
         if not isinstance(termination, OptimizationTermination):
             raise TypeError("termination must be an OptimizationTermination.")
         parameters = _validate_real_inexact_tree(

--- a/phydrax/optim/_iterative/_types.py
+++ b/phydrax/optim/_iterative/_types.py
@@ -225,6 +225,7 @@ class NonlinearLeastSquaresProblem(StrictModule):
     """Residual-valued nonlinear least-squares problem."""
 
     residual: Callable[[PyTree[Any], Any], Any]
+    bounds: Bounds | None
     has_aux: bool = eqx.field(static=True)
     problem_id: str = eqx.field(static=True)
 
@@ -234,14 +235,18 @@ class NonlinearLeastSquaresProblem(StrictModule):
         /,
         *,
         has_aux: bool = False,
+        bounds: Bounds | None = None,
         problem_id: str = "nonlinear-least-squares",
     ):
         if not callable(residual):
             raise TypeError("residual must be callable.")
+        if bounds is not None and not isinstance(bounds, Bounds):
+            raise TypeError("bounds must be Bounds or None.")
         identifier = str(problem_id)
         if not identifier:
             raise ValueError("problem_id must be non-empty.")
         self.residual = residual
+        self.bounds = bounds
         self.has_aux = bool(has_aux)
         self.problem_id = identifier
 

--- a/phydrax/optim/_least_squares.py
+++ b/phydrax/optim/_least_squares.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import abc
 from collections.abc import Callable
 from math import isfinite
 from typing import Any
@@ -16,12 +17,14 @@ from jaxtyping import Array, PyTree
 from .._linear_refresh import LinearRefreshState, prepare_refresh_state
 from .._strict import StrictModule
 from ..linalg import (
+    FunctionLinearOperator,
     GeneralizedLSMR,
     IdentityLinearOperator,
     JacobianLinearOperator,
     LeastSquaresProblem as LinearLeastSquaresProblem,
     LinearSolvePolicy,
     LinearSolveStatus,
+    OperatorProperties,
     prepare_linearization,
     PyTreeSpace,
     ScaledLinearOperator,
@@ -46,6 +49,11 @@ from ._iterative._types import (
     OptimizationProvenance,
     OptimizationStatus,
     OptimizationTermination,
+)
+from ._trust_region import (
+    solve_trust_region_subproblem,
+    SteihaugToint,
+    TrustRegionQuadraticProblem,
 )
 
 
@@ -1024,6 +1032,204 @@ class LevenbergMarquardt(AbstractLeastSquaresMethod):
         )
 
 
+class AbstractBoundedLeastSquaresMethod(AbstractLeastSquaresMethod):
+    """Shared complete-solve contract for bound-aware residual methods."""
+
+    subproblem: SteihaugToint
+    initial_radius: float = eqx.field(static=True)
+    maximum_radius: float = eqx.field(static=True)
+    minimum_radius: float = eqx.field(static=True)
+    damping_increase: float = eqx.field(static=True)
+    damping_decrease: float = eqx.field(static=True)
+    minimum_damping: float = eqx.field(static=True)
+    maximum_damping: float = eqx.field(static=True)
+    active_tolerance: float = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        subproblem: SteihaugToint | None = None,
+        initial_radius: float = 1.0,
+        maximum_radius: float = 1e4,
+        minimum_radius: float = 1e-12,
+        damping: float | None = None,
+        damping_increase: float = 2.0,
+        damping_decrease: float = 0.5,
+        minimum_damping: float = 1e-12,
+        maximum_damping: float = 1e12,
+        active_tolerance: float = 1e-10,
+    ):
+        subproblem_ = SteihaugToint() if subproblem is None else subproblem
+        if not isinstance(subproblem_, SteihaugToint):
+            raise TypeError("subproblem must be SteihaugToint or None.")
+        damping_ = self.default_damping if damping is None else float(damping)
+        values = tuple(
+            float(value)
+            for value in (
+                initial_radius,
+                maximum_radius,
+                minimum_radius,
+                damping_,
+                damping_increase,
+                damping_decrease,
+                minimum_damping,
+                maximum_damping,
+                active_tolerance,
+            )
+        )
+        if any(not isfinite(value) or value <= 0.0 for value in values[:3]):
+            raise ValueError("Bounded least-squares radii must be positive and finite.")
+        if not values[2] <= values[0] <= values[1]:
+            raise ValueError(
+                "Radii must satisfy minimum_radius <= initial_radius <= maximum_radius."
+            )
+        if not isfinite(values[3]) or values[3] < 0.0:
+            raise ValueError("damping must be finite and non-negative.")
+        if not isfinite(values[4]) or values[4] <= 1.0:
+            raise ValueError("damping_increase must be finite and exceed one.")
+        if not isfinite(values[5]) or not 0.0 < values[5] < 1.0:
+            raise ValueError("damping_decrease must lie in (0, 1).")
+        if any(not isfinite(value) or value <= 0.0 for value in values[6:8]):
+            raise ValueError("Damping bounds must be positive and finite.")
+        if not values[6] <= max(values[3], values[6]) <= values[7]:
+            raise ValueError("Initial damping must not exceed maximum_damping.")
+        if not isfinite(values[8]) or values[8] < 0.0:
+            raise ValueError("active_tolerance must be finite and non-negative.")
+        self.subproblem = subproblem_
+        self.initial_radius = values[0]
+        self.maximum_radius = values[1]
+        self.minimum_radius = values[2]
+        self.damping_increase = values[4]
+        self.damping_decrease = values[5]
+        self.minimum_damping = values[6]
+        self.maximum_damping = values[7]
+        self.active_tolerance = values[8]
+        self._initial_damping = values[3]
+
+    _initial_damping: float = eqx.field(static=True)
+
+    @property
+    @abc.abstractmethod
+    def default_damping(self) -> float:
+        raise NotImplementedError
+
+    @property
+    @abc.abstractmethod
+    def adaptive_damping(self) -> bool:
+        raise NotImplementedError
+
+    @property
+    @abc.abstractmethod
+    def method_id(self) -> str:
+        raise NotImplementedError
+
+    @property
+    def globalization_id(self) -> str:
+        return "projected-residual-trust-region"
+
+    @property
+    def capabilities(self) -> OptimizationCapabilities:
+        return OptimizationCapabilities(
+            scalar_objective=False,
+            residual_objective=True,
+            matrix_free=True,
+            prepared_refresh=False,
+            implicit_differentiation=False,
+        )
+
+    def init(self, parameters: PyTree[Any], /) -> LeastSquaresState:
+        parameters_ = _validate_real_inexact_tree(parameters, name="parameters")
+        dtype = jax.tree.leaves(parameters_)[0].dtype
+        metric_nan = jnp.asarray(jnp.nan, dtype=dtype)
+        return LeastSquaresState(
+            initial_optimality_norm=metric_nan,
+            damping=jnp.asarray(self._initial_damping, dtype=dtype),
+            metrics=IterativeStepMetrics(
+                objective=metric_nan,
+                damping=jnp.asarray(self.initial_radius, dtype=dtype),
+            ),
+        )
+
+    def prepare_state(
+        self,
+        residual_function,
+        parameters: PyTree[Any],
+        /,
+    ) -> LeastSquaresState:
+        if not callable(residual_function):
+            raise TypeError("residual_function must be callable.")
+        return self.init(parameters)
+
+    def step(
+        self,
+        residual_function,
+        parameters,
+        state,
+        /,
+        *,
+        termination,
+    ):
+        del residual_function, parameters, state, termination
+        raise ValueError(
+            "Bounded least-squares steps require problem bounds; use solve() or "
+            "phydrax.optim.least_squares()."
+        )
+
+    def step_metrics(self, state: LeastSquaresState, /) -> IterativeStepMetrics:
+        if not isinstance(state, LeastSquaresState):
+            raise TypeError("state must be LeastSquaresState.")
+        return state.metrics
+
+    def solve(
+        self,
+        problem: NonlinearLeastSquaresProblem,
+        initial_parameters: PyTree[Any],
+        /,
+        *,
+        termination: OptimizationTermination,
+        args: Any,
+    ) -> LeastSquaresResult:
+        return _solve_bounded_least_squares(
+            self,
+            problem,
+            initial_parameters,
+            termination=termination,
+            args=args,
+        )
+
+
+class BoundedGaussNewton(AbstractBoundedLeastSquaresMethod):
+    """Projected matrix-free Gauss--Newton trust-region method."""
+
+    @property
+    def default_damping(self) -> float:
+        return 0.0
+
+    @property
+    def adaptive_damping(self) -> bool:
+        return False
+
+    @property
+    def method_id(self) -> str:
+        return "bounded-gauss-newton"
+
+
+class BoundedLevenbergMarquardt(AbstractBoundedLeastSquaresMethod):
+    """Projected Levenberg--Marquardt with ratio-based damping and radius."""
+
+    @property
+    def default_damping(self) -> float:
+        return 1e-3
+
+    @property
+    def adaptive_damping(self) -> bool:
+        return True
+
+    @property
+    def method_id(self) -> str:
+        return "bounded-levenberg-marquardt"
+
+
 class _LeastSquaresRun(StrictModule):
     parameters: PyTree[Array]
     state: LeastSquaresState
@@ -1039,6 +1245,360 @@ class _LeastSquaresRun(StrictModule):
         self.parameters = parameters
         self.state = state
         self.status = jnp.asarray(status, dtype=jnp.int32)
+
+
+def _solve_bounded_least_squares(
+    method: AbstractBoundedLeastSquaresMethod,
+    problem: NonlinearLeastSquaresProblem,
+    initial_parameters: PyTree[Any],
+    /,
+    *,
+    termination: OptimizationTermination,
+    args: Any,
+) -> LeastSquaresResult:
+    if not isinstance(problem, NonlinearLeastSquaresProblem):
+        raise TypeError("problem must be NonlinearLeastSquaresProblem.")
+    if problem.bounds is None:
+        raise ValueError("A bounded least-squares method requires problem.bounds.")
+    if not isinstance(termination, OptimizationTermination):
+        raise TypeError("termination must be OptimizationTermination.")
+    bounds = problem.bounds
+    parameters = bounds.project(
+        _validate_real_inexact_tree(
+            initial_parameters,
+            name="initial_parameters",
+        )
+    )
+
+    def residual_function(candidate):
+        residual, _ = problem.value(candidate, args)
+        return residual
+
+    state = method.init(parameters)
+    initial_status = jnp.where(
+        _tree_allfinite(parameters),
+        int(OptimizationStatus.ITERATING),
+        int(OptimizationStatus.NONFINITE_INPUT),
+    ).astype(jnp.int32)
+    run = _LeastSquaresRun(parameters, state, initial_status)
+
+    def condition(current):
+        within_evaluations = (
+            jnp.asarray(True)
+            if termination.maximum_evaluations is None
+            else current.state.residual_evaluations + 2 <= termination.maximum_evaluations
+        )
+        return (
+            (current.status == int(OptimizationStatus.ITERATING))
+            & (current.state.iteration < termination.maximum_steps)
+            & within_evaluations
+        )
+
+    def body(current):
+        model = _prepare_residual_model(residual_function, current.parameters)
+        projected_gradient = bounds.projected_gradient(
+            current.parameters,
+            model.gradient,
+        )
+        optimality = _tree_norm(projected_gradient)
+        initial_optimality = jnp.where(
+            current.state.iteration == 0,
+            optimality,
+            current.state.initial_optimality_norm,
+        )
+        finite = (
+            jnp.isfinite(model.objective)
+            & jnp.isfinite(optimality)
+            & _tree_allfinite(current.parameters)
+            & _tree_allfinite(model.residual)
+            & _tree_allfinite(model.gradient)
+        )
+        converged = optimality <= termination.optimality_threshold(initial_optimality)
+
+        def terminal(_):
+            status = jnp.where(
+                ~finite,
+                int(OptimizationStatus.NONFINITE_EVALUATION),
+                int(OptimizationStatus.SUCCESS),
+            ).astype(jnp.int32)
+            next_state = LeastSquaresState(
+                iteration=current.state.iteration + 1,
+                initial_optimality_norm=initial_optimality,
+                damping=current.state.damping,
+                accepted_steps=current.state.accepted_steps,
+                rejected_steps=current.state.rejected_steps + (~finite).astype(jnp.int32),
+                residual_evaluations=current.state.residual_evaluations + 1,
+                scalar_evaluations=current.state.scalar_evaluations,
+                scalar_gradient_evaluations=(current.state.scalar_gradient_evaluations),
+                scalar_hvp_evaluations=current.state.scalar_hvp_evaluations,
+                jvp_evaluations=current.state.jvp_evaluations,
+                vjp_evaluations=current.state.vjp_evaluations + 1,
+                linear_iterations=current.state.linear_iterations,
+                linear_solves=current.state.linear_solves,
+                direction_fallbacks=current.state.direction_fallbacks,
+                setup_refreshes=current.state.setup_refreshes,
+                numeric_refreshes=current.state.numeric_refreshes,
+                linear_refresh_state=current.state.linear_refresh_state,
+                metrics=IterativeStepMetrics(
+                    objective=model.objective,
+                    optimality_norm=optimality,
+                    step_norm=current.state.metrics.step_norm,
+                    accepted_step_size=current.state.metrics.accepted_step_size,
+                    accepted=finite,
+                    damping=current.state.metrics.damping,
+                    reduction_ratio=current.state.metrics.reduction_ratio,
+                    status=status,
+                ),
+            )
+            return _LeastSquaresRun(current.parameters, next_state, status)
+
+        def take_step(_):
+            active = bounds.active_mask(
+                current.parameters,
+                model.gradient,
+                tolerance=method.active_tolerance,
+            )
+            free_gradient = jax.tree.map(
+                lambda value, mask: jnp.where(mask, 0.0, value),
+                model.gradient,
+                active,
+            )
+            space = PyTreeSpace(current.parameters)
+
+            def normal_action(direction):
+                free_direction = jax.tree.map(
+                    lambda value, mask: jnp.where(mask, 0.0, value),
+                    direction,
+                    active,
+                )
+                image = model.jacobian.mv(free_direction)
+                normal = model.jacobian.adjoint_mv(image)
+                regularized = _tree_add_scaled(
+                    normal,
+                    free_direction,
+                    current.state.damping,
+                )
+                return jax.tree.map(
+                    lambda value, mask: jnp.where(mask, 0.0, value),
+                    regularized,
+                    active,
+                )
+
+            normal_operator = FunctionLinearOperator(
+                normal_action,
+                source=space,
+                target=space,
+                properties=OperatorProperties(
+                    self_adjoint=True,
+                    positive_semidefinite=True,
+                    evidence={
+                        "self_adjoint": "construction",
+                        "positive_semidefinite": "construction",
+                    },
+                ),
+                operator_id="bounded-gauss-newton-normal-operator",
+                closure_convert=False,
+            )
+            radius = current.state.metrics.damping
+            subproblem = solve_trust_region_subproblem(
+                TrustRegionQuadraticProblem(
+                    normal_operator,
+                    free_gradient,
+                    radius,
+                ),
+                method=method.subproblem,
+            )
+            unprojected = _tree_add_scaled(
+                current.parameters,
+                subproblem.step,
+                1.0,
+            )
+            candidate = bounds.project(unprojected)
+            displacement = jax.tree.map(
+                lambda new, old: new - old,
+                candidate,
+                current.parameters,
+            )
+            normal_displacement = normal_operator.mv(displacement)
+            predicted = -(
+                _tree_inner(model.gradient, displacement)
+                + 0.5 * _tree_inner(displacement, normal_displacement)
+            )
+            candidate_residual = residual_function(candidate)
+            candidate_objective = 0.5 * _tree_inner(
+                candidate_residual,
+                candidate_residual,
+            )
+            actual = model.objective - candidate_objective
+            ratio = actual / jnp.maximum(predicted, 1e-30)
+            candidate_finite = (
+                _tree_allfinite(candidate)
+                & _tree_allfinite(candidate_residual)
+                & jnp.isfinite(candidate_objective)
+            )
+            accepted = (
+                subproblem.successful
+                & candidate_finite
+                & jnp.isfinite(predicted)
+                & (predicted > 0.0)
+                & jnp.isfinite(ratio)
+                & (ratio >= 1e-4)
+            )
+            step_norm = _tree_norm(displacement)
+            shrink = (
+                ~subproblem.successful
+                | ~candidate_finite
+                | ~jnp.isfinite(ratio)
+                | (ratio < 0.25)
+            )
+            expand = accepted & (ratio > 0.75) & subproblem.diagnostics.boundary_hit
+            next_radius = jnp.where(
+                shrink,
+                jnp.maximum(method.minimum_radius, 0.25 * radius),
+                jnp.where(
+                    expand,
+                    jnp.minimum(method.maximum_radius, 2.0 * radius),
+                    radius,
+                ),
+            )
+            next_damping = (
+                jnp.where(
+                    accepted & (ratio > 0.75),
+                    jnp.maximum(
+                        method.minimum_damping,
+                        method.damping_decrease * current.state.damping,
+                    ),
+                    jnp.where(
+                        ~accepted | (ratio < 0.25),
+                        jnp.minimum(
+                            method.maximum_damping,
+                            method.damping_increase
+                            * jnp.maximum(
+                                current.state.damping,
+                                method.minimum_damping,
+                            ),
+                        ),
+                        current.state.damping,
+                    ),
+                )
+                if method.adaptive_damping
+                else jnp.asarray(0.0, dtype=current.state.damping.dtype)
+            )
+            accepted_parameters = _tree_where(
+                accepted,
+                candidate,
+                current.parameters,
+            )
+            stagnated = (
+                accepted
+                & (
+                    step_norm
+                    <= termination.step_threshold(_tree_norm(accepted_parameters))
+                )
+                & (optimality > termination.optimality_threshold(initial_optimality))
+            )
+            failed = (~accepted) & (next_radius <= method.minimum_radius)
+            status = jnp.where(
+                stagnated,
+                int(OptimizationStatus.STAGNATION),
+                jnp.where(
+                    failed,
+                    int(OptimizationStatus.TRUST_REGION_FAILED),
+                    int(OptimizationStatus.ITERATING),
+                ),
+            ).astype(jnp.int32)
+            hessian_actions = subproblem.diagnostics.hessian_actions + 1
+            next_state = LeastSquaresState(
+                iteration=current.state.iteration + 1,
+                initial_optimality_norm=initial_optimality,
+                damping=next_damping,
+                accepted_steps=current.state.accepted_steps + accepted.astype(jnp.int32),
+                rejected_steps=current.state.rejected_steps
+                + (~accepted).astype(jnp.int32),
+                residual_evaluations=current.state.residual_evaluations + 2,
+                scalar_evaluations=current.state.scalar_evaluations,
+                scalar_gradient_evaluations=(current.state.scalar_gradient_evaluations),
+                scalar_hvp_evaluations=current.state.scalar_hvp_evaluations,
+                jvp_evaluations=current.state.jvp_evaluations + hessian_actions,
+                vjp_evaluations=current.state.vjp_evaluations + hessian_actions + 1,
+                linear_iterations=current.state.linear_iterations
+                + subproblem.diagnostics.iterations,
+                linear_solves=current.state.linear_solves + 1,
+                direction_fallbacks=current.state.direction_fallbacks,
+                setup_refreshes=current.state.setup_refreshes + 1,
+                numeric_refreshes=current.state.numeric_refreshes + 1,
+                linear_refresh_state=current.state.linear_refresh_state,
+                metrics=IterativeStepMetrics(
+                    objective=jnp.where(
+                        accepted,
+                        candidate_objective,
+                        model.objective,
+                    ),
+                    optimality_norm=optimality,
+                    step_norm=step_norm,
+                    accepted_step_size=jnp.where(accepted, 1.0, 0.0),
+                    accepted=accepted,
+                    linear_iterations=subproblem.diagnostics.iterations,
+                    damping=next_radius,
+                    reduction_ratio=ratio,
+                    status=status,
+                ),
+            )
+            return _LeastSquaresRun(accepted_parameters, next_state, status)
+
+        return jax.lax.cond(
+            (~finite) | converged,
+            terminal,
+            take_step,
+            None,
+        )
+
+    run = jax.lax.while_loop(condition, body, run)
+    exhausted_evaluations = (
+        jnp.asarray(False)
+        if termination.maximum_evaluations is None
+        else run.state.residual_evaluations >= termination.maximum_evaluations
+    )
+    status = jnp.where(
+        run.status == int(OptimizationStatus.ITERATING),
+        jnp.where(
+            exhausted_evaluations,
+            int(OptimizationStatus.MAXIMUM_EVALUATIONS_REACHED),
+            int(OptimizationStatus.MAXIMUM_STEPS_REACHED),
+        ),
+        run.status,
+    ).astype(jnp.int32)
+    packaged = _package_least_squares_result(
+        method,
+        problem,
+        _LeastSquaresRun(run.parameters, run.state, status),
+        residual_function,
+        termination,
+        args,
+    )
+    diagnostics = eqx.tree_at(
+        lambda value: value.primal_feasibility,
+        packaged.diagnostics,
+        bounds.violation(packaged.parameters),
+    )
+    provenance = OptimizationProvenance(
+        problem_id=problem.problem_id,
+        method=method.method_id,
+        backend="phydrax-native",
+        globalization=method.globalization_id,
+        matrix_free=True,
+        implicit_differentiation=False,
+        notes="Every accepted least-squares parameter is projected into its bounds.",
+    )
+    return LeastSquaresResult(
+        packaged.parameters,
+        packaged.residual,
+        packaged.objective,
+        packaged.auxiliary,
+        packaged.status,
+        diagnostics,
+        provenance,
+    )
 
 
 def _run_least_squares_iterations(
@@ -1214,6 +1774,11 @@ def _solve_least_squares(
     termination: OptimizationTermination,
     args: Any,
 ) -> LeastSquaresResult:
+    if problem.bounds is not None:
+        raise ValueError(
+            "GaussNewton, LevenbergMarquardt, and finite-difference methods "
+            "do not silently ignore bounds; use a bounded least-squares method."
+        )
     parameters = _validate_least_squares_inputs(
         problem,
         initial_parameters,
@@ -1270,6 +1835,9 @@ def least_squares(
 
 
 __all__ = [
+    "AbstractBoundedLeastSquaresMethod",
+    "BoundedGaussNewton",
+    "BoundedLevenbergMarquardt",
     "GaussNewton",
     "LeastSquaresState",
     "LevenbergMarquardt",

--- a/phydrax/optim/_trust_region.py
+++ b/phydrax/optim/_trust_region.py
@@ -1,0 +1,412 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from enum import IntEnum
+from math import isfinite
+from typing import Any
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array, PyTree
+
+from .._strict import StrictModule
+from .._tree_math import tree_allfinite
+from ..linalg import AbstractLinearOperator, AbstractPreconditioner
+
+
+class TrustRegionSubproblemStatus(IntEnum):
+    """Terminal status of an operator trust-region quadratic solve."""
+
+    CONVERGED = 0
+    BOUNDARY_REACHED = 1
+    NEGATIVE_CURVATURE = 2
+    MAXIMUM_STEPS_REACHED = 3
+    NONFINITE_EVALUATION = 4
+    INVALID_MODEL = 5
+
+
+class TrustRegionQuadraticProblem(StrictModule):
+    """Self-adjoint quadratic model with one trust-region radius."""
+
+    hessian: AbstractLinearOperator
+    gradient: PyTree[Array]
+    radius: Array
+
+    def __init__(
+        self,
+        hessian: AbstractLinearOperator,
+        gradient: PyTree[Any],
+        radius: Any,
+        /,
+    ):
+        if not isinstance(hessian, AbstractLinearOperator):
+            raise TypeError("hessian must be AbstractLinearOperator.")
+        if hessian.batch_shape:
+            raise ValueError("Trust-region Hessians must be unbatched.")
+        if not hessian.source.compatible(hessian.target):
+            raise ValueError("Trust-region Hessians must be endomorphisms.")
+        if not hessian.properties.certifies("self_adjoint"):
+            raise ValueError(
+                "Trust-region Hessians require certified self-adjoint structure."
+            )
+        gradient_ = hessian.source.validate(gradient)
+        radius_ = jnp.asarray(radius)
+        if radius_.shape != ():
+            raise ValueError("Trust-region radius must be scalar.")
+        radius_ = eqx.error_if(
+            radius_,
+            ~jnp.isfinite(radius_) | (radius_ <= 0.0),
+            "Trust-region radius must be finite and positive.",
+        )
+        self.hessian = hessian
+        self.gradient = gradient_
+        self.radius = radius_
+
+
+class SteihaugToint(StrictModule):
+    """Preconditioned truncated CG for a self-adjoint trust-region model."""
+
+    relative_tolerance: float = eqx.field(static=True)
+    absolute_tolerance: float = eqx.field(static=True)
+    maximum_steps: int = eqx.field(static=True)
+    curvature_tolerance: float = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        relative_tolerance: float = 1e-7,
+        absolute_tolerance: float = 1e-10,
+        maximum_steps: int = 200,
+        curvature_tolerance: float = 0.0,
+    ):
+        relative = float(relative_tolerance)
+        absolute = float(absolute_tolerance)
+        steps = int(maximum_steps)
+        curvature = float(curvature_tolerance)
+        if any(
+            not isfinite(value) or value < 0.0
+            for value in (relative, absolute, curvature)
+        ):
+            raise ValueError("Trust-region tolerances must be finite and non-negative.")
+        if steps < 1:
+            raise ValueError("maximum_steps must be positive.")
+        self.relative_tolerance = relative
+        self.absolute_tolerance = absolute
+        self.maximum_steps = steps
+        self.curvature_tolerance = curvature
+
+
+class TrustRegionSubproblemDiagnostics(StrictModule):
+    """Operator work and model evidence from a trust-region solve."""
+
+    iterations: Array
+    hessian_actions: Array
+    preconditioner_applications: Array
+    initial_residual_norm: Array
+    final_residual_norm: Array
+    step_norm: Array
+    predicted_reduction: Array
+    minimum_curvature: Array
+    boundary_hit: Array
+    negative_curvature: Array
+
+
+class TrustRegionSubproblemResult(StrictModule):
+    """Trust-region step with explicit termination evidence."""
+
+    step: PyTree[Array]
+    status: Array
+    diagnostics: TrustRegionSubproblemDiagnostics
+
+    @property
+    def successful(self) -> Array:
+        return (
+            (self.status == int(TrustRegionSubproblemStatus.CONVERGED))
+            | (self.status == int(TrustRegionSubproblemStatus.BOUNDARY_REACHED))
+            | (self.status == int(TrustRegionSubproblemStatus.NEGATIVE_CURVATURE))
+        )
+
+
+class _TrustRegionRun(StrictModule):
+    step: PyTree[Array]
+    residual: PyTree[Array]
+    preconditioned_residual: PyTree[Array]
+    direction: PyTree[Array]
+    residual_pairing: Array
+    residual_norm: Array
+    iteration: Array
+    hessian_actions: Array
+    preconditioner_applications: Array
+    minimum_curvature: Array
+    status: Array
+
+
+def _inner(space, left, right, /) -> Array:
+    return jnp.real(space.inner(left, right))
+
+
+def _norm(space, value, /) -> Array:
+    return jnp.sqrt(jnp.maximum(_inner(space, value, value), 0.0))
+
+
+def _add_scaled(base, direction, scale, /):
+    return jax.tree.map(lambda x, d: x + scale * d, base, direction)
+
+
+def _negative(value, /):
+    return jax.tree.map(jnp.negative, value)
+
+
+def _apply_preconditioner(preconditioner, residual, /):
+    return residual if preconditioner is None else preconditioner.apply(residual)
+
+
+def _boundary_rate(space, step, direction, radius, /) -> Array:
+    a = _inner(space, direction, direction)
+    b = 2.0 * _inner(space, step, direction)
+    c = _inner(space, step, step) - radius * radius
+    discriminant = jnp.maximum(b * b - 4.0 * a * c, 0.0)
+    return (-b + jnp.sqrt(discriminant)) / jnp.maximum(2.0 * a, 1e-30)
+
+
+def solve_trust_region_subproblem(
+    problem: TrustRegionQuadraticProblem,
+    /,
+    *,
+    method: SteihaugToint | None = None,
+    preconditioner: AbstractPreconditioner | None = None,
+) -> TrustRegionSubproblemResult:
+    """Solve one matrix-free quadratic trust-region subproblem."""
+    if not isinstance(problem, TrustRegionQuadraticProblem):
+        raise TypeError("problem must be TrustRegionQuadraticProblem.")
+    method_ = SteihaugToint() if method is None else method
+    if not isinstance(method_, SteihaugToint):
+        raise TypeError("method must be SteihaugToint or None.")
+    space = problem.hessian.source
+    if preconditioner is not None:
+        if not isinstance(preconditioner, AbstractPreconditioner):
+            raise TypeError("preconditioner must be AbstractPreconditioner or None.")
+        if not preconditioner.space.compatible(space):
+            raise ValueError("Trust-region preconditioner space is incompatible.")
+        properties = preconditioner.properties
+        if not (
+            properties.certifies("linear")
+            and properties.certifies("stationary")
+            and properties.certifies("self_adjoint")
+            and properties.certifies("positive_definite")
+        ):
+            raise ValueError(
+                "Steihaug-Toint preconditioning requires fixed linear SPD evidence."
+            )
+    gradient = space.validate(problem.gradient)
+    initial_norm = _norm(space, gradient)
+    threshold = method_.absolute_tolerance + method_.relative_tolerance * initial_norm
+    preconditioned = space.validate(_apply_preconditioner(preconditioner, gradient))
+    pairing = _inner(space, gradient, preconditioned)
+    finite = (
+        tree_allfinite(gradient)
+        & tree_allfinite(preconditioned)
+        & jnp.isfinite(initial_norm)
+        & jnp.isfinite(pairing)
+    )
+    initially_converged = finite & (initial_norm <= threshold)
+    initial_status = jnp.where(
+        ~finite,
+        int(TrustRegionSubproblemStatus.NONFINITE_EVALUATION),
+        jnp.where(
+            initially_converged,
+            int(TrustRegionSubproblemStatus.CONVERGED),
+            int(TrustRegionSubproblemStatus.INVALID_MODEL)
+            if preconditioner is not None
+            else int(TrustRegionSubproblemStatus.MAXIMUM_STEPS_REACHED),
+        ),
+    ).astype(jnp.int32)
+    initial_status = jnp.where(
+        finite & ~initially_converged & (pairing > 0.0),
+        -1,
+        initial_status,
+    ).astype(jnp.int32)
+    run = _TrustRegionRun(
+        step=space.zeros(),
+        residual=gradient,
+        preconditioned_residual=preconditioned,
+        direction=_negative(preconditioned),
+        residual_pairing=pairing,
+        residual_norm=initial_norm,
+        iteration=jnp.asarray(0, dtype=jnp.int32),
+        hessian_actions=jnp.asarray(0, dtype=jnp.int32),
+        preconditioner_applications=jnp.asarray(
+            0 if preconditioner is None else 1,
+            dtype=jnp.int32,
+        ),
+        minimum_curvature=jnp.asarray(jnp.inf, dtype=initial_norm.dtype),
+        status=initial_status,
+    )
+
+    def condition(current):
+        return (current.status == -1) & (current.iteration < method_.maximum_steps)
+
+    def body(current):
+        hessian_direction = space.validate(problem.hessian.mv(current.direction))
+        curvature = _inner(space, current.direction, hessian_direction)
+        direction_norm_squared = _inner(space, current.direction, current.direction)
+        normalized_curvature = curvature / jnp.maximum(direction_norm_squared, 1e-30)
+        nonfinite = (
+            ~tree_allfinite(hessian_direction)
+            | ~jnp.isfinite(curvature)
+            | ~jnp.isfinite(normalized_curvature)
+        )
+        negative = normalized_curvature <= method_.curvature_tolerance
+        alpha = jnp.where(
+            negative | nonfinite,
+            0.0,
+            current.residual_pairing / jnp.maximum(curvature, 1e-30),
+        )
+        unconstrained = _add_scaled(current.step, current.direction, alpha)
+        crosses = _norm(space, unconstrained) >= problem.radius
+        boundary = negative | crosses
+        rate = _boundary_rate(
+            space,
+            current.step,
+            current.direction,
+            problem.radius,
+        )
+        boundary_step = _add_scaled(current.step, current.direction, rate)
+        trial_step = jax.tree.map(
+            lambda bounded, free: jnp.where(boundary, bounded, free),
+            boundary_step,
+            unconstrained,
+        )
+        trial_residual = _add_scaled(
+            current.residual,
+            hessian_direction,
+            alpha,
+        )
+        trial_preconditioned = space.validate(
+            _apply_preconditioner(preconditioner, trial_residual)
+        )
+        trial_pairing = _inner(space, trial_residual, trial_preconditioned)
+        trial_norm = _norm(space, trial_residual)
+        converged = (~boundary) & (trial_norm <= threshold)
+        usable_pairing = jnp.isfinite(trial_pairing) & (trial_pairing > 0.0)
+        beta = trial_pairing / jnp.maximum(current.residual_pairing, 1e-30)
+        next_direction = jax.tree.map(
+            lambda z, d: -z + beta * d,
+            trial_preconditioned,
+            current.direction,
+        )
+        status = jnp.where(
+            nonfinite,
+            int(TrustRegionSubproblemStatus.NONFINITE_EVALUATION),
+            jnp.where(
+                negative,
+                int(TrustRegionSubproblemStatus.NEGATIVE_CURVATURE),
+                jnp.where(
+                    crosses,
+                    int(TrustRegionSubproblemStatus.BOUNDARY_REACHED),
+                    jnp.where(
+                        converged,
+                        int(TrustRegionSubproblemStatus.CONVERGED),
+                        jnp.where(
+                            usable_pairing,
+                            -1,
+                            int(TrustRegionSubproblemStatus.INVALID_MODEL),
+                        ),
+                    ),
+                ),
+            ),
+        ).astype(jnp.int32)
+        return _TrustRegionRun(
+            step=jax.tree.map(
+                lambda new, old: jnp.where(nonfinite, old, new),
+                trial_step,
+                current.step,
+            ),
+            residual=jax.tree.map(
+                lambda new, old: jnp.where(boundary | nonfinite, old, new),
+                trial_residual,
+                current.residual,
+            ),
+            preconditioned_residual=jax.tree.map(
+                lambda new, old: jnp.where(boundary | nonfinite, old, new),
+                trial_preconditioned,
+                current.preconditioned_residual,
+            ),
+            direction=jax.tree.map(
+                lambda new, old: jnp.where(boundary | nonfinite, old, new),
+                next_direction,
+                current.direction,
+            ),
+            residual_pairing=jnp.where(
+                boundary | nonfinite,
+                current.residual_pairing,
+                trial_pairing,
+            ),
+            residual_norm=jnp.where(
+                boundary | nonfinite,
+                current.residual_norm,
+                trial_norm,
+            ),
+            iteration=current.iteration + 1,
+            hessian_actions=current.hessian_actions + 1,
+            preconditioner_applications=current.preconditioner_applications
+            + (0 if preconditioner is None else 1),
+            minimum_curvature=jnp.minimum(
+                current.minimum_curvature,
+                normalized_curvature,
+            ),
+            status=status,
+        )
+
+    run = jax.lax.while_loop(condition, body, run)
+    status = jnp.where(
+        run.status == -1,
+        int(TrustRegionSubproblemStatus.MAXIMUM_STEPS_REACHED),
+        run.status,
+    ).astype(jnp.int32)
+    hessian_step = space.validate(problem.hessian.mv(run.step))
+    predicted_reduction = -(
+        _inner(space, gradient, run.step) + 0.5 * _inner(space, run.step, hessian_step)
+    )
+    final_finite = tree_allfinite(run.step) & jnp.isfinite(predicted_reduction)
+    status = jnp.where(
+        ~final_finite,
+        int(TrustRegionSubproblemStatus.NONFINITE_EVALUATION),
+        status,
+    ).astype(jnp.int32)
+    diagnostics = TrustRegionSubproblemDiagnostics(
+        iterations=run.iteration,
+        hessian_actions=run.hessian_actions + 1,
+        preconditioner_applications=run.preconditioner_applications,
+        initial_residual_norm=initial_norm,
+        final_residual_norm=run.residual_norm,
+        step_norm=_norm(space, run.step),
+        predicted_reduction=predicted_reduction,
+        minimum_curvature=run.minimum_curvature,
+        boundary_hit=(
+            (status == int(TrustRegionSubproblemStatus.BOUNDARY_REACHED))
+            | (status == int(TrustRegionSubproblemStatus.NEGATIVE_CURVATURE))
+        ),
+        negative_curvature=(
+            status == int(TrustRegionSubproblemStatus.NEGATIVE_CURVATURE)
+        ),
+    )
+    return TrustRegionSubproblemResult(
+        step=run.step,
+        status=status,
+        diagnostics=diagnostics,
+    )
+
+
+__all__ = [
+    "SteihaugToint",
+    "TrustRegionQuadraticProblem",
+    "TrustRegionSubproblemDiagnostics",
+    "TrustRegionSubproblemResult",
+    "TrustRegionSubproblemStatus",
+    "solve_trust_region_subproblem",
+]

--- a/phydrax/optim/_unconstrained.py
+++ b/phydrax/optim/_unconstrained.py
@@ -15,6 +15,7 @@ from jaxtyping import Array, PyTree
 
 from .._linear_refresh import LinearRefreshState
 from .._strict import StrictModule
+from ..linalg import FunctionLinearOperator, OperatorProperties, PyTreeSpace
 from ._iterative._base import AbstractScalarIterativeMethod
 from ._iterative._globalization import (
     strong_wolfe_line_search,
@@ -36,6 +37,11 @@ from ._iterative._types import (
     OptimizationTermination,
 )
 from ._scalar import solve_scalar_iterative
+from ._trust_region import (
+    solve_trust_region_subproblem,
+    SteihaugToint,
+    TrustRegionQuadraticProblem,
+)
 
 
 class _AbstractScalarExtensionState(StrictModule):
@@ -495,7 +501,7 @@ class NonlinearConjugateGradient(AbstractScalarIterativeMethod):
         )
 
 
-class NewtonTrustRegionState(_AbstractScalarExtensionState):
+class DenseNewtonDoglegState(_AbstractScalarExtensionState):
     """Accepted-point scalar state with a persistent trust-region radius."""
 
     trust_radius: Array
@@ -505,7 +511,7 @@ class NewtonTrustRegionState(_AbstractScalarExtensionState):
         self.trust_radius = jnp.asarray(trust_radius)
 
 
-class NewtonTrustRegion(AbstractScalarIterativeMethod):
+class DenseNewtonDogleg(AbstractScalarIterativeMethod):
     """Dense Newton dogleg method with ratio-based trust-region acceptance."""
 
     initial_radius: float = eqx.field(static=True)
@@ -575,7 +581,7 @@ class NewtonTrustRegion(AbstractScalarIterativeMethod):
 
     @property
     def method_id(self) -> str:
-        return "newton-trust-region/dogleg"
+        return "dense-newton-dogleg"
 
     @property
     def globalization_id(self) -> str:
@@ -591,16 +597,16 @@ class NewtonTrustRegion(AbstractScalarIterativeMethod):
             implicit_differentiation=True,
         )
 
-    def init(self, parameters: PyTree[Any], /) -> NewtonTrustRegionState:
+    def init(self, parameters: PyTree[Any], /) -> DenseNewtonDoglegState:
         parameters = _validate_real_inexact_tree(parameters, name="parameters")
         flat, _ = ravel_pytree(parameters)
         if int(flat.size) > self.max_dense_dimension:
             raise ValueError(
-                f"NewtonTrustRegion has {flat.size} variables, exceeding "
+                f"DenseNewtonDogleg has {flat.size} variables, exceeding "
                 f"max_dense_dimension={self.max_dense_dimension}."
             )
         metric_nan = jnp.asarray(jnp.nan, dtype=flat.dtype)
-        return NewtonTrustRegionState(
+        return DenseNewtonDoglegState(
             trust_radius=jnp.asarray(self.initial_radius, dtype=flat.dtype),
             initial_optimality_norm=metric_nan,
             metrics=IterativeStepMetrics(objective=metric_nan),
@@ -611,7 +617,7 @@ class NewtonTrustRegion(AbstractScalarIterativeMethod):
         value_function,
         parameters: PyTree[Any],
         /,
-    ) -> NewtonTrustRegionState:
+    ) -> DenseNewtonDoglegState:
         if not callable(value_function):
             raise TypeError("value_function must be callable.")
         return self.init(parameters)
@@ -624,15 +630,15 @@ class NewtonTrustRegion(AbstractScalarIterativeMethod):
         /,
         *,
         termination: OptimizationTermination | None,
-    ) -> tuple[PyTree[Any], NewtonTrustRegionState, Any]:
+    ) -> tuple[PyTree[Any], DenseNewtonDoglegState, Any]:
         if not callable(value_function):
             raise TypeError("value_function must be callable.")
-        if not isinstance(state, NewtonTrustRegionState):
-            raise TypeError("state must be a NewtonTrustRegionState.")
+        if not isinstance(state, DenseNewtonDoglegState):
+            raise TypeError("state must be a DenseNewtonDoglegState.")
         flat_parameters, unravel = ravel_pytree(parameters)
         if int(flat_parameters.size) > self.max_dense_dimension:
             raise ValueError(
-                f"NewtonTrustRegion has {flat_parameters.size} variables, exceeding "
+                f"DenseNewtonDogleg has {flat_parameters.size} variables, exceeding "
                 f"max_dense_dimension={self.max_dense_dimension}."
             )
 
@@ -674,7 +680,7 @@ class NewtonTrustRegion(AbstractScalarIterativeMethod):
                     int(OptimizationStatus.MAXIMUM_EVALUATIONS_REACHED),
                 ),
             )
-            updated = NewtonTrustRegionState(
+            updated = DenseNewtonDoglegState(
                 trust_radius=state.trust_radius,
                 iteration=state.iteration + 1,
                 initial_optimality_norm=initial_optimality,
@@ -829,7 +835,7 @@ class NewtonTrustRegion(AbstractScalarIterativeMethod):
                 ),
             )
             fallback = ~newton_usable
-            updated = NewtonTrustRegionState(
+            updated = DenseNewtonDoglegState(
                 trust_radius=next_radius,
                 iteration=state.iteration + 1,
                 initial_optimality_norm=initial_optimality,
@@ -877,6 +883,374 @@ class NewtonTrustRegion(AbstractScalarIterativeMethod):
     def step_metrics(
         self, state: _AbstractScalarExtensionState, /
     ) -> IterativeStepMetrics:
+        if not isinstance(state, DenseNewtonDoglegState):
+            raise TypeError("state must be a DenseNewtonDoglegState.")
+        return state.metrics
+
+    def solve(
+        self,
+        problem: MinimizationProblem,
+        initial_parameters: PyTree[Any],
+        /,
+        *,
+        termination: OptimizationTermination,
+        args: Any,
+    ) -> MinimizationResult:
+        return solve_scalar_iterative(
+            self,
+            problem,
+            initial_parameters,
+            termination=termination,
+            args=args,
+        )
+
+
+class NewtonTrustRegionState(_AbstractScalarExtensionState):
+    """Accepted-point matrix-free trust-region state."""
+
+    trust_radius: Array
+
+    def __init__(self, *, trust_radius: Any, **kwargs: Any):
+        super().__init__(**kwargs)
+        self.trust_radius = jnp.asarray(trust_radius)
+
+
+class NewtonTrustRegion(AbstractScalarIterativeMethod):
+    """Matrix-free Newton method with a Steihaug--Toint trust region."""
+
+    subproblem: SteihaugToint
+    initial_radius: float = eqx.field(static=True)
+    maximum_radius: float = eqx.field(static=True)
+    minimum_radius: float = eqx.field(static=True)
+    acceptance_ratio: float = eqx.field(static=True)
+    shrink_ratio: float = eqx.field(static=True)
+    expansion_ratio: float = eqx.field(static=True)
+    shrink_factor: float = eqx.field(static=True)
+    expansion_factor: float = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        subproblem: SteihaugToint | None = None,
+        initial_radius: float = 1.0,
+        maximum_radius: float = 1e4,
+        minimum_radius: float = 1e-12,
+        acceptance_ratio: float = 1e-4,
+        shrink_ratio: float = 0.25,
+        expansion_ratio: float = 0.75,
+        shrink_factor: float = 0.25,
+        expansion_factor: float = 2.0,
+    ):
+        subproblem_ = SteihaugToint() if subproblem is None else subproblem
+        if not isinstance(subproblem_, SteihaugToint):
+            raise TypeError("subproblem must be SteihaugToint or None.")
+        values = tuple(
+            float(value)
+            for value in (
+                initial_radius,
+                maximum_radius,
+                minimum_radius,
+                acceptance_ratio,
+                shrink_ratio,
+                expansion_ratio,
+                shrink_factor,
+                expansion_factor,
+            )
+        )
+        if any(not isfinite(value) or value <= 0.0 for value in values):
+            raise ValueError("Trust-region controls must be positive and finite.")
+        if not values[2] <= values[0] <= values[1]:
+            raise ValueError(
+                "Radii must satisfy minimum_radius <= initial_radius <= maximum_radius."
+            )
+        if not 0.0 < values[3] < values[4] < values[5] < 1.0:
+            raise ValueError("Ratios must satisfy acceptance < shrink < expansion < one.")
+        if not 0.0 < values[6] < 1.0 or values[7] <= 1.0:
+            raise ValueError("Radius factors must shrink below and expand above one.")
+        self.subproblem = subproblem_
+        (
+            self.initial_radius,
+            self.maximum_radius,
+            self.minimum_radius,
+            self.acceptance_ratio,
+            self.shrink_ratio,
+            self.expansion_ratio,
+            self.shrink_factor,
+            self.expansion_factor,
+        ) = values
+
+    @property
+    def method_id(self) -> str:
+        return "newton-trust-region/steihaug-toint"
+
+    @property
+    def globalization_id(self) -> str:
+        return "trust-region-ratio"
+
+    @property
+    def capabilities(self) -> OptimizationCapabilities:
+        return OptimizationCapabilities(
+            scalar_objective=True,
+            residual_objective=False,
+            matrix_free=True,
+            prepared_refresh=False,
+            implicit_differentiation=True,
+        )
+
+    def init(self, parameters: PyTree[Any], /) -> NewtonTrustRegionState:
+        parameters_ = _validate_real_inexact_tree(parameters, name="parameters")
+        metric_nan = jnp.asarray(
+            jnp.nan,
+            dtype=jax.tree.leaves(parameters_)[0].dtype,
+        )
+        return NewtonTrustRegionState(
+            trust_radius=jnp.asarray(self.initial_radius, dtype=metric_nan.dtype),
+            initial_optimality_norm=metric_nan,
+            metrics=IterativeStepMetrics(objective=metric_nan),
+        )
+
+    def prepare_state(
+        self,
+        value_function,
+        parameters: PyTree[Any],
+        /,
+    ) -> NewtonTrustRegionState:
+        if not callable(value_function):
+            raise TypeError("value_function must be callable.")
+        return self.init(parameters)
+
+    def step(
+        self,
+        value_function,
+        parameters: PyTree[Any],
+        state: _AbstractScalarExtensionState,
+        /,
+        *,
+        termination: OptimizationTermination | None,
+    ) -> tuple[PyTree[Any], NewtonTrustRegionState, Any]:
+        if not callable(value_function):
+            raise TypeError("value_function must be callable.")
+        if not isinstance(state, NewtonTrustRegionState):
+            raise TypeError("state must be a NewtonTrustRegionState.")
+        parameters_ = _validate_real_inexact_tree(parameters, name="parameters")
+        value, gradient = jax.value_and_grad(value_function)(parameters_)
+        optimality = _tree_norm(gradient)
+        initial_optimality = jnp.where(
+            state.iteration == 0,
+            optimality,
+            state.initial_optimality_norm,
+        )
+        finite = (
+            jnp.isfinite(value)
+            & jnp.isfinite(optimality)
+            & _tree_allfinite(parameters_)
+            & _tree_allfinite(gradient)
+        )
+        converged = (
+            jnp.asarray(False)
+            if termination is None
+            else optimality <= termination.optimality_threshold(initial_optimality)
+        )
+        budget_allows_candidate = (
+            jnp.asarray(True)
+            if termination is None or termination.maximum_evaluations is None
+            else state.objective_evaluations + 2 <= termination.maximum_evaluations
+        )
+        _, static_state = eqx.partition(state, eqx.is_array)
+
+        def terminal_step(_):
+            status = jnp.where(
+                ~finite,
+                int(OptimizationStatus.NONFINITE_EVALUATION),
+                jnp.where(
+                    converged,
+                    int(OptimizationStatus.SUCCESS),
+                    int(OptimizationStatus.MAXIMUM_EVALUATIONS_REACHED),
+                ),
+            ).astype(jnp.int32)
+            updated = NewtonTrustRegionState(
+                trust_radius=state.trust_radius,
+                iteration=state.iteration + 1,
+                initial_optimality_norm=initial_optimality,
+                accepted_steps=state.accepted_steps,
+                rejected_steps=state.rejected_steps + (~finite).astype(jnp.int32),
+                objective_evaluations=state.objective_evaluations + 1,
+                gradient_evaluations=state.gradient_evaluations + 1,
+                hvp_evaluations=state.hvp_evaluations,
+                linear_solves=state.linear_solves,
+                linear_iterations=state.linear_iterations,
+                setup_refreshes=state.setup_refreshes,
+                numeric_refreshes=state.numeric_refreshes,
+                linear_refresh_state=state.linear_refresh_state,
+                direction_fallbacks=state.direction_fallbacks,
+                metrics=IterativeStepMetrics(
+                    objective=value,
+                    optimality_norm=optimality,
+                    step_norm=state.metrics.step_norm,
+                    accepted_step_size=state.metrics.accepted_step_size,
+                    globalization_evaluations=(state.metrics.globalization_evaluations),
+                    accepted=finite,
+                    damping=state.trust_radius,
+                    reduction_ratio=state.metrics.reduction_ratio,
+                    status=status,
+                ),
+            )
+            dynamic, _ = eqx.partition(updated, eqx.is_array)
+            return parameters_, dynamic, value
+
+        def trust_region_step(_):
+            linearized_gradient, hessian_action = jax.linearize(
+                jax.grad(value_function),
+                parameters_,
+            )
+            space = PyTreeSpace(parameters_)
+            hessian = FunctionLinearOperator(
+                hessian_action,
+                source=space,
+                target=space,
+                properties=OperatorProperties(
+                    self_adjoint=True,
+                    evidence={"self_adjoint": "construction"},
+                ),
+                operator_id="objective-hessian-action",
+                closure_convert=False,
+            )
+            subproblem = solve_trust_region_subproblem(
+                TrustRegionQuadraticProblem(
+                    hessian,
+                    linearized_gradient,
+                    state.trust_radius,
+                ),
+                method=self.subproblem,
+            )
+            direction = subproblem.step
+            candidate = _tree_add_scaled(parameters_, direction, 1.0)
+            candidate_value, candidate_gradient = jax.value_and_grad(value_function)(
+                candidate
+            )
+            predicted = subproblem.diagnostics.predicted_reduction
+            actual = value - candidate_value
+            ratio = actual / jnp.maximum(predicted, 1e-30)
+            candidate_finite = (
+                jnp.isfinite(candidate_value)
+                & _tree_allfinite(candidate)
+                & _tree_allfinite(candidate_gradient)
+            )
+            accepted = (
+                subproblem.successful
+                & candidate_finite
+                & jnp.isfinite(predicted)
+                & (predicted > 0.0)
+                & jnp.isfinite(ratio)
+                & (ratio >= self.acceptance_ratio)
+            )
+            step_norm = _tree_norm(direction)
+            shrink = (
+                ~subproblem.successful
+                | ~candidate_finite
+                | ~jnp.isfinite(ratio)
+                | (ratio < self.shrink_ratio)
+            )
+            expand = (
+                accepted
+                & (ratio > self.expansion_ratio)
+                & subproblem.diagnostics.boundary_hit
+            )
+            next_radius = jnp.where(
+                shrink,
+                jnp.maximum(
+                    self.minimum_radius,
+                    self.shrink_factor * state.trust_radius,
+                ),
+                jnp.where(
+                    expand,
+                    jnp.minimum(
+                        self.maximum_radius,
+                        self.expansion_factor * state.trust_radius,
+                    ),
+                    state.trust_radius,
+                ),
+            )
+            accepted_parameters = _tree_where(accepted, candidate, parameters_)
+            accepted_optimality = jnp.where(
+                accepted,
+                _tree_norm(candidate_gradient),
+                optimality,
+            )
+            stagnated = (
+                jnp.asarray(False)
+                if termination is None
+                else accepted
+                & (
+                    step_norm
+                    <= termination.step_threshold(_tree_norm(accepted_parameters))
+                )
+                & (
+                    accepted_optimality
+                    > termination.optimality_threshold(initial_optimality)
+                )
+            )
+            failed = (~accepted) & (next_radius <= self.minimum_radius)
+            status = jnp.where(
+                stagnated,
+                int(OptimizationStatus.STAGNATION),
+                jnp.where(
+                    failed,
+                    int(OptimizationStatus.TRUST_REGION_FAILED),
+                    int(OptimizationStatus.ITERATING),
+                ),
+            ).astype(jnp.int32)
+            updated = NewtonTrustRegionState(
+                trust_radius=next_radius,
+                iteration=state.iteration + 1,
+                initial_optimality_norm=initial_optimality,
+                accepted_steps=state.accepted_steps + accepted.astype(jnp.int32),
+                rejected_steps=state.rejected_steps + (~accepted).astype(jnp.int32),
+                objective_evaluations=state.objective_evaluations + 2,
+                gradient_evaluations=state.gradient_evaluations + 3,
+                hvp_evaluations=(
+                    state.hvp_evaluations + subproblem.diagnostics.hessian_actions
+                ),
+                linear_solves=state.linear_solves + 1,
+                linear_iterations=(
+                    state.linear_iterations + subproblem.diagnostics.iterations
+                ),
+                setup_refreshes=state.setup_refreshes,
+                numeric_refreshes=state.numeric_refreshes,
+                linear_refresh_state=state.linear_refresh_state,
+                direction_fallbacks=state.direction_fallbacks,
+                metrics=IterativeStepMetrics(
+                    objective=jnp.where(accepted, candidate_value, value),
+                    optimality_norm=accepted_optimality,
+                    step_norm=step_norm,
+                    accepted_step_size=jnp.where(accepted, 1.0, 0.0),
+                    accepted=accepted,
+                    linear_iterations=subproblem.diagnostics.iterations,
+                    damping=next_radius,
+                    reduction_ratio=ratio,
+                    status=status,
+                ),
+            )
+            dynamic, _ = eqx.partition(updated, eqx.is_array)
+            return (
+                accepted_parameters,
+                dynamic,
+                jnp.where(accepted, candidate_value, value),
+            )
+
+        next_parameters, dynamic_state, objective = jax.lax.cond(
+            (~finite) | converged | (~budget_allows_candidate),
+            terminal_step,
+            trust_region_step,
+            None,
+        )
+        return next_parameters, eqx.combine(dynamic_state, static_state), objective
+
+    def step_metrics(
+        self,
+        state: _AbstractScalarExtensionState,
+        /,
+    ) -> IterativeStepMetrics:
         if not isinstance(state, NewtonTrustRegionState):
             raise TypeError("state must be a NewtonTrustRegionState.")
         return state.metrics
@@ -901,6 +1275,8 @@ class NewtonTrustRegion(AbstractScalarIterativeMethod):
 
 __all__ = [
     "BetaMethod",
+    "DenseNewtonDogleg",
+    "DenseNewtonDoglegState",
     "NewtonTrustRegion",
     "NewtonTrustRegionState",
     "NonlinearConjugateGradient",

--- a/tests/unit/nonlinear/test_advanced_methods.py
+++ b/tests/unit/nonlinear/test_advanced_methods.py
@@ -390,7 +390,7 @@ def test_nonlinear_gmres_rejects_a_harmful_affine_combination_and_restarts():
         return 1.0 - 0.1 * (state - 1.0) + 10.0 * jnp.maximum(state - 2.0, 0.0) ** 2
 
     method = nl.NonlinearGMRES(
-        lambda state, args: state + 1.0,
+        nl.FunctionNonlinearUpdate(lambda state, args: state + 1.0),
         history=2,
         safeguard_factor=1.0,
     )

--- a/tests/unit/nonlinear/test_composition_substrate.py
+++ b/tests/unit/nonlinear/test_composition_substrate.py
@@ -1,0 +1,259 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import equinox as eqx
+import jax.numpy as jnp
+import pytest
+
+import phydrax as phx
+
+
+nl = phx.nonlinear
+la = phx.linalg
+
+
+def _termination(**kwargs):
+    return nl.NonlinearTermination(
+        absolute_residual=kwargs.pop("absolute_residual", 1e-9),
+        relative_residual=0.0,
+        maximum_steps=kwargs.pop("maximum_steps", 20),
+        **kwargs,
+    )
+
+
+def test_function_update_distinguishes_application_from_root_convergence_and_refresh():
+    problem = nl.NonlinearSystemProblem(
+        lambda state, target: state - target,
+        problem_id="finite-update",
+    )
+    update = nl.FunctionNonlinearUpdate(
+        lambda state, target: state + 0.5 * (target - state),
+        update_id="half-correction",
+    )
+    prepared = nl.prepare_nonlinear_update(
+        problem,
+        jnp.asarray([0.0]),
+        update,
+        args=jnp.asarray([2.0]),
+    )
+    result, next_prepared = nl.apply_prepared_nonlinear_update(
+        prepared,
+        jnp.asarray([0.0]),
+        args=jnp.asarray([2.0]),
+    )
+
+    assert bool(result.applied)
+    assert jnp.allclose(result.state, jnp.asarray([1.0]))
+    assert float(result.diagnostics.final_residual_norm) == pytest.approx(1.0)
+    assert result.status == int(nl.NonlinearUpdateStatus.APPLIED)
+    assert next_prepared.plan.plan_id == prepared.plan.plan_id
+
+    refreshed = nl.refresh_nonlinear_update(
+        next_prepared,
+        problem,
+        result.state,
+        args=jnp.asarray([3.0]),
+    )
+    assert refreshed.plan.plan_id == prepared.plan.plan_id
+    assert int(refreshed.numeric_version) == 1
+
+
+def test_update_budget_rejects_before_callable_proposal():
+    problem = nl.NonlinearSystemProblem(lambda state, target: state - target)
+    update = nl.FunctionNonlinearUpdate(lambda state, target: target)
+    prepared = nl.prepare_nonlinear_update(
+        problem,
+        jnp.asarray([0.0]),
+        update,
+        args=jnp.asarray([2.0]),
+    )
+    result, _ = nl.apply_prepared_nonlinear_update(
+        prepared,
+        jnp.asarray([0.0]),
+        args=jnp.asarray([2.0]),
+        control=nl.NonlinearUpdateControl(maximum_residual_evaluations=1),
+    )
+
+    assert not bool(result.applied)
+    assert result.status == int(nl.NonlinearUpdateStatus.BUDGET_EXHAUSTED)
+    assert jnp.allclose(result.state, jnp.asarray([0.0]))
+
+
+def test_additive_multiplicative_and_optimal_compositions_preserve_physical_residual():
+    problem = nl.NonlinearSystemProblem(lambda state, target: state - target)
+    half = nl.FunctionNonlinearUpdate(
+        lambda state, target: state + 0.5 * (target - state),
+        update_id="half",
+    )
+    quarter = nl.FunctionNonlinearUpdate(
+        lambda state, target: state + 0.25 * (target - state),
+        update_id="quarter",
+    )
+    initial = jnp.asarray([0.0])
+    target = jnp.asarray([2.0])
+
+    additive = nl.CompositeNonlinearUpdate(
+        (half, quarter),
+        kind="additive",
+        weights=(1.0, 2.0),
+    )
+    additive_prepared = nl.prepare_nonlinear_update(
+        problem,
+        initial,
+        additive,
+        args=target,
+    )
+    additive_result, _ = nl.apply_prepared_nonlinear_update(
+        additive_prepared,
+        initial,
+        args=target,
+    )
+    assert bool(additive_result.applied)
+    assert jnp.allclose(additive_result.state, target)
+    assert jnp.allclose(additive_result.residual, jnp.zeros_like(target))
+    assert len(additive_result.components) == 2
+
+    multiplicative = nl.CompositeNonlinearUpdate(
+        (half, half),
+        kind="multiplicative",
+    )
+    multiplicative_prepared = nl.prepare_nonlinear_update(
+        problem,
+        initial,
+        multiplicative,
+        args=target,
+    )
+    multiplicative_result, _ = nl.apply_prepared_nonlinear_update(
+        multiplicative_prepared,
+        initial,
+        args=target,
+    )
+    assert jnp.allclose(multiplicative_result.state, jnp.asarray([1.5]))
+    assert jnp.allclose(multiplicative_result.residual, jnp.asarray([-0.5]))
+
+    optimal = nl.CompositeNonlinearUpdate(
+        (quarter, half),
+        kind="residual-optimal",
+        regularization=0.0,
+    )
+    optimal_prepared = nl.prepare_nonlinear_update(
+        problem,
+        initial,
+        optimal,
+        args=target,
+    )
+    optimal_result, _ = nl.apply_prepared_nonlinear_update(
+        optimal_prepared,
+        initial,
+        args=target,
+    )
+    assert bool(optimal_result.applied)
+    assert float(optimal_result.diagnostics.final_residual_norm) <= 1.0
+
+
+def test_typed_ngmres_and_richardson_solve_and_raw_callable_is_rejected():
+    problem = nl.NonlinearSystemProblem(lambda state, target: state - target)
+    exact = nl.FunctionNonlinearUpdate(lambda state, target: target)
+
+    ngmres = nl.NonlinearGMRES(exact)
+    ngmres_result = ngmres.solve(
+        problem,
+        jnp.asarray([0.0]),
+        args=jnp.asarray([2.0]),
+        termination=_termination(maximum_steps=5),
+    )
+    richardson_result = nl.NonlinearRichardson(exact).solve(
+        problem,
+        jnp.asarray([0.0]),
+        args=jnp.asarray([2.0]),
+        termination=_termination(maximum_steps=5),
+    )
+
+    assert bool(ngmres_result.successful)
+    assert bool(richardson_result.successful)
+    with pytest.raises(TypeError, match="AbstractNonlinearUpdate"):
+        nl.NonlinearGMRES(lambda state, args: state)
+
+
+def _subdomain(index, target):
+    space = la.ArraySpace((1,), dtype=jnp.float64)
+    return nl.NonlinearSubdomain(
+        lambda state: state[index : index + 1],
+        lambda residual: residual[index : index + 1],
+        lambda correction: (
+            jnp.zeros((2,), dtype=correction.dtype).at[index].set(correction[0])
+        ),
+        lambda local, global_state, args: local - args[index : index + 1],
+        nl.FunctionNonlinearUpdate(
+            lambda local, context: context[1][index : index + 1],
+            update_id=f"exact-local-{index}",
+        ),
+        state_space=space,
+        residual_space=space,
+        subdomain_id=f"block-{index}",
+    )
+
+
+def test_nonlinear_schwarz_gauss_seidel_and_aspin_certify_global_system():
+    target = jnp.asarray([2.0, 3.0], dtype=jnp.float64)
+    problem = nl.NonlinearSystemProblem(
+        lambda state, args: state - args,
+        problem_id="block-root",
+    )
+    subdomains = (_subdomain(0, target), _subdomain(1, target))
+    initial = jnp.zeros((2,), dtype=jnp.float64)
+
+    for update in (
+        nl.NonlinearAdditiveSchwarz(subdomains),
+        nl.NonlinearMultiplicativeSchwarz(subdomains),
+        nl.NonlinearGaussSeidel(subdomains),
+    ):
+        prepared = nl.prepare_nonlinear_update(problem, initial, update, args=target)
+        result, _ = nl.apply_prepared_nonlinear_update(
+            prepared,
+            initial,
+            args=target,
+        )
+        assert bool(result.applied)
+        assert jnp.allclose(result.state, target)
+        assert jnp.allclose(result.residual, jnp.zeros_like(target))
+
+    aspin = nl.ASPIN(nl.NonlinearAdditiveSchwarz(subdomains))
+    aspin_result = aspin.solve(
+        problem,
+        initial,
+        args=target,
+        termination=_termination(maximum_steps=20),
+    )
+    assert bool(aspin_result.successful)
+    assert jnp.allclose(aspin_result.state, target, atol=1e-8)
+    assert aspin_result.provenance.method_id == "aspin"
+    assert not aspin_result.diagnostics.counts_complete
+
+
+def test_prepared_function_update_follows_filtered_jit_pattern():
+    problem = nl.NonlinearSystemProblem(lambda state, target: state - target)
+    prepared = nl.prepare_nonlinear_update(
+        problem,
+        jnp.asarray([0.0]),
+        nl.FunctionNonlinearUpdate(lambda state, target: target),
+        args=jnp.asarray([2.0]),
+    )
+
+    @eqx.filter_jit
+    def apply(current, state, target):
+        result, next_current = nl.apply_prepared_nonlinear_update(
+            current,
+            state,
+            args=target,
+        )
+        return result.state, next_current
+
+    state, next_prepared = apply(
+        prepared,
+        jnp.asarray([0.0]),
+        jnp.asarray([2.0]),
+    )
+    assert jnp.allclose(state, jnp.asarray([2.0]))
+    assert next_prepared.plan.plan_id == prepared.plan.plan_id

--- a/tests/unit/nonlinear/test_feasible_vi.py
+++ b/tests/unit/nonlinear/test_feasible_vi.py
@@ -1,0 +1,108 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import equinox as eqx
+import jax.numpy as jnp
+import pytest
+
+import phydrax as phx
+
+
+nl = phx.nonlinear
+
+
+def _termination():
+    return nl.NonlinearTermination(
+        absolute_residual=1e-10,
+        relative_residual=0.0,
+        maximum_steps=30,
+    )
+
+
+def test_preserve_box_never_exposes_domain_restricted_operator_to_outside_state():
+    def operator(state, args):
+        del args
+        return jnp.where(state < 0.0, jnp.nan, state - 1.0)
+
+    problem = nl.VariationalInequalityProblem(
+        operator,
+        nl.Bounds(0.0, jnp.inf),
+        problem_id="nonnegative-domain",
+    )
+    result = nl.SemismoothNewton(feasibility="preserve-box").solve(
+        problem,
+        jnp.asarray([-2.0]),
+        termination=_termination(),
+    )
+
+    assert bool(result.successful)
+    assert jnp.all(result.state >= 0.0)
+    assert jnp.allclose(result.state, jnp.asarray([1.0]), atol=1e-9)
+    assert bool(result.certificate.feasible)
+    assert bool(result.certificate.certified)
+    assert "feasibility=preserve-box" in result.provenance.notes
+
+
+def test_prepared_vi_refresh_reuses_plan_and_rejects_bound_topology_change():
+    problem = nl.VariationalInequalityProblem(
+        lambda state, target: state - target,
+        nl.Bounds(0.0, jnp.inf),
+        problem_id="prepared-vi",
+    )
+    method = nl.SemismoothNewton(feasibility="preserve-box")
+    prepared = nl.prepare_variational_inequality(
+        problem,
+        jnp.asarray([0.5]),
+        method=method,
+        termination=_termination(),
+        args=jnp.asarray([1.0]),
+    )
+    first = nl.solve_prepared_variational_inequality(prepared)
+    refreshed = nl.refresh_variational_inequality(
+        prepared,
+        problem,
+        first.state,
+        args=jnp.asarray([2.0]),
+    )
+    second = nl.solve_prepared_variational_inequality(refreshed)
+
+    assert bool(first.successful)
+    assert bool(second.successful)
+    assert jnp.allclose(second.state, jnp.asarray([2.0]), atol=1e-8)
+    assert refreshed.nonlinear.linear_plan_id == prepared.nonlinear.linear_plan_id
+    assert int(refreshed.numeric_version) == 1
+
+    changed_topology = nl.VariationalInequalityProblem(
+        lambda state, target: state - target,
+        nl.Bounds(-jnp.inf, jnp.inf),
+        problem_id="prepared-vi",
+    )
+    with pytest.raises(ValueError, match="bound topology"):
+        nl.refresh_variational_inequality(
+            prepared,
+            changed_topology,
+            first.state,
+            args=jnp.asarray([2.0]),
+        )
+
+
+def test_prepared_feasible_vi_supports_filtered_jit_solve():
+    problem = nl.VariationalInequalityProblem(
+        lambda state, target: state - target,
+        nl.Bounds(0.0, 1.0),
+        problem_id="jitted-feasible-vi",
+    )
+    prepared = nl.prepare_variational_inequality(
+        problem,
+        jnp.asarray([0.0]),
+        method=nl.SemismoothNewton(feasibility="preserve-box"),
+        termination=_termination(),
+        args=jnp.asarray([2.0]),
+    )
+
+    @eqx.filter_jit
+    def solve(current):
+        return nl.solve_prepared_variational_inequality(current).state
+
+    assert jnp.allclose(solve(prepared), jnp.asarray([1.0]))

--- a/tests/unit/nonlinear/test_prepared_lifecycle.py
+++ b/tests/unit/nonlinear/test_prepared_lifecycle.py
@@ -201,6 +201,8 @@ def test_prepared_nonlinear_rejects_unsupported_methods_and_is_public():
         nl.prepare_nonlinear(
             problem,
             jnp.zeros(1),
-            method=nl.NonlinearGMRES(lambda state, args: state),
+            method=nl.NonlinearGMRES(
+                nl.FunctionNonlinearUpdate(lambda state, args: state)
+            ),
             termination=_termination(),
         )

--- a/tests/unit/optim/test_operator_trust_region.py
+++ b/tests/unit/optim/test_operator_trust_region.py
@@ -1,0 +1,197 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax.numpy as jnp
+import pytest
+from jaxtyping import Array
+
+import phydrax as phx
+
+
+la = phx.linalg
+opt = phx.optim
+
+
+class _NoMaterializeSelfAdjoint(la.AbstractLinearOperator):
+    diagonal: Array
+
+    def __init__(self, diagonal):
+        diagonal_ = jnp.asarray(diagonal)
+        self.diagonal = diagonal_
+        self.source = la.ArraySpace(diagonal_.shape, dtype=diagonal_.dtype)
+        self.target = self.source
+        self.properties = la.OperatorProperties(
+            self_adjoint=True,
+            evidence={"self_adjoint": "construction"},
+        )
+        self.capabilities = la.OperatorCapabilities(
+            transpose=True,
+            adjoint=True,
+            materialize=False,
+        )
+        self.batch_shape = ()
+        self.operator_id = "no-materialize-self-adjoint"
+
+    def mv(self, vector):
+        return self.diagonal * self.source.validate(vector)
+
+    def transpose_mv(self, vector):
+        return self.mv(vector)
+
+    def adjoint_mv(self, vector):
+        return self.mv(vector)
+
+    def _materialize(self):
+        raise AssertionError("Trust-region solve must remain matrix-free.")
+
+
+def test_steihaug_toint_recovers_interior_newton_step_without_materialization():
+    operator = _NoMaterializeSelfAdjoint(jnp.asarray([2.0, 4.0]))
+    result = opt.solve_trust_region_subproblem(
+        opt.TrustRegionQuadraticProblem(
+            operator,
+            jnp.asarray([-2.0, -4.0]),
+            10.0,
+        )
+    )
+
+    assert bool(result.successful)
+    assert result.status == int(opt.TrustRegionSubproblemStatus.CONVERGED)
+    assert jnp.allclose(result.step, jnp.ones((2,)), atol=1e-8)
+    assert float(result.diagnostics.predicted_reduction) == pytest.approx(3.0)
+    assert not bool(result.diagnostics.boundary_hit)
+
+
+def test_steihaug_toint_reports_boundary_and_negative_curvature():
+    positive = _NoMaterializeSelfAdjoint(jnp.asarray([1.0, 1.0]))
+    boundary = opt.solve_trust_region_subproblem(
+        opt.TrustRegionQuadraticProblem(
+            positive,
+            jnp.asarray([-2.0, 0.0]),
+            0.5,
+        )
+    )
+    assert boundary.status == int(opt.TrustRegionSubproblemStatus.BOUNDARY_REACHED)
+    assert float(jnp.linalg.norm(boundary.step)) == pytest.approx(0.5)
+
+    indefinite = _NoMaterializeSelfAdjoint(jnp.asarray([-1.0, 2.0]))
+    negative = opt.solve_trust_region_subproblem(
+        opt.TrustRegionQuadraticProblem(
+            indefinite,
+            jnp.asarray([1.0, 0.0]),
+            1.0,
+        )
+    )
+    assert negative.status == int(opt.TrustRegionSubproblemStatus.NEGATIVE_CURVATURE)
+    assert bool(negative.diagnostics.negative_curvature)
+    assert float(jnp.linalg.norm(negative.step)) == pytest.approx(1.0)
+
+
+def _optimization_termination(maximum_steps=30):
+    return opt.OptimizationTermination(
+        absolute_optimality=1e-9,
+        relative_optimality=0.0,
+        maximum_steps=maximum_steps,
+    )
+
+
+def test_matrix_free_newton_trust_region_has_no_dense_dimension_cap():
+    size = 1024
+    target = jnp.ones((size,))
+    problem = opt.MinimizationProblem(
+        lambda parameters, expected: 0.5 * jnp.sum((parameters - expected) ** 2),
+        problem_id="large-matrix-free-trust-region",
+    )
+    result = opt.minimize(
+        problem,
+        jnp.zeros((size,)),
+        args=target,
+        method=opt.NewtonTrustRegion(initial_radius=64.0),
+        termination=_optimization_termination(maximum_steps=10),
+    )
+
+    assert bool(result.successful)
+    assert jnp.allclose(result.parameters, target)
+    assert result.provenance.method == "newton-trust-region/steihaug-toint"
+    assert int(result.diagnostics.hvp_evaluations) > 0
+
+
+def test_dense_dogleg_remains_an_explicit_small_system_method():
+    problem = opt.MinimizationProblem(
+        lambda parameters, _: 0.5 * jnp.sum((parameters - 1.0) ** 2)
+    )
+    result = opt.minimize(
+        problem,
+        jnp.zeros((2,)),
+        method=opt.DenseNewtonDogleg(),
+        termination=_optimization_termination(),
+    )
+    assert bool(result.successful)
+    assert result.provenance.method == "dense-newton-dogleg"
+
+
+def test_bounded_newton_trust_region_preserves_active_bounds():
+    problem = opt.MinimizationProblem(
+        lambda parameters, target: 0.5 * jnp.sum((parameters - target) ** 2),
+        bounds=opt.Bounds(0.0, 1.0),
+        problem_id="bounded-trust-region",
+    )
+    result = opt.minimize(
+        problem,
+        jnp.asarray([0.2, 0.2]),
+        args=jnp.asarray([2.0, -0.5]),
+        method=opt.BoundedNewtonTrustRegion(initial_radius=2.0),
+        termination=_optimization_termination(),
+    )
+
+    assert bool(result.successful)
+    assert jnp.allclose(result.parameters, jnp.asarray([1.0, 0.0]))
+    assert float(result.diagnostics.primal_feasibility) == 0.0
+    assert result.provenance.globalization == "projected-trust-region"
+    assert int(result.diagnostics.active_constraints) == 2
+
+
+@pytest.mark.parametrize(
+    "method",
+    [opt.BoundedGaussNewton(), opt.BoundedLevenbergMarquardt()],
+)
+def test_bounded_least_squares_uses_residual_model_and_never_leaves_box(method):
+    def residual(parameters, target):
+        return jnp.where(
+            (parameters < 0.0) | (parameters > 1.0),
+            jnp.nan,
+            parameters - target,
+        )
+
+    problem = opt.NonlinearLeastSquaresProblem(
+        residual,
+        bounds=opt.Bounds(0.0, 1.0),
+        problem_id="bounded-residual",
+    )
+    result = opt.least_squares(
+        problem,
+        jnp.asarray([-1.0, 2.0]),
+        args=jnp.asarray([2.0, -0.5]),
+        method=method,
+        termination=_optimization_termination(),
+    )
+
+    assert bool(result.successful)
+    assert jnp.allclose(result.parameters, jnp.asarray([1.0, 0.0]), atol=1e-7)
+    assert float(result.diagnostics.primal_feasibility) == 0.0
+    assert result.provenance.globalization == "projected-residual-trust-region"
+
+
+def test_unbounded_least_squares_method_rejects_declared_bounds():
+    problem = opt.NonlinearLeastSquaresProblem(
+        lambda parameters, target: parameters - target,
+        bounds=opt.Bounds(0.0, 1.0),
+    )
+    with pytest.raises(ValueError, match="do not silently ignore bounds"):
+        opt.least_squares(
+            problem,
+            jnp.asarray([0.5]),
+            args=jnp.asarray([1.0]),
+            method=opt.GaussNewton(),
+        )

--- a/tests/unit/test_advanced_solver_benchmark_harness.py
+++ b/tests/unit/test_advanced_solver_benchmark_harness.py
@@ -269,6 +269,7 @@ def test_public_phydrax_adapter_declares_every_representative_family():
             "optimization.unconstrained",
             "optimization.constrained",
             "optimization.proximal",
+            "optimization.bounded-least-squares",
             "optimization.linear-program",
             "optimization.quadratic-program",
         }
@@ -290,6 +291,7 @@ def test_capabilities_cli_emits_all_common_solver_families(capsys):
         "optimization.unconstrained",
         "optimization.constrained",
         "optimization.proximal",
+        "optimization.bounded-least-squares",
         "optimization.linear-program",
         "optimization.quadratic-program",
         "optimization.conic-program",


### PR DESCRIPTION
## Summary

This PR absorbs the highest-leverage nonlinear composition and trust-region ideas from PETSc SNES/TAO into Phydrax without mirroring PETSc's runtime registry or duplicating bounded and unbounded solver families.

It adds two reusable numerical nuclei:

- a prepared finite nonlinear-update graph, distinct from complete root convergence;
- an operator-based Steihaug--Toint trust-region quadratic solver.

These support nonlinear composition, Schwarz decomposition, ASPIN, strict-feasible complementarity, large-scale Newton trust regions, bound-constrained Newton methods, and bound-aware residual optimization while preserving Phydrax's PyTree, JIT, provenance, and physical-certification contracts.

## Nonlinear update substrate

- Adds `AbstractNonlinearUpdate`, typed update status/capabilities/control/diagnostics/provenance/result values, deterministic plans, prepared state, numeric refresh, and finite-work application.
- Adds explicit callable, Newton-step, Picard, and FAS update implementations.
- Separates `NonlinearUpdateStatus.APPLIED` from `NonlinearStatus.SUCCESS`: a finite Newton step or FAS cycle can apply without claiming a root.
- Retains the original physical state, residual, auxiliary output, spaces, work, and plan identity across preparation and refresh.
- Makes arbitrary callables cross the public boundary only through `FunctionNonlinearUpdate`.

## Composition and nonlinear preconditioning

- Adds static multiplicative, weighted additive, and safeguarded residual-optimal `CompositeNonlinearUpdate` graphs.
- Adds physical-residual Armijo `NonlinearRichardson`.
- Migrates `NonlinearGMRES` from raw callables to prepared typed updates and aggregates nested derivative/linear work.
- Promotes `FASNonlinearPreconditioner` to a typed update while retaining exact tau-corrected V/W/F cycles and level diagnostics.
- Preserves hard work allocation across child graphs and independently evaluates every combined candidate against the original problem.

## Nonlinear decomposition and ASPIN

- Adds explicit `NonlinearSubdomain` contracts with state/residual restriction, local residuals, correction prolongation, weights, and typed local updates.
- Adds additive and multiplicative nonlinear Schwarz plus ordered nonlinear Gauss--Seidel.
- Adds `ASPIN`, using additive Schwarz as a left nonlinear preconditioner and preparing local dense inverse Jacobians for reuse within each outer approximate-Jacobian action.
- ASPIN always finalizes through the original physical problem; a transformed residual cannot certify a false root.
- Nested ASPIN work that cannot be counted portably is marked with `counts_complete=False` rather than estimated.

## Variational inequalities

- Extends `SemismoothNewton` with explicit `allow-infeasible` and `preserve-box` policies.
- The strict path projects every trial before operator evaluation and returns an exactly projected accepted state.
- Adds plan/prepare/refresh/solve lifecycle objects for repeated VI solves.
- Refresh preserves problem identity, spaces, derivative structure, and the finite/infinite/fixed bound-role topology.
- Final success still requires the independent natural/Fischer--Burmeister complementarity certificate.

## Matrix-free trust regions

- Adds `TrustRegionQuadraticProblem`, `SteihaugToint`, typed statuses/results/diagnostics, optional fixed SPD preconditioning, exact boundary intersection, and negative-curvature evidence.
- Replaces the scalar `NewtonTrustRegion` dense Hessian/eigendecomposition path with a matrix-free Hessian action and removes the former dimension cap.
- Retains the former small-system implementation explicitly as `DenseNewtonDogleg`; no compatibility alias or hidden dense fallback is retained.
- Adds `BoundedNewtonTrustRegion` over a masked free-variable Hessian action. Predicted reduction is recomputed for the actual projected displacement.

## Bound-aware nonlinear least squares

- Adds optional `Bounds` to `NonlinearLeastSquaresProblem`.
- Existing unbounded methods reject declared bounds instead of silently ignoring them.
- Adds matrix-free `BoundedGaussNewton` and `BoundedLevenbergMarquardt` with projected active sets, free-variable normal operators, trust-region acceptance, and ratio-based LM damping.
- Every accepted residual evaluation remains inside the declared box.

## API cutovers

- `NonlinearGMRES` now requires an `AbstractNonlinearUpdate`; use `FunctionNonlinearUpdate` for a callable proposal.
- `optim.NewtonTrustRegion` is now the matrix-free Steihaug--Toint method.
- `DenseNewtonDogleg` is the explicit dense small-system route.
- Bound-aware least-squares methods are complete-solve methods; generic step-only consumers reject them because bounds belong to the problem contract.

## Documentation and benchmark contracts

- Updates the nonlinear and optimization API guides, advanced-solver cookbook, solver-substrate guide, complete Phydrax overview, and changelog.
- Extends the advanced-solver benchmark schema with a deterministic active-bound least-squares case, projected-stationarity certificate, Phydrax adapter, and SciPy reference adapter.
- Keeps unsupported backend rows explicit rather than substituting another algorithm.