### PR TITLE
Add scalable non-Markovian and many-body open systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## Unreleased
 
 ### Added
+- Added Gaussian bosonic Lindblad dynamics, quantum-jump ensembles, adaptive
+  bosonic Fock spaces, pseudomode/reaction-coordinate embeddings, HEOM,
+  memory-kernel and TCL evolution, tensor-network states and truncation
+  evidence, and process-tensor MPO contracts.
+
 - Added projective-line Calabi–Yau campaign preparation, residue and induced
   hypersurface geometry, positivity-globalized Kähler-potential solving,
   Hermitian spectral/Sylvester infrastructure, faithful Bures density geometry,

--- a/docs/api/solver/nonmarkov_manybody.md
+++ b/docs/api/solver/nonmarkov_manybody.md
@@ -1,0 +1,58 @@
+# Non-Markovian and many-body open quantum systems
+
+Phydrax uses representation-specific open-system solvers. A finite truncation is
+never presented as an exact unbounded-Hilbert result.
+
+## Exact Gaussian bosonic sector
+
+`BosonicGaussianState` represents means and covariances under the declared
+canonical commutation convention. `GaussianLindbladProblem` evolves quadratic
+Hamiltonian and linear-noise systems without a Fock cutoff.
+
+::: phydrax.metrix.BosonicGaussianState
+
+::: phydrax.metrix.BosonicGaussianChannel
+
+::: phydrax.solver.GaussianLindbladProblem
+
+## Quantum trajectories and Fock spaces
+
+`QuantumJumpProblem` unravels Lindblad dynamics into pure-state trajectories.
+`BosonicFockSpace` supplies explicit local cutoffs, matrix-free ladder actions,
+and top-occupation evidence.
+
+::: phydrax.solver.QuantumJumpProblem
+
+::: phydrax.solver.solve_quantum_jump_ensemble
+
+::: phydrax.operators.quantum.BosonicFockSpace
+
+## Non-Markovian embeddings and HEOM
+
+Pseudomodes enlarge the physical system into a Markovian model. HEOM represents
+bath memory with a fixed auxiliary hierarchy; only the root auxiliary is a
+physical density matrix.
+
+::: phydrax.operators.quantum.BathCorrelationExpansion
+
+::: phydrax.solver.PseudomodeEmbeddingProblem
+
+::: phydrax.solver.HEOMProblem
+
+## Memory kernels and TCL
+
+`MemoryKernelMasterEquation` and `TimeLocalOpenSystemProblem` remain separate
+from `LindbladProblem`. Negative time-local rates are not clipped. Bounded
+small-system dynamical maps may be checked through Choi positivity.
+
+::: phydrax.solver.MemoryKernelMasterEquation
+
+::: phydrax.solver.TimeLocalOpenSystemProblem
+
+::: phydrax.solver.DynamicalMapPhysicality
+
+## Tensor and process networks
+
+The `phydrax.tensor_network` package provides fixed-capacity MPS, MPO, locally
+purified density, two-site gate truncation, and process-tensor MPO contracts.
+Every bond truncation reports discarded weight.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -267,6 +267,7 @@ nav:
             - Overview: "api/solver/index.md"
             - Time integrators: "api/solver/time_integrators.md"
             - Differential equations: "api/solver/differential.md"
+            - Non-Markovian and many-body quantum systems: "api/solver/nonmarkov_manybody.md"
             - Differential-algebraic equations: "api/solver/differential_algebraic.md"
             - Delay and functional differential equations: "api/solver/delay.md"
             - Functional solver: "api/solver/functional_solver.md"

--- a/phydrax/__init__.py
+++ b/phydrax/__init__.py
@@ -37,6 +37,7 @@ from . import (
     sparse,
     special,
     stochastic,
+    tensor_network,
     terms,
     transport,
     uq,
@@ -77,5 +78,6 @@ __all__ = [
     "solver",
     "stochastic",
     "uq",
+    "tensor_network",
     "weighting",
 ]

--- a/phydrax/metrix/__init__.py
+++ b/phydrax/metrix/__init__.py
@@ -31,6 +31,11 @@ from ._atlas import (
 )
 from ._atlas_cover import AtlasCover, AtlasOverlap, ChartSupport
 from ._bigraded_forms import bigraded_wedge, BigradedForm, partial, partial_bar
+from ._bosonic_gaussian import (
+    BosonicGaussianChannel,
+    BosonicGaussianState,
+    canonical_commutation_matrix,
+)
 from ._boundary import (
     induced_boundary_density,
     induced_boundary_metric,
@@ -540,5 +545,8 @@ __all__ = [
     "faithful_density_from_generator",
     "principal_purification",
     "uhlmann_alignment",
+    "BosonicGaussianChannel",
+    "BosonicGaussianState",
+    "canonical_commutation_matrix",
     "PatchwiseTensorField",
 ]

--- a/phydrax/metrix/_bosonic_gaussian.py
+++ b/phydrax/metrix/_bosonic_gaussian.py
@@ -1,0 +1,141 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import equinox as eqx
+import jax.numpy as jnp
+from jaxtyping import Array, ArrayLike
+
+from .._strict import StrictModule
+
+
+def canonical_commutation_matrix(mode_count: int, /, *, dtype=float) -> Array:
+    modes = int(mode_count)
+    if modes < 1:
+        raise ValueError("mode_count must be positive.")
+    block = jnp.asarray([[0.0, 1.0], [-1.0, 0.0]], dtype=dtype)
+    return jnp.kron(jnp.eye(modes, dtype=dtype), block)
+
+
+class BosonicGaussianState(StrictModule):
+    mean: Array
+    covariance: Array
+    symplectic_form: Array
+    uncertainty_margin: Array
+    symmetry_residual: Array
+    symplectic_eigenvalues: Array
+    purity: Array
+    valid: Array
+    mode_count: int = eqx.field(static=True)
+    hbar: float = eqx.field(static=True)
+
+    def __init__(
+        self,
+        mean: ArrayLike,
+        covariance: ArrayLike,
+        /,
+        *,
+        hbar: float = 1.0,
+        tolerance: float = 1e-9,
+    ):
+        mean_ = jnp.asarray(mean)
+        covariance_ = jnp.asarray(covariance, dtype=mean_.dtype)
+        if mean_.ndim != 1 or mean_.shape[0] % 2:
+            raise ValueError("Gaussian mean must have even vector dimension.")
+        if covariance_.shape != (mean_.shape[0], mean_.shape[0]):
+            raise ValueError("Gaussian covariance shape must match the mean dimension.")
+        modes = mean_.shape[0] // 2
+        omega = canonical_commutation_matrix(modes, dtype=mean_.dtype)
+        symmetric = 0.5 * (covariance_ + covariance_.T)
+        uncertainty = symmetric.astype(complex) + 0.5j * float(hbar) * omega
+        margin = jnp.min(jnp.linalg.eigvalsh(uncertainty))
+        eigenvalues = jnp.linalg.eigvals(1j * omega @ symmetric)
+        symplectic = jnp.sort(jnp.abs(eigenvalues))[::2]
+        determinant = jnp.linalg.det(2.0 * symmetric / float(hbar))
+        purity = 1.0 / jnp.sqrt(jnp.maximum(determinant, 1.0))
+        residual = jnp.max(jnp.abs(covariance_ - covariance_.T))
+        self.mean = mean_
+        self.covariance = symmetric
+        self.symplectic_form = omega
+        self.uncertainty_margin = margin
+        self.symmetry_residual = residual
+        self.symplectic_eigenvalues = symplectic
+        self.purity = purity
+        self.valid = (
+            jnp.all(jnp.isfinite(mean_))
+            & jnp.all(jnp.isfinite(covariance_))
+            & (residual <= tolerance)
+            & (margin >= -tolerance)
+        )
+        self.mode_count = modes
+        self.hbar = float(hbar)
+
+
+class BosonicGaussianChannel(StrictModule):
+    x: Array
+    y: Array
+    displacement: Array
+    cp_margin: Array
+    valid: Array
+    mode_count: int = eqx.field(static=True)
+    channel_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        x: ArrayLike,
+        y: ArrayLike,
+        displacement: ArrayLike,
+        /,
+        *,
+        channel_id: str,
+        hbar: float = 1.0,
+        tolerance: float = 1e-9,
+    ):
+        x_ = jnp.asarray(x)
+        y_ = jnp.asarray(y, dtype=x_.dtype)
+        displacement_ = jnp.asarray(displacement, dtype=x_.dtype)
+        if x_.ndim != 2 or x_.shape[0] != x_.shape[1] or x_.shape[0] % 2:
+            raise ValueError("Gaussian channel X must be an even square matrix.")
+        if y_.shape != x_.shape or displacement_.shape != (x_.shape[0],):
+            raise ValueError("Gaussian channel Y/displacement shapes do not match X.")
+        modes = x_.shape[0] // 2
+        omega = canonical_commutation_matrix(modes, dtype=x_.dtype)
+        cp_matrix = 0.5 * (y_ + y_.T).astype(complex) + 0.5j * float(hbar) * (
+            omega - x_ @ omega @ x_.T
+        )
+        margin = jnp.min(jnp.linalg.eigvalsh(cp_matrix))
+        self.x = x_
+        self.y = 0.5 * (y_ + y_.T)
+        self.displacement = displacement_
+        self.cp_margin = margin
+        self.valid = jnp.all(jnp.isfinite(cp_matrix)) & (margin >= -tolerance)
+        self.mode_count = modes
+        self.channel_id = str(channel_id)
+
+    def apply(self, state: BosonicGaussianState, /) -> BosonicGaussianState:
+        if state.mode_count != self.mode_count:
+            raise ValueError("Gaussian state and channel mode counts differ.")
+        return BosonicGaussianState(
+            self.x @ state.mean + self.displacement,
+            self.x @ state.covariance @ self.x.T + self.y,
+            hbar=state.hbar,
+        )
+
+    def compose(self, after: BosonicGaussianChannel, /) -> BosonicGaussianChannel:
+        if after.mode_count != self.mode_count:
+            raise ValueError("Gaussian channel mode counts differ.")
+        return BosonicGaussianChannel(
+            after.x @ self.x,
+            after.x @ self.y @ after.x.T + after.y,
+            after.x @ self.displacement + after.displacement,
+            channel_id=f"{after.channel_id}∘{self.channel_id}",
+        )
+
+
+__all__ = [
+    "BosonicGaussianChannel",
+    "BosonicGaussianState",
+    "canonical_commutation_matrix",
+]

--- a/phydrax/operators/quantum/__init__.py
+++ b/phydrax/operators/quantum/__init__.py
@@ -38,6 +38,12 @@ from ._dynamics import (
     schrodinger_residual,
     von_neumann_residual,
 )
+from ._fock import (
+    BosonicFockSpace,
+    FockCutoffEvidence,
+    jaynes_cummings_hamiltonian,
+    kerr_hamiltonian,
+)
 from ._information import (
     density_fidelity,
     purity,
@@ -45,12 +51,27 @@ from ._information import (
     trace_distance,
     von_neumann_entropy,
 )
+from ._open_contracts import (
+    ApproximationAxis,
+    OpenSystemApproximationEvidence,
+    OpenSystemPhysicalityEvidence,
+    OpenSystemRefinement,
+    PhysicalityStatus,
+    QuantumGeneratorAction,
+    QuantumObservablePlan,
+)
 from ._open_system import lindblad_dissipator, lindblad_residual
 from ._propagation import (
     apply_unitary_to_state,
     conjugate_density,
     density_invariant_residuals,
     unitarity_residual,
+)
+from ._pseudomode import (
+    BathCorrelationExpansion,
+    lorentzian_pseudomode,
+    Pseudomode,
+    ReactionCoordinateMapping,
 )
 from ._states import (
     density_expectation,
@@ -107,4 +128,19 @@ __all__ = [
     "density_invariant_residuals",
     "quantum_geometric_tensor",
     "unitarity_residual",
+    "ApproximationAxis",
+    "BathCorrelationExpansion",
+    "BosonicFockSpace",
+    "FockCutoffEvidence",
+    "OpenSystemApproximationEvidence",
+    "OpenSystemPhysicalityEvidence",
+    "OpenSystemRefinement",
+    "PhysicalityStatus",
+    "Pseudomode",
+    "QuantumGeneratorAction",
+    "QuantumObservablePlan",
+    "ReactionCoordinateMapping",
+    "jaynes_cummings_hamiltonian",
+    "kerr_hamiltonian",
+    "lorentzian_pseudomode",
 ]

--- a/phydrax/operators/quantum/_fock.py
+++ b/phydrax/operators/quantum/_fock.py
@@ -1,0 +1,215 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from math import prod
+from typing import Sequence
+
+import equinox as eqx
+import jax.numpy as jnp
+from jaxtyping import Array, ArrayLike
+
+from ..._strict import StrictModule
+from ._open_contracts import ApproximationAxis, OpenSystemApproximationEvidence
+
+
+class FockCutoffEvidence(StrictModule):
+    top_level_probability: Array
+    boundary_amplitude: Array
+    valid: Array
+    approximation: OpenSystemApproximationEvidence
+
+    def __init__(
+        self,
+        top_level_probability: ArrayLike,
+        boundary_amplitude: ArrayLike,
+        cutoffs: Sequence[int],
+        /,
+    ):
+        top = jnp.asarray(top_level_probability)
+        boundary = jnp.asarray(boundary_amplitude)
+        self.top_level_probability = top
+        self.boundary_amplitude = boundary
+        self.valid = jnp.all(jnp.isfinite(top)) & jnp.all(top >= 0.0)
+        self.approximation = OpenSystemApproximationEvidence(
+            "bosonic-fock",
+            tuple(
+                ApproximationAxis(f"mode-{index}-cutoff", cutoff)
+                for index, cutoff in enumerate(cutoffs)
+            ),
+            local_error=jnp.max(top),
+            valid=self.valid,
+        )
+
+
+class BosonicFockSpace(StrictModule):
+    cutoffs: tuple[int, ...] = eqx.field(static=True)
+    mode_count: int = eqx.field(static=True)
+    dimension: int = eqx.field(static=True)
+    space_id: str = eqx.field(static=True)
+
+    def __init__(self, cutoffs: Sequence[int], /):
+        cutoffs_ = tuple(int(value) for value in cutoffs)
+        if not cutoffs_ or any(value < 2 for value in cutoffs_):
+            raise ValueError("Every Fock cutoff must be at least two.")
+        self.cutoffs = cutoffs_
+        self.mode_count = len(cutoffs_)
+        self.dimension = prod(cutoffs_)
+        self.space_id = "fock:" + "x".join(str(value) for value in cutoffs_)
+
+    def occupations(self) -> Array:
+        indices = jnp.arange(self.dimension)
+        values = []
+        remainder = indices
+        for cutoff in reversed(self.cutoffs):
+            values.append(remainder % cutoff)
+            remainder = remainder // cutoff
+        return jnp.stack(tuple(reversed(values)), axis=-1)
+
+    def annihilate(self, state: ArrayLike, mode: int, /) -> Array:
+        vector = jnp.asarray(state)
+        if vector.shape != (self.dimension,):
+            raise ValueError("Fock state-vector dimension is invalid.")
+        mode_ = int(mode)
+        if not 0 <= mode_ < self.mode_count:
+            raise ValueError("mode index is out of range.")
+        tensor = jnp.moveaxis(vector.reshape(self.cutoffs), mode_, 0)
+        cutoff = self.cutoffs[mode_]
+        result = jnp.zeros_like(tensor)
+        result = result.at[:-1].set(
+            jnp.sqrt(jnp.arange(1, cutoff)).reshape(
+                (cutoff - 1,) + (1,) * (tensor.ndim - 1)
+            )
+            * tensor[1:]
+        )
+        return jnp.moveaxis(result, 0, mode_).reshape(-1)
+
+    def create(self, state: ArrayLike, mode: int, /) -> Array:
+        vector = jnp.asarray(state)
+        if vector.shape != (self.dimension,):
+            raise ValueError("Fock state-vector dimension is invalid.")
+        mode_ = int(mode)
+        if not 0 <= mode_ < self.mode_count:
+            raise ValueError("mode index is out of range.")
+        tensor = jnp.moveaxis(vector.reshape(self.cutoffs), mode_, 0)
+        cutoff = self.cutoffs[mode_]
+        result = jnp.zeros_like(tensor)
+        result = result.at[1:].set(
+            jnp.sqrt(jnp.arange(1, cutoff)).reshape(
+                (cutoff - 1,) + (1,) * (tensor.ndim - 1)
+            )
+            * tensor[:-1]
+        )
+        return jnp.moveaxis(result, 0, mode_).reshape(-1)
+
+    def annihilation_matrix(self, mode: int, /) -> Array:
+        mode_ = int(mode)
+        if not 0 <= mode_ < self.mode_count:
+            raise ValueError("mode index is out of range.")
+        matrices = []
+        for index, cutoff in enumerate(self.cutoffs):
+            if index == mode_:
+                local = jnp.diag(jnp.sqrt(jnp.arange(1, cutoff)), 1)
+            else:
+                local = jnp.eye(cutoff)
+            matrices.append(local)
+        result = matrices[0]
+        for matrix in matrices[1:]:
+            result = jnp.kron(result, matrix)
+        return result.astype(complex)
+
+    def creation_matrix(self, mode: int, /) -> Array:
+        return jnp.conj(self.annihilation_matrix(mode).T)
+
+    def number_matrix(self, mode: int, /) -> Array:
+        creation = self.creation_matrix(mode)
+        annihilation = self.annihilation_matrix(mode)
+        return creation @ annihilation
+
+    def cutoff_evidence(self, state: ArrayLike, /) -> FockCutoffEvidence:
+        vector = jnp.asarray(state)
+        if vector.shape != (self.dimension,):
+            raise ValueError("Fock state-vector dimension is invalid.")
+        probabilities = jnp.abs(vector) ** 2
+        occupations = self.occupations()
+        top = jnp.stack(
+            [
+                jnp.sum(
+                    jnp.where(
+                        occupations[:, mode] == cutoff - 1,
+                        probabilities,
+                        0.0,
+                    )
+                )
+                for mode, cutoff in enumerate(self.cutoffs)
+            ]
+        )
+        return FockCutoffEvidence(top, jnp.sqrt(top), self.cutoffs)
+
+    def embed(self, state: ArrayLike, fine: BosonicFockSpace, /) -> Array:
+        vector = jnp.asarray(state)
+        if vector.shape != (self.dimension,):
+            raise ValueError("Coarse Fock state has the wrong dimension.")
+        if fine.mode_count != self.mode_count or any(
+            fine_cutoff < cutoff
+            for cutoff, fine_cutoff in zip(self.cutoffs, fine.cutoffs, strict=True)
+        ):
+            raise ValueError("Fine Fock space must contain every coarse occupation.")
+        coarse_occupations = self.occupations()
+        multipliers = []
+        multiplier = 1
+        for cutoff in reversed(fine.cutoffs):
+            multipliers.append(multiplier)
+            multiplier *= cutoff
+        multipliers = jnp.asarray(tuple(reversed(multipliers)))
+        fine_indices = jnp.sum(coarse_occupations * multipliers, axis=-1)
+        return (
+            jnp.zeros((fine.dimension,), dtype=vector.dtype).at[fine_indices].set(vector)
+        )
+
+
+def kerr_hamiltonian(
+    space: BosonicFockSpace,
+    mode: int,
+    frequency: float,
+    nonlinearity: float,
+    /,
+) -> Array:
+    number = space.number_matrix(mode)
+    identity = jnp.eye(space.dimension, dtype=complex)
+    return float(frequency) * number + 0.5 * float(nonlinearity) * number @ (
+        number - identity
+    )
+
+
+def jaynes_cummings_hamiltonian(
+    cutoff: int,
+    cavity_frequency: float,
+    qubit_frequency: float,
+    coupling: float,
+    /,
+) -> tuple[BosonicFockSpace, Array]:
+    cavity = BosonicFockSpace((int(cutoff),))
+    annihilation = cavity.annihilation_matrix(0)
+    creation = jnp.conj(annihilation.T)
+    sigma_plus = jnp.asarray([[0, 1], [0, 0]], dtype=complex)
+    sigma_minus = jnp.conj(sigma_plus.T)
+    sigma_z = jnp.asarray([[1, 0], [0, -1]], dtype=complex)
+    number = cavity.number_matrix(0)
+    hamiltonian = (
+        float(cavity_frequency) * jnp.kron(number, jnp.eye(2))
+        + 0.5 * float(qubit_frequency) * jnp.kron(jnp.eye(cavity.dimension), sigma_z)
+        + float(coupling)
+        * (jnp.kron(annihilation, sigma_plus) + jnp.kron(creation, sigma_minus))
+    )
+    return cavity, hamiltonian
+
+
+__all__ = [
+    "BosonicFockSpace",
+    "FockCutoffEvidence",
+    "jaynes_cummings_hamiltonian",
+    "kerr_hamiltonian",
+]

--- a/phydrax/operators/quantum/_open_contracts.py
+++ b/phydrax/operators/quantum/_open_contracts.py
@@ -1,0 +1,178 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from typing import Any, Literal, TypeAlias
+
+import equinox as eqx
+import jax.numpy as jnp
+from jaxtyping import Array, ArrayLike
+
+from ..._strict import StrictModule
+
+
+PhysicalityStatus: TypeAlias = Literal["valid", "invalid", "unknown"]
+
+
+class ApproximationAxis(StrictModule):
+    name: str = eqx.field(static=True)
+    value: Array
+    parent_value: Array | None
+    units: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        name: str,
+        value: ArrayLike,
+        /,
+        *,
+        parent_value: ArrayLike | None = None,
+        units: str = "dimensionless",
+    ):
+        identifier = str(name)
+        if not identifier:
+            raise ValueError("Approximation-axis name must be non-empty.")
+        self.name = identifier
+        self.value = jnp.asarray(value)
+        self.parent_value = None if parent_value is None else jnp.asarray(parent_value)
+        self.units = str(units)
+
+
+class OpenSystemApproximationEvidence(StrictModule):
+    axes: tuple[ApproximationAxis, ...]
+    local_error: Array
+    statistical_error: Array
+    valid: Array
+    representation_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        representation_id: str,
+        axes: Sequence[ApproximationAxis],
+        /,
+        *,
+        local_error: ArrayLike = 0.0,
+        statistical_error: ArrayLike = 0.0,
+        valid: ArrayLike = True,
+    ):
+        self.representation_id = str(representation_id)
+        self.axes = tuple(axes)
+        self.local_error = jnp.asarray(local_error)
+        self.statistical_error = jnp.asarray(statistical_error)
+        self.valid = jnp.asarray(valid, dtype=bool)
+
+
+class OpenSystemPhysicalityEvidence(StrictModule):
+    trace_residual: Array
+    hermiticity_residual: Array
+    positivity_margin: Array
+    channel_cp_margin: Array
+    valid: Array
+    status: PhysicalityStatus = eqx.field(static=True)
+
+    def __init__(
+        self,
+        /,
+        *,
+        trace_residual: ArrayLike = jnp.nan,
+        hermiticity_residual: ArrayLike = jnp.nan,
+        positivity_margin: ArrayLike = jnp.nan,
+        channel_cp_margin: ArrayLike = jnp.nan,
+        status: PhysicalityStatus = "unknown",
+    ):
+        if status not in ("valid", "invalid", "unknown"):
+            raise ValueError("Unknown physicality status.")
+        self.trace_residual = jnp.asarray(trace_residual)
+        self.hermiticity_residual = jnp.asarray(hermiticity_residual)
+        self.positivity_margin = jnp.asarray(positivity_margin)
+        self.channel_cp_margin = jnp.asarray(channel_cp_margin)
+        self.status = status
+        self.valid = jnp.asarray(status == "valid")
+
+
+class QuantumGeneratorAction(StrictModule):
+    action_function: Callable[[Array, Array, Any], Array]
+    representation_id: str = eqx.field(static=True)
+    generator_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        action: Callable[[Array, Array, Any], Array],
+        /,
+        *,
+        representation_id: str,
+        generator_id: str,
+    ):
+        if not callable(action):
+            raise TypeError("Generator action must be callable.")
+        self.action_function = action
+        self.representation_id = str(representation_id)
+        self.generator_id = str(generator_id)
+
+    def __call__(self, time: Array, state: Array, args: Any = None, /) -> Array:
+        result = jnp.asarray(self.action_function(time, state, args))
+        if result.shape != state.shape:
+            raise ValueError("Generator action must preserve the state shape.")
+        return result
+
+
+class QuantumObservablePlan(StrictModule):
+    reducer: Callable[[Any], Array]
+    observable_id: str = eqx.field(static=True)
+    exact: bool = eqx.field(static=True)
+
+    def __init__(
+        self,
+        reducer: Callable[[Any], Array],
+        /,
+        *,
+        observable_id: str,
+        exact: bool,
+    ):
+        if not callable(reducer):
+            raise TypeError("Observable reducer must be callable.")
+        self.reducer = reducer
+        self.observable_id = str(observable_id)
+        self.exact = bool(exact)
+
+    def __call__(self, state: Any, /) -> Array:
+        return jnp.asarray(self.reducer(state))
+
+
+class OpenSystemRefinement(StrictModule):
+    coarse_representation_id: str = eqx.field(static=True)
+    fine_representation_id: str = eqx.field(static=True)
+    axis: ApproximationAxis
+    state_embedding: Callable[[Any], Any]
+
+    def __init__(
+        self,
+        coarse_representation_id: str,
+        fine_representation_id: str,
+        axis: ApproximationAxis,
+        state_embedding: Callable[[Any], Any],
+        /,
+    ):
+        if not callable(state_embedding):
+            raise TypeError("state_embedding must be callable.")
+        self.coarse_representation_id = str(coarse_representation_id)
+        self.fine_representation_id = str(fine_representation_id)
+        self.axis = axis
+        self.state_embedding = state_embedding
+
+    def embed(self, state: Any, /) -> Any:
+        return self.state_embedding(state)
+
+
+__all__ = [
+    "ApproximationAxis",
+    "OpenSystemApproximationEvidence",
+    "OpenSystemPhysicalityEvidence",
+    "OpenSystemRefinement",
+    "PhysicalityStatus",
+    "QuantumGeneratorAction",
+    "QuantumObservablePlan",
+]

--- a/phydrax/operators/quantum/_pseudomode.py
+++ b/phydrax/operators/quantum/_pseudomode.py
@@ -1,0 +1,155 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import equinox as eqx
+import jax.numpy as jnp
+from jaxtyping import Array, ArrayLike
+
+from ..._strict import StrictModule
+
+
+class BathCorrelationExpansion(StrictModule):
+    coefficients: Array
+    exponents: Array
+    fit_residual: Array
+    valid: Array
+    expansion_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        coefficients: ArrayLike,
+        exponents: ArrayLike,
+        /,
+        *,
+        expansion_id: str,
+        fit_residual: ArrayLike = 0.0,
+    ):
+        coefficients_ = jnp.asarray(coefficients)
+        exponents_ = jnp.asarray(exponents, dtype=coefficients_.dtype)
+        if coefficients_.ndim != 1 or exponents_.shape != coefficients_.shape:
+            raise ValueError("Bath expansion coefficients/exponents must be vectors.")
+        self.coefficients = coefficients_
+        self.exponents = exponents_
+        self.fit_residual = jnp.asarray(fit_residual)
+        self.valid = (
+            jnp.all(jnp.isfinite(coefficients_))
+            & jnp.all(jnp.isfinite(exponents_))
+            & jnp.all(jnp.real(exponents_) > 0.0)
+            & jnp.isfinite(self.fit_residual)
+        )
+        self.expansion_id = str(expansion_id)
+
+    @property
+    def rank(self) -> int:
+        return int(self.coefficients.shape[0])
+
+    def __call__(self, time: ArrayLike, /) -> Array:
+        value = jnp.asarray(time)
+        return jnp.sum(
+            self.coefficients * jnp.exp(-value[..., None] * self.exponents), axis=-1
+        )
+
+    def residual_against(
+        self,
+        target: Callable[[Array], Array],
+        times: ArrayLike,
+        /,
+    ) -> Array:
+        values = jnp.asarray(times)
+        reference = jnp.asarray(target(values))
+        if reference.shape != values.shape:
+            raise ValueError("Bath target must preserve time shape.")
+        return jnp.sqrt(jnp.mean(jnp.abs(self(values) - reference) ** 2))
+
+
+class Pseudomode(StrictModule):
+    frequency: float = eqx.field(static=True)
+    damping: float = eqx.field(static=True)
+    coupling: complex = eqx.field(static=True)
+    cutoff: int = eqx.field(static=True)
+    mode_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        frequency: float,
+        damping: float,
+        coupling: complex,
+        /,
+        *,
+        cutoff: int,
+        mode_id: str,
+    ):
+        if damping < 0.0 or int(cutoff) < 2:
+            raise ValueError("Pseudomode damping/cutoff are invalid.")
+        self.frequency = float(frequency)
+        self.damping = float(damping)
+        self.coupling = complex(coupling)
+        self.cutoff = int(cutoff)
+        self.mode_id = str(mode_id)
+
+
+class ReactionCoordinateMapping(StrictModule):
+    frequency: float = eqx.field(static=True)
+    coupling: float = eqx.field(static=True)
+    residual_damping: float = eqx.field(static=True)
+    mapping_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        frequency: float,
+        coupling: float,
+        residual_damping: float,
+        /,
+        *,
+        mapping_id: str,
+    ):
+        if coupling < 0.0 or residual_damping < 0.0:
+            raise ValueError("Reaction-coordinate parameters must be non-negative.")
+        self.frequency = float(frequency)
+        self.coupling = float(coupling)
+        self.residual_damping = float(residual_damping)
+        self.mapping_id = str(mapping_id)
+
+
+def lorentzian_pseudomode(
+    center_frequency: float,
+    linewidth: float,
+    coupling: float,
+    /,
+    *,
+    cutoff: int = 8,
+) -> tuple[BathCorrelationExpansion, Pseudomode, ReactionCoordinateMapping]:
+    coefficient = float(coupling) ** 2
+    exponent = 0.5 * float(linewidth) + 1j * float(center_frequency)
+    expansion = BathCorrelationExpansion(
+        jnp.asarray([coefficient], dtype=complex),
+        jnp.asarray([exponent], dtype=complex),
+        expansion_id="lorentzian-one-pole",
+    )
+    mode = Pseudomode(
+        center_frequency,
+        linewidth,
+        coupling,
+        cutoff=cutoff,
+        mode_id="lorentzian-pseudomode",
+    )
+    mapping = ReactionCoordinateMapping(
+        center_frequency,
+        coupling,
+        linewidth,
+        mapping_id="lorentzian-reaction-coordinate",
+    )
+    return expansion, mode, mapping
+
+
+__all__ = [
+    "BathCorrelationExpansion",
+    "Pseudomode",
+    "ReactionCoordinateMapping",
+    "lorentzian_pseudomode",
+]

--- a/phydrax/solver/__init__.py
+++ b/phydrax/solver/__init__.py
@@ -235,6 +235,12 @@ from ._functional_differential import (
     solve_functional_differential,
 )
 from ._functional_solver import FunctionalSolver
+from ._gaussian_lindblad import (
+    damped_thermal_oscillator,
+    GaussianLindbladProblem,
+    GaussianLindbladSolution,
+    solve_gaussian_lindblad,
+)
 from ._generalized_alpha import (
     GeneralizedAlphaMethod,
     GeneralizedAlphaSolution,
@@ -252,6 +258,14 @@ from ._geometric import (
     solver_state_geometry,
     SRKMK,
     StormerVerlet,
+)
+from ._heom import (
+    drude_lorentz_qubit_heom,
+    HEOMHierarchy,
+    HEOMProblem,
+    HEOMSolution,
+    solve_heom,
+    thermal_drude_lorentz_qubit_heom,
 )
 from ._implicit_runge_kutta import (
     GaussLegendreInterpolation,
@@ -312,6 +326,16 @@ from ._memory import (
     VolterraKernel,
     VolterraVectorField,
 )
+from ._memory_kernel import (
+    DynamicalMapPhysicality,
+    exponential_memory_qubit_problem,
+    MemoryKernelMasterEquation,
+    OpenSystemHistorySolution,
+    QuantumMemoryKernel,
+    solve_memory_kernel,
+    solve_time_local_open_system,
+    TimeLocalOpenSystemProblem,
+)
 from ._multirate import (
     multirate_amr_subcycling_plan,
     MultiratePartitionedRK,
@@ -346,6 +370,19 @@ from ._probabilistic_ode import (
     ProbabilisticODEStatus,
     ProbabilisticODEUpdate,
     solve_probabilistic_ode,
+)
+from ._pseudomode import (
+    jaynes_cummings_pseudomode_problem,
+    PseudomodeEmbeddingProblem,
+    PseudomodeSolution,
+    solve_pseudomode,
+)
+from ._quantum_jump import (
+    amplitude_damping_trajectory_problem,
+    QuantumJumpProblem,
+    QuantumTrajectoryEnsemble,
+    solve_quantum_jump_ensemble,
+    StateVectorOperator,
 )
 from ._quantum_propagation import (
     solve_unitary_propagator,
@@ -496,6 +533,33 @@ __all__ = [
     "solve_lindblad",
     "solve_quantum_tomography",
     "tetrahedral_qubit_tomography",
+    "DynamicalMapPhysicality",
+    "GaussianLindbladProblem",
+    "GaussianLindbladSolution",
+    "HEOMHierarchy",
+    "HEOMProblem",
+    "HEOMSolution",
+    "MemoryKernelMasterEquation",
+    "OpenSystemHistorySolution",
+    "PseudomodeEmbeddingProblem",
+    "PseudomodeSolution",
+    "QuantumJumpProblem",
+    "QuantumMemoryKernel",
+    "QuantumTrajectoryEnsemble",
+    "StateVectorOperator",
+    "TimeLocalOpenSystemProblem",
+    "amplitude_damping_trajectory_problem",
+    "damped_thermal_oscillator",
+    "drude_lorentz_qubit_heom",
+    "exponential_memory_qubit_problem",
+    "jaynes_cummings_pseudomode_problem",
+    "solve_gaussian_lindblad",
+    "solve_heom",
+    "solve_memory_kernel",
+    "solve_pseudomode",
+    "solve_quantum_jump_ensemble",
+    "solve_time_local_open_system",
+    "thermal_drude_lorentz_qubit_heom",
     "SeparableHamiltonianResult",
     "integrate_stormer_verlet",
     "stormer_verlet_step",

--- a/phydrax/solver/_gaussian_lindblad.py
+++ b/phydrax/solver/_gaussian_lindblad.py
@@ -1,0 +1,177 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array, ArrayLike
+
+from .._strict import StrictModule
+from ..metrix import BosonicGaussianState
+
+
+class GaussianLindbladProblem(StrictModule):
+    drift: Array
+    diffusion: Array
+    forcing: Array
+    initial_state: BosonicGaussianState
+    problem_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        drift: ArrayLike,
+        diffusion: ArrayLike,
+        forcing: ArrayLike,
+        initial_state: BosonicGaussianState,
+        /,
+        *,
+        problem_id: str = "gaussian-lindblad",
+    ):
+        if not isinstance(initial_state, BosonicGaussianState):
+            raise TypeError("initial_state must be BosonicGaussianState.")
+        drift_ = jnp.asarray(drift, dtype=initial_state.mean.dtype)
+        diffusion_ = jnp.asarray(diffusion, dtype=initial_state.mean.dtype)
+        forcing_ = jnp.asarray(forcing, dtype=initial_state.mean.dtype)
+        dimension = initial_state.mean.shape[0]
+        if drift_.shape != (dimension, dimension) or diffusion_.shape != drift_.shape:
+            raise ValueError("Gaussian drift/diffusion shapes are invalid.")
+        if forcing_.shape != (dimension,):
+            raise ValueError("Gaussian forcing shape is invalid.")
+        self.drift = drift_
+        self.diffusion = 0.5 * (diffusion_ + diffusion_.T)
+        self.forcing = forcing_
+        self.initial_state = initial_state
+        self.problem_id = str(problem_id)
+
+    def rhs(self, mean: Array, covariance: Array, /) -> tuple[Array, Array]:
+        return (
+            self.drift @ mean + self.forcing,
+            self.drift @ covariance + covariance @ self.drift.T + self.diffusion,
+        )
+
+    def stationary_state(self) -> BosonicGaussianState:
+        dimension = self.drift.shape[0]
+        identity = jnp.eye(dimension, dtype=self.drift.dtype)
+        operator = jnp.kron(identity, self.drift) + jnp.kron(self.drift, identity)
+        covariance = jnp.linalg.solve(operator, -self.diffusion.reshape(-1)).reshape(
+            self.diffusion.shape
+        )
+        mean = jnp.linalg.solve(self.drift, -self.forcing)
+        return BosonicGaussianState(mean, covariance, hbar=self.initial_state.hbar)
+
+
+class GaussianLindbladSolution(StrictModule):
+    means: Array
+    covariances: Array
+    times: Array
+    uncertainty_margins: Array
+    valid: Array
+    problem_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        means: ArrayLike,
+        covariances: ArrayLike,
+        times: ArrayLike,
+        /,
+        *,
+        problem_id: str,
+        hbar: float,
+    ):
+        self.means = jnp.asarray(means)
+        self.covariances = jnp.asarray(covariances)
+        self.times = jnp.asarray(times)
+        margins = jax.vmap(
+            lambda mean, covariance: (
+                BosonicGaussianState(mean, covariance, hbar=hbar).uncertainty_margin
+            )
+        )(self.means, self.covariances)
+        self.uncertainty_margins = margins
+        self.valid = (
+            jnp.all(jnp.isfinite(self.means))
+            & jnp.all(jnp.isfinite(self.covariances))
+            & jnp.all(margins >= -1e-8)
+        )
+        self.problem_id = str(problem_id)
+
+
+def solve_gaussian_lindblad(
+    problem: GaussianLindbladProblem,
+    /,
+    *,
+    step_size: ArrayLike,
+    steps: int,
+) -> GaussianLindbladSolution:
+    count = int(steps)
+    step = jnp.asarray(step_size, dtype=problem.drift.dtype).reshape(())
+    if count < 0 or float(step) <= 0.0:
+        raise ValueError("steps and step_size must be positive.")
+
+    def advance(state, _):
+        mean, covariance = state
+        k1_mean, k1_covariance = problem.rhs(mean, covariance)
+        k2_mean, k2_covariance = problem.rhs(
+            mean + 0.5 * step * k1_mean,
+            covariance + 0.5 * step * k1_covariance,
+        )
+        k3_mean, k3_covariance = problem.rhs(
+            mean + 0.5 * step * k2_mean,
+            covariance + 0.5 * step * k2_covariance,
+        )
+        k4_mean, k4_covariance = problem.rhs(
+            mean + step * k3_mean,
+            covariance + step * k3_covariance,
+        )
+        next_mean = mean + step * (k1_mean + 2 * k2_mean + 2 * k3_mean + k4_mean) / 6
+        next_covariance = (
+            covariance
+            + step
+            * (k1_covariance + 2 * k2_covariance + 2 * k3_covariance + k4_covariance)
+            / 6
+        )
+        next_covariance = 0.5 * (next_covariance + next_covariance.T)
+        return (next_mean, next_covariance), (next_mean, next_covariance)
+
+    initial = (problem.initial_state.mean, problem.initial_state.covariance)
+    _, trajectory = jax.lax.scan(advance, initial, xs=None, length=count)
+    means = jnp.concatenate((initial[0][None, :], trajectory[0]), axis=0)
+    covariances = jnp.concatenate((initial[1][None, :, :], trajectory[1]), axis=0)
+    return GaussianLindbladSolution(
+        means,
+        covariances,
+        step * jnp.arange(count + 1),
+        problem_id=problem.problem_id,
+        hbar=problem.initial_state.hbar,
+    )
+
+
+def damped_thermal_oscillator(
+    damping: float,
+    thermal_occupation: float,
+    /,
+) -> GaussianLindbladProblem:
+    gamma = float(damping)
+    occupation = float(thermal_occupation)
+    if gamma <= 0.0 or occupation < 0.0:
+        raise ValueError("Damping must be positive and occupation non-negative.")
+    drift = -0.5 * gamma * jnp.eye(2)
+    diffusion = gamma * (occupation + 0.5) * jnp.eye(2)
+    initial = BosonicGaussianState(jnp.zeros(2), 0.5 * jnp.eye(2))
+    return GaussianLindbladProblem(
+        drift,
+        diffusion,
+        jnp.zeros(2),
+        initial,
+        problem_id="damped-thermal-oscillator",
+    )
+
+
+__all__ = [
+    "GaussianLindbladProblem",
+    "GaussianLindbladSolution",
+    "damped_thermal_oscillator",
+    "solve_gaussian_lindblad",
+]

--- a/phydrax/solver/_heom.py
+++ b/phydrax/solver/_heom.py
@@ -1,0 +1,249 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from itertools import product
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array, ArrayLike
+
+from .._strict import StrictModule
+from ..operators.quantum import BathCorrelationExpansion
+
+
+class HEOMHierarchy(StrictModule):
+    multi_indices: Array
+    levels: Array
+    upward: Array
+    downward: Array
+    depth: int = eqx.field(static=True)
+    term_count: int = eqx.field(static=True)
+    auxiliary_count: int = eqx.field(static=True)
+
+    def __init__(self, term_count: int, depth: int, /):
+        terms = int(term_count)
+        depth_ = int(depth)
+        if terms < 1 or depth_ < 0:
+            raise ValueError("HEOM term count/depth are invalid.")
+        indices = tuple(
+            values
+            for values in product(range(depth_ + 1), repeat=terms)
+            if sum(values) <= depth_
+        )
+        lookup = {values: index for index, values in enumerate(indices)}
+        upward = []
+        downward = []
+        for values in indices:
+            up_row = []
+            down_row = []
+            for term in range(terms):
+                up = list(values)
+                up[term] += 1
+                down = list(values)
+                down[term] -= 1
+                up_row.append(lookup.get(tuple(up), -1))
+                down_row.append(lookup.get(tuple(down), -1) if down[term] >= 0 else -1)
+            upward.append(up_row)
+            downward.append(down_row)
+        self.multi_indices = jnp.asarray(indices, dtype=jnp.int32)
+        self.levels = jnp.sum(self.multi_indices, axis=-1)
+        self.upward = jnp.asarray(upward, dtype=jnp.int32)
+        self.downward = jnp.asarray(downward, dtype=jnp.int32)
+        self.depth = depth_
+        self.term_count = terms
+        self.auxiliary_count = len(indices)
+
+
+class HEOMProblem(StrictModule):
+    hamiltonian: Array
+    coupling_operator: Array
+    expansion: BathCorrelationExpansion
+    hierarchy: HEOMHierarchy
+    initial_state: Array
+    problem_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        hamiltonian: ArrayLike,
+        coupling_operator: ArrayLike,
+        expansion: BathCorrelationExpansion,
+        hierarchy: HEOMHierarchy,
+        initial_density: ArrayLike,
+        /,
+        *,
+        problem_id: str = "heom",
+    ):
+        hamiltonian_ = jnp.asarray(hamiltonian)
+        coupling = jnp.asarray(coupling_operator, dtype=hamiltonian_.dtype)
+        density = jnp.asarray(initial_density, dtype=hamiltonian_.dtype)
+        if hamiltonian_.ndim != 2 or hamiltonian_.shape[0] != hamiltonian_.shape[1]:
+            raise ValueError("HEOM Hamiltonian must be square.")
+        if coupling.shape != hamiltonian_.shape or density.shape != hamiltonian_.shape:
+            raise ValueError("HEOM operator/state shapes are incompatible.")
+        if hierarchy.term_count != expansion.rank:
+            raise ValueError("HEOM hierarchy and bath expansion ranks differ.")
+        auxiliaries = (
+            jnp.zeros((hierarchy.auxiliary_count,) + density.shape, dtype=density.dtype)
+            .at[0]
+            .set(density)
+        )
+        self.hamiltonian = hamiltonian_
+        self.coupling_operator = coupling
+        self.expansion = expansion
+        self.hierarchy = hierarchy
+        self.initial_state = auxiliaries
+        self.problem_id = str(problem_id)
+
+    def rhs(self, auxiliaries: ArrayLike, /) -> Array:
+        values = jnp.asarray(auxiliaries)
+        result = jnp.zeros_like(values)
+        coupling = self.coupling_operator
+        for auxiliary in range(self.hierarchy.auxiliary_count):
+            rho = values[auxiliary]
+            derivative = -1j * (self.hamiltonian @ rho - rho @ self.hamiltonian)
+            occupation = self.hierarchy.multi_indices[auxiliary]
+            derivative = derivative - jnp.sum(occupation * self.expansion.exponents) * rho
+            for term in range(self.hierarchy.term_count):
+                up = self.hierarchy.upward[auxiliary, term]
+                down = self.hierarchy.downward[auxiliary, term]
+                upper = values[jnp.maximum(up, 0)]
+                upper_term = -1j * (coupling @ upper - upper @ coupling)
+                derivative = derivative + jnp.where(up >= 0, upper_term, 0.0)
+                lower = values[jnp.maximum(down, 0)]
+                coefficient = self.expansion.coefficients[term]
+                lower_term = (
+                    -1j
+                    * occupation[term]
+                    * (
+                        coefficient * coupling @ lower
+                        - jnp.conj(coefficient) * lower @ coupling
+                    )
+                )
+                derivative = derivative + jnp.where(down >= 0, lower_term, 0.0)
+            result = result.at[auxiliary].set(derivative)
+        return result
+
+
+class HEOMSolution(StrictModule):
+    root_states: Array
+    final_auxiliaries: Array
+    times: Array
+    maximum_auxiliary_norm_by_level: Array
+    valid: Array
+    problem_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        problem: HEOMProblem,
+        root_states: ArrayLike,
+        final_auxiliaries: ArrayLike,
+        times: ArrayLike,
+        /,
+    ):
+        roots = jnp.asarray(root_states)
+        auxiliaries = jnp.asarray(final_auxiliaries)
+        self.root_states = roots
+        self.final_auxiliaries = auxiliaries
+        self.times = jnp.asarray(times)
+        norms = jnp.linalg.norm(auxiliaries, axis=(-2, -1))
+        self.maximum_auxiliary_norm_by_level = jnp.stack(
+            [
+                jnp.max(jnp.where(problem.hierarchy.levels == level, norms, 0.0))
+                for level in range(problem.hierarchy.depth + 1)
+            ]
+        )
+        trace = jnp.trace(roots, axis1=-2, axis2=-1)
+        hermiticity = jnp.max(
+            jnp.abs(roots - jnp.swapaxes(jnp.conj(roots), -1, -2)), axis=(-2, -1)
+        )
+        self.valid = (
+            jnp.all(jnp.isfinite(roots))
+            & jnp.all(jnp.abs(trace - 1.0) <= 1e-6)
+            & jnp.all(hermiticity <= 1e-6)
+        )
+        self.problem_id = problem.problem_id
+
+
+def solve_heom(
+    problem: HEOMProblem,
+    /,
+    *,
+    step_size: ArrayLike,
+    steps: int,
+) -> HEOMSolution:
+    step = jnp.asarray(step_size, dtype=float).reshape(())
+    count = int(steps)
+    if count < 0 or float(step) <= 0.0:
+        raise ValueError("HEOM steps and step_size must be positive.")
+
+    def advance(state, _):
+        k1 = problem.rhs(state)
+        k2 = problem.rhs(state + 0.5 * step * k1)
+        k3 = problem.rhs(state + 0.5 * step * k2)
+        k4 = problem.rhs(state + step * k3)
+        next_state = state + step * (k1 + 2 * k2 + 2 * k3 + k4) / 6
+        return next_state, next_state[0]
+
+    final, roots = jax.lax.scan(advance, problem.initial_state, xs=None, length=count)
+    roots = jnp.concatenate((problem.initial_state[0][None, ...], roots), axis=0)
+    return HEOMSolution(problem, roots, final, step * jnp.arange(count + 1))
+
+
+def drude_lorentz_qubit_heom(
+    coupling_strength: float,
+    decay_rate: float,
+    initial_density: ArrayLike,
+    /,
+    *,
+    depth: int = 2,
+) -> HEOMProblem:
+    expansion = BathCorrelationExpansion(
+        jnp.asarray([float(coupling_strength)], dtype=complex),
+        jnp.asarray([float(decay_rate)], dtype=complex),
+        expansion_id="drude-lorentz-one-term",
+    )
+    hierarchy = HEOMHierarchy(1, depth)
+    sigma_z = jnp.asarray([[1, 0], [0, -1]], dtype=complex)
+    return HEOMProblem(
+        jnp.zeros((2, 2), dtype=complex),
+        sigma_z,
+        expansion,
+        hierarchy,
+        initial_density,
+        problem_id="drude-lorentz-qubit-heom",
+    )
+
+
+def thermal_drude_lorentz_qubit_heom(
+    coupling_strength: float,
+    decay_rate: float,
+    temperature: float,
+    initial_density: ArrayLike,
+    /,
+    *,
+    depth: int = 2,
+) -> HEOMProblem:
+    """One-term finite-temperature Drude approximation with explicit truncation."""
+    if temperature <= 0.0:
+        raise ValueError("temperature must be positive.")
+    thermal_factor = 1.0 / jnp.tanh(float(decay_rate) / (2.0 * float(temperature)))
+    return drude_lorentz_qubit_heom(
+        float(coupling_strength) * float(thermal_factor),
+        decay_rate,
+        initial_density,
+        depth=depth,
+    )
+
+
+__all__ = [
+    "HEOMHierarchy",
+    "HEOMProblem",
+    "HEOMSolution",
+    "drude_lorentz_qubit_heom",
+    "solve_heom",
+    "thermal_drude_lorentz_qubit_heom",
+]

--- a/phydrax/solver/_memory_kernel.py
+++ b/phydrax/solver/_memory_kernel.py
@@ -1,0 +1,250 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import equinox as eqx
+import jax.numpy as jnp
+from jaxtyping import Array, ArrayLike
+
+from .._strict import StrictModule
+
+
+class QuantumMemoryKernel(StrictModule):
+    action_function: Callable[[Array, Array], Array]
+    dimension: int = eqx.field(static=True)
+    memory_horizon: float = eqx.field(static=True)
+    kernel_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        action: Callable[[Array, Array], Array],
+        dimension: int,
+        /,
+        *,
+        memory_horizon: float,
+        kernel_id: str,
+    ):
+        if not callable(action):
+            raise TypeError("Memory-kernel action must be callable.")
+        if memory_horizon <= 0.0:
+            raise ValueError("memory_horizon must be positive.")
+        self.action_function = action
+        self.dimension = int(dimension)
+        self.memory_horizon = float(memory_horizon)
+        self.kernel_id = str(kernel_id)
+
+    def __call__(self, lag: ArrayLike, density: ArrayLike, /) -> Array:
+        rho = jnp.asarray(density)
+        if rho.shape != (self.dimension, self.dimension):
+            raise ValueError("Memory-kernel density shape is invalid.")
+        result = jnp.asarray(self.action_function(jnp.asarray(lag), rho))
+        if result.shape != rho.shape:
+            raise ValueError("Memory-kernel action must preserve density shape.")
+        return jnp.where(jnp.asarray(lag) <= self.memory_horizon, result, 0.0)
+
+
+class MemoryKernelMasterEquation(StrictModule):
+    local_generator: Callable[[Array, Array], Array]
+    kernel: QuantumMemoryKernel
+    initial_density: Array
+    problem_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        local_generator: Callable[[Array, Array], Array],
+        kernel: QuantumMemoryKernel,
+        initial_density: ArrayLike,
+        /,
+        *,
+        problem_id: str = "memory-kernel-master",
+    ):
+        if not callable(local_generator):
+            raise TypeError("local_generator must be callable.")
+        density = jnp.asarray(initial_density)
+        if density.shape != (kernel.dimension, kernel.dimension):
+            raise ValueError("Initial density shape does not match the memory kernel.")
+        self.local_generator = local_generator
+        self.kernel = kernel
+        self.initial_density = density
+        self.problem_id = str(problem_id)
+
+
+class TimeLocalOpenSystemProblem(StrictModule):
+    generator: Callable[[Array, Array], Array]
+    initial_density: Array
+    problem_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        generator: Callable[[Array, Array], Array],
+        initial_density: ArrayLike,
+        /,
+        *,
+        problem_id: str = "time-local-open-system",
+    ):
+        if not callable(generator):
+            raise TypeError("generator must be callable.")
+        density = jnp.asarray(initial_density)
+        if density.ndim != 2 or density.shape[0] != density.shape[1]:
+            raise ValueError("Initial density must be square.")
+        self.generator = generator
+        self.initial_density = density
+        self.problem_id = str(problem_id)
+
+
+class OpenSystemHistorySolution(StrictModule):
+    states: Array
+    times: Array
+    trace_residuals: Array
+    hermiticity_residuals: Array
+    minimum_eigenvalues: Array
+    valid: Array
+    problem_id: str = eqx.field(static=True)
+
+    def __init__(self, states: ArrayLike, times: ArrayLike, /, *, problem_id: str):
+        values = jnp.asarray(states)
+        self.states = values
+        self.times = jnp.asarray(times)
+        self.trace_residuals = jnp.abs(jnp.trace(values, axis1=-2, axis2=-1) - 1.0)
+        self.hermiticity_residuals = jnp.max(
+            jnp.abs(values - jnp.swapaxes(jnp.conj(values), -1, -2)), axis=(-2, -1)
+        )
+        self.minimum_eigenvalues = jnp.min(
+            jnp.linalg.eigvalsh(0.5 * (values + jnp.swapaxes(jnp.conj(values), -1, -2))),
+            axis=-1,
+        )
+        self.valid = (
+            jnp.all(jnp.isfinite(values))
+            & jnp.all(self.trace_residuals <= 1e-6)
+            & jnp.all(self.hermiticity_residuals <= 1e-6)
+        )
+        self.problem_id = str(problem_id)
+
+
+class DynamicalMapPhysicality(StrictModule):
+    choi_matrix: Array
+    cp_margin: Array
+    trace_preservation_residual: Array
+    valid: Array
+
+    def __init__(self, superoperator: ArrayLike, dimension: int, /):
+        matrix = jnp.asarray(superoperator)
+        size = int(dimension)
+        if matrix.shape != (size * size, size * size):
+            raise ValueError("Superoperator shape is invalid.")
+        choi = jnp.zeros((size, size, size, size), dtype=matrix.dtype)
+        for row in range(size):
+            for column in range(size):
+                basis = (
+                    jnp.zeros((size, size), dtype=matrix.dtype).at[row, column].set(1.0)
+                )
+                output = (matrix @ basis.reshape(-1)).reshape((size, size))
+                choi = choi.at[row, :, column, :].set(output)
+        flat_choi = choi.reshape((size * size, size * size))
+        flat_choi = 0.5 * (flat_choi + jnp.conj(flat_choi.T))
+        partial_trace = jnp.trace(choi, axis1=1, axis2=3)
+        self.choi_matrix = flat_choi
+        self.cp_margin = jnp.min(jnp.linalg.eigvalsh(flat_choi))
+        self.trace_preservation_residual = jnp.max(
+            jnp.abs(partial_trace - jnp.eye(size, dtype=matrix.dtype))
+        )
+        self.valid = (
+            jnp.all(jnp.isfinite(matrix))
+            & (self.cp_margin >= -1e-8)
+            & (self.trace_preservation_residual <= 1e-8)
+        )
+
+
+def solve_memory_kernel(
+    problem: MemoryKernelMasterEquation,
+    /,
+    *,
+    step_size: ArrayLike,
+    steps: int,
+) -> OpenSystemHistorySolution:
+    step = jnp.asarray(step_size, dtype=float).reshape(())
+    count = int(steps)
+    if count < 0 or float(step) <= 0.0:
+        raise ValueError("steps and step_size must be positive.")
+    states = [problem.initial_density]
+    for current in range(count):
+        time = step * current
+        density = states[-1]
+        memory = jnp.zeros_like(density)
+        lower = max(0, current - int(problem.kernel.memory_horizon / float(step)))
+        for past in range(lower, current + 1):
+            lag = time - step * past
+            weight = 0.5 if past in (lower, current) and current > lower else 1.0
+            memory = memory + weight * problem.kernel(lag, states[past])
+        derivative = problem.local_generator(time, density) + step * memory
+        candidate = density + step * derivative
+        states.append(candidate)
+    values = jnp.stack(states)
+    return OpenSystemHistorySolution(
+        values, step * jnp.arange(count + 1), problem_id=problem.problem_id
+    )
+
+
+def solve_time_local_open_system(
+    problem: TimeLocalOpenSystemProblem,
+    /,
+    *,
+    step_size: ArrayLike,
+    steps: int,
+) -> OpenSystemHistorySolution:
+    step = jnp.asarray(step_size, dtype=float).reshape(())
+    count = int(steps)
+    states = [problem.initial_density]
+    for index in range(count):
+        time = step * index
+        state = states[-1]
+        derivative = problem.generator(time, state)
+        candidate = state + step * derivative
+        states.append(candidate)
+    return OpenSystemHistorySolution(
+        jnp.stack(states), step * jnp.arange(count + 1), problem_id=problem.problem_id
+    )
+
+
+def exponential_memory_qubit_problem(
+    strength: float,
+    decay: float,
+    initial_density: ArrayLike,
+    /,
+) -> MemoryKernelMasterEquation:
+    sigma_minus = jnp.asarray([[0, 0], [1, 0]], dtype=complex)
+    sigma_plus = jnp.conj(sigma_minus.T)
+
+    def kernel(lag, density):
+        commutator = sigma_minus @ density @ sigma_plus - 0.5 * (
+            sigma_plus @ sigma_minus @ density + density @ sigma_plus @ sigma_minus
+        )
+        return float(strength) * jnp.exp(-float(decay) * lag) * commutator
+
+    return MemoryKernelMasterEquation(
+        lambda time, density: jnp.zeros_like(density),
+        QuantumMemoryKernel(
+            kernel,
+            2,
+            memory_horizon=8.0 / max(float(decay), 1e-12),
+            kernel_id="exponential-qubit-memory",
+        ),
+        initial_density,
+        problem_id="exponential-memory-qubit",
+    )
+
+
+__all__ = [
+    "DynamicalMapPhysicality",
+    "MemoryKernelMasterEquation",
+    "OpenSystemHistorySolution",
+    "QuantumMemoryKernel",
+    "TimeLocalOpenSystemProblem",
+    "exponential_memory_qubit_problem",
+    "solve_memory_kernel",
+    "solve_time_local_open_system",
+]

--- a/phydrax/solver/_pseudomode.py
+++ b/phydrax/solver/_pseudomode.py
@@ -1,0 +1,124 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import equinox as eqx
+import jax.numpy as jnp
+from jaxtyping import Array, ArrayLike
+
+from .._strict import StrictModule
+from ..operators.quantum import Pseudomode
+from ..operators.quantum._fock import jaynes_cummings_hamiltonian
+from ._lindblad import LindbladProblem, LindbladSolution, solve_lindblad
+
+
+class PseudomodeEmbeddingProblem(StrictModule):
+    mode: Pseudomode
+    lindblad_problem: LindbladProblem
+    system_dimension: int = eqx.field(static=True)
+    embedding_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        mode: Pseudomode,
+        lindblad_problem: LindbladProblem,
+        /,
+        *,
+        system_dimension: int,
+        embedding_id: str,
+    ):
+        self.mode = mode
+        self.lindblad_problem = lindblad_problem
+        self.system_dimension = int(system_dimension)
+        self.embedding_id = str(embedding_id)
+
+    def reduced_system_density(self, enlarged_density: ArrayLike, /) -> Array:
+        density = jnp.asarray(enlarged_density)
+        cutoff = self.mode.cutoff
+        system = self.system_dimension
+        expected = cutoff * system
+        if density.shape != (expected, expected):
+            raise ValueError("Enlarged density shape does not match the embedding.")
+        tensor = density.reshape((cutoff, system, cutoff, system))
+        return jnp.trace(tensor, axis1=0, axis2=2)
+
+
+class PseudomodeSolution(StrictModule):
+    enlarged: LindbladSolution
+    reduced_states: Array
+    valid: Array
+    embedding_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        problem: PseudomodeEmbeddingProblem,
+        enlarged: LindbladSolution,
+        /,
+    ):
+        self.enlarged = enlarged
+        self.reduced_states = jnp.stack(
+            [problem.reduced_system_density(state) for state in enlarged.states]
+        )
+        traces = jnp.trace(self.reduced_states, axis1=-2, axis2=-1)
+        minimum = jnp.min(jnp.linalg.eigvalsh(self.reduced_states), axis=-1)
+        self.valid = (
+            enlarged.valid
+            & jnp.all(jnp.abs(traces - 1.0) <= 1e-8)
+            & jnp.all(minimum >= -1e-8)
+        )
+        self.embedding_id = problem.embedding_id
+
+
+def jaynes_cummings_pseudomode_problem(
+    mode: Pseudomode,
+    initial_system_density: ArrayLike,
+    /,
+) -> PseudomodeEmbeddingProblem:
+    cavity, hamiltonian = jaynes_cummings_hamiltonian(
+        mode.cutoff,
+        mode.frequency,
+        mode.frequency,
+        abs(mode.coupling),
+    )
+    initial_mode = jnp.zeros((mode.cutoff, mode.cutoff), dtype=complex).at[0, 0].set(1.0)
+    system_density = jnp.asarray(initial_system_density)
+    initial = jnp.kron(initial_mode, system_density)
+    # Keep the enlarged initial state faithful for the dense solver contract.
+    epsilon = 1e-8
+    initial = (1.0 - epsilon) * initial + epsilon * jnp.eye(
+        initial.shape[0]
+    ) / initial.shape[0]
+    jump = jnp.sqrt(mode.damping) * jnp.kron(cavity.annihilation_matrix(0), jnp.eye(2))
+    lindblad = LindbladProblem(
+        hamiltonian,
+        jump[None, ...],
+        initial,
+        problem_id="jaynes-cummings-pseudomode",
+    )
+    return PseudomodeEmbeddingProblem(
+        mode,
+        lindblad,
+        system_dimension=2,
+        embedding_id="jaynes-cummings-pseudomode",
+    )
+
+
+def solve_pseudomode(
+    problem: PseudomodeEmbeddingProblem,
+    /,
+    *,
+    step_size: ArrayLike,
+    steps: int,
+) -> PseudomodeSolution:
+    enlarged = solve_lindblad(problem.lindblad_problem, step_size=step_size, steps=steps)
+    return PseudomodeSolution(problem, enlarged)
+
+
+__all__ = [
+    "PseudomodeEmbeddingProblem",
+    "PseudomodeSolution",
+    "jaynes_cummings_pseudomode_problem",
+    "solve_pseudomode",
+]

--- a/phydrax/solver/_quantum_jump.py
+++ b/phydrax/solver/_quantum_jump.py
@@ -1,0 +1,254 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array, ArrayLike
+
+from .._strict import StrictModule
+from ..operators.quantum import ApproximationAxis, OpenSystemApproximationEvidence
+
+
+class StateVectorOperator(StrictModule):
+    action_function: Callable[[Array], Array]
+    adjoint_function: Callable[[Array], Array]
+    dimension: int = eqx.field(static=True)
+    operator_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        action: Callable[[Array], Array],
+        adjoint_action: Callable[[Array], Array],
+        dimension: int,
+        /,
+        *,
+        operator_id: str,
+    ):
+        if not callable(action) or not callable(adjoint_action):
+            raise TypeError("Operator and adjoint actions must be callable.")
+        self.action_function = action
+        self.adjoint_function = adjoint_action
+        self.dimension = int(dimension)
+        self.operator_id = str(operator_id)
+
+    @classmethod
+    def from_matrix(cls, matrix: ArrayLike, /, *, operator_id: str):
+        value = jnp.asarray(matrix)
+        if value.ndim != 2 or value.shape[0] != value.shape[1]:
+            raise ValueError("Operator matrix must be square.")
+        return cls(
+            lambda state: value @ state,
+            lambda state: jnp.conj(value.T) @ state,
+            value.shape[0],
+            operator_id=operator_id,
+        )
+
+    def __call__(self, state: ArrayLike, /) -> Array:
+        value = jnp.asarray(state)
+        if value.shape != (self.dimension,):
+            raise ValueError("State-vector shape does not match the operator.")
+        result = jnp.asarray(self.action_function(value))
+        if result.shape != value.shape:
+            raise ValueError("Operator action must preserve state shape.")
+        return result
+
+    def adjoint(self, state: ArrayLike, /) -> Array:
+        value = jnp.asarray(state)
+        if value.shape != (self.dimension,):
+            raise ValueError("State-vector shape does not match the operator.")
+        result = jnp.asarray(self.adjoint_function(value))
+        if result.shape != value.shape:
+            raise ValueError("Adjoint action must preserve state shape.")
+        return result
+
+
+class QuantumJumpProblem(StrictModule):
+    hamiltonian: StateVectorOperator
+    collapse_operators: tuple[StateVectorOperator, ...]
+    initial_state: Array
+    problem_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        hamiltonian: StateVectorOperator,
+        collapse_operators: Sequence[StateVectorOperator],
+        initial_state: ArrayLike,
+        /,
+        *,
+        problem_id: str = "quantum-jump",
+    ):
+        if not isinstance(hamiltonian, StateVectorOperator):
+            raise TypeError("hamiltonian must be a StateVectorOperator.")
+        collapse = tuple(collapse_operators)
+        if any(
+            not isinstance(operator, StateVectorOperator)
+            or operator.dimension != hamiltonian.dimension
+            for operator in collapse
+        ):
+            raise ValueError("Collapse operators must share the Hamiltonian dimension.")
+        state = jnp.asarray(initial_state)
+        if state.shape != (hamiltonian.dimension,):
+            raise ValueError("Initial state dimension does not match the Hamiltonian.")
+        norm = jnp.linalg.norm(state)
+        if not bool(jax.device_get(jnp.isfinite(norm) & (norm > 0.0))):
+            raise ValueError("Initial state must have finite nonzero norm.")
+        self.hamiltonian = hamiltonian
+        self.collapse_operators = collapse
+        self.initial_state = state / norm
+        self.problem_id = str(problem_id)
+
+
+class QuantumTrajectoryEnsemble(StrictModule):
+    states: Array
+    jump_channels: Array
+    jump_mask: Array
+    times: Array
+    approximation: OpenSystemApproximationEvidence
+    valid: Array
+    problem_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        states: ArrayLike,
+        jump_channels: ArrayLike,
+        jump_mask: ArrayLike,
+        times: ArrayLike,
+        /,
+        *,
+        step_size: ArrayLike,
+        problem_id: str,
+    ):
+        self.states = jnp.asarray(states)
+        self.jump_channels = jnp.asarray(jump_channels, dtype=jnp.int32)
+        self.jump_mask = jnp.asarray(jump_mask, dtype=bool)
+        self.times = jnp.asarray(times)
+        norm_residual = jnp.max(jnp.abs(jnp.linalg.norm(self.states, axis=-1) - 1.0))
+        self.valid = jnp.all(jnp.isfinite(self.states)) & (norm_residual <= 1e-6)
+        self.approximation = OpenSystemApproximationEvidence(
+            "quantum-trajectory-ensemble",
+            (
+                ApproximationAxis("trajectory-count", self.states.shape[0]),
+                ApproximationAxis("time-step", step_size, units="time"),
+            ),
+            statistical_error=1.0 / jnp.sqrt(float(self.states.shape[0])),
+            local_error=jnp.asarray(step_size),
+            valid=self.valid,
+        )
+        self.problem_id = str(problem_id)
+
+    def observable(self, operator: StateVectorOperator, /) -> tuple[Array, Array]:
+        values = jax.vmap(
+            jax.vmap(lambda state: jnp.real(jnp.vdot(state, operator(state))))
+        )(self.states)
+        return jnp.mean(values, axis=0), jnp.std(values, axis=0) / jnp.sqrt(
+            float(values.shape[0])
+        )
+
+    def empirical_density(self) -> Array:
+        final = self.states[:, -1, :]
+        return jnp.mean(
+            jax.vmap(lambda state: state[:, None] * jnp.conj(state[None, :]))(final),
+            axis=0,
+        )
+
+
+def _trajectory(
+    problem: QuantumJumpProblem,
+    key: Array,
+    step: Array,
+    count: int,
+):
+    channel_count = len(problem.collapse_operators)
+
+    def advance(state, index):
+        local_key = jax.random.fold_in(key, index)
+        collapsed = jnp.stack(
+            [operator(state) for operator in problem.collapse_operators]
+        )
+        rates = jnp.real(jnp.einsum("ki,ki->k", jnp.conj(collapsed), collapsed))
+        probabilities = step * rates
+        total = jnp.sum(probabilities)
+        jump = jax.random.uniform(local_key) < jnp.minimum(total, 1.0)
+        safe_total = jnp.maximum(total, jnp.finfo(probabilities.dtype).tiny)
+        channel = jax.random.categorical(
+            local_key, jnp.log(jnp.maximum(probabilities / safe_total, 1e-30))
+        )
+        selected = collapsed[jnp.minimum(channel, max(channel_count - 1, 0))]
+        jump_state = selected / jnp.maximum(jnp.linalg.norm(selected), 1e-30)
+        effective = -1j * problem.hamiltonian(state)
+        for operator, collapsed_state in zip(
+            problem.collapse_operators, collapsed, strict=True
+        ):
+            effective = effective - 0.5 * operator.adjoint(collapsed_state)
+        no_jump = state + step * effective
+        no_jump = no_jump / jnp.linalg.norm(no_jump)
+        next_state = jnp.where(jump, jump_state, no_jump)
+        return next_state, (next_state, channel, jump)
+
+    _, history = jax.lax.scan(advance, problem.initial_state, jnp.arange(count))
+    states = jnp.concatenate((problem.initial_state[None, :], history[0]), axis=0)
+    return states, history[1], history[2]
+
+
+def solve_quantum_jump_ensemble(
+    problem: QuantumJumpProblem,
+    key: Array,
+    /,
+    *,
+    step_size: ArrayLike,
+    steps: int,
+    trajectory_count: int,
+) -> QuantumTrajectoryEnsemble:
+    step = jnp.asarray(step_size, dtype=float).reshape(())
+    count = int(steps)
+    trajectories = int(trajectory_count)
+    if count < 0 or trajectories < 1 or float(step) <= 0.0:
+        raise ValueError("Trajectory count, steps, and step size must be positive.")
+    keys = jax.random.split(key, trajectories)
+    states, channels, masks = jax.vmap(
+        lambda local_key: _trajectory(problem, local_key, step, count)
+    )(keys)
+    return QuantumTrajectoryEnsemble(
+        states,
+        channels,
+        masks,
+        step * jnp.arange(count + 1),
+        step_size=step,
+        problem_id=problem.problem_id,
+    )
+
+
+def amplitude_damping_trajectory_problem(
+    damping_rate: float,
+    initial_state: ArrayLike,
+    /,
+) -> QuantumJumpProblem:
+    lowering = jnp.asarray([[0.0, 1.0], [0.0, 0.0]], dtype=complex)
+    return QuantumJumpProblem(
+        StateVectorOperator.from_matrix(
+            jnp.zeros((2, 2), dtype=complex), operator_id="zero-hamiltonian"
+        ),
+        (
+            StateVectorOperator.from_matrix(
+                jnp.sqrt(float(damping_rate)) * lowering,
+                operator_id="amplitude-damping-jump",
+            ),
+        ),
+        initial_state,
+        problem_id="amplitude-damping-trajectories",
+    )
+
+
+__all__ = [
+    "QuantumJumpProblem",
+    "QuantumTrajectoryEnsemble",
+    "StateVectorOperator",
+    "amplitude_damping_trajectory_problem",
+    "solve_quantum_jump_ensemble",
+]

--- a/phydrax/tensor_network/__init__.py
+++ b/phydrax/tensor_network/__init__.py
@@ -1,0 +1,30 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from ._core import LocallyPurifiedDensity, MatrixProductOperator, MatrixProductState
+from ._evolution import TensorTruncationEvidence, apply_two_site_gate, product_mps
+from ._process_tensor import (
+    markov_process_tensor,
+    ProcessTensorMPO,
+    ProcessTensorPhysicality,
+    ProcessTomographyResult,
+    QuantumIntervention,
+    reconstruct_markov_process_tensor,
+)
+
+
+__all__ = [
+    "LocallyPurifiedDensity",
+    "MatrixProductOperator",
+    "MatrixProductState",
+    "TensorTruncationEvidence",
+    "ProcessTensorMPO",
+    "ProcessTensorPhysicality",
+    "ProcessTomographyResult",
+    "QuantumIntervention",
+    "markov_process_tensor",
+    "reconstruct_markov_process_tensor",
+    "apply_two_site_gate",
+    "product_mps",
+]

--- a/phydrax/tensor_network/_core.py
+++ b/phydrax/tensor_network/_core.py
@@ -1,0 +1,123 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import jax.numpy as jnp
+from jaxtyping import Array, ArrayLike
+
+from .._strict import StrictModule
+
+
+class MatrixProductState(StrictModule):
+    tensors: tuple[Array, ...]
+    site_count: int
+    physical_dimensions: tuple[int, ...]
+    bond_dimensions: tuple[int, ...]
+
+    def __init__(self, tensors: Sequence[ArrayLike], /):
+        values = tuple(jnp.asarray(tensor) for tensor in tensors)
+        if not values or any(tensor.ndim != 3 for tensor in values):
+            raise ValueError("MPS tensors must have shape (left, physical, right).")
+        if values[0].shape[0] != 1 or values[-1].shape[-1] != 1:
+            raise ValueError("Open-boundary MPS edge bonds must be one.")
+        for left, right in zip(values[:-1], values[1:], strict=True):
+            if left.shape[-1] != right.shape[0]:
+                raise ValueError("Adjacent MPS bond dimensions must match.")
+        self.tensors = values
+        self.site_count = len(values)
+        self.physical_dimensions = tuple(int(tensor.shape[1]) for tensor in values)
+        self.bond_dimensions = tuple(int(tensor.shape[-1]) for tensor in values[:-1])
+
+    def to_dense(self) -> Array:
+        state = self.tensors[0][0]
+        for tensor in self.tensors[1:]:
+            state = jnp.tensordot(state, tensor, axes=(-1, 0))
+        return state[..., 0].reshape(-1)
+
+    def norm(self) -> Array:
+        return jnp.linalg.norm(self.to_dense())
+
+    def normalized(self) -> MatrixProductState:
+        norm = self.norm()
+        tensors = (self.tensors[0] / norm,) + self.tensors[1:]
+        return MatrixProductState(tensors)
+
+
+class MatrixProductOperator(StrictModule):
+    tensors: tuple[Array, ...]
+    site_count: int
+    output_dimensions: tuple[int, ...]
+    input_dimensions: tuple[int, ...]
+
+    def __init__(self, tensors: Sequence[ArrayLike], /):
+        values = tuple(jnp.asarray(tensor) for tensor in tensors)
+        if not values or any(tensor.ndim != 4 for tensor in values):
+            raise ValueError("MPO tensors require (left, output, input, right).")
+        if values[0].shape[0] != 1 or values[-1].shape[-1] != 1:
+            raise ValueError("Open-boundary MPO edge bonds must be one.")
+        for left, right in zip(values[:-1], values[1:], strict=True):
+            if left.shape[-1] != right.shape[0]:
+                raise ValueError("Adjacent MPO bonds must match.")
+        self.tensors = values
+        self.site_count = len(values)
+        self.output_dimensions = tuple(int(tensor.shape[1]) for tensor in values)
+        self.input_dimensions = tuple(int(tensor.shape[2]) for tensor in values)
+
+    def to_dense(self) -> Array:
+        operator = self.tensors[0][0]
+        for tensor in self.tensors[1:]:
+            operator = jnp.tensordot(operator, tensor, axes=(-1, 0))
+        operator = operator[..., 0]
+        output_axes = tuple(range(0, 2 * self.site_count, 2))
+        input_axes = tuple(range(1, 2 * self.site_count, 2))
+        operator = jnp.transpose(operator, output_axes + input_axes)
+        return operator.reshape((prod(self.output_dimensions), prod(self.input_dimensions)))
+
+
+class LocallyPurifiedDensity(StrictModule):
+    tensors: tuple[Array, ...]
+    site_count: int
+    physical_dimensions: tuple[int, ...]
+    purification_dimensions: tuple[int, ...]
+
+    def __init__(self, tensors: Sequence[ArrayLike], /):
+        values = tuple(jnp.asarray(tensor) for tensor in tensors)
+        if not values or any(tensor.ndim != 4 for tensor in values):
+            raise ValueError("Purification tensors require (left, physical, kraus, right).")
+        if values[0].shape[0] != 1 or values[-1].shape[-1] != 1:
+            raise ValueError("Purification edge bonds must be one.")
+        for left, right in zip(values[:-1], values[1:], strict=True):
+            if left.shape[-1] != right.shape[0]:
+                raise ValueError("Adjacent purification bonds must match.")
+        self.tensors = values
+        self.site_count = len(values)
+        self.physical_dimensions = tuple(int(tensor.shape[1]) for tensor in values)
+        self.purification_dimensions = tuple(int(tensor.shape[2]) for tensor in values)
+
+    def amplitude(self) -> Array:
+        amplitude = self.tensors[0][0]
+        for tensor in self.tensors[1:]:
+            amplitude = jnp.tensordot(amplitude, tensor, axes=(-1, 0))
+        amplitude = amplitude[..., 0]
+        physical_axes = tuple(range(0, 2 * self.site_count, 2))
+        kraus_axes = tuple(range(1, 2 * self.site_count, 2))
+        amplitude = jnp.transpose(amplitude, physical_axes + kraus_axes)
+        return amplitude.reshape(
+            (prod(self.physical_dimensions), prod(self.purification_dimensions))
+        )
+
+    def density(self) -> Array:
+        amplitude = self.amplitude()
+        density = amplitude @ jnp.conj(amplitude.T)
+        return density / jnp.trace(density)
+
+
+# Local import avoids exposing a utility dependency in public signatures.
+from math import prod
+
+
+__all__ = ["LocallyPurifiedDensity", "MatrixProductOperator", "MatrixProductState"]

--- a/phydrax/tensor_network/_evolution.py
+++ b/phydrax/tensor_network/_evolution.py
@@ -1,0 +1,81 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+from jaxtyping import Array, ArrayLike
+
+from .._strict import StrictModule
+from ._core import MatrixProductState
+
+
+class TensorTruncationEvidence(StrictModule):
+    retained_rank: int
+    available_rank: int
+    discarded_weight: Array
+    valid: Array
+
+    def __init__(
+        self,
+        retained_rank: int,
+        available_rank: int,
+        discarded_weight: ArrayLike,
+        /,
+    ):
+        self.retained_rank = int(retained_rank)
+        self.available_rank = int(available_rank)
+        self.discarded_weight = jnp.asarray(discarded_weight)
+        self.valid = jnp.isfinite(self.discarded_weight) & (self.discarded_weight >= 0.0)
+
+
+def apply_two_site_gate(
+    state: MatrixProductState,
+    left_site: int,
+    gate: ArrayLike,
+    /,
+    *,
+    maximum_bond_dimension: int,
+) -> tuple[MatrixProductState, TensorTruncationEvidence]:
+    if not isinstance(state, MatrixProductState):
+        raise TypeError("state must be a MatrixProductState.")
+    site = int(left_site)
+    if not 0 <= site < state.site_count - 1:
+        raise ValueError("Two-site gate index is out of range.")
+    left = state.tensors[site]
+    right = state.tensors[site + 1]
+    d_left = left.shape[1]
+    d_right = right.shape[1]
+    gate_ = jnp.asarray(gate)
+    if gate_.shape != (d_left, d_right, d_left, d_right):
+        raise ValueError("Gate shape must be (out_left,out_right,in_left,in_right).")
+    theta = jnp.tensordot(left, right, axes=(-1, 0))
+    theta = jnp.einsum("abij,lijr->labr", gate_, theta)
+    matrix = theta.reshape((left.shape[0] * d_left, d_right * right.shape[-1]))
+    u, singular_values, vh = jnp.linalg.svd(matrix, full_matrices=False)
+    available = singular_values.shape[0]
+    retained = min(int(maximum_bond_dimension), available)
+    discarded = jnp.sum(singular_values[retained:] ** 2)
+    u = u[:, :retained]
+    singular_values = singular_values[:retained]
+    vh = vh[:retained, :]
+    new_left = u.reshape((left.shape[0], d_left, retained))
+    new_right = (singular_values[:, None] * vh).reshape(
+        (retained, d_right, right.shape[-1])
+    )
+    tensors = list(state.tensors)
+    tensors[site] = new_left
+    tensors[site + 1] = new_right
+    result = MatrixProductState(tuple(tensors)).normalized()
+    return result, TensorTruncationEvidence(retained, available, discarded)
+
+
+def product_mps(local_states: ArrayLike, /) -> MatrixProductState:
+    values = jnp.asarray(local_states)
+    if values.ndim != 2:
+        raise ValueError("Product MPS inputs require shape (site, physical).")
+    return MatrixProductState(tuple(value[None, :, None] for value in values))
+
+
+__all__ = ["TensorTruncationEvidence", "apply_two_site_gate", "product_mps"]

--- a/phydrax/tensor_network/_process_tensor.py
+++ b/phydrax/tensor_network/_process_tensor.py
@@ -1,0 +1,243 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import equinox as eqx
+import jax.numpy as jnp
+from jaxtyping import Array, ArrayLike
+
+from .._strict import StrictModule
+from ..solver._memory_kernel import DynamicalMapPhysicality
+
+
+def _superoperator_from_kraus(kraus: Array) -> Array:
+    dimension = kraus.shape[-1]
+    basis = jnp.eye(dimension * dimension, dtype=kraus.dtype).reshape(
+        (dimension * dimension, dimension, dimension)
+    )
+    outputs = jnp.stack(
+        [
+            sum(
+                operator @ value @ jnp.conj(operator.T)
+                for operator in kraus
+            ).reshape(-1)
+            for value in basis
+        ]
+    )
+    return jnp.swapaxes(outputs, -1, -2)
+
+
+class QuantumIntervention(StrictModule):
+    kraus_operators: Array
+    superoperator: Array
+    completeness_residual: Array
+    trace_nonincreasing: Array
+    valid: Array
+    intervention_id: str = eqx.field(static=True)
+
+    def __init__(self, kraus_operators: ArrayLike, /, *, intervention_id: str):
+        kraus = jnp.asarray(kraus_operators)
+        if kraus.ndim != 3 or kraus.shape[-2] != kraus.shape[-1]:
+            raise ValueError("Kraus operators require shape (count,n,n).")
+        dimension = kraus.shape[-1]
+        completeness = sum(jnp.conj(operator.T) @ operator for operator in kraus)
+        difference = jnp.eye(dimension, dtype=kraus.dtype) - completeness
+        minimum = jnp.min(jnp.linalg.eigvalsh(0.5 * (difference + jnp.conj(difference.T))))
+        self.kraus_operators = kraus
+        self.superoperator = _superoperator_from_kraus(kraus)
+        self.completeness_residual = jnp.max(jnp.abs(completeness - jnp.eye(dimension)))
+        self.trace_nonincreasing = minimum >= -1e-9
+        self.valid = jnp.all(jnp.isfinite(kraus)) & self.trace_nonincreasing
+        self.intervention_id = str(intervention_id)
+
+    @property
+    def dimension(self) -> int:
+        return int(self.kraus_operators.shape[-1])
+
+    def apply(self, density: ArrayLike, /) -> tuple[Array, Array]:
+        rho = jnp.asarray(density)
+        output = sum(
+            operator @ rho @ jnp.conj(operator.T)
+            for operator in self.kraus_operators
+        )
+        probability = jnp.real(jnp.trace(output))
+        normalized = jnp.where(probability > 0.0, output / probability, output)
+        return normalized, probability
+
+
+class ProcessTensorPhysicality(StrictModule):
+    local_cp_margins: Array
+    local_tp_residuals: Array
+    causality_residual: Array
+    valid: Array
+    status: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        local_cp_margins: ArrayLike,
+        local_tp_residuals: ArrayLike,
+        /,
+        *,
+        status: str,
+    ):
+        self.local_cp_margins = jnp.asarray(local_cp_margins)
+        self.local_tp_residuals = jnp.asarray(local_tp_residuals)
+        self.causality_residual = jnp.max(self.local_tp_residuals)
+        self.valid = (
+            jnp.all(self.local_cp_margins >= -1e-8)
+            & jnp.all(self.local_tp_residuals <= 1e-8)
+        )
+        self.status = str(status)
+
+
+class ProcessTensorMPO(StrictModule):
+    tensors: tuple[Array, ...]
+    initial_density: Array
+    dimension: int = eqx.field(static=True)
+    temporal_bond_dimensions: tuple[int, ...] = eqx.field(static=True)
+    process_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        tensors: Sequence[ArrayLike],
+        initial_density: ArrayLike,
+        /,
+        *,
+        process_id: str,
+    ):
+        values = tuple(jnp.asarray(tensor) for tensor in tensors)
+        density = jnp.asarray(initial_density)
+        if density.ndim != 2 or density.shape[0] != density.shape[1]:
+            raise ValueError("Initial process state must be square.")
+        physical = density.size
+        if not values or any(
+            tensor.ndim != 4 or tensor.shape[1:3] != (physical, physical)
+            for tensor in values
+        ):
+            raise ValueError("Process tensors require (left,out,in,right) tensors.")
+        if values[0].shape[0] != 1 or values[-1].shape[-1] != 1:
+            raise ValueError("Process-tensor edge bonds must be one.")
+        for left, right in zip(values[:-1], values[1:], strict=True):
+            if left.shape[-1] != right.shape[0]:
+                raise ValueError("Adjacent process-tensor bonds must match.")
+        self.tensors = values
+        self.initial_density = density
+        self.dimension = density.shape[0]
+        self.temporal_bond_dimensions = tuple(
+            int(tensor.shape[-1]) for tensor in values[:-1]
+        )
+        self.process_id = str(process_id)
+
+    def contract(
+        self,
+        interventions: Sequence[QuantumIntervention] | None = None,
+        /,
+    ) -> tuple[Array, Array]:
+        operations = (
+            tuple(interventions)
+            if interventions is not None
+            else tuple(
+                QuantumIntervention(
+                    jnp.eye(self.dimension, dtype=self.initial_density.dtype)[None, ...],
+                    intervention_id=f"identity:{index}",
+                )
+                for index in range(len(self.tensors))
+            )
+        )
+        if len(operations) != len(self.tensors):
+            raise ValueError("One intervention is required per process time slot.")
+        state = self.initial_density.reshape((1, -1))
+        probability = jnp.asarray(1.0)
+        for tensor, intervention in zip(self.tensors, operations, strict=True):
+            state = jnp.einsum("li,loir->ro", state, tensor)
+            state = jnp.einsum("oi,ri->ro", intervention.superoperator, state)
+            density = state.sum(axis=0).reshape((self.dimension, self.dimension))
+            trace = jnp.real(jnp.trace(density))
+            probability = probability * trace
+            state = state / jnp.maximum(trace, 1e-30)
+        return state[0].reshape((self.dimension, self.dimension)), probability
+
+    def physicality(self) -> ProcessTensorPhysicality:
+        if any(tensor.shape[0] != 1 or tensor.shape[-1] != 1 for tensor in self.tensors):
+            return ProcessTensorPhysicality(
+                jnp.asarray([jnp.nan]),
+                jnp.asarray([jnp.nan]),
+                status="unknown-general-temporal-bond",
+            )
+        reports = [
+            DynamicalMapPhysicality(tensor[0, :, :, 0], self.dimension)
+            for tensor in self.tensors
+        ]
+        return ProcessTensorPhysicality(
+            jnp.stack([report.cp_margin for report in reports]),
+            jnp.stack([report.trace_preservation_residual for report in reports]),
+            status="local-markov-factorization",
+        )
+
+
+def markov_process_tensor(
+    superoperators: Sequence[ArrayLike],
+    initial_density: ArrayLike,
+    /,
+    *,
+    process_id: str = "markov-process",
+) -> ProcessTensorMPO:
+    tensors = tuple(jnp.asarray(operator)[None, :, :, None] for operator in superoperators)
+    return ProcessTensorMPO(tensors, initial_density, process_id=process_id)
+
+
+class ProcessTomographyResult(StrictModule):
+    process_tensor: ProcessTensorMPO
+    reconstruction_residual: Array
+    valid: Array
+
+    def __init__(
+        self,
+        process_tensor: ProcessTensorMPO,
+        reconstruction_residual: ArrayLike,
+        /,
+    ):
+        self.process_tensor = process_tensor
+        self.reconstruction_residual = jnp.asarray(reconstruction_residual)
+        self.valid = (
+            process_tensor.physicality().valid
+            & jnp.isfinite(self.reconstruction_residual)
+        )
+
+
+def reconstruct_markov_process_tensor(
+    observed_superoperators: Sequence[ArrayLike],
+    initial_density: ArrayLike,
+    /,
+    *,
+    process_id: str = "reconstructed-markov-process",
+) -> ProcessTomographyResult:
+    process = markov_process_tensor(
+        observed_superoperators, initial_density, process_id=process_id
+    )
+    residual = jnp.max(
+        jnp.stack(
+            [
+                jnp.linalg.norm(
+                    process.tensors[index][0, :, :, 0]
+                    - jnp.asarray(observed_superoperators[index])
+                )
+                for index in range(len(process.tensors))
+            ]
+        )
+    )
+    return ProcessTomographyResult(process, residual)
+
+
+__all__ = [
+    "ProcessTensorMPO",
+    "ProcessTensorPhysicality",
+    "ProcessTomographyResult",
+    "QuantumIntervention",
+    "markov_process_tensor",
+    "reconstruct_markov_process_tensor",
+]

--- a/tests/unit/solver/test_nonmarkov_manybody.py
+++ b/tests/unit/solver/test_nonmarkov_manybody.py
@@ -1,0 +1,119 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax
+import jax.numpy as jnp
+
+import phydrax as phx
+
+
+def test_gaussian_bosonic_lindblad_reaches_thermal_state():
+    problem = phx.solver.damped_thermal_oscillator(0.4, 1.0)
+    stationary = problem.stationary_state()
+    assert bool(stationary.valid)
+    assert jnp.allclose(stationary.covariance, 1.5 * jnp.eye(2))
+    solution = phx.solver.solve_gaussian_lindblad(problem, step_size=0.05, steps=10)
+    assert bool(solution.valid)
+    assert solution.covariances[-1, 0, 0] > solution.covariances[0, 0, 0]
+
+
+def test_quantum_jump_ensemble_replays_and_decays():
+    problem = phx.solver.amplitude_damping_trajectory_problem(
+        0.5, jnp.asarray([0.0j, 1.0 + 0.0j])
+    )
+    first = phx.solver.solve_quantum_jump_ensemble(
+        problem,
+        jax.random.PRNGKey(2),
+        step_size=0.02,
+        steps=20,
+        trajectory_count=32,
+    )
+    second = phx.solver.solve_quantum_jump_ensemble(
+        problem,
+        jax.random.PRNGKey(2),
+        step_size=0.02,
+        steps=20,
+        trajectory_count=32,
+    )
+    assert bool(first.valid)
+    assert jnp.array_equal(first.states, second.states)
+    assert jnp.sum(first.jump_mask) > 0
+
+
+def test_fock_ladder_cutoff_and_embedding_are_explicit():
+    coarse = phx.operators.quantum.BosonicFockSpace((3,))
+    fine = phx.operators.quantum.BosonicFockSpace((5,))
+    state = jnp.asarray([0.0j, 0.0j, 1.0 + 0.0j])
+    annihilated = coarse.annihilate(state, 0)
+    assert jnp.allclose(annihilated, jnp.asarray([0.0j, jnp.sqrt(2.0), 0.0j]))
+    evidence = coarse.cutoff_evidence(state)
+    assert jnp.allclose(evidence.top_level_probability, 1.0)
+    embedded = coarse.embed(state, fine)
+    assert embedded.shape == (5,)
+    assert jnp.allclose(embedded[:3], state)
+
+
+def test_pseudomode_reduction_and_bath_expansion():
+    expansion, mode, mapping = phx.operators.quantum.lorentzian_pseudomode(
+        1.0, 0.5, 0.2, cutoff=3
+    )
+    assert bool(expansion.valid)
+    assert mapping.coupling == 0.2
+    initial = jnp.asarray([[0.01 + 0.0j, 0.0j], [0.0j, 0.99 + 0.0j]])
+    problem = phx.solver.jaynes_cummings_pseudomode_problem(mode, initial)
+    solution = phx.solver.solve_pseudomode(problem, step_size=0.02, steps=2)
+    assert bool(solution.valid)
+    assert solution.reduced_states.shape == (3, 2, 2)
+
+
+def test_heom_topology_and_root_state():
+    initial = jnp.asarray([[0.6 + 0.0j, 0.0j], [0.0j, 0.4 + 0.0j]])
+    problem = phx.solver.thermal_drude_lorentz_qubit_heom(
+        0.05, 1.0, 2.0, initial, depth=1
+    )
+    assert problem.hierarchy.auxiliary_count == 2
+    solution = phx.solver.solve_heom(problem, step_size=0.01, steps=2)
+    assert bool(solution.valid)
+    assert solution.root_states.shape == (3, 2, 2)
+
+
+def test_memory_kernel_and_dynamical_map_physicality():
+    initial = jnp.asarray([[0.6 + 0.0j, 0.0j], [0.0j, 0.4 + 0.0j]])
+    problem = phx.solver.exponential_memory_qubit_problem(0.05, 1.0, initial)
+    solution = phx.solver.solve_memory_kernel(problem, step_size=0.01, steps=2)
+    assert bool(solution.valid)
+    identity = jnp.eye(4, dtype=complex)
+    report = phx.solver.DynamicalMapPhysicality(identity, 2)
+    assert bool(report.valid)
+
+
+def test_tensor_network_purification_and_gate_truncation():
+    state = phx.tensor_network.product_mps(
+        jnp.asarray([[1.0, 0.0], [1.0, 0.0]], dtype=complex)
+    )
+    assert jnp.allclose(state.norm(), 1.0)
+    swap = jnp.eye(4, dtype=complex).reshape((2, 2, 2, 2))
+    evolved, evidence = phx.tensor_network.apply_two_site_gate(
+        state, 0, swap, maximum_bond_dimension=2
+    )
+    assert bool(evidence.valid)
+    assert jnp.allclose(evolved.norm(), 1.0)
+    purification = phx.tensor_network.LocallyPurifiedDensity(
+        (jnp.asarray([[[[1.0]], [[0.0]]]], dtype=complex),)
+    )
+    assert jnp.allclose(jnp.trace(purification.density()), 1.0)
+
+
+def test_markov_process_tensor_contracts_identity_interventions():
+    identity = jnp.eye(4, dtype=complex)
+    initial = jnp.asarray([[0.7 + 0.0j, 0.0j], [0.0j, 0.3 + 0.0j]])
+    process = phx.tensor_network.markov_process_tensor((identity, identity), initial)
+    final, probability = process.contract()
+    assert jnp.allclose(final, initial)
+    assert jnp.allclose(probability, 1.0)
+    assert bool(process.physicality().valid)
+    reconstructed = phx.tensor_network.reconstruct_markov_process_tensor(
+        (identity, identity), initial
+    )
+    assert bool(reconstructed.valid)

--- a/tools/open_quantum_benchmarks.py
+++ b/tools/open_quantum_benchmarks.py
@@ -1,0 +1,76 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import argparse
+import json
+from time import perf_counter
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+
+import phydrax as phx
+
+
+def _benchmark(function, argument, repeats):
+    compiled = eqx.filter_jit(function)
+    start = perf_counter()
+    output = jax.block_until_ready(compiled(argument))
+    first = perf_counter() - start
+    start = perf_counter()
+    for _ in range(repeats):
+        output = jax.block_until_ready(compiled(argument))
+    return {
+        "compile_and_first_seconds": first,
+        "steady_seconds": (perf_counter() - start) / repeats,
+        "output_bytes": int(output.size * output.dtype.itemsize),
+    }
+
+
+def run_benchmarks(*, repeats=5):
+    gaussian = phx.solver.damped_thermal_oscillator(0.4, 1.0)
+    fock = phx.operators.quantum.BosonicFockSpace((16,))
+    state = jnp.zeros((16,), dtype=complex).at[3].set(1.0)
+    heom = phx.solver.drude_lorentz_qubit_heom(
+        0.05,
+        1.0,
+        jnp.asarray([[0.6 + 0j, 0j], [0j, 0.4 + 0j]]),
+        depth=2,
+    )
+    return {
+        "backend": jax.default_backend(),
+        "records": {
+            "gaussian_rhs": _benchmark(
+                lambda covariance: gaussian.rhs(gaussian.initial_state.mean, covariance)[
+                    1
+                ],
+                gaussian.initial_state.covariance,
+                repeats,
+            ),
+            "fock_annihilation": _benchmark(
+                lambda vector: fock.annihilate(vector, 0), state, repeats
+            ),
+            "heom_rhs": _benchmark(heom.rhs, heom.initial_state, repeats),
+        },
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repeats", type=int, default=5)
+    parser.add_argument("--smoke", action="store_true")
+    arguments = parser.parse_args()
+    print(
+        json.dumps(
+            run_benchmarks(repeats=1 if arguments.smoke else arguments.repeats),
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Relationship

This PR builds on the Calabi–Yau and Bures quantum-information campaigns merged in #109. It adds representation-specific foundations for non-Markovian dynamics, unbounded bosonic systems, and many-body open-system evolution.

## Shared open-system contracts

- Add generator-action, observable-reduction, approximation-evidence, physicality-evidence, and representation-refinement contracts.
- Keep computational auxiliaries distinct from physical states.
- Archive every approximation axis explicitly, including trajectory count, timestep, Fock cutoff, hierarchy depth, memory horizon, tensor bond dimension, and temporal bond dimension.
- Preserve `unknown` as a distinct physicality status rather than treating unevaluated evidence as success.

## Gaussian bosonic open systems

- Add `BosonicGaussianState` with mean, covariance, commutation convention, uncertainty margin, symplectic spectrum, and purity.
- Add `BosonicGaussianChannel` with complete-positivity margin and channel composition.
- Add `GaussianLindbladProblem` and `GaussianLindbladSolution` for affine mean and Lyapunov covariance dynamics.
- Add stationary Gaussian state solves.
- Add a damped thermal oscillator workflow.

This sector is exact for Gaussian states under quadratic Hamiltonians and linear Gaussian noise; it does not use a Fock cutoff.

## Quantum-jump trajectories

- Add matrix-free `StateVectorOperator` actions with explicit adjoint actions.
- Add `QuantumJumpProblem` and fixed-step stochastic unraveling.
- Add no-jump effective dynamics, collapse-rate evaluation, channel sampling, and normalized post-jump states.
- Add deterministic semantic trajectory keys.
- Add `QuantumTrajectoryEnsemble`, observable means and Monte Carlo uncertainty, and empirical-density reconstruction.
- Add an amplitude-damping trajectory workflow.

The current foundation uses fixed-step jump timing. Event-driven norm-threshold integration is intentionally left as the next production layer.

## Bosonic Fock spaces

- Add `BosonicFockSpace` with explicit per-mode cutoffs and occupation indexing.
- Add matrix-free creation and annihilation actions.
- Add number and bounded ladder matrices for diagnostics.
- Add top-level population and boundary-amplitude cutoff evidence.
- Add exact nested coarse-to-fine state embedding.
- Add Kerr and Jaynes–Cummings reference Hamiltonians.

Every Fock result remains explicitly cutoff-dependent.

## Pseudomodes and reaction coordinates

- Add `BathCorrelationExpansion` with exponential terms and fit residual.
- Add `Pseudomode` and `ReactionCoordinateMapping` contracts.
- Add a Lorentzian one-pole constructor.
- Add a Jaynes–Cummings enlarged Markovian embedding.
- Add reduced physical-system density extraction and pseudomode solution evidence.

Non-Gaussian pseudomodes use explicit finite Fock cutoffs.

## Hierarchical equations of motion

- Add fixed-capacity HEOM multi-index topology, hierarchy levels, and up/down neighbor tables.
- Add auxiliary density state and sparse hierarchy coupling.
- Add root-density extraction and maximum auxiliary norm by tier.
- Add fixed-step HEOM evolution.
- Add one-term Drude–Lorentz and finite-temperature one-term qubit workflows.

Only the root auxiliary is treated as a physical density matrix; higher auxiliaries are not required to be positive, Hermitian, or trace one.

## Memory-kernel and TCL evolution

- Add `QuantumMemoryKernel` with causal finite-memory support.
- Add `MemoryKernelMasterEquation` and `TimeLocalOpenSystemProblem`, separate from the Lindblad contract.
- Add fixed-history memory quadrature and time-local evolution.
- Add bounded-system dynamical-map Choi diagnostics for complete positivity and trace preservation.
- Add an exponential-memory qubit workflow.

Memory-kernel states and TCL rates are not clipped or projected into Lindblad form.

## Tensor-network and process-tensor foundations

- Add public `phydrax.tensor_network` package.
- Add MPS, MPO, and locally purified density representations.
- Add dense reference contractions, product-state construction, two-site gate application, SVD bond truncation, and discarded-weight evidence.
- Add Kraus quantum interventions.
- Add process-tensor MPO representations and temporal-bond contracts.
- Add intervention contraction, local Markov-factor Choi evidence, and bounded Markov process reconstruction.

General temporal-bond process physicality remains explicitly unknown until full quantum-comb causality constraints are implemented.

## Public surface and documentation

- Export the Gaussian geometry through `phydrax.metrix`.
- Export Fock, pseudomode, and shared open-system contracts through `phydrax.operators.quantum`.
- Export Gaussian, trajectory, pseudomode, HEOM, memory-kernel, and TCL solvers through `phydrax.solver`.
- Export `phydrax.tensor_network` at the package root.
- Add dedicated non-Markovian and many-body open-system documentation.
- Update the changelog and focused performance catalog.

## Explicit boundaries retained

- No finite Fock cutoff is presented as an exact unbounded result.
- No dense density matrix is required for trajectory observables.
- No event-driven jump timing claim yet.
- No production MPS-TDVP or locally purified Lindblad campaign yet.
- No HEOM convergence claim without depth/correlation refinement.
- No direct-kernel complete-positivity guarantee.
- No general process-tensor causality claim for nontrivial temporal bonds.