### PR TITLE
feat(terms): add likelihood-backed supervised classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## Unreleased
 
 ### Added
+- Added likelihood-backed binary and multiclass empirical classification terms
+  with encoded target schemas, case masks, positive statistical sample weights,
+  posterior-compatible raw log probabilities, classification diagnostics, and a
+  gathered categorical hard-label kernel that avoids one-hot target allocation.
+
 - Added regular, first-order conic primal JVP/VJP operators over audited
   `ConicProgram` executions, with cached dense projection-KKT Jacobians,
   native-bound cotangents, projection/linear regularity evidence, and exact

--- a/docs/all-of-phydrax.md
+++ b/docs/all-of-phydrax.md
@@ -590,8 +590,10 @@ Below are the common SciML regimes expressed in Phydrax’s primitives.
   See [API reference](api/phydrax.md).
 - **Data assimilation / hybrid physics-data**: pair `Observation` conditions
   with finite sources and `ObservationPenalty` terms; use specialized
-  `SupervisedDatasetTerm`, `RaggedTimeSeriesDataTerm`, and
-  `TrajectoryCaseDataTerm` where their dataset semantics apply. Use
+  `SupervisedDatasetTerm`, `SupervisedClassificationTerm`,
+  `RaggedTimeSeriesDataTerm`, and `TrajectoryCaseDataTerm` where their dataset
+  semantics apply. `SupervisedClassificationTerm` contributes Bernoulli or
+  categorical negative log likelihood alongside ordinary physics terms. Use
   `TrajectorySignal` for fixed measured forcings/covariates on ragged trajectory
   domains, and evaluate held-out terms for diagnostics.
   See [API reference](api/phydrax.md).

--- a/docs/api/terms.md
+++ b/docs/api/terms.md
@@ -21,6 +21,21 @@ Different sampled terms receive deterministic distinct subkeys. The sampling
 policy must remain static during a compiled training run; changing probe count, path
 count, or chunk shape requires a separate compilation.
 
+## Supervised empirical terms
+
+`SupervisedClassificationTerm` trains one Bernoulli logit for binary targets or
+full terminal-axis categorical logits for mutually exclusive multiclass targets.
+Encoded labels, case masks, statistical sample weights, and train/evaluation index
+subsets remain explicit. The generated Bernoulli or categorical likelihood is also
+available through the posterior-compatible `log_prob(...)` path.
+
+::: phydrax.terms.SupervisedClassificationTerm
+
+---
+
+::: phydrax.terms.SupervisedLikelihoodTerm
+
+
 ## Feynman--Kac regression
 
 `FeynmanKacRegressionTerm` fits value and optional control fields to frozen

--- a/docs/guides/ml.md
+++ b/docs/guides/ml.md
@@ -265,6 +265,14 @@ vocabularies, one-vs-one voting, output-code construction, classifier-chain
 ordering, and exact isotonic blocks are discrete; smooth chains and smooth
 isotonic calibration are separately named alternatives.
 
+These recipes fit complete classical estimators from `MLBatch`. To train an
+arbitrary neural or physics-composed `DomainFunction`, use
+`phydrax.terms.SupervisedClassificationTerm` with the same `TargetSchema`.
+Binary outputs are one Bernoulli logit; mutually exclusive multiclass outputs are
+full categorical logits on the final axis. Independent multilabel probabilities and
+uncalibrated margins are different mathematical objects and are not accepted by
+that term.
+
 ### Decomposition and latent representations
 
 `decomposition` provides `PCA`, `IncrementalPCA`, `POD`, `TruncatedSVD`,

--- a/docs/guides_domain.md
+++ b/docs/guides_domain.md
@@ -145,6 +145,35 @@ term = phx.terms.SupervisedDatasetTerm(
 )
 ```
 
+For binary or mutually exclusive multiclass labels on those rows, train canonical
+logits with `SupervisedClassificationTerm`:
+
+```python
+labels = jnp.asarray([0, 0, 1], dtype=jnp.int32)
+schema = phx.ml.TargetSchema(
+    "binary",
+    names=("regime",),
+    class_labels=("laminar", "turbulent"),
+)
+
+classification = phx.terms.SupervisedClassificationTerm(
+    "regime_logit",
+    dataset_domain.component(),
+    labels,
+    schema,
+    sampling=phx.domain.PointSampling(32, design="uniform"),
+)
+```
+
+Binary fields return one scalar logit. Multiclass fields return `K` full logits on
+their final axis, and their schema must declare all `K` class labels. Targets are
+encoded integer indices; `class_labels` retains the external vocabulary. Use
+`sample_mask` for row exclusion, `indices` for train/evaluation splits, and positive
+`sample_weight` values for an explicit empirical risk. The scalar `weight` instead
+scales the complete term relative to physics terms. A dense labelled field can use
+one dataset row per site, with area or volume weights supplied explicitly as
+`sample_weight`.
+
 Use `HyperRectangle` when the feature dimensions are continuous variables of the
 problem. Use `DatasetDomain` when the empirical row distribution is the domain you
 want to average over.

--- a/docs/guides_solver.md
+++ b/docs/guides_solver.md
@@ -642,13 +642,22 @@ of those outputs.
 - `tensorboard_every`: TensorBoard scalar cadence. By default it follows `log_every`
   when `log_every > 0`, otherwise it writes every iteration.
 
-For data-fit terms such as `SupervisedDatasetTerm`, `RaggedTimeSeriesDataTerm`,
-or `TrajectoryCaseDataTerm`, per-term logs also include supervised-data
-diagnostics:
+Regression data-fit terms such as `SupervisedDatasetTerm`,
+`RaggedTimeSeriesDataTerm`, or `TrajectoryCaseDataTerm` report:
 
 - `data_accuracy`: `1 - data_relative_l2_error`
 - `data_relative_l2_error`: prediction-target relative L2 error
 - `data_rmse`: root mean squared prediction-target error
+
+`SupervisedClassificationTerm` instead reports classification evidence from the
+exact prepared mini-batch:
+
+- `data_negative_log_likelihood`
+- `data_accuracy`
+- `data_brier_score`
+- `data_effective_weight`
+- `data_valid`
+- `data_status`
 
 When ragged trajectory data is enforced with
 `phx.enforcement.enforce_ragged_time_series(...)`, the data is part of the ansatz

--- a/docs/guides_uncertainty.md
+++ b/docs/guides_uncertainty.md
@@ -849,9 +849,10 @@ JSON and Parquet artifacts under
 
 ## Observation likelihoods and proper scores
 
-Native likelihoods include fixed-scale Gaussian, heteroscedastic Gaussian, and
-Student-t observations. `SupervisedLikelihoodTerm` aligns targets through a
-`DatasetDomain` and can score a transformed physical observable:
+Native likelihoods include Bernoulli and categorical observations, fixed-scale and
+heteroscedastic Gaussian observations, and Student-t observations.
+`SupervisedLikelihoodTerm` aligns targets through a `DatasetDomain` and can score a
+transformed physical observable:
 
 ```python
 dataset = phx.domain.DatasetDomain(jnp.linspace(0.0, 1.0, 64)[:, None])
@@ -869,6 +870,14 @@ term = phx.terms.SupervisedLikelihoodTerm(
 
 This supports state values, derivatives, fluxes, stresses, integrals, and sensor
 transforms without treating a PDE residual as measurement noise.
+
+`SupervisedClassificationTerm` binds encoded binary labels to Bernoulli log-odds or
+encoded multiclass labels to full categorical logits. Its cross-entropy objective is
+the corresponding negative log likelihood, so it composes directly with physics
+terms without creating a second loss implementation. Classification diagnostics use
+the categorical-specific `class_probabilities(...)` conversion; likelihoods do not
+claim a generic distributional mean, which need not exist for other observation
+families such as Student-t laws with low degrees of freedom.
 
 Report held-out negative log likelihood, CRPS (Gaussian, Student-t, or empirical
 ensemble), energy score for multivariate fields, interval coverage, and interval
@@ -1122,10 +1131,13 @@ posterior = phx.uq.PosteriorProblem(
 ```
 
 `FunctionalSolver.loss()` is a training objective, not a posterior density. Arbitrary
-term scales, changing collocation samples, and mean reductions do not define
-likelihood normalization. For a `SupervisedLikelihoodTerm`, call
+term scales, statistical `sample_weight` values, changing collocation samples, and
+mean reductions do not define likelihood normalization. For a
+`SupervisedLikelihoodTerm` or `SupervisedClassificationTerm`, call
 `observed_batch()` once and sum its unreduced `log_prob(...)` values inside the
-posterior likelihood. Never call random `sample()` from a posterior density.
+posterior likelihood. `sample_mask` removes unobserved cases, while optimizer
+weights do not become likelihood powers. Never call random `sample()` from a
+posterior density.
 
 Use `FixedObservationLikelihood`, `FixedResidualLikelihood`, and
 `FixedSupervisedLikelihood` to construct deterministic, sum-reduced normalized

--- a/phydrax/_exponential_family/_categorical.py
+++ b/phydrax/_exponential_family/_categorical.py
@@ -58,6 +58,48 @@ class CategoricalFamily(_AbstractAnalyticExponentialFamily):
         values = values.astype(jnp.result_type(values, 0.0))
         return self.natural(values[..., :-1] - values[..., -1, None])
 
+    def log_prob_from_logits(
+        self,
+        logits: ArrayLike,
+        target: ArrayLike,
+        /,
+    ) -> Array:
+        """Return hard-label log probabilities without materializing one-hot targets."""
+        values = jnp.asarray(logits)
+        if jnp.issubdtype(values.dtype, jnp.complexfloating):
+            raise TypeError("Categorical logits must be real-valued.")
+        if values.ndim == 0 or int(values.shape[-1]) != self.num_categories:
+            raise ValueError(
+                "Categorical full logits must end in num_categories="
+                f"{self.num_categories}; got {values.shape}."
+            )
+        values = values.astype(jnp.result_type(values, 0.0))
+
+        raw_target = jnp.asarray(target)
+        if jnp.issubdtype(raw_target.dtype, jnp.complexfloating):
+            raise TypeError("Categorical observations must be real-valued labels.")
+        if raw_target.shape != values.shape[:-1]:
+            raise ValueError(
+                "Categorical targets must match the logits batch shape; "
+                f"got logits={values.shape} and target={raw_target.shape}."
+            )
+        observation = raw_target.astype(jnp.result_type(raw_target, 0.0))
+        target_valid = (
+            jnp.isfinite(observation)
+            & (observation >= 0.0)
+            & (observation < self.num_categories)
+            & (observation == jnp.floor(observation))
+        )
+        logits_valid = jnp.all(jnp.isfinite(values), axis=-1)
+        valid = logits_valid & target_valid
+        safe_target = jnp.where(target_valid, observation, 0.0).astype(jnp.int32)
+        safe_logits = jnp.where(logits_valid[..., None], values, 0.0)
+        selected = jnp.take_along_axis(safe_logits, safe_target[..., None], axis=-1)[
+            ..., 0
+        ]
+        result = selected - jax.nn.logsumexp(safe_logits, axis=-1)
+        return jnp.where(valid, result, -jnp.inf)
+
     def probabilities_from_natural(self, natural: NaturalCoordinates, /) -> Array:
         """Return conventional full category probabilities."""
         domain = self.natural_domain(natural)

--- a/phydrax/_likelihoods.py
+++ b/phydrax/_likelihoods.py
@@ -8,6 +8,7 @@ from abc import abstractmethod
 from typing import Any, Literal
 
 import equinox as eqx
+import jax
 import jax.numpy as jnp
 import jax.random as jr
 import jax.scipy as jsp
@@ -157,20 +158,29 @@ class CategoricalExponentialFamilyLikelihood(AbstractLikelihood):
             )
         return location_array, target_array
 
-    def _natural(self, location: ArrayLike, /):
+    def _full_logits(self, location: ArrayLike, /) -> Array:
         values = jnp.asarray(location)
         if jnp.issubdtype(values.dtype, jnp.complexfloating):
             raise TypeError("Categorical predictions must be real-valued.")
+        if values.ndim == 0 or int(values.shape[-1]) != self.prediction_dimension:
+            raise ValueError(
+                "Categorical predictions must end in coordinate dimension "
+                f"{self.prediction_dimension}; got {values.shape}."
+            )
         values = values.astype(jnp.result_type(values, 0.0))
         if self.prediction_coordinates == "natural":
-            if values.ndim == 0 or int(values.shape[-1]) != (
-                self.family.signature.dimension
-            ):
-                raise ValueError(
-                    "Categorical natural predictions have an incompatible shape."
-                )
-            return self.family.natural(values)
-        return self.family.natural_from_logits(values)
+            return jnp.concatenate(
+                (values, jnp.zeros_like(values[..., :1])),
+                axis=-1,
+            )
+        return values
+
+    def _natural(self, location: ArrayLike, /):
+        return self.family.natural_from_logits(self._full_logits(location))
+
+    def class_probabilities(self, location: ArrayLike, /) -> Array:
+        """Return conventional probabilities on the complete category simplex."""
+        return jax.nn.softmax(self._full_logits(location), axis=-1)
 
     def log_prob(
         self, location: ArrayLike, target: ArrayLike, /, **parameters: Any
@@ -181,7 +191,10 @@ class CategoricalExponentialFamilyLikelihood(AbstractLikelihood):
                 f"{tuple(parameters)!r}."
             )
         aligned_location, aligned_target = self.align_observations(location, target)
-        return self.family.log_prob(self._natural(aligned_location), aligned_target)
+        return self.family.log_prob_from_logits(
+            self._full_logits(aligned_location),
+            aligned_target,
+        )
 
     def sample(self, key, location: ArrayLike, /, **parameters: Any) -> Array:
         if parameters:

--- a/phydrax/terms/__init__.py
+++ b/phydrax/terms/__init__.py
@@ -16,6 +16,7 @@ from .._term import (
     TermEvaluation,
 )
 from ._bsde import BSDETerm
+from ._classification import SupervisedClassificationTerm
 from ._cochain import cochain_residual_field, CochainResidualTerm
 from ._deep_bsde import (
     deep_bsde_rollout,
@@ -189,6 +190,7 @@ __all__ = [
     "SpatialSinkhornDivergenceTerm",
     "SpatialUnbalancedSinkhornDivergenceTerm",
     "ScoreSampleProvider",
+    "SupervisedClassificationTerm",
     "SupervisedDatasetBatch",
     "SupervisedDatasetTerm",
     "SupervisedLikelihoodTerm",

--- a/phydrax/terms/_classification.py
+++ b/phydrax/terms/_classification.py
@@ -1,0 +1,185 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from typing import Any, Literal
+
+import equinox as eqx
+import jax.numpy as jnp
+from jaxtyping import Array, ArrayLike, Key
+
+from phydrax.domain import DomainComponent, DomainFunction, PointSampling
+
+from .._doc import DOC_KEY0
+from .._exponential_family import BernoulliFamily, CategoricalFamily
+from .._likelihoods import (
+    CategoricalExponentialFamilyLikelihood,
+    ScalarNaturalExponentialFamilyLikelihood,
+)
+from ..ml._schema import TargetSchema
+from ..ml.metrics import accuracy_score, brier_score, log_loss
+from ._likelihood import _AbstractSupervisedLikelihoodTerm
+from ._supervised_dataset import SupervisedDatasetBatch
+
+
+class SupervisedClassificationTerm(_AbstractSupervisedLikelihoodTerm):
+    """Train canonical binary or multiclass logits on an empirical dataset."""
+
+    target_schema: TargetSchema
+    classification_kind: Literal["binary", "multiclass"] = eqx.field(static=True)
+    class_count: int = eqx.field(static=True)
+
+    def __init__(
+        self,
+        field: str,
+        component: DomainComponent,
+        targets: ArrayLike,
+        target_schema: TargetSchema,
+        /,
+        *,
+        sampling: PointSampling,
+        observation_operator: Callable[[DomainFunction], DomainFunction] | None = None,
+        sample_mask: ArrayLike | None = None,
+        sample_weight: ArrayLike | None = None,
+        weight: ArrayLike = 1.0,
+        reduction: Literal["mean", "sum"] = "mean",
+        indices: ArrayLike | None = None,
+        label: str | None = None,
+    ):
+        if not isinstance(target_schema, TargetSchema):
+            raise TypeError("target_schema must be a TargetSchema.")
+        kind = target_schema.kind
+        if kind == "binary":
+            class_count = 2
+            likelihood = ScalarNaturalExponentialFamilyLikelihood(BernoulliFamily())
+        elif kind == "multiclass":
+            class_count = target_schema.num_classes
+            if class_count < 2:
+                raise ValueError(
+                    "Multiclass classification requires class_labels to declare every "
+                    "output class."
+                )
+            likelihood = CategoricalExponentialFamilyLikelihood(
+                CategoricalFamily(class_count),
+                prediction_coordinates="full_logits",
+            )
+        else:
+            raise ValueError(
+                "SupervisedClassificationTerm supports binary and multiclass "
+                "TargetSchema kinds."
+            )
+
+        encoded = jnp.asarray(targets)
+        if encoded.ndim == 2 and int(encoded.shape[1]) == 1:
+            encoded = encoded[:, 0]
+        if encoded.ndim != 1:
+            raise ValueError("Classification targets must have shape (N,) or (N, 1).")
+        if encoded.dtype != jnp.bool_ and not jnp.issubdtype(encoded.dtype, jnp.integer):
+            raise TypeError("Classification targets must be integer or Boolean labels.")
+
+        term_weight = jnp.asarray(weight, dtype=float)
+        if term_weight.ndim != 0 or not bool(jnp.isfinite(term_weight)):
+            raise ValueError("weight must be a finite scalar.")
+        if bool(term_weight < 0.0):
+            raise ValueError("Classification term weight must be nonnegative.")
+
+        super().__init__(
+            str(field),
+            component,
+            encoded,
+            likelihood,
+            sampling=sampling,
+            observation_operator=observation_operator,
+            sample_mask=sample_mask,
+            sample_weight=sample_weight,
+            weight=term_weight,
+            reduction=reduction,
+            indices=indices,
+            label=label,
+        )
+
+        configured = (
+            jnp.arange(self.domain.size, dtype=jnp.int32)
+            if self.indices is None
+            else self.indices
+        )
+        active_targets = self.values[configured]
+        if bool(jnp.any(active_targets < 0)) or bool(
+            jnp.any(active_targets >= class_count)
+        ):
+            raise ValueError(
+                f"Configured classification targets must lie within [0, {class_count})."
+            )
+
+        self.target_schema = target_schema
+        self.classification_kind = kind
+        self.class_count = class_count
+
+    def data_metrics(
+        self,
+        functions: Mapping[str, DomainFunction],
+        /,
+        *,
+        key: Key[Array, ""] = DOC_KEY0,
+        batch: SupervisedDatasetBatch | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Array]:
+        """Return classification diagnostics on the exact prepared mini-batch."""
+        batch_value = self.sample(key=key) if batch is None else batch
+        location, target = self.likelihood.align_observations(
+            self._location(functions, batch_value, key=key, **kwargs),
+            batch_value.target,
+        )
+        labels = jnp.asarray(target, dtype=jnp.int32)
+        if self.classification_kind == "binary":
+            logits = jnp.stack((jnp.zeros_like(location), location), axis=-1)
+            prediction = (location >= 0.0).astype(jnp.int32)
+            brier = brier_score(
+                labels,
+                location,
+                sample_weight=batch_value.sample_weight,
+                from_logits=True,
+            )
+        else:
+            logits = jnp.asarray(location)
+            prediction = jnp.argmax(logits, axis=-1).astype(jnp.int32)
+            probabilities = self.likelihood.class_probabilities(logits)
+            brier = brier_score(
+                labels,
+                probabilities,
+                sample_weight=batch_value.sample_weight,
+            )
+
+        negative_log_likelihood = log_loss(
+            labels,
+            logits,
+            sample_weight=batch_value.sample_weight,
+            from_logits=True,
+        )
+        accuracy = accuracy_score(
+            labels,
+            prediction,
+            sample_weight=batch_value.sample_weight,
+        )
+        return {
+            "data_negative_log_likelihood": jnp.asarray(
+                negative_log_likelihood.value, dtype=float
+            ).reshape(()),
+            "data_accuracy": jnp.asarray(accuracy.value, dtype=float).reshape(()),
+            "data_brier_score": jnp.asarray(brier.value, dtype=float).reshape(()),
+            "data_effective_weight": jnp.asarray(
+                negative_log_likelihood.effective_weight, dtype=float
+            ).reshape(()),
+            "data_valid": jnp.asarray(negative_log_likelihood.valid, dtype=bool).reshape(
+                ()
+            ),
+            "data_status": jnp.asarray(
+                negative_log_likelihood.status, dtype=jnp.int32
+            ).reshape(()),
+        }
+
+
+__all__ = ["SupervisedClassificationTerm"]

--- a/phydrax/terms/_data_metrics.py
+++ b/phydrax/terms/_data_metrics.py
@@ -103,13 +103,26 @@ def reduce_supervised_loss(
     /,
     *,
     reduction: str,
+    sample_weight: ArrayLike | None = None,
 ) -> Array:
-    """Reduce per-sample supervised losses with a common mean/sum policy."""
+    """Reduce per-sample supervised losses with a common weighted policy."""
     per_sample_arr = jnp.asarray(per_sample, dtype=float)
+    if sample_weight is None:
+        weighted = per_sample_arr
+        mass = jnp.asarray(per_sample_arr.size, dtype=per_sample_arr.dtype)
+    else:
+        weights = jnp.asarray(sample_weight, dtype=float)
+        if weights.shape != per_sample_arr.shape:
+            raise ValueError(
+                "sample_weight must match the per-sample loss shape; "
+                f"got weights={weights.shape} and losses={per_sample_arr.shape}."
+            )
+        weighted = weights * per_sample_arr
+        mass = jnp.sum(weights)
     if reduction == "mean":
-        reduced = jnp.mean(per_sample_arr)
+        reduced = jnp.sum(weighted) / mass
     elif reduction == "sum":
-        reduced = jnp.sum(per_sample_arr)
+        reduced = jnp.sum(weighted)
     else:
         raise ValueError("reduction must be either 'mean' or 'sum'.")
     return jnp.asarray(reduced, dtype=float).reshape(())
@@ -123,7 +136,7 @@ def validate_supervised_targets(
     name: str,
 ) -> Array:
     """Validate a target array with a leading empirical-case axis."""
-    arr = jnp.asarray(values, dtype=float)
+    arr = jnp.asarray(values)
     if arr.ndim == 0:
         raise ValueError(f"{name} values must have shape (N, ...).")
     if int(arr.shape[0]) != int(leading_size):
@@ -154,6 +167,66 @@ def validate_case_indices(
     if bool(jnp.any(idx < 0)) or bool(jnp.any(idx >= int(size))):
         raise ValueError(f"{name} must be within [0, {int(size)}).")
     return idx
+
+
+def validate_case_mask(
+    mask: ArrayLike | None,
+    /,
+    *,
+    size: int,
+    name: str = "sample_mask",
+) -> Array | None:
+    """Validate an optional Boolean mask over empirical cases."""
+    if mask is None:
+        return None
+    result = jnp.asarray(mask)
+    if result.dtype != jnp.bool_:
+        raise TypeError(f"{name} must be Boolean.")
+    if result.shape != (int(size),):
+        raise ValueError(f"{name} must have shape ({int(size)},), got {result.shape}.")
+    return result
+
+
+def configured_case_indices(
+    indices: ArrayLike | None,
+    mask: ArrayLike | None,
+    /,
+    *,
+    size: int,
+    indices_name: str = "indices",
+    mask_name: str = "sample_mask",
+) -> Array | None:
+    """Return the ordered non-empty intersection of an index subset and mask."""
+    selected = validate_case_indices(indices, size=size, name=indices_name)
+    valid = validate_case_mask(mask, size=size, name=mask_name)
+    if valid is None:
+        return selected
+    candidates = jnp.arange(int(size), dtype=jnp.int32) if selected is None else selected
+    configured = candidates[valid[candidates]]
+    if int(configured.shape[0]) == 0:
+        raise ValueError("The configured empirical case population must be non-empty.")
+    return configured
+
+
+def validate_case_weights(
+    weights: ArrayLike | None,
+    /,
+    *,
+    size: int,
+    indices: Array | None,
+    name: str = "sample_weight",
+) -> Array | None:
+    """Validate positive statistical weights on configured empirical cases."""
+    if weights is None:
+        return None
+    result = jnp.asarray(weights, dtype=float)
+    if result.shape != (int(size),):
+        raise ValueError(f"{name} must have shape ({int(size)},), got {result.shape}.")
+    configured = jnp.arange(int(size), dtype=jnp.int32) if indices is None else indices
+    active = result[configured]
+    if bool(jnp.any(~jnp.isfinite(active))) or bool(jnp.any(active <= 0.0)):
+        raise ValueError(f"{name} must be finite and strictly positive.")
+    return result
 
 
 def sample_case_indices(

--- a/phydrax/terms/_likelihood.py
+++ b/phydrax/terms/_likelihood.py
@@ -8,6 +8,7 @@ from collections.abc import Callable, Mapping
 from typing import Any, Literal
 
 import coordax as cx
+import jax
 import jax.numpy as jnp
 from jaxtyping import Array, ArrayLike, Key
 
@@ -18,16 +19,20 @@ from .._likelihoods import AbstractLikelihood
 from .._term import AbstractSamplingTerm
 from ._data_metrics import (
     case_sample_count,
+    configured_case_indices,
     normalize_case_sampling,
+    reduce_supervised_loss,
     sample_case_indices,
-    validate_case_indices,
+    validate_case_weights,
     validate_supervised_targets,
 )
 from ._supervised_dataset import SupervisedDatasetBatch
 
 
-class SupervisedLikelihoodTerm(AbstractSamplingTerm):
-    """Score direct or operator-transformed dataset observations by a likelihood."""
+class _AbstractSupervisedLikelihoodTerm(AbstractSamplingTerm):
+    """Shared dataset-likelihood sampling and reduction implementation."""
+
+    __strict_abstract__ = True
 
     fields: tuple[str, ...]
     location_var: str
@@ -40,6 +45,7 @@ class SupervisedLikelihoodTerm(AbstractSamplingTerm):
     likelihood: AbstractLikelihood
     observation_operator: Callable[[DomainFunction], DomainFunction] | None
     weight: Array
+    sample_weight: Array | None
     indices: Array | None
     label: str | None
 
@@ -55,20 +61,21 @@ class SupervisedLikelihoodTerm(AbstractSamplingTerm):
         scale_var: str | None = None,
         observation_operator: Callable[[DomainFunction], DomainFunction] | None = None,
         weight: ArrayLike = 1.0,
+        sample_mask: ArrayLike | None = None,
+        sample_weight: ArrayLike | None = None,
         reduction: Literal["mean", "sum"] = "mean",
         indices: ArrayLike | None = None,
         label: str | None = None,
     ):
+        owner = type(self).__name__
         if not isinstance(component.domain, DatasetDomain):
-            raise TypeError(
-                "SupervisedLikelihoodTerm requires a DatasetDomain component."
-            )
+            raise TypeError(f"{owner} requires a DatasetDomain component.")
         if not isinstance(likelihood, AbstractLikelihood):
             raise TypeError("likelihood must implement AbstractLikelihood.")
         sampling_ = normalize_case_sampling(
             sampling,
             labels=component.domain.labels,
-            owner="SupervisedLikelihoodTerm",
+            owner=owner,
         )
         reduction_value = str(reduction)
         if reduction_value not in ("mean", "sum"):
@@ -100,7 +107,17 @@ class SupervisedLikelihoodTerm(AbstractSamplingTerm):
         if weight_array.ndim != 0 or not bool(jnp.isfinite(weight_array)):
             raise ValueError("weight must be a finite scalar.")
         self.weight = weight_array
-        self.indices = validate_case_indices(indices, size=domain.size, name="indices")
+        configured = configured_case_indices(
+            indices,
+            sample_mask,
+            size=domain.size,
+        )
+        self.sample_weight = validate_case_weights(
+            sample_weight,
+            size=domain.size,
+            indices=configured,
+        )
+        self.indices = configured
         self.label = None if label is None else str(label)
 
     @property
@@ -123,6 +140,9 @@ class SupervisedLikelihoodTerm(AbstractSamplingTerm):
             points=self.domain.points_from_indices(indices, structure=layout),
             target=self.values[indices],
             indices=indices,
+            sample_weight=(
+                None if self.sample_weight is None else self.sample_weight[indices]
+            ),
         )
 
     def observed_batch(self) -> SupervisedDatasetBatch:
@@ -138,6 +158,9 @@ class SupervisedLikelihoodTerm(AbstractSamplingTerm):
             points=self.domain.points_from_indices(indices, structure=layout),
             target=self.values[indices],
             indices=indices,
+            sample_weight=(
+                None if self.sample_weight is None else self.sample_weight[indices]
+            ),
         )
 
     def log_prob(
@@ -203,17 +226,29 @@ class SupervisedLikelihoodTerm(AbstractSamplingTerm):
     ) -> Array:
         del iter_
         batch_value = self.sample(key=key) if batch is None else batch
-        per_case = -self.log_prob(
-            functions,
-            key=key,
-            batch=batch_value,
-            **kwargs,
-        )
-        if self.reduction == "mean":
-            reduced = jnp.mean(per_case)
-        else:
-            reduced = jnp.sum(per_case)
-        return self.weight * jnp.asarray(reduced, dtype=float).reshape(())
+
+        def zero_loss() -> Array:
+            return jnp.zeros((), dtype=jnp.result_type(self.weight, float))
+
+        def active_loss() -> Array:
+            per_case = -self.log_prob(
+                functions,
+                key=key,
+                batch=batch_value,
+                **kwargs,
+            )
+            reduced = reduce_supervised_loss(
+                per_case,
+                reduction=self.reduction,
+                sample_weight=batch_value.sample_weight,
+            )
+            return self.weight * jnp.asarray(reduced, dtype=float).reshape(())
+
+        return jax.lax.cond(self.weight == 0.0, zero_loss, active_loss)
+
+
+class SupervisedLikelihoodTerm(_AbstractSupervisedLikelihoodTerm):
+    """Score direct or operator-transformed dataset observations by a likelihood."""
 
 
 __all__ = ["SupervisedLikelihoodTerm"]

--- a/phydrax/terms/_supervised_dataset.py
+++ b/phydrax/terms/_supervised_dataset.py
@@ -40,6 +40,7 @@ class SupervisedDatasetBatch(StrictModule):
     points: PointBatch
     target: Array
     indices: Array
+    sample_weight: Array | None
 
     def __init__(
         self,
@@ -47,10 +48,37 @@ class SupervisedDatasetBatch(StrictModule):
         points: PointBatch,
         target: ArrayLike,
         indices: ArrayLike,
+        sample_weight: ArrayLike | None = None,
     ):
+        target_array = jnp.asarray(target)
+        indices_array = jnp.asarray(indices, dtype=jnp.int32)
+        if indices_array.ndim != 1:
+            raise ValueError("Supervised dataset batch indices must be one-dimensional.")
+        if target_array.ndim == 0 or int(target_array.shape[0]) != int(
+            indices_array.shape[0]
+        ):
+            raise ValueError(
+                "Supervised dataset batch targets must retain the sampled case axis."
+            )
+        if sample_weight is None:
+            weight_array = None
+        else:
+            weight_array = jnp.asarray(sample_weight, dtype=float)
+            if weight_array.shape != indices_array.shape:
+                raise ValueError(
+                    "Supervised dataset batch sample weights must match its indices."
+                )
+            if bool(jnp.any(~jnp.isfinite(weight_array))) or bool(
+                jnp.any(weight_array <= 0.0)
+            ):
+                raise ValueError(
+                    "Supervised dataset batch sample weights must be finite and "
+                    "strictly positive."
+                )
         self.points = points
-        self.target = jnp.asarray(target, dtype=float)
-        self.indices = jnp.asarray(indices, dtype=jnp.int32)
+        self.target = target_array
+        self.indices = indices_array
+        self.sample_weight = weight_array
 
 
 def _validate_targets(domain: DatasetDomain, values: ArrayLike, /) -> Array:

--- a/phydrax/uq/_posterior_terms.py
+++ b/phydrax/uq/_posterior_terms.py
@@ -20,7 +20,7 @@ from .._strict import StrictModule
 
 if TYPE_CHECKING:
     from ..domain import DomainFunction
-    from ..terms._likelihood import SupervisedLikelihoodTerm
+    from ..terms._likelihood import _AbstractSupervisedLikelihoodTerm
     from ..terms._supervised_dataset import SupervisedDatasetBatch
     from ._gp_scalar import (
         ExactGaussianProcessDiscrepancy,
@@ -205,7 +205,7 @@ class GaussianProcessMarginalLikelihood(AbstractPosteriorTerm):
 class FixedSupervisedLikelihood(AbstractPosteriorTerm):
     """Adapter from a supervised likelihood term and its frozen full batch."""
 
-    term: SupervisedLikelihoodTerm
+    term: _AbstractSupervisedLikelihoodTerm
     batch: SupervisedDatasetBatch
     functions_fn: Callable[[PyTree[Any]], Mapping[str, DomainFunction]] = eqx.field(
         static=True
@@ -213,18 +213,18 @@ class FixedSupervisedLikelihood(AbstractPosteriorTerm):
 
     def __init__(
         self,
-        term: SupervisedLikelihoodTerm,
+        term: _AbstractSupervisedLikelihoodTerm,
         functions: Callable[[PyTree[Any]], Mapping[str, DomainFunction]],
         /,
         *,
         batch: SupervisedDatasetBatch | None = None,
         label: str | None = None,
     ):
-        from ..terms._likelihood import SupervisedLikelihoodTerm
+        from ..terms._likelihood import _AbstractSupervisedLikelihoodTerm
         from ..terms._supervised_dataset import SupervisedDatasetBatch
 
-        if not isinstance(term, SupervisedLikelihoodTerm):
-            raise TypeError("term must be a SupervisedLikelihoodTerm.")
+        if not isinstance(term, _AbstractSupervisedLikelihoodTerm):
+            raise TypeError("term must be a supervised likelihood term.")
         if not callable(functions):
             raise TypeError("functions must be callable.")
         batch_value = term.observed_batch() if batch is None else batch

--- a/tests/unit/constraints/test_supervised_classification.py
+++ b/tests/unit/constraints/test_supervised_classification.py
@@ -1,0 +1,173 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import phydrax as phx
+
+
+def test_binary_classification_matches_weighted_bernoulli_nll_and_metrics():
+    logits = jnp.asarray([-2.0, -0.4, 0.6, 2.2])
+    domain = phx.domain.DatasetDomain(logits[:, None])
+    targets = jnp.asarray([0, 0, 1, 1], dtype=jnp.int32)
+    weights = jnp.asarray([1.0, 2.0, 3.0, 4.0])
+
+    @domain.Function("data")
+    def field(row):
+        return row[0]
+
+    term = phx.terms.SupervisedClassificationTerm(
+        "logit",
+        domain.component(),
+        targets,
+        phx.ml.TargetSchema(
+            "binary",
+            names=("stability",),
+            class_labels=("unstable", "stable"),
+        ),
+        sampling=phx.domain.PointSampling(4, design="uniform"),
+        sample_weight=weights,
+    )
+    batch = term.observed_batch()
+    expected_per_case = jax.nn.softplus(logits) - targets * logits
+    expected = jnp.sum(weights * expected_per_case) / jnp.sum(weights)
+    metrics = term.data_metrics({"logit": field}, batch=batch)
+
+    np.testing.assert_allclose(term.loss({"logit": field}, batch=batch), expected)
+    np.testing.assert_allclose(metrics["data_negative_log_likelihood"], expected)
+    np.testing.assert_allclose(metrics["data_accuracy"], 1.0)
+    np.testing.assert_allclose(metrics["data_effective_weight"], jnp.sum(weights))
+    assert bool(metrics["data_valid"])
+    assert int(metrics["data_status"]) == phx.ml.metrics.METRIC_SUCCESS
+    assert 0.0 <= float(metrics["data_brier_score"]) < 0.25
+
+
+def test_multiclass_classification_matches_log_softmax_and_is_shift_invariant():
+    logits = jnp.asarray(
+        [
+            [3.0, 0.2, -1.0],
+            [-0.5, 2.0, 0.1],
+            [0.2, -0.7, 2.4],
+            [1.5, 0.8, -0.3],
+        ]
+    )
+    domain = phx.domain.DatasetDomain(logits)
+    targets = jnp.asarray([0, 1, 2, 0], dtype=jnp.int32)
+
+    @domain.Function("data")
+    def field(row):
+        return row
+
+    @domain.Function("data")
+    def shifted_field(row):
+        return row + 17.0
+
+    term = phx.terms.SupervisedClassificationTerm(
+        "phase_logits",
+        domain.component(),
+        targets,
+        phx.ml.TargetSchema(
+            "multiclass",
+            names=("phase",),
+            class_labels=("solid", "liquid", "gas"),
+        ),
+        sampling=phx.domain.PointSampling(4, design="uniform"),
+    )
+    batch = term.observed_batch()
+    expected = -jnp.mean(
+        jax.nn.log_softmax(logits, axis=-1)[jnp.arange(targets.size), targets]
+    )
+    metrics = term.data_metrics({"phase_logits": field}, batch=batch)
+
+    np.testing.assert_allclose(term.loss({"phase_logits": field}, batch=batch), expected)
+    np.testing.assert_allclose(
+        term.loss({"phase_logits": shifted_field}, batch=batch), expected, atol=2e-15
+    )
+    np.testing.assert_allclose(metrics["data_negative_log_likelihood"], expected)
+    np.testing.assert_allclose(metrics["data_accuracy"], 1.0)
+    assert bool(metrics["data_valid"])
+
+
+def test_zero_weight_short_circuits_nonfinite_nll_and_gradient():
+    domain = phx.domain.DatasetDomain(jnp.asarray([[1.0], [2.0]]))
+    term = phx.terms.SupervisedClassificationTerm(
+        "u",
+        domain.component(),
+        jnp.asarray([0, 1], dtype=jnp.int32),
+        phx.ml.TargetSchema("binary", class_labels=(0, 1)),
+        sampling=phx.domain.PointSampling(2, design="uniform"),
+        weight=0.0,
+    )
+    batch = term.observed_batch()
+
+    def objective(coefficient):
+        field = domain.Function("data")(
+            lambda row: coefficient * row[0] / jnp.asarray(0.0)
+        )
+        return term.loss({"u": field}, batch=batch)
+
+    value, gradient = jax.value_and_grad(objective)(jnp.asarray(1.0))
+
+    assert value == 0.0
+    assert gradient == 0.0
+    assert jnp.isfinite(gradient)
+
+
+def test_classification_validates_schema_targets_masks_and_output_width():
+    domain = phx.domain.DatasetDomain(jnp.asarray([[2.0], [-1.0], [0.5]]))
+    sampling = phx.domain.PointSampling(3, design="uniform")
+    binary = phx.ml.TargetSchema("binary", class_labels=(0, 1))
+
+    with pytest.raises(ValueError, match="binary and multiclass"):
+        phx.terms.SupervisedClassificationTerm(
+            "u",
+            domain.component(),
+            jnp.asarray([0, 1, 0]),
+            phx.ml.TargetSchema("continuous"),
+            sampling=sampling,
+        )
+    with pytest.raises(ValueError, match="class_labels"):
+        phx.terms.SupervisedClassificationTerm(
+            "u",
+            domain.component(),
+            jnp.asarray([0, 1, 0]),
+            phx.ml.TargetSchema("multiclass"),
+            sampling=sampling,
+        )
+    with pytest.raises(TypeError, match="integer or Boolean"):
+        phx.terms.SupervisedClassificationTerm(
+            "u",
+            domain.component(),
+            jnp.asarray([0.0, 1.0, 0.0]),
+            binary,
+            sampling=sampling,
+        )
+    with pytest.raises(ValueError, match=r"within \[0, 2\)"):
+        phx.terms.SupervisedClassificationTerm(
+            "u",
+            domain.component(),
+            jnp.asarray([0, 2, 0]),
+            binary,
+            sampling=sampling,
+        )
+
+    masked = phx.terms.SupervisedClassificationTerm(
+        "u",
+        domain.component(),
+        jnp.asarray([0, -99, 1]),
+        binary,
+        sampling=sampling,
+        sample_mask=jnp.asarray([True, False, True]),
+    )
+    assert jnp.array_equal(masked.observed_batch().target, jnp.asarray([0, 1]))
+
+    @domain.Function("data")
+    def wrong_width(row):
+        return jnp.asarray([row[0], -row[0], 0.0])
+
+    with pytest.raises(ValueError, match="incompatible"):
+        masked.loss({"u": wrong_width}, batch=masked.observed_batch())

--- a/tests/unit/constraints/test_supervised_likelihood.py
+++ b/tests/unit/constraints/test_supervised_likelihood.py
@@ -1,0 +1,115 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import phydrax as phx
+
+
+def _zero_field(domain):
+    @domain.Function("data")
+    def field(row):
+        return 0.0 * row[0]
+
+    return field
+
+
+def test_supervised_likelihood_preserves_targets_filters_cases_and_weights_risk():
+    rows = jnp.arange(4.0)[:, None]
+    domain = phx.domain.DatasetDomain(rows)
+    targets = jnp.asarray([0, 1, -99, 3], dtype=jnp.int32)
+    sample_mask = jnp.asarray([True, True, False, True])
+    sample_weight = jnp.asarray([1.0, 2.0, jnp.nan, 4.0])
+    likelihood = phx.uq.GaussianLikelihood(1.0)
+    field = _zero_field(domain)
+    term = phx.terms.SupervisedLikelihoodTerm(
+        "u",
+        domain.component(),
+        targets,
+        likelihood,
+        sampling=phx.domain.PointSampling(2, design="uniform"),
+        indices=jnp.asarray([3, 2, 1]),
+        sample_mask=sample_mask,
+        sample_weight=sample_weight,
+    )
+    batch = term.observed_batch()
+    per_case = -likelihood.log_prob(jnp.zeros((2,)), jnp.asarray([3, 1]))
+
+    assert batch.target.dtype == jnp.int32
+    assert jnp.array_equal(batch.indices, jnp.asarray([3, 1]))
+    assert jnp.array_equal(batch.target, jnp.asarray([3, 1]))
+    assert jnp.array_equal(batch.sample_weight, jnp.asarray([4.0, 2.0]))
+    np.testing.assert_allclose(
+        term.log_prob({"u": field}, batch=batch),
+        -per_case,
+        atol=2e-15,
+    )
+    np.testing.assert_allclose(
+        term.loss({"u": field}, batch=batch),
+        jnp.sum(batch.sample_weight * per_case) / jnp.sum(batch.sample_weight),
+        atol=2e-15,
+    )
+
+    summed = phx.terms.SupervisedLikelihoodTerm(
+        "u",
+        domain.component(),
+        targets,
+        likelihood,
+        sampling=phx.domain.PointSampling(2, design="uniform"),
+        indices=jnp.asarray([3, 2, 1]),
+        sample_mask=sample_mask,
+        sample_weight=sample_weight,
+        reduction="sum",
+    )
+    np.testing.assert_allclose(
+        summed.loss({"u": field}, batch=summed.observed_batch()),
+        jnp.sum(jnp.asarray([4.0, 2.0]) * per_case),
+        atol=2e-15,
+    )
+
+
+def test_supervised_likelihood_rejects_invalid_case_masks_and_weights():
+    domain = phx.domain.DatasetDomain(jnp.arange(3.0)[:, None])
+    common = {
+        "sampling": phx.domain.PointSampling(2, design="uniform"),
+    }
+
+    with pytest.raises(TypeError, match="Boolean"):
+        phx.terms.SupervisedLikelihoodTerm(
+            "u",
+            domain.component(),
+            jnp.zeros((3,)),
+            phx.uq.GaussianLikelihood(1.0),
+            sample_mask=jnp.ones((3,)),
+            **common,
+        )
+    with pytest.raises(ValueError, match="non-empty"):
+        phx.terms.SupervisedLikelihoodTerm(
+            "u",
+            domain.component(),
+            jnp.zeros((3,)),
+            phx.uq.GaussianLikelihood(1.0),
+            sample_mask=jnp.zeros((3,), dtype=bool),
+            **common,
+        )
+    with pytest.raises(ValueError, match="strictly positive"):
+        phx.terms.SupervisedLikelihoodTerm(
+            "u",
+            domain.component(),
+            jnp.zeros((3,)),
+            phx.uq.GaussianLikelihood(1.0),
+            sample_weight=jnp.asarray([1.0, 0.0, 1.0]),
+            **common,
+        )
+    with pytest.raises(ValueError, match="shape"):
+        phx.terms.SupervisedLikelihoodTerm(
+            "u",
+            domain.component(),
+            jnp.zeros((3,)),
+            phx.uq.GaussianLikelihood(1.0),
+            sample_weight=jnp.ones((2,)),
+            **common,
+        )

--- a/tests/unit/solver/test_solve_logging.py
+++ b/tests/unit/solver/test_solve_logging.py
@@ -74,6 +74,27 @@ def _make_dataset_solver_with_eval(seed: int = 0) -> FunctionalSolver:
     )
 
 
+def _make_classification_solver(seed: int = 0) -> FunctionalSolver:
+    rows = jnp.asarray([[-1.0], [-0.4], [0.6], [1.2]])
+    domain = DatasetDomain(rows)
+    model = MLP(
+        in_size=1,
+        out_size="scalar",
+        hidden_sizes=(),
+        key=jr.key(seed),
+    )
+    logits = domain.Model("data")(model)
+    classification = phx.terms.SupervisedClassificationTerm(
+        "logits",
+        domain.component(),
+        jnp.asarray([0, 0, 1, 1], dtype=jnp.int32),
+        phx.ml.TargetSchema("binary", class_labels=("negative", "positive")),
+        sampling=PointSampling(4, design="uniform"),
+        label="binary_data",
+    )
+    return FunctionalSolver(functions={"logits": logits}, terms=[classification])
+
+
 def _make_dataset_solver_with_two_train_terms(seed: int = 0) -> FunctionalSolver:
     rows = jnp.linspace(0.0, 1.0, 8).reshape((-1, 1))
     domain = DatasetDomain(rows)
@@ -164,6 +185,27 @@ def test_solve_text_log_includes_observation_data_metrics(tmp_path):
     assert "data_accuracy=" in text
     assert "data_relative_l2_error=" in text
     assert "data_rmse=" in text
+
+
+def test_solve_text_log_includes_classification_data_metrics(tmp_path):
+    solver = _make_classification_solver()
+    log_path = tmp_path / "classification.log"
+
+    solver.solve(
+        num_iter=1,
+        optim=optax.adam(1e-2),
+        seed=0,
+        log_every=1,
+        log_path=log_path,
+    )
+
+    text = log_path.read_text(encoding="utf-8")
+    assert "data_negative_log_likelihood=" in text
+    assert "data_accuracy=" in text
+    assert "data_brier_score=" in text
+    assert "data_effective_weight=" in text
+    assert "data_valid=" in text
+    assert "data_status=" in text
 
 
 def test_solve_text_log_includes_evaluation_terms(tmp_path):

--- a/tests/unit/test_constraint_public_api.py
+++ b/tests/unit/test_constraint_public_api.py
@@ -74,6 +74,7 @@ PUBLIC_TERM_API = {
     "SoftQuantileFunctional",
     "SpatialSinkhornDivergenceTerm",
     "SpatialUnbalancedSinkhornDivergenceTerm",
+    "SupervisedClassificationTerm",
     "SupervisedDatasetBatch",
     "SupervisedDatasetTerm",
     "SupervisedLikelihoodTerm",

--- a/tests/unit/uq/test_categorical_family.py
+++ b/tests/unit/uq/test_categorical_family.py
@@ -66,6 +66,31 @@ def test_categorical_full_logits_are_identified_and_support_is_explicit():
         family.natural_from_logits(jnp.ones((2,)))
 
 
+def test_categorical_gathered_log_prob_preserves_family_invalid_contract():
+    family = phx.uq.CategoricalFamily(3)
+    logits = jnp.asarray(
+        [
+            [10_000.0, -10_000.0, 0.0],
+            [0.2, 0.3, -0.4],
+            [-0.5, 0.8, 0.1],
+            [1.0, -0.7, 0.2],
+        ]
+    )
+    labels = jnp.asarray([0.0, -1.0, 3.0, 1.5])
+    natural = family.natural_from_logits(logits)
+    gathered = family.log_prob_from_logits(logits, labels)
+    generic = family.log_prob(natural, labels)
+
+    np.testing.assert_allclose(gathered, generic, atol=2e-15)
+    assert jnp.isfinite(gathered[0])
+    assert jnp.all(jnp.isneginf(gathered[1:]))
+    np.testing.assert_allclose(
+        family.log_prob_from_logits(logits + 13.0, labels),
+        gathered,
+        atol=2e-12,
+    )
+
+
 def test_categorical_mean_domain_and_projection_report_missing_categories():
     family = phx.uq.CategoricalFamily(3)
     interior = family.mean_domain(family.mean(jnp.asarray([0.2, 0.3])))
@@ -123,6 +148,16 @@ def test_categorical_likelihood_declares_coordinate_and_target_axes():
 
     np.testing.assert_allclose(full.log_prob(logits, labels), expected, atol=2e-15)
     np.testing.assert_allclose(minimal.log_prob(natural, labels), expected, atol=2e-15)
+    np.testing.assert_allclose(
+        full.class_probabilities(logits),
+        minimal.class_probabilities(natural),
+        atol=2e-15,
+    )
+    np.testing.assert_allclose(
+        jnp.sum(full.class_probabilities(logits), axis=-1),
+        jnp.ones((2,)),
+        atol=2e-15,
+    )
     assert full.sample(jr.key(4), logits).shape == labels.shape
     with pytest.raises(ValueError, match="coordinate dimension"):
         full.align_observations(jnp.ones((2, 2)), labels)

--- a/tests/unit/uq/test_posterior_terms.py
+++ b/tests/unit/uq/test_posterior_terms.py
@@ -138,6 +138,7 @@ def test_fixed_supervised_likelihood_preserves_operator_and_ignores_training_wei
         sampling=phx.domain.PointSampling(3, design="uniform"),
         observation_operator=lambda function: 2.0 * function,
         weight=1000.0,
+        sample_weight=jnp.arange(1.0, 7.0),
         reduction="mean",
         label="flux_sensors",
     )
@@ -152,6 +153,39 @@ def test_fixed_supervised_likelihood_preserves_operator_and_ignores_training_wei
     assert observed.shape == (6,)
     assert jnp.allclose(observed, expected)
     assert jnp.allclose(term.log_prob(jnp.asarray(2.0)), expected.sum())
+
+
+def test_fixed_supervised_likelihood_accepts_classification_sibling():
+    logits = jnp.asarray([[2.0, -1.0, 0.2], [-0.5, 1.4, 0.1], [0.0, -0.3, 1.7]])
+    targets = jnp.asarray([0, 1, 2], dtype=jnp.int32)
+    domain = phx.domain.DatasetDomain(logits)
+
+    @domain.Function("data")
+    def field(row):
+        return row
+
+    supervised = phx.terms.SupervisedClassificationTerm(
+        "phase",
+        domain.component(),
+        targets,
+        phx.ml.TargetSchema(
+            "multiclass",
+            class_labels=("solid", "liquid", "gas"),
+        ),
+        sampling=phx.domain.PointSampling(3, design="uniform"),
+        weight=50.0,
+        sample_weight=jnp.asarray([3.0, 2.0, 1.0]),
+        label="phase_sensors",
+    )
+    term = phx.uq.FixedSupervisedLikelihood(
+        supervised,
+        lambda _: {"phase": field},
+    )
+    expected = jax.nn.log_softmax(logits, axis=-1)[jnp.arange(targets.size), targets]
+
+    assert term.label == "phase_sensors"
+    assert jnp.allclose(term.per_case_log_prob(None), expected)
+    assert jnp.allclose(term.log_prob(None), jnp.sum(expected))
 
 
 def test_composite_terms_construct_problem_without_hidden_reweighting():


### PR DESCRIPTION
## Summary

- add `phydrax.terms.SupervisedClassificationTerm` for likelihood-backed binary and mutually exclusive multiclass supervision on `DatasetDomain`
- compose classification risk with ordinary `FunctionalSolver` physics terms while retaining posterior-compatible raw likelihood semantics
- add explicit empirical case masks, positive statistical sample weights, weighted reductions, and classification diagnostics
- specialize categorical hard-label evaluation with gathered logits instead of one-hot target allocation

## Public classification contract

`SupervisedClassificationTerm` consumes encoded targets plus an existing `TargetSchema`:

- `kind="binary"` binds one scalar model output to Bernoulli log-odds
- `kind="multiclass"` binds the final model-output axis to full categorical logits and requires the complete class vocabulary
- active targets must be integer or Boolean encoded indices; masked rows are removed before likelihood arithmetic
- `indices` defines train/evaluation subsets, `sample_mask` excludes rows, `sample_weight` defines positive statistical risk weights, and scalar `weight` composes the complete term with other objectives

The term reports negative log likelihood, exact accuracy, Brier score, effective weight, validity, and status from the exact prepared mini-batch used by the objective.

## Likelihood and posterior semantics

- preserve supervised target dtype through sampled batches
- keep `log_prob(...)` unweighted and unreduced per empirical case so optimizer weights never silently become likelihood powers
- refactor the dataset-likelihood implementation into a private strict abstract base with `SupervisedLikelihoodTerm` and `SupervisedClassificationTerm` as sibling concrete terms
- allow `FixedSupervisedLikelihood` to consume either sibling without exposing the private base publicly
- use `jax.lax.cond` to bypass likelihood evaluation for zero-weight terms, preventing disabled nonfinite predictions from contaminating values or gradients

## Categorical contracts

- add `CategoricalFamily.log_prob_from_logits(...)` using direct target-logit gathering
- preserve the exponential-family invalid-observation contract: invalid labels produce negative-infinite log probability
- add categorical-specific `class_probabilities(...)` without claiming a generic distributional mean for likelihood families where one may not exist
- retain equivalent full-logit and identified natural-coordinate behavior

## Scope

This change intentionally supports canonical binary and mutually exclusive multiclass classification only. Independent multilabel, ordinal, structured-geometry, focal, overlap, and soft-target objectives remain separate future mathematical surfaces rather than implicit modes of this term.

## Documentation

Update the domain, solver, ML, uncertainty, scalar-term API, package catalog, and changelog surfaces with the new contracts and weighting distinctions.