### PR TITLE
feat(solver): add real-imaginary Diffrax state packing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
   conjugacy-preserving modal spatial noise; internal-linalg Galerkin, boundary-lift,
   and generalized tau formulations; and diagonal ETDRK2/4 integration with shared
   stable phi-three matrix actions.
+- Added explicit real/imaginary Diffrax state packing for complex ODE, split, CDE,
+  and stochastic paths. Public states remain complex; temporal evidence records the
+  doubled real backend shape, dtype, tolerance geometry, and policy, while native and
+  reject strategies remain explicit.
 - Added public callable adaptive interval and triangle engines that reuse
   `AdaptiveQuadraturePlan`, `AdaptiveTrianglePlan`, `IntegrationPrecisionPolicy`,
   `IntegrationEstimate`, bounded partitions, statuses, and error-kind diagnostics.

--- a/docs/api/solver/differential.md
+++ b/docs/api/solver/differential.md
@@ -123,6 +123,40 @@ solve. Native implicit methods likewise require coefficient, stage, and residual
 precision to match storage while permitting wider accumulation and decisions.
 Dense output applies the declared output dtype instead of leaking backend storage.
 
+### Complex Diffrax state representation
+
+`solve_diffrax`, `solve_diffrax_ensemble`, and `solve_diffrax_cde` keep their public
+state complex while defaulting Diffrax execution to one real array with shape
+`(2,) + state_shape`. The leading entries are the real and imaginary components.
+Drift, diffusion, events, dense interpolation, arguments, and saved trajectories are
+adapted at the backend boundary; the packed axis never appears in
+`DifferentialSolution`.
+
+For a complex diffusion with shape `state_shape + noise_shape`, the backend diffusion
+has shape `(2,) + state_shape + noise_shape`. Both components use the same real
+Wiener controls. This realizes the complex SDE as one coupled real system and avoids
+Diffrax's native array contraction conjugating a complex diffusion column.
+
+Adaptive tolerances use componentwise real geometry over the doubled system.
+`TemporalSolveEvidence.state_packing` records the public/backend dtypes and shapes,
+tolerance geometry, policy, and realized adapter identity.
+
+`DiffraxComplexStatePolicy` provides three explicit strategies:
+
+- `\"real_imag\"` is the default safe adapter;
+- `\"native\"` opts into Diffrax's native complex path and its upstream limitation;
+- `\"reject\"` refuses complex initial state.
+
+Real states retain the native path and existing configuration identity. Nontrivial
+state geometry is not silently doubled: real/imaginary packing rejects it until an
+explicit product-geometry contract exists.
+
+::: phydrax.solver.DiffraxComplexStatePolicy
+
+---
+
+::: phydrax.solver.ComplexStatePackingEvidence
+
 ## Markov cubature weak solve
 
 `solve_markov_cubature` consumes the same stochastic `DifferentialProblem`, but

--- a/docs/cookbook/stochastic_dynamics.md
+++ b/docs/cookbook/stochastic_dynamics.md
@@ -422,6 +422,12 @@ at physical boundaries. Fourier noise modes are projections of real
 weighted-orthonormal eigenfunctions, so their complex columns preserve conjugate
 symmetry under real Wiener coefficients.
 
+The returned trajectories remain complex modal arrays. Internally, the standard
+Diffrax backend stacks real and imaginary components along one leading size-two axis,
+uses the same real Wiener increment for both, and removes that axis before returning
+the solution. `solution.temporal_evidence.state_packing` records this realized
+representation.
+
 Uniform periodic finite differences use `periodic_finite_difference`; bounded FD2
 operators can use `diagonalize_fd_laplacian`. `EigenbasisDiscretization` reuses a
 precomputed `phydrax.discretization.SpectralDecomposition` while preserving

--- a/docs/guides_solver_substrates.md
+++ b/docs/guides_solver_substrates.md
@@ -221,6 +221,20 @@ coarse pseudoinverse. V/W/F/full cycle semantics come from the generic
 `FDExecutionPrecisionPolicy`; compatibility, gauge, and residual-norm decisions
 remain in its certification precision.
 
+## Temporal backend state representation
+
+`DifferentialProblem` owns the public state dtype and shape independently of the
+temporal backend representation. Standard Diffrax solves preserve real states
+natively. Complex states default to `DiffraxComplexStatePolicy(\"real_imag\")`, which
+prepares a real backend state with shape `(2,) + state_shape`, componentwise real
+adaptive tolerance geometry, and explicit packing evidence.
+
+Vector fields, stochastic coefficients, complex argument leaves, events, dense
+interpolation, and saved trajectories cross this boundary through one prepared
+adapter. Diffusion control axes remain trailing, so both real components contract
+against the same declared Wiener controls. Nontrivial state geometry and the separate
+delay/jump Diffrax backends are not assigned an inferred packing contract.
+
 ## Execution, distribution, and production lifecycle
 
 `StencilExecutionPlan` lowers regular interiors to one offset/weight kernel and retains

--- a/docs/guides_spectral_methods.md
+++ b/docs/guides_spectral_methods.md
@@ -102,11 +102,11 @@ weighted-orthonormal Laplacian modes and then projects them into full complex
 storage. Its complex modal columns preserve conjugate symmetry under real Wiener
 coefficients; independent one-sided Fourier modes are never substituted.
 
-!!! warning
-    Diffrax currently labels complex-dtype integration as work in progress. The
-    conjugate-symmetric spectral SPDE paths are covered by replay, reality, and
-    analytic-moment tests, but Phydrax does not strengthen that upstream guarantee.
-    Use an explicitly real-valued state formulation when that guarantee is required.
+Diffrax solves keep this public modal state complex but execute it as one coupled
+real system with backend shape `(2,) + modal_shape`. The adapter applies the same
+real Wiener controls to both components and reconstructs complex states before every
+spectral callback, event, dense query, and saved output. Explicit native-complex and
+reject policies remain available through `DiffraxComplexStatePolicy`.
 
 The compiled state is modal. Use `compiled.project_state` for initial data and
 `compiled.reconstruct_state` for observables and output. Constant-coefficient scalar

--- a/phydrax/_temporal_precision.py
+++ b/phydrax/_temporal_precision.py
@@ -203,6 +203,15 @@ class TemporalPrecisionPolicy(StrictModule, NonTrainableState):
     ) -> None:
         observed = self.validate_state(state)
         state_real = _real_component(observed)
+        if (
+            observed != state_real
+            and self.output_dtype is not None
+            and _real_component(self.output_dtype) == self.output_dtype
+        ):
+            raise ValueError(
+                "Complex Diffrax state requires a complex output dtype; explicit "
+                "real/imaginary projection belongs outside the temporal backend."
+            )
         coefficient = (
             state_real if self.coefficient_dtype is None else self.coefficient_dtype
         )

--- a/phydrax/solver/__init__.py
+++ b/phydrax/solver/__init__.py
@@ -211,6 +211,11 @@ from ._differential_algebraic import (
 from ._diffrax_backend import solve_diffrax, solve_diffrax_ensemble
 from ._diffrax_cde import ControlledDifferentialSolution, solve_diffrax_cde
 from ._diffrax_delay_backend import solve_diffrax_delay
+from ._diffrax_state_packing import (
+    ComplexStatePackingEvidence,
+    DiffraxComplexStatePolicy,
+    DiffraxComplexStateStrategy,
+)
 from ._driving_path import (
     AbstractDifferentiableDrivingPath,
     CallableDrivingPath,
@@ -1049,6 +1054,9 @@ __all__ = [
     "TemporalEquationForm",
     "TemporalMethodCapabilities",
     "TemporalMethodClass",
+    "ComplexStatePackingEvidence",
+    "DiffraxComplexStatePolicy",
+    "DiffraxComplexStateStrategy",
     "TemporalSolveEvidence",
     "TemporalPrecisionPolicy",
     "ThetaMethod",

--- a/phydrax/solver/_diffrax_backend.py
+++ b/phydrax/solver/_diffrax_backend.py
@@ -17,6 +17,12 @@ from jaxtyping import Array, ArrayLike
 from ..stochastic import WienerRealization
 from ._differential import DifferentialProblem, DifferentialSolution
 from ._differential_ir import lower_deterministic_problem
+from ._diffrax_state_packing import (
+    _prepare_diffrax_state_adapter,
+    _PreparedDiffraxStateAdapter,
+    _validate_real_backend_tree,
+    DiffraxComplexStatePolicy,
+)
 from ._geometric import (
     AbstractGeometricSolver,
     CommutatorFreeSolver,
@@ -62,6 +68,7 @@ class _VectorizedDenseInterpolation(eqx.Module):
 
     interpolation: dfx.DenseInterpolation
     precision: TemporalPrecisionPolicy
+    state_adapter: _PreparedDiffraxStateAdapter
     sample_shape: tuple[int, ...] = eqx.field(static=True)
 
     def __init__(
@@ -69,6 +76,7 @@ class _VectorizedDenseInterpolation(eqx.Module):
         interpolation: dfx.DenseInterpolation,
         sample_shape: tuple[int, ...],
         precision: TemporalPrecisionPolicy,
+        state_adapter: _PreparedDiffraxStateAdapter,
         /,
     ):
         samples = tuple(int(size) for size in sample_shape)
@@ -85,6 +93,7 @@ class _VectorizedDenseInterpolation(eqx.Module):
             is_leaf=eqx.is_array,
         )
         self.precision = precision
+        self.state_adapter = state_adapter
         self.sample_shape = samples
 
     @eqx.filter_jit
@@ -125,6 +134,7 @@ class _VectorizedDenseInterpolation(eqx.Module):
                 lambda time: interpolation.evaluate(time, left=left)
             )(flat_times)
         )(self.interpolation)
+        values = self.state_adapter.unpack_values(values, 2)
         return self.precision.output(
             values.reshape(self.sample_shape + query.shape + values.shape[2:])
         )
@@ -159,19 +169,29 @@ def _realized_wiener_path(
     return brownian, jnp.asarray(path_sign, dtype=dtype)
 
 
-def _vector_field(function):
+def _vector_field(function, state_adapter: _PreparedDiffraxStateAdapter, /):
     def evaluate(t, state, args):
-        return jnp.asarray(function(t, state, args))
+        public_state = state_adapter.unpack_state(state)
+        public_args = state_adapter.unpack_args(args)
+        value = function(t, public_state, public_args)
+        return state_adapter.pack_state(value, owner="Vector field")
 
     return evaluate
 
 
-def _combined_diffusion(problem: DifferentialProblem, path_sign: Array, /):
+def _combined_diffusion(
+    problem: DifferentialProblem,
+    path_sign: Array,
+    state_adapter: _PreparedDiffraxStateAdapter,
+    /,
+):
     def evaluate(time, state, args):
-        state_shape = tuple(jnp.shape(state))
+        public_state = state_adapter.unpack_state(state)
+        public_args = state_adapter.unpack_args(args)
+        state_shape = tuple(jnp.shape(public_state))
         columns = []
         for term in problem.wiener_terms:
-            value = jnp.asarray(term.coefficient(time, state, args))
+            value = jnp.asarray(term.coefficient(time, public_state, public_args))
             expected_shape = state_shape + term.noise_shape
             if tuple(value.shape) != expected_shape:
                 raise ValueError(
@@ -179,7 +199,8 @@ def _combined_diffusion(problem: DifferentialProblem, path_sign: Array, /):
                     f"{expected_shape}; got {value.shape}."
                 )
             columns.append(value.reshape(state_shape + (term.noise_size,)))
-        return path_sign * jnp.concatenate(columns, axis=-1)
+        combined = path_sign * jnp.concatenate(columns, axis=-1)
+        return state_adapter.pack_diffusion(combined, problem.noise_shape)
 
     return evaluate
 
@@ -515,6 +536,7 @@ def _solve_evidence(
     adjoint: Any,
     event: Any | None,
     precision: TemporalPrecisionPolicy,
+    state_adapter: _PreparedDiffraxStateAdapter,
     /,
     *,
     rtol: float,
@@ -531,6 +553,9 @@ def _solve_evidence(
     controller_id = configuration_id(controller, prefix="controller")
     adjoint_id = configuration_id(adjoint, prefix="adjoint")
     event_id = None if event is None else configuration_id(event, prefix="event")
+    adapter_configuration = (
+        () if state_adapter.evidence is None else (state_adapter.evidence.evidence_id,)
+    )
     resolved_configuration_id = (
         explicit_configuration_id
         if explicit_configuration_id is not None
@@ -546,7 +571,8 @@ def _solve_evidence(
                 bool(dense),
                 max_steps,
                 precision.policy_id,
-            ),
+            )
+            + adapter_configuration,
             prefix="temporal-configuration",
         )
     )
@@ -565,6 +591,7 @@ def _solve_evidence(
             problem.initial_state,
             problem.t0,
         ),
+        state_packing=state_adapter.evidence,
     )
 
 
@@ -577,6 +604,7 @@ def _native_solution(
     path_sign: Array | None,
     solver: Any,
     precision: TemporalPrecisionPolicy,
+    state_adapter: _PreparedDiffraxStateAdapter,
     stepsize_controller: Any,
     adjoint: Any,
     dt0: ArrayLike | None,
@@ -591,8 +619,8 @@ def _native_solution(
         lowered = lower_deterministic_problem(problem)
         assert lowered.implicit_rhs is not None
         terms = dfx.MultiTerm(
-            dfx.ODETerm(_vector_field(lowered.explicit_rhs)),
-            dfx.ODETerm(_vector_field(lowered.implicit_rhs)),
+            dfx.ODETerm(_vector_field(lowered.explicit_rhs, state_adapter)),
+            dfx.ODETerm(_vector_field(lowered.implicit_rhs, state_adapter)),
         )
         start = problem.t0
         end = problem.t1
@@ -623,9 +651,9 @@ def _native_solution(
             real_dtype,
         )
         terms = dfx.MultiTerm(
-            dfx.ODETerm(_vector_field(problem.drift)),
+            dfx.ODETerm(_vector_field(problem.drift, state_adapter)),
             dfx.ControlTerm(
-                _combined_diffusion(problem, signed_path),
+                _combined_diffusion(problem, signed_path, state_adapter),
                 brownian,
             ),
         )
@@ -636,7 +664,7 @@ def _native_solution(
         end = problem.t1
         resolved_dt0 = dt0
         lowered = lower_deterministic_problem(problem)
-        terms = dfx.ODETerm(_vector_field(lowered.explicit_rhs))
+        terms = dfx.ODETerm(_vector_field(lowered.explicit_rhs, state_adapter))
     time_dtype = jnp.asarray(problem.initial_state).real.dtype
     start = precision.coefficient(jnp.asarray(start, dtype=time_dtype))
     end = precision.coefficient(jnp.asarray(end, dtype=time_dtype))
@@ -646,18 +674,26 @@ def _native_solution(
         if resolved_dt0 is None
         else precision.coefficient(jnp.asarray(resolved_dt0, dtype=time_dtype))
     )
+    backend_state = state_adapter.pack_state(
+        problem.initial_state,
+        owner="Initial state",
+    )
+    backend_args = state_adapter.pack_args(problem.args)
+    backend_event = state_adapter.wrap_event(event)
+    if state_adapter.active:
+        _validate_real_backend_tree((terms, backend_state, backend_args))
     return dfx.diffeqsolve(
         terms,
         solver,
         t0=start,
         t1=end,
         dt0=resolved_dt0,
-        y0=problem.initial_state,
-        args=problem.args,
+        y0=backend_state,
+        args=backend_args,
         saveat=dfx.SaveAt(ts=save_times, dense=dense),
         stepsize_controller=stepsize_controller,
         adjoint=adjoint,
-        event=event,
+        event=backend_event,
         max_steps=max_steps,
         throw=bool(throw),
     )
@@ -675,12 +711,18 @@ def _dense_interpolation(
     native: Any,
     sample_shape: tuple[int, ...],
     precision: TemporalPrecisionPolicy,
+    state_adapter: _PreparedDiffraxStateAdapter,
     /,
 ) -> Any:
     interpolation = native.interpolation
     if interpolation is None:
         raise RuntimeError("Diffrax did not return the requested dense interpolation.")
-    return _VectorizedDenseInterpolation(interpolation, sample_shape, precision)
+    return _VectorizedDenseInterpolation(
+        interpolation,
+        sample_shape,
+        precision,
+        state_adapter,
+    )
 
 
 def _reshape_native_sample_shape(native: Any, sample_shape: tuple[int, ...], /) -> Any:
@@ -717,6 +759,7 @@ def solve_diffrax(
     throw: bool = False,
     solver_configuration_id: str | None = None,
     precision: TemporalPrecisionPolicy | None = None,
+    complex_state_policy: DiffraxComplexStatePolicy | None = None,
 ) -> DifferentialSolution:
     """Solve one explicit, additive-split, or stochastic differential problem."""
     if not isinstance(problem, (DifferentialProblem, SplitDifferentialProblem)):
@@ -746,6 +789,15 @@ def solve_diffrax(
         internal_precision=isinstance(selected_solver, (SSPRK33, SSPRK54)),
     )
     _validated_state_geometry_solver(problem, selected_solver)
+    state_adapter = _prepare_diffrax_state_adapter(
+        problem.initial_state,
+        complex_state_policy,
+        problem.state_geometry,
+    )
+    if state_adapter.active and isinstance(selected_solver, AbstractGeometricSolver):
+        raise ValueError(
+            "Real/imaginary packing does not support geometric Diffrax solvers."
+        )
     if isinstance(selected_solver, AbstractGeometricSolver) and dt0 is None:
         raise ValueError("Geometric solvers require an explicit fixed dt0.")
     if realization is not None:
@@ -767,6 +819,7 @@ def solve_diffrax(
         selected_adjoint,
         event,
         precision,
+        state_adapter,
         rtol=rtol,
         atol=atol,
         dt0=dt0,
@@ -782,6 +835,7 @@ def solve_diffrax(
         path_sign=None if realization is None else realization.path_signs,
         solver=selected_solver,
         precision=precision,
+        state_adapter=state_adapter,
         stepsize_controller=controller,
         adjoint=selected_adjoint,
         dt0=dt0,
@@ -791,13 +845,15 @@ def solve_diffrax(
         throw=throw,
     )
     native_times = jnp.asarray(native.ts)
-    native_states = precision.output(native.ys)
+    native_states = precision.output(state_adapter.unpack_values(native.ys, 1))
     solver_id, resolved_method = _solver_provenance(selected_solver)
     return DifferentialSolution(
         times=native_times,
         states=native_states,
         valid=_valid_values(native_times, native_states, sample_ndim=0),
-        interpolation=_dense_interpolation(native, (), precision) if dense else None,
+        interpolation=(
+            _dense_interpolation(native, (), precision, state_adapter) if dense else None
+        ),
         backend_result=native.result,
         stats=native.stats,
         event_mask=native.event_mask,
@@ -834,6 +890,7 @@ def solve_diffrax_ensemble(
     throw: bool = False,
     solver_configuration_id: str | None = None,
     precision: TemporalPrecisionPolicy | None = None,
+    complex_state_policy: DiffraxComplexStatePolicy | None = None,
 ) -> DifferentialSolution:
     """Solve the coupled SDE batch encoded by one Wiener realization."""
     if not isinstance(problem, DifferentialProblem):
@@ -856,6 +913,15 @@ def solve_diffrax_ensemble(
         internal_precision=isinstance(selected_solver, (SSPRK33, SSPRK54)),
     )
     _validated_state_geometry_solver(problem, selected_solver)
+    state_adapter = _prepare_diffrax_state_adapter(
+        problem.initial_state,
+        complex_state_policy,
+        problem.state_geometry,
+    )
+    if state_adapter.active and isinstance(selected_solver, AbstractGeometricSolver):
+        raise ValueError(
+            "Real/imaginary packing does not support geometric Diffrax solvers."
+        )
     _validated_stochastic_solver(problem, selected_solver, realization)
     _validated_method_form(problem, selected_solver)
     controller = _resolved_controller(
@@ -874,6 +940,7 @@ def solve_diffrax_ensemble(
         selected_adjoint,
         event,
         precision,
+        state_adapter,
         rtol=rtol,
         atol=atol,
         dt0=dt0,
@@ -895,6 +962,7 @@ def solve_diffrax_ensemble(
             path_sign=sign,
             solver=selected_solver,
             precision=precision,
+            state_adapter=state_adapter,
             stepsize_controller=controller,
             adjoint=selected_adjoint,
             dt0=dt0,
@@ -909,7 +977,12 @@ def solve_diffrax_ensemble(
         realization.sample_shape,
     )
     native_times = jnp.asarray(native.ts)
-    native_states = precision.output(native.ys)
+    native_states = precision.output(
+        state_adapter.unpack_values(
+            native.ys,
+            len(realization.sample_shape) + 1,
+        )
+    )
     solver_id, resolved_method = _solver_provenance(selected_solver)
     return DifferentialSolution(
         times=native_times,
@@ -921,7 +994,12 @@ def solve_diffrax_ensemble(
         ),
         sample_shape=realization.sample_shape,
         interpolation=(
-            _dense_interpolation(native, realization.sample_shape, precision)
+            _dense_interpolation(
+                native,
+                realization.sample_shape,
+                precision,
+                state_adapter,
+            )
             if dense
             else None
         ),

--- a/phydrax/solver/_diffrax_cde.py
+++ b/phydrax/solver/_diffrax_cde.py
@@ -18,6 +18,7 @@ from .._strict import StrictModule
 from ..stochastic import AbstractRoughControl
 from ._differential import DifferentialProblem, DifferentialSolution
 from ._diffrax_backend import solve_diffrax
+from ._diffrax_state_packing import DiffraxComplexStatePolicy
 from ._driving_path import (
     AbstractDifferentiableDrivingPath,
     CallableDrivingPath,
@@ -252,6 +253,7 @@ def solve_diffrax_cde(
     dense: bool = False,
     max_steps: int | None = 4096,
     throw: bool = False,
+    complex_state_policy: DiffraxComplexStatePolicy | None = None,
 ) -> ControlledDifferentialSolution:
     """Solve a smooth controlled differential equation through ``solve_diffrax``.
 
@@ -305,6 +307,7 @@ def solve_diffrax_cde(
         dense=dense,
         max_steps=max_steps,
         throw=throw,
+        complex_state_policy=complex_state_policy,
     )
     return ControlledDifferentialSolution(
         solution,

--- a/phydrax/solver/_diffrax_state_packing.py
+++ b/phydrax/solver/_diffrax_state_packing.py
@@ -1,0 +1,353 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from typing import Any, Literal, TypeAlias
+
+import diffrax as dfx
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array, ArrayLike
+
+from .._fingerprint import canonical_fingerprint
+from .._precision import precision_dtype_name
+from .._strict import StrictModule
+from .._trainable import NonTrainableState
+
+
+DiffraxComplexStateStrategy: TypeAlias = Literal["real_imag", "native", "reject"]
+RealizedDiffraxStateStrategy: TypeAlias = Literal["real_imag", "native"]
+ToleranceGeometry: TypeAlias = Literal["componentwise_real", "backend_native"]
+
+
+class DiffraxComplexStatePolicy(StrictModule, NonTrainableState):
+    """Select the backend representation used for a complex Diffrax state."""
+
+    strategy: DiffraxComplexStateStrategy = eqx.field(static=True)
+    policy_id: str = eqx.field(static=True)
+
+    def __init__(self, strategy: DiffraxComplexStateStrategy = "real_imag"):
+        if strategy not in ("real_imag", "native", "reject"):
+            raise ValueError(
+                "Diffrax complex-state strategy must be 'real_imag', 'native', or "
+                "'reject'."
+            )
+        self.strategy = strategy
+        self.policy_id = canonical_fingerprint(
+            {
+                "kind": "diffrax-complex-state-policy",
+                "strategy": strategy,
+            }
+        )
+
+
+class ComplexStatePackingEvidence(StrictModule, NonTrainableState):
+    """Realized public-to-backend representation for one complex state."""
+
+    strategy: RealizedDiffraxStateStrategy = eqx.field(static=True)
+    public_dtype: str = eqx.field(static=True)
+    backend_dtype: str = eqx.field(static=True)
+    public_shape: tuple[int, ...] = eqx.field(static=True)
+    backend_shape: tuple[int, ...] = eqx.field(static=True)
+    tolerance_geometry: ToleranceGeometry = eqx.field(static=True)
+    policy_id: str = eqx.field(static=True)
+    evidence_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        strategy: RealizedDiffraxStateStrategy,
+        public_dtype: str,
+        backend_dtype: str,
+        public_shape: tuple[int, ...],
+        backend_shape: tuple[int, ...],
+        tolerance_geometry: ToleranceGeometry,
+        policy_id: str,
+    ):
+        if strategy not in ("real_imag", "native"):
+            raise ValueError("Unknown realized Diffrax state strategy.")
+        if tolerance_geometry not in ("componentwise_real", "backend_native"):
+            raise ValueError("Unknown Diffrax tolerance geometry.")
+        public_shape_ = tuple(int(size) for size in public_shape)
+        backend_shape_ = tuple(int(size) for size in backend_shape)
+        if any(size <= 0 for size in public_shape_ + backend_shape_):
+            raise ValueError("State packing shapes must contain positive dimensions.")
+        if not public_dtype or not backend_dtype or not policy_id:
+            raise ValueError("State packing dtype and policy IDs must be non-empty.")
+        self.strategy = strategy
+        self.public_dtype = public_dtype
+        self.backend_dtype = backend_dtype
+        self.public_shape = public_shape_
+        self.backend_shape = backend_shape_
+        self.tolerance_geometry = tolerance_geometry
+        self.policy_id = policy_id
+        self.evidence_id = canonical_fingerprint(
+            {
+                "kind": "complex-state-packing-evidence",
+                "strategy": strategy,
+                "public_dtype": public_dtype,
+                "backend_dtype": backend_dtype,
+                "public_shape": list(public_shape_),
+                "backend_shape": list(backend_shape_),
+                "tolerance_geometry": tolerance_geometry,
+                "policy": policy_id,
+            }
+        )
+
+
+class _PackedComplexLeaf(StrictModule):
+    real: Array
+    imag: Array
+
+    def __init__(self, value: ArrayLike, /):
+        array = jnp.asarray(value)
+        if not jnp.iscomplexobj(array):
+            raise TypeError("Packed argument leaves must be complex-valued.")
+        self.real = jnp.real(array)
+        self.imag = jnp.imag(array)
+
+
+def _is_complex_arraylike(value: Any, /) -> bool:
+    return bool(eqx.is_array_like(value) and jnp.iscomplexobj(value))
+
+
+def _pack_complex_tree(tree: Any, /) -> Any:
+    return jax.tree.map(
+        lambda value: (
+            _PackedComplexLeaf(value) if _is_complex_arraylike(value) else value
+        ),
+        tree,
+        is_leaf=_is_complex_arraylike,
+    )
+
+
+def _unpack_complex_tree(tree: Any, /) -> Any:
+    return jax.tree.map(
+        lambda value: (
+            jax.lax.complex(value.real, value.imag)
+            if isinstance(value, _PackedComplexLeaf)
+            else value
+        ),
+        tree,
+        is_leaf=lambda value: isinstance(value, _PackedComplexLeaf),
+    )
+
+
+class _PackedEventCondition(eqx.Module):
+    condition: Any
+    adapter: "_PreparedDiffraxStateAdapter"
+
+    def __init__(self, condition: Any, adapter: "_PreparedDiffraxStateAdapter", /):
+        self.condition = _pack_complex_tree(condition)
+        self.adapter = adapter
+
+    def __call__(self, t, y, args, **kwargs):
+        condition = _unpack_complex_tree(self.condition)
+        return condition(
+            t,
+            self.adapter.unpack_state(y),
+            self.adapter.unpack_args(args),
+            **kwargs,
+        )
+
+
+class _PreparedDiffraxStateAdapter(StrictModule, NonTrainableState):
+    """Prepared identity or leading-axis real/imaginary state representation."""
+
+    mode: RealizedDiffraxStateStrategy = eqx.field(static=True)
+    state_shape: tuple[int, ...] = eqx.field(static=True)
+    backend_shape: tuple[int, ...] = eqx.field(static=True)
+    public_dtype: str = eqx.field(static=True)
+    backend_dtype: str = eqx.field(static=True)
+    evidence: ComplexStatePackingEvidence | None
+
+    def __init__(
+        self,
+        *,
+        mode: RealizedDiffraxStateStrategy,
+        state_shape: tuple[int, ...],
+        public_dtype: str,
+        backend_dtype: str,
+        evidence: ComplexStatePackingEvidence | None,
+    ):
+        shape = tuple(int(size) for size in state_shape)
+        if any(size <= 0 for size in shape):
+            raise ValueError("Diffrax state shape must contain positive dimensions.")
+        if mode not in ("real_imag", "native"):
+            raise ValueError("Unknown prepared Diffrax state mode.")
+        self.mode = mode
+        self.state_shape = shape
+        self.backend_shape = (2,) + shape if mode == "real_imag" else shape
+        self.public_dtype = public_dtype
+        self.backend_dtype = backend_dtype
+        self.evidence = evidence
+
+    @property
+    def active(self) -> bool:
+        return self.mode == "real_imag"
+
+    def _public_value(self, value: ArrayLike, owner: str, /) -> Array:
+        array = jnp.asarray(value)
+        if tuple(array.shape) != self.state_shape:
+            raise ValueError(
+                f"{owner} must have public state shape {self.state_shape}; "
+                f"got {array.shape}."
+            )
+        return array.astype(jnp.dtype(self.public_dtype))
+
+    def pack_state(self, value: ArrayLike, /, *, owner: str = "State") -> Array:
+        array = self._public_value(value, owner)
+        if not self.active:
+            return array
+        return jnp.stack((jnp.real(array), jnp.imag(array)), axis=0)
+
+    def unpack_state(self, value: ArrayLike, /) -> Array:
+        array = jnp.asarray(value)
+        if tuple(array.shape) != self.backend_shape:
+            raise ValueError(
+                f"Packed backend state must have shape {self.backend_shape}; "
+                f"got {array.shape}."
+            )
+        if not self.active:
+            return array
+        return jax.lax.complex(array[0], array[1])
+
+    def pack_diffusion(
+        self,
+        value: ArrayLike,
+        noise_shape: tuple[int, ...],
+        /,
+    ) -> Array:
+        array = jnp.asarray(value)
+        expected = self.state_shape + tuple(int(size) for size in noise_shape)
+        if tuple(array.shape) != expected:
+            raise ValueError(
+                f"Diffusion must have public state-plus-noise shape {expected}; "
+                f"got {array.shape}."
+            )
+        array = array.astype(jnp.dtype(self.public_dtype))
+        if not self.active:
+            return array
+        return jnp.stack((jnp.real(array), jnp.imag(array)), axis=0)
+
+    def unpack_values(self, value: ArrayLike, pair_axis: int, /) -> Array:
+        array = jnp.asarray(value)
+        if not self.active:
+            return array
+        axis = int(pair_axis)
+        if axis < 0:
+            axis += array.ndim
+        if axis < 0 or axis >= array.ndim or int(array.shape[axis]) != 2:
+            raise ValueError(
+                "Packed Diffrax values must expose one size-two real/imaginary axis."
+            )
+        real = jnp.take(array, 0, axis=axis)
+        imag = jnp.take(array, 1, axis=axis)
+        return jax.lax.complex(real, imag)
+
+    def pack_args(self, args: Any, /) -> Any:
+        return _pack_complex_tree(args) if self.active else args
+
+    def unpack_args(self, args: Any, /) -> Any:
+        return _unpack_complex_tree(args) if self.active else args
+
+    def wrap_event(self, event: Any | None, /) -> Any | None:
+        if event is None or not self.active:
+            return event
+        if not isinstance(event, dfx.Event):
+            raise TypeError(
+                "Complex packed Diffrax solves require event to be diffrax.Event or None."
+            )
+        conditions = jax.tree.map(
+            lambda condition: _PackedEventCondition(condition, self),
+            event.cond_fn,
+            is_leaf=callable,
+        )
+        return dfx.Event(
+            conditions,
+            root_finder=event.root_finder,
+            direction=event.direction,
+        )
+
+
+def _prepare_diffrax_state_adapter(
+    initial_state: ArrayLike,
+    policy: DiffraxComplexStatePolicy | None,
+    state_geometry: Any | None,
+    /,
+) -> _PreparedDiffraxStateAdapter:
+    state = jnp.asarray(initial_state)
+    shape = tuple(int(size) for size in state.shape)
+    public_dtype = precision_dtype_name(state.dtype)
+    resolved = DiffraxComplexStatePolicy() if policy is None else policy
+    if not isinstance(resolved, DiffraxComplexStatePolicy):
+        raise TypeError("complex_state_policy must be DiffraxComplexStatePolicy or None.")
+    if not jnp.iscomplexobj(state):
+        return _PreparedDiffraxStateAdapter(
+            mode="native",
+            state_shape=shape,
+            public_dtype=public_dtype,
+            backend_dtype=public_dtype,
+            evidence=None,
+        )
+    if resolved.strategy == "reject":
+        raise ValueError("Complex Diffrax state was rejected by the selected policy.")
+    if resolved.strategy == "native":
+        evidence = ComplexStatePackingEvidence(
+            strategy="native",
+            public_dtype=public_dtype,
+            backend_dtype=public_dtype,
+            public_shape=shape,
+            backend_shape=shape,
+            tolerance_geometry="backend_native",
+            policy_id=resolved.policy_id,
+        )
+        return _PreparedDiffraxStateAdapter(
+            mode="native",
+            state_shape=shape,
+            public_dtype=public_dtype,
+            backend_dtype=public_dtype,
+            evidence=evidence,
+        )
+    if state_geometry is not None and not state_geometry.trivial:
+        raise ValueError(
+            "Real/imaginary Diffrax packing requires trivial Euclidean state geometry; "
+            "select native complex execution explicitly or provide a real formulation."
+        )
+    backend_dtype = precision_dtype_name(state.real.dtype)
+    evidence = ComplexStatePackingEvidence(
+        strategy="real_imag",
+        public_dtype=public_dtype,
+        backend_dtype=backend_dtype,
+        public_shape=shape,
+        backend_shape=(2,) + shape,
+        tolerance_geometry="componentwise_real",
+        policy_id=resolved.policy_id,
+    )
+    return _PreparedDiffraxStateAdapter(
+        mode="real_imag",
+        state_shape=shape,
+        public_dtype=public_dtype,
+        backend_dtype=backend_dtype,
+        evidence=evidence,
+    )
+
+
+def _validate_real_backend_tree(tree: Any, /) -> None:
+    if any(
+        eqx.is_array_like(value) and jnp.iscomplexobj(value)
+        for value in jax.tree.leaves(tree)
+    ):
+        raise ValueError(
+            "Real/imaginary Diffrax packing left a visible complex backend leaf."
+        )
+
+
+__all__ = [
+    "ComplexStatePackingEvidence",
+    "DiffraxComplexStatePolicy",
+    "DiffraxComplexStateStrategy",
+]

--- a/phydrax/solver/_quantum_propagation.py
+++ b/phydrax/solver/_quantum_propagation.py
@@ -24,6 +24,7 @@ from ..metrix import (
 from ..operators.quantum._propagation import unitarity_residual
 from ._differential import DifferentialProblem, DifferentialSolution
 from ._diffrax_backend import solve_diffrax
+from ._diffrax_state_packing import DiffraxComplexStatePolicy
 from ._geometric import CommutatorFreeSolver
 from ._temporal_precision import TemporalPrecisionPolicy
 
@@ -273,6 +274,7 @@ def solve_unitary_propagator(
         max_steps=max_steps,
         throw=False,
         precision=precision_,
+        complex_state_policy=DiffraxComplexStatePolicy("native"),
     )
     geometry_precision = problem.geometry_precision
     unitarity = geometry_precision.decision(

--- a/phydrax/solver/_temporal_method.py
+++ b/phydrax/solver/_temporal_method.py
@@ -14,6 +14,7 @@ from .._fingerprint import canonical_fingerprint
 from .._precision import PrecisionEvidenceEnvelope
 from .._strict import StrictModule
 from .._trainable import NonTrainableState
+from ._diffrax_state_packing import ComplexStatePackingEvidence
 
 
 TemporalEquationForm: TypeAlias = Literal[
@@ -175,6 +176,7 @@ class TemporalSolveEvidence(StrictModule, NonTrainableState):
     dense: bool = eqx.field(static=True)
     maximum_steps: int | None = eqx.field(static=True)
     precision_evidence: PrecisionEvidenceEnvelope | None
+    state_packing: ComplexStatePackingEvidence | None
 
     def __init__(
         self,
@@ -191,6 +193,7 @@ class TemporalSolveEvidence(StrictModule, NonTrainableState):
         dense: bool,
         maximum_steps: int | None,
         precision_evidence: PrecisionEvidenceEnvelope | None = None,
+        state_packing: ComplexStatePackingEvidence | None = None,
     ):
         if not isinstance(capabilities, TemporalMethodCapabilities):
             raise TypeError("capabilities must be TemporalMethodCapabilities.")
@@ -215,6 +218,11 @@ class TemporalSolveEvidence(StrictModule, NonTrainableState):
             raise TypeError(
                 "precision_evidence must be PrecisionEvidenceEnvelope or None."
             )
+        if state_packing is not None and not isinstance(
+            state_packing,
+            ComplexStatePackingEvidence,
+        ):
+            raise TypeError("state_packing must be ComplexStatePackingEvidence or None.")
         self.capabilities = capabilities
         self.equation_form = equation_form
         self.backend_id, self.configuration_id, self.controller_id, self.adjoint_id = (
@@ -225,6 +233,7 @@ class TemporalSolveEvidence(StrictModule, NonTrainableState):
         self.dense = bool(dense)
         self.maximum_steps = limit
         self.precision_evidence = precision_evidence
+        self.state_packing = state_packing
 
 
 def qualified_type_name(value: Any, /) -> str:

--- a/tests/integration/test_spde_solver.py
+++ b/tests/integration/test_spde_solver.py
@@ -183,6 +183,9 @@ def test_stochastic_allen_cahn_semidiscretization_is_finite_and_reproducible():
     assert jnp.all(jnp.isfinite(first.states))
     assert jnp.array_equal(first.states, replay.states)
     assert jnp.max(jnp.abs(jnp.imag(physical_states))) < 1e-10
+    assert first.temporal_evidence is not None
+    assert first.temporal_evidence.state_packing is not None
+    assert first.temporal_evidence.state_packing.strategy == "real_imag"
 
 
 def test_two_dimensional_tensor_state_preserves_channels_and_noise_axes():

--- a/tests/unit/solver/test_diffrax_backend.py
+++ b/tests/unit/solver/test_diffrax_backend.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Any
 
 import diffrax as dfx
@@ -5,6 +6,7 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import optimistix as optx
 import pytest
 
 import phydrax as phx
@@ -585,3 +587,302 @@ def test_wiener_term_validates_names_shapes_and_uniqueness():
             t1=1.0,
             wiener_terms=(first, first),
         )
+
+
+def test_complex_ode_packing_matches_explicit_real_system_dense_and_gradient():
+    initial = jnp.asarray([1.0 + 0.25j], dtype=jnp.complex128)
+    save_times = jnp.linspace(0.0, 0.6, 7)
+
+    def solve_complex(real_rate):
+        rate = real_rate + 0.7j
+        problem = phx.solver.DifferentialProblem(
+            lambda t, state, args: args["rate"] * state + 0.2 * jnp.conj(state),
+            initial,
+            t0=0.0,
+            t1=0.6,
+            args={"rate": rate},
+        )
+        return phx.solver.solve_diffrax(
+            problem,
+            save_times=save_times,
+            dense=True,
+            rtol=1e-9,
+            atol=1e-11,
+        )
+
+    def solve_real(real_rate):
+        def drift(time, state, args):
+            del time, args
+            real, imag = state
+            return jnp.stack(
+                (
+                    (real_rate + 0.2) * real - 0.7 * imag,
+                    0.7 * real + (real_rate - 0.2) * imag,
+                )
+            )
+
+        problem = phx.solver.DifferentialProblem(
+            drift,
+            jnp.stack((jnp.real(initial), jnp.imag(initial))),
+            t0=0.0,
+            t1=0.6,
+        )
+        return phx.solver.solve_diffrax(
+            problem,
+            save_times=save_times,
+            dense=True,
+            rtol=1e-9,
+            atol=1e-11,
+        )
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "error",
+            message="Complex dtype support in Diffrax.*",
+        )
+        complex_solution = solve_complex(jnp.asarray(-0.4))
+    real_solution = solve_real(jnp.asarray(-0.4))
+    expected = jax.lax.complex(
+        real_solution.states[:, 0],
+        real_solution.states[:, 1],
+    )
+    queries = jnp.asarray([0.15, 0.45])
+    expected_dense = jax.lax.complex(
+        real_solution.evaluate(queries)[:, 0],
+        real_solution.evaluate(queries)[:, 1],
+    )
+    gradient = jax.grad(
+        lambda rate: jnp.sum(jnp.abs(solve_complex(rate).states[-1]) ** 2)
+    )(jnp.asarray(-0.4))
+    reference_gradient = jax.grad(
+        lambda rate: jnp.sum(jnp.abs(solve_real(rate).states[-1]) ** 2)
+    )(jnp.asarray(-0.4))
+    evidence = complex_solution.temporal_evidence
+
+    assert evidence is not None
+    assert evidence.state_packing is not None
+    assert evidence.state_packing.strategy == "real_imag"
+    assert evidence.state_packing.public_shape == (1,)
+    assert evidence.state_packing.backend_shape == (2, 1)
+    assert evidence.state_packing.public_dtype == "complex128"
+    assert evidence.state_packing.backend_dtype == "float64"
+    assert complex_solution.states.shape == (7, 1)
+    assert complex_solution.states.dtype == jnp.complex128
+    assert jnp.allclose(complex_solution.states, expected, rtol=2e-8, atol=2e-9)
+    assert jnp.allclose(
+        complex_solution.evaluate(queries),
+        expected_dense,
+        rtol=2e-8,
+        atol=2e-9,
+    )
+    assert jnp.allclose(gradient, reference_gradient, rtol=2e-7, atol=2e-8)
+
+
+def test_complex_sde_packing_matches_real_system_pathwise_and_in_ensemble():
+    complex_term = phx.solver.WienerTerm(
+        "imaginary",
+        lambda t, state, args: 1j * jnp.ones(state.shape + (1,)),
+        (1,),
+        structure="additive",
+    )
+    real_term = phx.solver.WienerTerm(
+        "imaginary",
+        lambda t, state, args: jnp.broadcast_to(
+            jnp.asarray([[[0.0]], [[1.0]]]),
+            state.shape + (1,),
+        ),
+        (1,),
+        structure="additive",
+    )
+    complex_problem = phx.solver.DifferentialProblem(
+        lambda t, state, args: jnp.zeros_like(state),
+        jnp.asarray([0.0 + 0.0j]),
+        t0=0.0,
+        t1=0.2,
+        wiener_terms=(complex_term,),
+    )
+    real_problem = phx.solver.DifferentialProblem(
+        lambda t, state, args: jnp.zeros_like(state),
+        jnp.zeros((2, 1)),
+        t0=0.0,
+        t1=0.2,
+        wiener_terms=(real_term,),
+    )
+    scalar_realization = _realization(
+        81,
+        support=(0.0, 0.2),
+        tolerance=1e-4,
+    )
+    save_times = jnp.asarray([0.05, 0.1, 0.2])
+
+    complex_solution = phx.solver.solve_diffrax(
+        complex_problem,
+        save_times=save_times,
+        realization=scalar_realization,
+        solver=dfx.Euler(),
+        dt0=0.01,
+    )
+    real_solution = phx.solver.solve_diffrax(
+        real_problem,
+        save_times=save_times,
+        realization=scalar_realization,
+        solver=dfx.Euler(),
+        dt0=0.01,
+    )
+    expected = jax.lax.complex(
+        real_solution.states[:, 0],
+        real_solution.states[:, 1],
+    )
+
+    ensemble_realization = _realization(
+        82,
+        sample_shape=(2, 3),
+        support=(0.0, 0.2),
+        tolerance=1e-4,
+    )
+    complex_ensemble = phx.solver.solve_diffrax_ensemble(
+        complex_problem,
+        save_times=save_times,
+        realization=ensemble_realization,
+        solver=dfx.Euler(),
+        dt0=0.01,
+        dense=True,
+    )
+    real_ensemble = phx.solver.solve_diffrax_ensemble(
+        real_problem,
+        save_times=save_times,
+        realization=ensemble_realization,
+        solver=dfx.Euler(),
+        dt0=0.01,
+        dense=True,
+    )
+    expected_ensemble = jax.lax.complex(
+        real_ensemble.states[..., 0, :],
+        real_ensemble.states[..., 1, :],
+    )
+    queries = jnp.asarray([0.025, 0.175])
+    real_dense = real_ensemble.evaluate(queries)
+    expected_dense = jax.lax.complex(
+        real_dense[..., 0, :],
+        real_dense[..., 1, :],
+    )
+
+    assert jnp.array_equal(complex_solution.states, expected)
+    assert complex_ensemble.states.shape == (2, 3, 3, 1)
+    assert jnp.array_equal(complex_ensemble.states, expected_ensemble)
+    assert jnp.array_equal(complex_ensemble.evaluate(queries), expected_dense)
+    assert complex_ensemble.temporal_evidence.state_packing is not None
+    assert (
+        complex_ensemble.temporal_evidence.state_packing.tolerance_geometry
+        == "componentwise_real"
+    )
+
+
+def test_complex_packing_wraps_events_and_split_dynamics():
+    event = dfx.Event(
+        lambda t, state, args, **kwargs: jnp.real(state[0]) - 0.5,
+        root_finder=optx.Newton(rtol=1e-9, atol=1e-9),
+    )
+    problem = phx.solver.DifferentialProblem(
+        lambda t, state, args: -state,
+        jnp.asarray([1.0 + 0.0j]),
+        t0=0.0,
+        t1=2.0,
+    )
+    event_solution = phx.solver.solve_diffrax(
+        problem,
+        save_times=jnp.asarray([0.0, 0.6, 0.8]),
+        event=event,
+        dt0=0.05,
+    )
+    split = phx.solver.SplitDifferentialProblem(
+        lambda t, state, args: 1j * state,
+        lambda t, state, args: -9.0 * state,
+        jnp.asarray([1.0 + 0.0j]),
+        t0=0.0,
+        t1=0.2,
+    )
+    split_solution = phx.solver.solve_diffrax(
+        split,
+        save_times=jnp.asarray([0.2]),
+        rtol=1e-8,
+        atol=1e-10,
+    )
+
+    assert event_solution.event_terminated
+    assert jnp.isfinite(event_solution.states[:2]).all()
+    assert jnp.isinf(event_solution.states[-1]).all()
+    assert split_solution.temporal_evidence.state_packing is not None
+    assert split_solution.temporal_evidence.equation_form == "additive-ode"
+    assert jnp.allclose(
+        split_solution.states[-1, 0],
+        jnp.exp((-9.0 + 1j) * 0.2),
+        rtol=3e-7,
+        atol=3e-8,
+    )
+
+
+def test_complex_state_policy_precision_and_real_bypass_are_explicit():
+    complex_problem = phx.solver.DifferentialProblem(
+        lambda t, state, args: 1j * state,
+        jnp.asarray([1.0 + 0.0j]),
+        t0=0.0,
+        t1=0.1,
+    )
+    with pytest.raises(ValueError, match="strategy"):
+        phx.solver.DiffraxComplexStatePolicy("typo")
+    with pytest.raises(ValueError, match="rejected"):
+        phx.solver.solve_diffrax(
+            complex_problem,
+            save_times=jnp.asarray([0.1]),
+            complex_state_policy=phx.solver.DiffraxComplexStatePolicy("reject"),
+        )
+    with pytest.raises(ValueError, match="complex output dtype"):
+        phx.solver.solve_diffrax(
+            complex_problem,
+            save_times=jnp.asarray([0.1]),
+            precision=phx.solver.TemporalPrecisionPolicy(output_dtype=jnp.float64),
+        )
+    geometry = phx.metrix.SpecialOrthogonalStateGeometry(2)
+    geometric_problem = phx.solver.DifferentialProblem(
+        lambda t, state, args: jnp.zeros_like(state),
+        jnp.eye(2, dtype=jnp.complex128),
+        t0=0.0,
+        t1=0.1,
+        state_geometry=geometry,
+    )
+    with pytest.raises(ValueError, match="trivial Euclidean"):
+        phx.solver.solve_diffrax(
+            geometric_problem,
+            save_times=jnp.asarray([0.1]),
+            dt0=0.01,
+        )
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="Complex dtype support in Diffrax.*",
+        )
+        native = phx.solver.solve_diffrax(
+            complex_problem,
+            save_times=jnp.asarray([0.1]),
+            complex_state_policy=phx.solver.DiffraxComplexStatePolicy("native"),
+        )
+    assert native.temporal_evidence.state_packing is not None
+    assert native.temporal_evidence.state_packing.strategy == "native"
+
+    real_problem = _geometric_problem()
+    implicit_default = phx.solver.solve_diffrax(
+        real_problem,
+        save_times=jnp.asarray([1.0]),
+    )
+    explicit_default = phx.solver.solve_diffrax(
+        real_problem,
+        save_times=jnp.asarray([1.0]),
+        complex_state_policy=phx.solver.DiffraxComplexStatePolicy(),
+    )
+    assert implicit_default.temporal_evidence.state_packing is None
+    assert explicit_default.temporal_evidence.state_packing is None
+    assert (
+        implicit_default.temporal_evidence.configuration_id
+        == explicit_default.temporal_evidence.configuration_id
+    )

--- a/tests/unit/solver/test_diffrax_cde.py
+++ b/tests/unit/solver/test_diffrax_cde.py
@@ -1,3 +1,5 @@
+import warnings
+
 import diffrax as dfx
 import equinox as eqx
 import jax
@@ -311,3 +313,42 @@ def test_rough_second_level_control_is_rejected_with_rde_direction():
             rough_path,
             save_times=jnp.asarray([1.0]),
         )
+
+
+def test_complex_cde_uses_real_imaginary_diffrax_packing():
+    path = _declared_path(
+        lambda time, side: jnp.asarray([time]),
+        lambda time, side: jnp.asarray([1.0]),
+        dimension=1,
+        path_id="complex-identity-control",
+    )
+    problem = phx.solver.RoughDifferentialProblem(
+        lambda time, state, args: 1j * state[..., None],
+        jnp.asarray([1.0 + 0.0j]),
+        driver_dimension=1,
+    )
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "error",
+            message="Complex dtype support in Diffrax.*",
+        )
+        solution = phx.solver.solve_diffrax_cde(
+            problem,
+            path,
+            save_times=jnp.asarray([0.5, 1.0]),
+            rtol=1e-9,
+            atol=1e-11,
+        )
+
+    evidence = solution.differential_solution.temporal_evidence
+    assert evidence is not None
+    assert evidence.state_packing is not None
+    assert evidence.state_packing.strategy == "real_imag"
+    assert solution.states.dtype == jnp.complex128
+    assert jnp.allclose(
+        solution.states[:, 0],
+        jnp.exp(1j * jnp.asarray([0.5, 1.0])),
+        rtol=2e-7,
+        atol=2e-9,
+    )

--- a/tests/unit/solver/test_unitary_propagator.py
+++ b/tests/unit/solver/test_unitary_propagator.py
@@ -25,6 +25,10 @@ def test_constant_hamiltonian_unitary_propagation_and_density_action():
     assert bool(jnp.all(solution.valid))
     assert jnp.allclose(solution.propagators[-1], expected, atol=2e-5)
     assert solution.maximum_unitarity_residual < 1e-8
+    evidence = solution.differential_solution.temporal_evidence
+    assert evidence is not None
+    assert evidence.state_packing is not None
+    assert evidence.state_packing.strategy == "native"
 
     state = jnp.asarray([1.0 + 0.0j, 0.0j])
     density = jnp.outer(state, jnp.conj(state))

--- a/tools/spectral_pde_benchmarks.py
+++ b/tools/spectral_pde_benchmarks.py
@@ -31,6 +31,13 @@ class SpectralPDEBenchmarkRecord:
     maximum_drift_error: float
     parameter_gradient_error: float
     alias_defect: float
+    state_packing_evidence_id: str
+    packed_backend_shape: tuple[int, ...]
+    packed_public_bytes: int
+    packed_backend_bytes: int
+    packed_diffrax_wall_ms: float
+    explicit_real_wall_ms: float
+    packed_pathwise_defect: float
     finite: bool
 
     @property
@@ -40,6 +47,8 @@ class SpectralPDEBenchmarkRecord:
             and self.maximum_drift_error <= 1e-9
             and self.parameter_gradient_error <= 1e-8
             and self.alias_defect <= 1e-9
+            and self.packed_pathwise_defect <= 1e-8
+            and self.packed_public_bytes == self.packed_backend_bytes
         )
 
 
@@ -149,11 +158,69 @@ def run_spectral_pde_benchmark(
     gradient_error = jnp.abs(actual_gradient - expected_gradient)
     report = dealiasing.report
     itemsize = jnp.dtype(space.plan.precision.coefficient_dtype).itemsize
+    real_rate = -0.2
+    imaginary_rate = 0.5
+    conjugate_rate = 0.1
+    complex_problem = phx.solver.DifferentialProblem(
+        lambda time, value, args: (
+            (real_rate + 1j * imaginary_rate) * value + conjugate_rate * jnp.conj(value)
+        ),
+        state,
+        t0=0.0,
+        t1=0.05,
+    )
+
+    def real_drift(time, value, args):
+        del time, args
+        real, imag = value
+        return jnp.stack(
+            (
+                (real_rate + conjugate_rate) * real - imaginary_rate * imag,
+                imaginary_rate * real + (real_rate - conjugate_rate) * imag,
+            )
+        )
+
+    real_problem = phx.solver.DifferentialProblem(
+        real_drift,
+        jnp.stack((jnp.real(state), jnp.imag(state))),
+        t0=0.0,
+        t1=0.05,
+    )
+    packed_started = time.perf_counter()
+    packed_solution = phx.solver.solve_diffrax(
+        complex_problem,
+        save_times=jnp.asarray([0.05]),
+        rtol=1e-8,
+        atol=1e-10,
+    )
+    jax.block_until_ready(packed_solution.states)
+    packed_wall = 1e3 * (time.perf_counter() - packed_started)
+    real_started = time.perf_counter()
+    real_solution = phx.solver.solve_diffrax(
+        real_problem,
+        save_times=jnp.asarray([0.05]),
+        rtol=1e-8,
+        atol=1e-10,
+    )
+    jax.block_until_ready(real_solution.states)
+    real_wall = 1e3 * (time.perf_counter() - real_started)
+    expected_packed = jax.lax.complex(
+        real_solution.states[:, 0],
+        real_solution.states[:, 1],
+    )
+    packed_defect = jnp.max(jnp.abs(packed_solution.states - expected_packed))
+    packing = packed_solution.temporal_evidence.state_packing
+    if packing is None:
+        raise RuntimeError("Complex Diffrax benchmark did not prepare state packing.")
+    backend_itemsize = jnp.dtype(packing.backend_dtype).itemsize
+    public_bytes = state.size * state.dtype.itemsize
+    backend_bytes = 2 * state.size * backend_itemsize
     finite = bool(
         jnp.all(jnp.isfinite(actual))
         & jnp.isfinite(maximum_error)
         & jnp.isfinite(gradient_error)
         & jnp.isfinite(alias_defect)
+        & jnp.isfinite(packed_defect)
     )
     return SpectralPDEBenchmarkRecord(
         mode_count=count,
@@ -170,6 +237,13 @@ def run_spectral_pde_benchmark(
         maximum_drift_error=float(maximum_error),
         parameter_gradient_error=float(gradient_error),
         alias_defect=float(alias_defect),
+        state_packing_evidence_id=packing.evidence_id,
+        packed_backend_shape=packing.backend_shape,
+        packed_public_bytes=int(public_bytes),
+        packed_backend_bytes=int(backend_bytes),
+        packed_diffrax_wall_ms=float(packed_wall),
+        explicit_real_wall_ms=float(real_wall),
+        packed_pathwise_defect=float(packed_defect),
         finite=finite,
     )
 


### PR DESCRIPTION
## Summary

Add an explicit solver-level real/imaginary state adapter for complex Diffrax problems while preserving complex public problems, callbacks, dense interpolation, events, and solutions.

The adapter keeps three independent identities separate:

- public scientific state representation;
- internal Diffrax execution representation;
- temporal method and controller configuration.

Complex spatial or quantum representations therefore remain complex at the Phydrax boundary. Only the ordinary Euclidean Diffrax backend state is realified.

## Motivation

Diffrax currently labels native complex integration as work in progress. Its array-valued `ControlTerm` also contracts vector fields through a conjugating tensor product. For complex diffusion `G` driven by real Wiener controls, native execution can therefore apply `conj(G)` rather than the intended `G`.

Distributional checks can miss this when the affected direction is symmetric. The adapter instead realizes one coupled real system pathwise:

```text
public state z
backend state stack(Re(z), Im(z), axis=0)
```

For public state shape `S` and noise shape `N`:

```text
public state:       S, complex
backend state:      (2,) + S, real
public diffusion:   S + N, complex
backend diffusion:  (2,) + S + N, real
```

The leading pair axis leaves every stochastic control axis trailing, exactly where `diffrax.ControlTerm` expects it. Both components contract against the same real Wiener increments.

## Complex-state policy

Add `DiffraxComplexStatePolicy` with three explicit strategies:

- `real_imag`: default safe realification;
- `native`: explicit opt-in to Diffrax's native complex path;
- `reject`: refuse a complex initial state.

Real-valued problems remain on the native path. Their configuration identity is unchanged and no packed axis is introduced.

The policy is available on:

- `solve_diffrax`;
- `solve_diffrax_ensemble`;
- `solve_diffrax_cde`.

## Prepared adapter

Introduce one internal prepared adapter that owns:

- public and backend shapes;
- public complex and backend real dtypes;
- state and drift packing;
- diffusion packing with trailing noise axes;
- recursive complex-argument packing;
- event reconstruction;
- saved and dense-output reconstruction;
- validation that no visible complex leaf reaches Diffrax under the real/imaginary policy.

The backend state uses one real array, not a two-leaf PyTree. This preserves Diffrax's existing control structure and permits ordinary real controllers and solvers to operate on the doubled system.

## Callback and argument boundary

Every packed callback receives the original public complex state:

1. unpack the leading real/imaginary axis;
2. reconstruct complex argument leaves;
3. evaluate the user drift or stochastic coefficient;
4. validate the public shape;
5. repack the result.

Complex leaves inside nested argument PyTrees are represented internally as real pairs and reconstructed before callback evaluation. Real and static leaves are unchanged.

## Deterministic, split, and controlled dynamics

Ordinary ODEs default to the packed real execution path when their initial state is complex.

`SplitDifferentialProblem` packs explicit and implicit terms independently. Diffrax's real nonlinear solve then sees the complete coupled real Jacobian, including non-holomorphic dependencies.

`solve_diffrax_cde` forwards the same policy after lowering a differentiable first-level control to `DifferentialProblem`. Public `ControlledDifferentialSolution` values remain complex.

## Stochastic dynamics

Complex stochastic coefficients are concatenated under the existing named `WienerTerm` contract, signed by the selected realization path, and then packed with shape:

```text
(2,) + state_shape + (total_noise_size,)
```

This preserves:

- named term slices;
- real Wiener controls;
- Itô or Stratonovich interpretation;
- additive, commutative, and general structure declarations;
- realization replay, antithetic signs, and multidimensional sample shapes;
- Lévy-area capability checks.

Fourier spectral SPDE trajectories remain full-complex modal arrays publicly. Their conjugate-symmetric noise directions are integrated through the real backend without native complex `ControlTerm` conjugation.

## Dense output and events

Dense Diffrax interpolation remains internal to the packed state. `DifferentialSolution.evaluate` reconstructs complex values after sample and query axes and returns the original public state shape.

`diffrax.Event` condition trees are wrapped so every condition receives the public complex state and original arguments. Root finders and direction metadata remain unchanged. Unsupported event object types fail explicitly under packed execution.

## Precision and evidence

Add `ComplexStatePackingEvidence` with:

- realized strategy;
- public/backend dtype;
- public/backend shape;
- tolerance geometry;
- policy and evidence IDs.

`TemporalSolveEvidence.state_packing` retains this object. Packed adaptive tolerances use componentwise real geometry over the doubled system.

A complex public state may no longer request a real temporal output dtype. Explicit projection to real or imaginary observables belongs outside the temporal backend.

The packing evidence ID enters temporal configuration identity only when a complex strategy is realized. Real-state configuration identities remain unchanged.

## Geometric boundary

Generic real/imaginary packing does not infer a product geometry for a nontrivial complex manifold. Such problems fail unless native complex execution is selected explicitly.

`solve_unitary_propagator` uses a complex unitary or special-unitary Lie group with a right-group geometry and commutator-free solver. It now selects `DiffraxComplexStatePolicy("native")` explicitly and records that evidence. Correct realification of this path would require a dedicated packed Lie-group geometry, not ordinary Euclidean state doubling or warning suppression.

## Benchmark and documentation surface

Extend the spectral PDE benchmark with:

- packing evidence identity;
- public/backend shapes and byte counts;
- packed and explicit-real execution timing;
- pathwise defect against the mathematically equivalent real system.

Documentation now covers policy selection, pair-axis semantics, componentwise tolerances, diffusion control layout, events, dense output, geometry boundaries, and the distinction between packed Euclidean dynamics and explicitly native complex Lie-group propagation.

## Parent integration

This branch is rebased onto current `dev` after PR #126. The modal spectral SPDE surface and documentation are therefore already part of the parent branch; this pull request contains only the Diffrax packing adapter and its direct integrations.

## Deliberate boundaries

This change does not claim:

- generic PyTree-valued public differential state;
- inferred realification for nontrivial state geometry;
- packed execution for the separate delay, segmented-delay, jump, or rough Log-ODE backends;
- equivalence to native complex adaptive step sequences;
- complex-valued time or Wiener controls;
- silent fallback from packing to native complex execution;
- suppression of Diffrax's warning on explicitly native complex paths.