### PR TITLE
Add compensated conservation accounting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## Unreleased
 
 ### Added
+- Added shared twofold compensated conservation accounting across structured,
+  triangle, unstructured, spectral, and SBP conservation diagnostics, plus
+  finite-volume ledgers, remap, overset/sliding, multiblock, small-cell, and
+  diffusion certificates. Spectral diagnostics now honor their declared reduction
+  dtype before accumulation.
 - Reworked generic continuation around exact terminal coordinates, complete
   `phydrax.nonlinear` correctors, prepared Newton/trust-region reuse, explicit
   state/residual geometry, canonical real-coordinate maps for complex, algebra, and

--- a/NOTICE
+++ b/NOTICE
@@ -143,6 +143,15 @@ independently against its own kernel, Gaussian-process, posterior, search-eviden
 and state-space contracts. No Hyperoptax source code is copied or redistributed,
 and randomized Kriging Believer is not implemented.
 
+Accurate conservation accounting
+The cancellation-aware conservation reductions are independent implementations of
+the error-free TwoSum and Sum2 algorithms described by Takeshi Ogita, Siegfried M.
+Rump, and Shin'ichi Oishi, “Accurate Sum and Dot Product,” SIAM Journal on Scientific
+Computing 26(6), 1955–1988 (2005), DOI 10.1137/030601818.
+
+The design study inspected sigma-py/accupy, licensed under GPL-3.0. Phydrax does not
+copy, translate, bundle, link, import, or depend on accupy source or executables.
+
 Compatible electromagnetics and point-cloud calculus
 The compatible Maxwell, CPML, Whitney-form, adjoint, targeted-reconstruction, and
 point-cloud implementations are native Phydrax implementations derived from public

--- a/docs/api/discretization/finite_difference.md
+++ b/docs/api/discretization/finite_difference.md
@@ -174,6 +174,11 @@ reuses those prepared flux operators where the requested expression is conservat
 
 ## Periodic SBP flux differencing
 
+Periodic SBP conservation diagnostics use a twofold compensated reduction for the
+quadrature-weighted residual in the prepared grid dtype. The antisymmetric pairwise
+flux construction, entropy rates, and evolution residual are unchanged.
+
+
 ::: phydrax.discretization.TensorSBPPlan
 
 ---

--- a/docs/guides_finite_volume.md
+++ b/docs/guides_finite_volume.md
@@ -214,6 +214,18 @@ viscous flux plan because viscous entropy production is not yet represented sepa
 For bounded domains, the convective rate includes boundary transport; it is not a
 closed entropy-production certificate.
 
+## Conservation accounting
+
+Structured, triangle, and unstructured `residual_with_diagnostics()` paths reduce
+cell-rate, source, and outward-boundary contributions with a twofold compensated
+sum in the prepared reduction dtype. The conservation defect is one signed
+accumulation of the final rounded contributions, not a subtraction of independently
+rounded totals. Tiny nonzero defects remain dtype-scale evidence; they are not a
+discretization-error or cross-device reproducibility guarantee.
+
+Conservative multiblock interfaces, accepted flux ledgers, remap, overset/sliding
+coupling, and small-cell redistribution use the same accounting convention.
+
 ## Time execution
 
 Spatial dynamics do not own a stepper.
@@ -270,6 +282,10 @@ Moving meshes are not supported.
 `ConservativeMultiblockInterfacePlan` computes one conforming or nested 2:1 interface
 flux, orients the opposing trace, evaluates on the fine mortar, sums fine integrated
 fluxes to coarse faces, and reports the global conservation defect.
+
+The reported interface defect uses the compensated accounting reduction described
+above; AMR synchronization values selected to be elementwise identical remain zero
+by construction.
 
 `ConservativeAMRSubcyclingPlan` accumulates time-integrated coarse and fine interface
 fluxes. `FluxRegister` records orientation, refinement ratio, accumulation time, and the

--- a/docs/guides_spectral_methods.md
+++ b/docs/guides_spectral_methods.md
@@ -134,6 +134,12 @@ compiled = phx.equations.compile_conservation_problem(
 )
 ```
 
+Physical-state, residual, and source integrals are first cast through the prepared
+spectral `reduction_dtype` and then accumulated with a twofold compensated sum. The
+conservation defect reduces residual and negative source contributions together
+rather than subtracting two rounded integrals. This improves roundoff evidence without
+changing the modal residual or claiming exact arithmetic.
+
 The equation-owned `ConvexEntropyPair` supplies entropy, entropy variables, flux,
 and admissibility. Spectral diagnostics report total entropy and its semidiscrete
 rate. They do not claim entropy stability; a proven entropy-stable split form is a

--- a/docs/guides_unstructured_finite_volume.md
+++ b/docs/guides_unstructured_finite_volume.md
@@ -116,6 +116,12 @@ do not advance.
 The finite-volume precision policy remains authoritative for state, flux, reduction,
 and output dtypes. Nonlinear precision is derived from it unless supplied explicitly.
 
+Global conservation diagnostics and conservative transfer helpers use a twofold
+compensated reduction after the finite-volume precision policy has cast contributions
+to `reduction_dtype`. Remap, overset/sliding, accepted-ledger, multiblock, and
+small-cell defects accumulate signed final contributions together so separately
+rounded totals cannot create a false exact zero.
+
 ## Collocated incompressible pressure correction
 
 `PreparedUnstructuredCollocatedOperators` supplies:

--- a/phydrax/_numerics/_compensated.py
+++ b/phydrax/_numerics/_compensated.py
@@ -1,0 +1,156 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from math import prod
+
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array, ArrayLike
+
+
+Axis = int | tuple[int, ...] | None
+_SUPPORTED_REAL_DTYPES = (jnp.dtype(jnp.float32), jnp.dtype(jnp.float64))
+_BLOCK_SIZE = 32
+_BLOCK_THRESHOLD = 2 * _BLOCK_SIZE
+
+
+def two_sum(left: Array, right: Array, /) -> tuple[Array, Array]:
+    """Return a rounded sum and its error-free residual."""
+    total = left + right
+    virtual_right = total - left
+    error = (left - (total - virtual_right)) + (right - virtual_right)
+    return total, error
+
+
+def _real_dtype(dtype: jnp.dtype, /) -> jnp.dtype:
+    if jnp.issubdtype(dtype, jnp.complexfloating):
+        return jnp.empty((), dtype=dtype).real.dtype
+    return dtype
+
+
+def _flat_leading(value: Array, output_ndim: int, /) -> Array:
+    output_shape = value.shape[value.ndim - output_ndim :] if output_ndim else ()
+    reduction_shape = value.shape[: value.ndim - output_ndim]
+    return value.reshape((prod(reduction_shape),) + output_shape)
+
+
+def _accumulate(flat: Array, carry: tuple[Array, Array], /) -> tuple[Array, Array]:
+    def step(current, term):
+        high, correction = current
+        next_high, error = two_sum(high, term)
+        return (next_high, correction + error), None
+
+    return jax.lax.scan(step, carry, flat, unroll=1)[0]
+
+
+def _block_expansion(flat: Array, /) -> tuple[Array, Array]:
+    block_count = (flat.shape[0] + _BLOCK_SIZE - 1) // _BLOCK_SIZE
+    padding = block_count * _BLOCK_SIZE - flat.shape[0]
+    padded = jnp.pad(
+        flat,
+        ((0, padding),) + ((0, 0),) * (flat.ndim - 1),
+    )
+    blocked = padded.reshape((block_count, _BLOCK_SIZE) + flat.shape[1:])
+    block_shape = (block_count,) + flat.shape[1:]
+    carry = (
+        jnp.zeros(block_shape, dtype=flat.dtype),
+        jnp.zeros(block_shape, dtype=flat.dtype),
+    )
+    return _accumulate(jnp.swapaxes(blocked, 0, 1), carry)
+
+
+def compensated_sum_chunks(
+    chunks: tuple[ArrayLike, ...],
+    /,
+    *,
+    output_ndim: int = 0,
+) -> Array:
+    """Sum signed leading-axis chunks with a twofold compensated accumulator."""
+    if not chunks:
+        raise ValueError("compensated_sum_chunks requires at least one chunk.")
+    output_ndim_ = int(output_ndim)
+    if output_ndim_ < 0:
+        raise ValueError("output_ndim must be non-negative.")
+    arrays = tuple(jnp.asarray(chunk) for chunk in chunks)
+    if any(array.ndim < output_ndim_ for array in arrays):
+        raise ValueError("Every chunk must contain all declared output dimensions.")
+    output_shape = (
+        arrays[0].shape[arrays[0].ndim - output_ndim_ :] if output_ndim_ else ()
+    )
+    if any(
+        (array.shape[array.ndim - output_ndim_ :] if output_ndim_ else ())
+        != output_shape
+        for array in arrays[1:]
+    ):
+        raise ValueError("Compensated chunks must have identical trailing output shapes.")
+    dtype = jnp.result_type(*(array.dtype for array in arrays))
+    arrays = tuple(array.astype(dtype) for array in arrays)
+    flat_chunks = tuple(_flat_leading(array, output_ndim_) for array in arrays)
+    if not jnp.issubdtype(dtype, jnp.inexact) or _real_dtype(dtype) not in (
+        _SUPPORTED_REAL_DTYPES
+    ):
+        native = jnp.zeros(output_shape, dtype=dtype)
+        for flat in flat_chunks:
+            native = native + jnp.sum(flat, axis=0)
+        return native
+    reduced_chunks: list[Array] = []
+    for flat in flat_chunks:
+        if flat.shape[0] > _BLOCK_THRESHOLD:
+            high, correction = _block_expansion(flat)
+            reduced_chunks.extend((high, correction))
+        else:
+            reduced_chunks.append(flat)
+    carry = (
+        jnp.zeros(output_shape, dtype=dtype),
+        jnp.zeros(output_shape, dtype=dtype),
+    )
+    for reduced in reduced_chunks:
+        carry = _accumulate(reduced, carry)
+    high, correction = carry
+    return high + correction
+
+
+def _resolve_axes(axis: Axis, ndim: int, /) -> tuple[int, ...]:
+    if axis is None:
+        return tuple(range(ndim))
+    raw = (axis,) if isinstance(axis, int) else tuple(axis)
+    resolved = tuple(int(value) + ndim if int(value) < 0 else int(value) for value in raw)
+    if any(value < 0 or value >= ndim for value in resolved):
+        raise ValueError("axis contains an out-of-range reduction dimension.")
+    if len(set(resolved)) != len(resolved):
+        raise ValueError("axis contains duplicate reduction dimensions.")
+    return resolved
+
+
+def compensated_sum(
+    value: ArrayLike,
+    /,
+    *,
+    axis: Axis = None,
+    keepdims: bool = False,
+) -> Array:
+    """Sum explicit axes using the branch-free Sum2 error transformation."""
+    array = jnp.asarray(value)
+    axes = _resolve_axes(axis, array.ndim)
+    if not axes:
+        return array
+    output_axes = tuple(index for index in range(array.ndim) if index not in axes)
+    transposed = jnp.transpose(array, axes + output_axes)
+    flattened = transposed.reshape(
+        (prod(array.shape[index] for index in axes),)
+        + tuple(array.shape[index] for index in output_axes)
+    )
+    result = compensated_sum_chunks(
+        (flattened,),
+        output_ndim=len(output_axes),
+    )
+    if not keepdims:
+        return result
+    shape = tuple(1 if index in axes else array.shape[index] for index in range(array.ndim))
+    return result.reshape(shape)
+
+
+__all__ = ["compensated_sum", "compensated_sum_chunks", "two_sum"]

--- a/phydrax/discretization/finite_difference/_flux_differencing.py
+++ b/phydrax/discretization/finite_difference/_flux_differencing.py
@@ -15,6 +15,7 @@ import opt_einsum as oe
 from jaxtyping import Array, ArrayLike
 
 from ..._fingerprint import canonical_fingerprint
+from ..._numerics._compensated import compensated_sum
 from ..._strict import StrictModule
 from ..._trainable import NonTrainableState
 from .._core import (
@@ -438,7 +439,7 @@ class PreparedSBPConservationDynamics(StrictModule):
         convective_rate = jnp.sum(weights * convective_density)
         source_rate = jnp.sum(weights * source_density)
         total_entropy = jnp.sum(weights * self.entropy_pair.entropy(value))
-        conservation_rate = jnp.sum(
+        conservation_rate = compensated_sum(
             weights[..., None] * residual,
             axis=tuple(range(len(self.discretization.grid.shape))),
         )

--- a/phydrax/discretization/finite_volume/_diffusion.py
+++ b/phydrax/discretization/finite_volume/_diffusion.py
@@ -14,6 +14,7 @@ import numpy as np
 from jaxtyping import Array, ArrayLike
 
 from ..._fingerprint import canonical_fingerprint
+from ..._numerics._compensated import compensated_sum
 from ..._strict import StrictModule
 from ..._trainable import NonTrainableState
 from ...linalg import (
@@ -418,7 +419,15 @@ class PreparedConservativeDiffusion(AbstractLinearOperator):
         constant = jnp.ones(plan.grid.shape, dtype=self.source.dtype)
         constant_residual = float(np.asarray(jnp.max(jnp.abs(self.mv(constant)))))
         global_balance = float(
-            np.asarray(jnp.abs(jnp.sum(plan.grid.quadrature_weights * self.mv(constant))))
+            np.asarray(
+                jnp.abs(
+                    compensated_sum(
+                        self.precision.reduction(
+                            plan.grid.quadrature_weights * self.mv(constant)
+                        )
+                    )
+                )
+            )
         )
         self.conservation_report = FDConservationReport(
             constant_state_residual=constant_residual,

--- a/phydrax/discretization/finite_volume/_dynamics.py
+++ b/phydrax/discretization/finite_volume/_dynamics.py
@@ -14,6 +14,7 @@ import numpy as np
 from jaxtyping import Array, ArrayLike
 
 from ..._fingerprint import array_tree_fingerprint, canonical_fingerprint
+from ..._numerics._compensated import compensated_sum, compensated_sum_chunks
 from ..._precision import PrecisionEvidenceEnvelope
 from ..._strict import StrictModule
 from ..._trainable import NonTrainableState
@@ -790,6 +791,7 @@ class PreparedFiniteVolumeDynamics(StrictModule):
     ) -> tuple[Array, FiniteVolumeResidualDiagnostics]:
         value = jnp.asarray(state)
         self.precision.validate_state(value)
+        boundary_chunks: tuple[Array, ...] = ()
         source = self._source_value(time, value, args)
         if isinstance(self.method.interface_solver, AbstractNumericalFluxPlan):
             fluxes, speeds = self.face_fluxes(time, value, args)
@@ -806,10 +808,7 @@ class PreparedFiniteVolumeDynamics(StrictModule):
                         args,
                     )
                 )
-            boundary_flux = jnp.zeros(
-                (self.discretization.component_count,),
-                dtype=jnp.dtype(self.precision.reduction_dtype),
-            )
+            boundary_chunks_list: list[Array] = []
             for axis, flux in enumerate(fluxes):
                 if self.discretization.grid.structured_axes[axis].periodic:
                     continue
@@ -827,15 +826,19 @@ class PreparedFiniteVolumeDynamics(StrictModule):
                         axis=axis,
                     )
                 )
-                reduction_axes = tuple(range(lower.ndim - 1))
-                boundary_flux = self.precision.reduction(
-                    boundary_flux
-                    + jnp.sum(
-                        upper * upper_measure[..., None]
-                        - lower * lower_measure[..., None],
-                        axis=reduction_axes,
-                    )
+                boundary_chunks_list.append(
+                    upper * upper_measure[..., None]
+                    - lower * lower_measure[..., None]
                 )
+            boundary_chunks = tuple(boundary_chunks_list)
+            boundary_flux = (
+                compensated_sum_chunks(boundary_chunks, output_ndim=1)
+                if boundary_chunks
+                else jnp.zeros(
+                    (self.discretization.component_count,),
+                    dtype=jnp.dtype(self.precision.reduction_dtype),
+                )
+            )
         else:
             residual, speeds = self._wave_residual(time, value, args)
             residual = self.precision.reduction(residual) + self.precision.reduction(
@@ -849,15 +852,26 @@ class PreparedFiniteVolumeDynamics(StrictModule):
                 dtype=jnp.dtype(self.precision.reduction_dtype),
             )
         spatial_axes = tuple(range(len(self.discretization.cell_shape)))
-        source_integral = jnp.sum(
-            self.precision.reduction(self.effective_volumes[..., None] * source),
-            axis=spatial_axes,
+        source_terms = self.precision.reduction(
+            self.effective_volumes[..., None] * source
         )
-        change_integral = jnp.sum(
-            self.precision.reduction(self.effective_volumes[..., None] * residual),
-            axis=spatial_axes,
+        change_terms = self.precision.reduction(
+            self.effective_volumes[..., None] * residual
         )
-        defect = change_integral - source_integral + boundary_flux
+        if self.source is None:
+            source_integral = jnp.zeros(
+                (self.discretization.component_count,),
+                dtype=change_terms.dtype,
+            )
+            balance_chunks = (change_terms,) + boundary_chunks
+        else:
+            source_integral = compensated_sum(source_terms, axis=spatial_axes)
+            balance_chunks = (change_terms, -source_terms) + boundary_chunks
+        defect = (
+            compensated_sum_chunks(balance_chunks, output_ndim=1)
+            if isinstance(self.method.interface_solver, AbstractNumericalFluxPlan)
+            else boundary_flux
+        )
         rate = self._rate_from_speeds(speeds)
         entropy = None
         if self.entropy_pair is not None:

--- a/phydrax/discretization/finite_volume/_flux_ledger.py
+++ b/phydrax/discretization/finite_volume/_flux_ledger.py
@@ -12,6 +12,7 @@ import numpy as np
 from jaxtyping import Array, ArrayLike
 
 from ..._fingerprint import array_tree_fingerprint, canonical_fingerprint
+from ..._numerics._compensated import compensated_sum, compensated_sum_chunks
 from ..._strict import StrictModule
 
 
@@ -862,21 +863,29 @@ class FiniteVolumeAcceptedFluxIntegralLedger(StrictModule):
 
     def conservation_sums(self) -> tuple[Array, Array, Array]:
         """Return source, boundary-outward, and net-cell accepted content sums."""
-        source_sum = jnp.sum(self.source_integral, axis=0)
-        boundary_sum = jnp.zeros(self.component_shape, dtype=self.source_integral.dtype)
+        source_sum = compensated_sum(self.source_integral, axis=0)
+        boundary_chunks_list: list[Array] = []
         for block in self.blocks:
             boundary = (block.neighbour_cells < 0).reshape(
                 block.neighbour_cells.shape + (1,) * (block.flux_integral.ndim - 1)
             )
-            boundary_sum = boundary_sum + jnp.sum(
+            boundary_chunks_list.append(
                 jnp.where(
                     boundary,
                     block.flux_integral,
                     jnp.zeros((), dtype=block.flux_integral.dtype),
-                ),
-                axis=0,
+                )
             )
-        net_cell_sum = jnp.sum(self.scatter_content_integral(), axis=0)
+        boundary_chunks = tuple(boundary_chunks_list)
+        boundary_sum = (
+            compensated_sum_chunks(
+                boundary_chunks,
+                output_ndim=len(self.component_shape),
+            )
+            if boundary_chunks
+            else jnp.zeros(self.component_shape, dtype=self.source_integral.dtype)
+        )
+        net_cell_sum = compensated_sum(self.scatter_content_integral(), axis=0)
         return source_sum, boundary_sum, net_cell_sum
 
 

--- a/phydrax/discretization/finite_volume/_multiblock.py
+++ b/phydrax/discretization/finite_volume/_multiblock.py
@@ -11,6 +11,7 @@ import jax.numpy as jnp
 from jaxtyping import Array
 
 from ..._fingerprint import canonical_fingerprint
+from ..._numerics._compensated import compensated_sum_chunks
 from ..._strict import StrictModule
 from ..._trainable import NonTrainableState
 from ..multiblock import InterfaceOrientation
@@ -194,8 +195,9 @@ class ConservativeMultiblockInterfacePlan(StrictModule, NonTrainableState):
         left_integrated = _sum_to_shape(common, left_shape)
         right_oriented = -_sum_to_shape(common, right_shape)
         right_integrated = self.orientation.inverse(right_oriented, trailing_axes=1)
-        defect = jnp.sum(left_integrated, axis=tuple(range(len(left_shape)))) + jnp.sum(
-            right_integrated, axis=tuple(range(len(right_shape)))
+        defect = compensated_sum_chunks(
+            (left_integrated, right_integrated),
+            output_ndim=1,
         )
         return ConservativeMultiblockFluxResult(
             common_integrated_flux=common,

--- a/phydrax/discretization/finite_volume/_small_cell.py
+++ b/phydrax/discretization/finite_volume/_small_cell.py
@@ -12,6 +12,7 @@ import numpy as np
 from jaxtyping import Array, ArrayLike
 
 from ..._fingerprint import array_tree_fingerprint, canonical_fingerprint
+from ..._numerics._compensated import compensated_sum_chunks
 from ..._strict import StrictModule
 from ..._trainable import NonTrainableState
 from .._cell_complex import PolygonalConnectivity
@@ -488,8 +489,9 @@ class ConservativeSmallCellRedistributionPlan(StrictModule, NonTrainableState):
         redistributed = jnp.where(
             active, redistributed, jnp.zeros((), dtype=redistributed.dtype)
         )
-        conservation_defect = jnp.sum(redistributed, axis=0) - jnp.sum(
-            active_rate, axis=0
+        conservation_defect = compensated_sum_chunks(
+            (redistributed, -active_rate),
+            output_ndim=rate.ndim - 1,
         )
         real_dtype = jnp.real(rate).dtype
         roundoff_steps = max(1, cell_count + source_count * maximum_recipients)
@@ -512,9 +514,6 @@ class ConservativeSmallCellRedistributionPlan(StrictModule, NonTrainableState):
             jnp.any(conservation_failed),
             "Small-cell redistribution exceeds the content-rate dtype conservation "
             "tolerance.",
-        )
-        conservation_defect = jnp.sum(redistributed, axis=0) - jnp.sum(
-            active_rate, axis=0
         )
         return ConservativeSmallCellRedistributionResult(
             redistributed_rate=redistributed,

--- a/phydrax/discretization/finite_volume/_triangle_dynamics.py
+++ b/phydrax/discretization/finite_volume/_triangle_dynamics.py
@@ -13,6 +13,7 @@ import jax.numpy as jnp
 from jaxtyping import Array, ArrayLike
 
 from ..._fingerprint import canonical_fingerprint
+from ..._numerics._compensated import compensated_sum, compensated_sum_chunks
 from ..._precision import PrecisionEvidenceEnvelope
 from ..._strict import StrictModule
 from ..._trainable import NonTrainableState
@@ -469,23 +470,25 @@ class PreparedTriangleFiniteVolumeDynamics(StrictModule):
         integrated = self.precision.reduction(flux) * self.precision.reduction(
             self.discretization.face_measures[:, None]
         )
-        boundary_flux = jnp.sum(jnp.where(boundary[:, None], integrated, 0.0), axis=0)
-        source_integral = jnp.sum(
-            self.precision.reduction(self.discretization.cell_volumes[:, None] * source),
-            axis=0,
+        boundary_terms = jnp.where(boundary[:, None], integrated, 0.0)
+        source_terms = self.precision.reduction(
+            self.discretization.cell_volumes[:, None] * source
         )
-        change = jnp.sum(
-            self.precision.reduction(
-                self.discretization.cell_volumes[:, None] * residual
-            ),
-            axis=0,
+        change_terms = self.precision.reduction(
+            self.discretization.cell_volumes[:, None] * residual
+        )
+        boundary_flux = compensated_sum(boundary_terms, axis=0)
+        source_integral = compensated_sum(source_terms, axis=0)
+        defect = compensated_sum_chunks(
+            (change_terms, -source_terms, boundary_terms),
+            output_ndim=1,
         )
         return self.precision.storage(residual), TriangleFiniteVolumeDiagnostics(
             normal_flux=flux,
             signal_speed=speed,
             boundary_outward_flux=boundary_flux,
             source_integral=source_integral,
-            conservation_defect=change - source_integral + boundary_flux,
+            conservation_defect=defect,
             maximum_rate=jnp.max(self._cell_rate(speed)),
             precision_evidence=self.precision.evidence(),
         )

--- a/phydrax/discretization/finite_volume/_unstructured_dynamics.py
+++ b/phydrax/discretization/finite_volume/_unstructured_dynamics.py
@@ -15,6 +15,7 @@ import opt_einsum as oe
 from jaxtyping import Array, ArrayLike
 
 from ..._fingerprint import canonical_fingerprint
+from ..._numerics._compensated import compensated_sum, compensated_sum_chunks
 from ..._precision import PrecisionEvidenceEnvelope
 from ..._strict import StrictModule
 from ..._trainable import NonTrainableState
@@ -1764,23 +1765,25 @@ class PreparedUnstructuredFiniteVolumeDynamics(StrictModule):
         integrated = self.precision.reduction(flux) * self.precision.reduction(
             self.discretization.face_measures[:, None]
         )
-        boundary_flux = jnp.sum(jnp.where(boundary[:, None], integrated, 0.0), axis=0)
-        source_integral = jnp.sum(
-            self.precision.reduction(self.discretization.cell_volumes[:, None] * source),
-            axis=0,
+        boundary_terms = jnp.where(boundary[:, None], integrated, 0.0)
+        source_terms = self.precision.reduction(
+            self.discretization.cell_volumes[:, None] * source
         )
-        change = jnp.sum(
-            self.precision.reduction(
-                self.discretization.cell_volumes[:, None] * residual
-            ),
-            axis=0,
+        change_terms = self.precision.reduction(
+            self.discretization.cell_volumes[:, None] * residual
+        )
+        boundary_flux = compensated_sum(boundary_terms, axis=0)
+        source_integral = compensated_sum(source_terms, axis=0)
+        defect = compensated_sum_chunks(
+            (change_terms, -source_terms, boundary_terms),
+            output_ndim=1,
         )
         return self.precision.storage(residual), UnstructuredFiniteVolumeDiagnostics(
             normal_flux=flux,
             signal_speed=speed,
             boundary_outward_flux=boundary_flux,
             source_integral=source_integral,
-            conservation_defect=change - source_integral + boundary_flux,
+            conservation_defect=defect,
             maximum_rate=jnp.max(self._cell_rate(speed)),
             precision_evidence=self.precision.evidence(),
         )

--- a/phydrax/discretization/finite_volume/_unstructured_overset.py
+++ b/phydrax/discretization/finite_volume/_unstructured_overset.py
@@ -12,6 +12,7 @@ import numpy as np
 from jaxtyping import Array, ArrayLike
 
 from ..._fingerprint import array_tree_fingerprint, canonical_fingerprint
+from ..._numerics._compensated import compensated_sum_chunks
 from ..._strict import StrictModule
 from ..._trainable import NonTrainableState
 from ._unstructured import UnstructuredFiniteVolumeDiscretization
@@ -852,19 +853,17 @@ class UnstructuredOversetPlan(StrictModule, NonTrainableState):
                 "Overset receptor values must contain either all cells or routed cells."
             )
         trailing = (1,) * (donor.ndim - 1)
-        donor_integral = jnp.sum(
+        donor_terms = (
             donor[self.donor_indices]
-            * self.overlap_measures.astype(donor.dtype).reshape((-1,) + trailing),
-            axis=0,
+            * self.overlap_measures.astype(donor.dtype).reshape((-1,) + trailing)
         )
-        receptor_integral = jnp.sum(
-            receptor
-            * self.receptor_volumes.astype(receptor.dtype).reshape(
-                (-1,) + (1,) * (receptor.ndim - 1)
-            ),
-            axis=0,
+        receptor_terms = receptor * self.receptor_volumes.astype(
+            receptor.dtype
+        ).reshape((-1,) + (1,) * (receptor.ndim - 1))
+        return compensated_sum_chunks(
+            (receptor_terms, -donor_terms),
+            output_ndim=donor.ndim - 1,
         )
-        return receptor_integral - donor_integral
 
 
 class PeriodicSlidingCoupling(StrictModule, NonTrainableState):
@@ -938,14 +937,13 @@ class PeriodicSlidingCoupling(StrictModule, NonTrainableState):
     ) -> Array:
         left = jnp.asarray(left_flux_density)
         right = jnp.asarray(right_integrated_flux)
-        left_integrated = jnp.sum(
-            left
-            * self.left_measures.astype(left.dtype).reshape(
-                (-1,) + (1,) * (left.ndim - 1)
-            ),
-            axis=0,
+        left_terms = left * self.left_measures.astype(left.dtype).reshape(
+            (-1,) + (1,) * (left.ndim - 1)
         )
-        return left_integrated + jnp.sum(right, axis=0)
+        return compensated_sum_chunks(
+            (left_terms, right),
+            output_ndim=left.ndim - 1,
+        )
 
 
 class PeriodicSlidingRefreshArtifact(StrictModule, NonTrainableState):

--- a/phydrax/discretization/finite_volume/_unstructured_remap.py
+++ b/phydrax/discretization/finite_volume/_unstructured_remap.py
@@ -10,6 +10,7 @@ import numpy as np
 from jaxtyping import Array, ArrayLike
 
 from ..._fingerprint import array_tree_fingerprint, canonical_fingerprint
+from ..._numerics._compensated import compensated_sum_chunks
 from ..._strict import StrictModule
 from ..._trainable import NonTrainableState
 from ._unstructured import UnstructuredFiniteVolumeDiscretization
@@ -403,21 +404,22 @@ class UnstructuredConservativeRemapPlan(StrictModule, NonTrainableState):
             raise ValueError("source_cell_averages must begin with source cell count.")
         if target.ndim == 0 or target.shape[0] != self.target_volumes.size:
             raise ValueError("target_cell_averages must begin with target cell count.")
-        source_integral = jnp.sum(
+        source_terms = (
             self.source_volumes.astype(source.dtype).reshape(
                 (-1,) + (1,) * (source.ndim - 1)
             )
-            * source,
-            axis=0,
+            * source
         )
-        target_integral = jnp.sum(
+        target_terms = (
             self.target_volumes.astype(target.dtype).reshape(
                 (-1,) + (1,) * (target.ndim - 1)
             )
-            * target,
-            axis=0,
+            * target
         )
-        return target_integral - source_integral
+        return compensated_sum_chunks(
+            (target_terms, -source_terms),
+            output_ndim=source.ndim - 1,
+        )
 
     def conservation_defect_content(
         self, source_content: ArrayLike, target_content: ArrayLike, /
@@ -428,7 +430,10 @@ class UnstructuredConservativeRemapPlan(StrictModule, NonTrainableState):
             raise ValueError("source_content must begin with source cell count.")
         if target.ndim == 0 or target.shape[0] != self.target_volumes.size:
             raise ValueError("target_content must begin with target cell count.")
-        return jnp.sum(target, axis=0) - jnp.sum(source, axis=0)
+        return compensated_sum_chunks(
+            (target, -source),
+            output_ndim=source.ndim - 1,
+        )
 
 
 __all__ = ["UnstructuredConservativeRemapPlan", "UnstructuredRemapReport"]

--- a/phydrax/discretization/spectral/_conservation.py
+++ b/phydrax/discretization/spectral/_conservation.py
@@ -13,6 +13,7 @@ import opt_einsum as oe
 from jaxtyping import Array, ArrayLike
 
 from ..._fingerprint import canonical_fingerprint
+from ..._numerics._compensated import compensated_sum, compensated_sum_chunks
 from ..._precision import PrecisionEvidenceEnvelope
 from ..._strict import StrictModule
 from ..._trainable import NonTrainableState
@@ -256,15 +257,18 @@ class PreparedSpectralConservationDynamics(StrictModule):
         physical_state = self.discretization.reconstruct(coefficients)
         physical_residual = self.discretization.reconstruct(residual)
         physical_source = self.discretization.reconstruct(source)
-        weights = self.discretization.quadrature_weights[..., None]
-        total_integral = jnp.sum(
-            weights * physical_state, axis=tuple(range(len(self.discretization.axes)))
-        )
-        residual_integral = jnp.sum(
-            weights * physical_residual, axis=tuple(range(len(self.discretization.axes)))
-        )
-        source_integral = jnp.sum(
-            weights * physical_source, axis=tuple(range(len(self.discretization.axes)))
+        precision = self.discretization.plan.precision
+        spatial_axes = tuple(range(len(self.discretization.axes)))
+        weights = precision.reduction(self.discretization.quadrature_weights[..., None])
+        total_terms = precision.reduction(weights * physical_state)
+        residual_terms = precision.reduction(weights * physical_residual)
+        source_terms = precision.reduction(weights * physical_source)
+        total_integral = compensated_sum(total_terms, axis=spatial_axes)
+        residual_integral = compensated_sum(residual_terms, axis=spatial_axes)
+        source_integral = compensated_sum(source_terms, axis=spatial_axes)
+        conservation_defect = compensated_sum_chunks(
+            (residual_terms, -source_terms),
+            output_ndim=1,
         )
         entropy = None
         if self.entropy_pair is not None:
@@ -297,7 +301,7 @@ class PreparedSpectralConservationDynamics(StrictModule):
             total_integral=total_integral,
             semidiscrete_integral_rate=residual_integral,
             source_integral=source_integral,
-            conservation_defect=residual_integral - source_integral,
+            conservation_defect=conservation_defect,
             entropy=entropy,
             precision_evidence=self.discretization.precision_evidence,
             method_id=self.method.plan.method_id,

--- a/phydrax/discretization/spectral/_space.py
+++ b/phydrax/discretization/spectral/_space.py
@@ -254,7 +254,7 @@ class TensorSpectralDiscretization(AbstractStrongFormDiscretization):
                 }
             ),
         )
-        weights = grid.quadrature_weights
+        weights = grid.quadrature_weights.astype(plan.precision.physical_dtype)
         physical_layout = TensorDofLayout(
             plan.axis_names,
             physical_shape,

--- a/phydrax/special/_airy.py
+++ b/phydrax/special/_airy.py
@@ -16,6 +16,7 @@ import jax.numpy as jnp
 from jax import Array
 from jax.typing import ArrayLike
 
+from .._numerics._compensated import two_sum as _two_sum
 from ._dtype import promote_real
 
 
@@ -312,13 +313,6 @@ def _split(value: Array) -> tuple[Array, Array]:
         jnp.where(can_split, high, value),
         jnp.where(can_split, low, jnp.zeros_like(value)),
     )
-
-
-def _two_sum(left: Array, right: Array) -> tuple[Array, Array]:
-    total = left + right
-    right_virtual = total - left
-    error = (left - (total - right_virtual)) + (right - right_virtual)
-    return total, error
 
 
 def _two_product(left: Array, right: Array) -> tuple[Array, Array]:

--- a/tests/unit/discretization/test_cell_polynomial.py
+++ b/tests/unit/discretization/test_cell_polynomial.py
@@ -2,6 +2,8 @@
 # Copyright © 2026 PHYDRA, Inc. All rights reserved.
 #
 
+import math
+
 import equinox as eqx
 import jax
 import jax.numpy as jnp
@@ -910,6 +912,18 @@ def test_unstructured_weno_flux_quadrature_recovers_affine_advection_residual():
 
     state = _cell_averages(discretization, affine)[:, None]
     residual, diagnostics = compiled.residual_with_diagnostics(jnp.asarray(0.0), state)
+    flux, _ = compiled.face_fluxes(jnp.asarray(0.0), state)
+    balance_terms = np.asarray(discretization.cell_volumes[:, None] * residual)
+    integrated = np.asarray(flux * discretization.face_measures[:, None])
+    boundary_terms = np.where(
+        np.asarray(discretization.neighbour_cells < 0)[:, None],
+        integrated,
+        0.0,
+    )
+    expected_defect = math.fsum(
+        balance_terms[:, 0].tolist() + boundary_terms[:, 0].tolist()
+    )
+    assert float(diagnostics.conservation_defect[0]) == expected_defect
     expected = -(0.6 * 0.25 + (-0.25) * (-0.15))
     np.testing.assert_allclose(residual, expected, rtol=2e-9, atol=2e-9)
     np.testing.assert_allclose(

--- a/tests/unit/discretization/test_finite_volume_boundaries.py
+++ b/tests/unit/discretization/test_finite_volume_boundaries.py
@@ -2,6 +2,8 @@
 # Copyright © 2026 PHYDRA, Inc. All rights reserved.
 #
 
+import math
+
 import jax.numpy as jnp
 import numpy as np
 import pytest
@@ -137,6 +139,20 @@ def test_prescribed_outward_flux_controls_global_balance():
     residual, diagnostics = compiled.residual_with_diagnostics(
         0.0, jnp.ones(discretization.state_shape)
     )
+    balance_terms = np.asarray(discretization.cell_volumes[..., None] * residual)
+    expected_defect = np.asarray(
+        [
+            math.fsum(
+                balance_terms[:, index].tolist()
+                + [
+                    float(diagnostics.boundary_outward_flux[index]),
+                    -float(diagnostics.source_integral[index]),
+                ]
+            )
+            for index in range(balance_terms.shape[1])
+        ]
+    )
+    np.testing.assert_array_equal(diagnostics.conservation_defect, expected_defect)
 
     np.testing.assert_allclose(
         jnp.sum(discretization.cell_volumes[..., None] * residual, axis=0),

--- a/tests/unit/discretization/test_finite_volume_small_cell.py
+++ b/tests/unit/discretization/test_finite_volume_small_cell.py
@@ -2,6 +2,8 @@
 # Copyright © 2026 PHYDRA, Inc. All rights reserved.
 #
 
+import math
+
 import equinox as eqx
 import jax
 import jax.numpy as jnp
@@ -298,6 +300,29 @@ def test_vector_rates_are_componentwise_conservative_under_jit_and_grad():
         rate
     )
     np.testing.assert_allclose(gradient, jnp.ones_like(rate), atol=2.0e-15)
+
+
+@pytest.mark.parametrize("dtype", (jnp.float32, jnp.float64))
+def test_scale_separated_defect_matches_accurate_signed_sum(dtype):
+    plan = _four_recipient_plan()
+    rates = np.random.default_rng(20260826).normal(size=(9, 3))
+    rates *= np.asarray((1.0, 1.0e8, 1.0e16))
+    rate = jnp.asarray(rates, dtype=dtype)
+
+    result = eqx.filter_jit(plan.redistribute_rate)(rate)
+    combined = np.concatenate(
+        (np.asarray(result.redistributed_rate), -np.asarray(rate)),
+        axis=0,
+    )
+    expected = np.asarray(
+        [
+            math.fsum(combined[:, index].tolist())
+            for index in range(combined.shape[1])
+        ],
+        dtype=np.dtype(dtype),
+    )
+
+    np.testing.assert_array_equal(result.conservation_defect, expected)
 
 
 def test_float32_extreme_weights_renormalize_under_jit_and_conserve_gradient():

--- a/tests/unit/discretization/test_sbp_flux_differencing.py
+++ b/tests/unit/discretization/test_sbp_flux_differencing.py
@@ -1,3 +1,5 @@
+import math
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -129,6 +131,11 @@ def test_sbp_entropy_diagnostics_and_linearization_are_finite():
         )
     )
     residual, diagnostics = compiled.residual_with_diagnostics(0.0, state)
+    balance_terms = np.asarray(discretization.quadrature_weights[..., None] * residual)
+    expected_rate = np.asarray(
+        [math.fsum(balance_terms[:, index].tolist()) for index in range(balance_terms.shape[1])]
+    )
+    np.testing.assert_array_equal(diagnostics.conservation_rate, expected_rate)
     _, pushforward, pullback = compiled.linearize(0.0, state)
     tangent = jnp.ones_like(state) * 1e-3
 

--- a/tests/unit/discretization/test_triangle_finite_volume.py
+++ b/tests/unit/discretization/test_triangle_finite_volume.py
@@ -2,6 +2,8 @@
 # Copyright © 2026 PHYDRA, Inc. All rights reserved.
 #
 
+import math
+
 import equinox as eqx
 import jax
 import jax.numpy as jnp
@@ -479,6 +481,18 @@ def test_triangle_muscl_reports_distorted_mesh_residual_order_and_conservation()
         residual, diagnostics = compiled.residual_with_diagnostics(
             jnp.asarray(0.0), state
         )
+        flux, _ = compiled.face_fluxes(jnp.asarray(0.0), state)
+        balance_terms = np.asarray(discretization.cell_volumes[:, None] * residual)
+        integrated = np.asarray(flux * discretization.face_measures[:, None])
+        boundary_terms = np.where(
+            np.asarray(discretization.neighbour_cells < 0)[:, None],
+            integrated,
+            0.0,
+        )
+        expected_defect = math.fsum(
+            balance_terms[:, 0].tolist() + boundary_terms[:, 0].tolist()
+        )
+        assert float(diagnostics.conservation_defect[0]) == expected_defect
         boundary_edges = np.asarray(discretization.connectivity.boundary_edges)
         cell_edges = np.asarray(discretization.connectivity.cell_edges)
         interior_cells = ~np.any(boundary_edges[cell_edges], axis=1)

--- a/tests/unit/equations/test_spectral_conservation.py
+++ b/tests/unit/equations/test_spectral_conservation.py
@@ -1,4 +1,7 @@
+import math
+
 import jax.numpy as jnp
+import numpy as np
 
 import phydrax as phx
 
@@ -45,6 +48,23 @@ def test_periodic_spectral_conservation_and_entropy_diagnostics():
     state = space.project(physical)
 
     residual, diagnostics = compiled.residual_with_diagnostics(0.0, state)
+    physical_residual = space.reconstruct(residual)
+    balance_terms = np.asarray(space.quadrature_weights[..., None] * physical_residual)
+    expected_rate = np.asarray(
+        [math.fsum(balance_terms[:, index].tolist()) for index in range(balance_terms.shape[1])]
+    )
+    np.testing.assert_allclose(
+        diagnostics.semidiscrete_integral_rate,
+        expected_rate,
+        rtol=8e-15,
+        atol=0.0,
+    )
+    np.testing.assert_allclose(
+        diagnostics.conservation_defect,
+        expected_rate,
+        rtol=8e-15,
+        atol=0.0,
+    )
     expected = -2.0 * jnp.pi * jnp.cos(2.0 * jnp.pi * x)
 
     assert jnp.allclose(
@@ -57,3 +77,66 @@ def test_periodic_spectral_conservation_and_entropy_diagnostics():
     assert diagnostics.entropy is not None
     assert jnp.abs(diagnostics.entropy.semidiscrete_entropy_rate) < 1e-11
     assert diagnostics.entropy.admissible
+
+
+def test_spectral_conservation_honors_widened_reduction_precision():
+    precision = phx.discretization.SpectralPrecisionPolicy(
+        jnp.float32,
+        reduction_dtype=jnp.float64,
+        certification_dtype=jnp.float64,
+    )
+    space = phx.discretization.TensorSpectralPlan(
+        (phx.discretization.FourierBasisPlan(32),),
+        axis_names=("x",),
+        field_name="u",
+        precision=precision,
+    ).prepare(jnp.asarray([[0.0], [1.0]], dtype=jnp.float32))
+    system = phx.equations.ScalarConservationSystem(
+        1,
+        lambda state, axis, args: state,
+        lambda left, right, axis, args: jnp.ones(left.shape[:-1]),
+        system_id="mixed-precision-unit-advection",
+    )
+    problem = phx.equations.ConservationProblemIR(
+        "mixed-precision-advection",
+        "u",
+        system,
+        None,
+    )
+    method = phx.discretization.SpectralConservationMethodPlan(
+        phx.discretization.PseudospectralMethodPlan(),
+        flux_polynomial_degree=1,
+    )
+    compiled = phx.equations.compile_conservation_problem(
+        problem,
+        space,
+        method,
+    )
+    x = space.axes[0].nodes
+    state = space.project(jnp.sin(2.0 * jnp.pi * x)[..., None])
+
+    residual, diagnostics = compiled.residual_with_diagnostics(0.0, state)
+    physical_residual = precision.reduction(space.reconstruct(residual))
+    weights = precision.reduction(space.quadrature_weights[..., None])
+    balance_terms = np.asarray(weights * physical_residual)
+    expected = np.asarray(
+        [
+            math.fsum(balance_terms[:, index].tolist())
+            for index in range(balance_terms.shape[1])
+        ]
+    )
+
+    assert diagnostics.semidiscrete_integral_rate.dtype == jnp.float64
+    assert diagnostics.conservation_defect.dtype == jnp.float64
+    np.testing.assert_allclose(
+        diagnostics.semidiscrete_integral_rate,
+        expected,
+        rtol=8e-15,
+        atol=0.0,
+    )
+    np.testing.assert_allclose(
+        diagnostics.conservation_defect,
+        expected,
+        rtol=8e-15,
+        atol=0.0,
+    )

--- a/tests/unit/test_compensated_reductions.py
+++ b/tests/unit/test_compensated_reductions.py
@@ -1,0 +1,85 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import math
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from phydrax._numerics._compensated import compensated_sum, compensated_sum_chunks
+
+
+@pytest.mark.parametrize(
+    ("dtype", "large"),
+    ((jnp.float32, 1.0e8), (jnp.float64, 1.0e16)),
+)
+def test_compensated_sum_recovers_cancellation_and_derivative(dtype, large):
+    values = jnp.asarray((large, 1.0, -large), dtype=dtype)
+    reduced = jax.jit(compensated_sum)(values)
+    gradient = jax.grad(lambda candidate: compensated_sum(candidate))(values)
+
+    assert reduced == jnp.asarray(1.0, dtype=dtype)
+    np.testing.assert_array_equal(gradient, jnp.ones_like(values))
+
+
+def test_compensated_chunks_match_accurate_signed_component_sums():
+    left = jnp.asarray(
+        (
+            (1.0e16, 1.0e8),
+            (1.0, 3.0),
+            (-1.0e16, -1.0e8),
+        )
+    )
+    right = jnp.asarray(((2.0, -4.0), (-2.0, 4.0)))
+    chunks = (left, right)
+
+    actual = jax.jit(
+        lambda values: compensated_sum_chunks(values, output_ndim=1)
+    )(chunks)
+    combined = np.concatenate(tuple(np.asarray(value) for value in chunks), axis=0)
+    expected = np.asarray(
+        [math.fsum(combined[:, index].tolist()) for index in range(combined.shape[1])]
+    )
+
+    np.testing.assert_array_equal(actual, expected)
+
+
+def test_compensated_sum_preserves_axes_shapes_and_empty_identity():
+    values = jnp.arange(24.0).reshape((2, 3, 4))
+    expected = jnp.sum(values, axis=(0, 2), keepdims=True)
+    actual = compensated_sum(values, axis=(0, 2), keepdims=True)
+    empty = compensated_sum(jnp.empty((0, 3), dtype=jnp.float64), axis=0)
+    integers = compensated_sum(jnp.arange(6).reshape((2, 3)), axis=0)
+
+    np.testing.assert_array_equal(actual, expected)
+    np.testing.assert_array_equal(empty, jnp.zeros((3,), dtype=jnp.float64))
+    np.testing.assert_array_equal(integers, jnp.asarray((3, 5, 7)))
+
+
+def test_compensated_sum_preserves_complex_and_nonfinite_semantics():
+    complex_values = jnp.asarray(
+        (1.0e16 + 1.0e16j, 1.0 + 1.0j, -1.0e16 - 1.0e16j)
+    )
+    nonfinite = jnp.asarray(((jnp.inf, 1.0), (-jnp.inf, 2.0)))
+
+    assert compensated_sum(complex_values) == jnp.asarray(1.0 + 1.0j)
+    np.testing.assert_allclose(
+        compensated_sum(nonfinite, axis=0),
+        jnp.sum(nonfinite, axis=0),
+        equal_nan=True,
+    )
+
+
+def test_compensated_sum_vmaps_independent_reductions():
+    values = jnp.asarray(
+        (
+            (1.0e16, 1.0, -1.0e16),
+            (-1.0e16, 2.0, 1.0e16),
+        )
+    )
+    actual = jax.jit(jax.vmap(compensated_sum))(values)
+
+    np.testing.assert_array_equal(actual, jnp.asarray((1.0, 2.0)))

--- a/tools/precision_benchmarks.py
+++ b/tools/precision_benchmarks.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import platform
 import time
 from collections.abc import Callable
@@ -475,21 +476,31 @@ def _finite_volume_case(cells: int, repeats: int, /) -> dict[str, Any]:
             axis=-1,
         ).astype(dtype)
         state = precision.storage(system.primitive_to_conserved(primitive))
-        initial = phx.solver.FiniteVolumeRuntimeState(
+        initial = runtime.initialize_state(
             state,
             precision.decision(0.0),
             precision.decision(1e-4),
         )
         execute = eqx.filter_jit(
             lambda runtime=runtime, initial=initial: (
-                runtime.advance(initial).runtime_state.conservative_state
+                runtime.advance(initial).runtime_state.cell_average()
             )
         )
         value, seconds = _timed(execute, repeats)
         advanced = runtime.advance(initial)
-        _, diagnostics = compiled.dynamics.residual_with_diagnostics(
+        residual, diagnostics = compiled.dynamics.residual_with_diagnostics(
             precision.decision(0.0),
             state,
+        )
+        balance_terms = jax.device_get(
+            precision.reduction(discretization.cell_volumes[..., None] * residual)
+        ).reshape((-1, discretization.component_count))
+        reference = tuple(
+            math.fsum(balance_terms[:, index].tolist())
+            for index in range(discretization.component_count)
+        )
+        reported = tuple(
+            float(item) for item in jax.device_get(diagnostics.conservation_defect)
         )
         results[name] = {
             "seconds": seconds,
@@ -497,6 +508,10 @@ def _finite_volume_case(cells: int, repeats: int, /) -> dict[str, Any]:
             "state_dtype": value.dtype.name,
             "conservation_defect": float(
                 jnp.max(jnp.abs(diagnostics.conservation_defect))
+            ),
+            "conservation_reference_error": max(
+                abs(actual - expected)
+                for actual, expected in zip(reported, reference, strict=True)
             ),
             "precision_evidence_id": advanced.precision_evidence.evidence_id,
         }


### PR DESCRIPTION
## Summary

- add one private twofold compensated reduction substrate for cancellation-sensitive diagnostic sums
- apply a shared conservation-accounting convention across structured, triangle, unstructured, spectral, and periodic SBP conservation backends
- migrate finite-volume small-cell, multiblock, accepted-ledger, remap, overset/sliding, and diffusion accounting
- make spectral conservation honor its declared reduction dtype and bind physical quadrature weights to the physical-space dtype
- centralize Airy error-free addition on the shared TwoSum primitive without changing its specialized product transform

## Numerical contract

The new reducer accumulates final rounded signed contributions together instead of subtracting independently rounded totals. This prevents both false exact zeros and spurious nonzero balance defects while leaving physical residuals, fluxes, state updates, entropy formulas, and time integration unchanged.

Long reductions use a blocked hierarchical twofold expansion to limit sequential depth and workspace. Short reductions retain direct Sum2 accumulation. Non-floating inputs preserve native reduction behavior; float32, float64, and their complex companions retain their resolved dtype.

This is an internal diagnostic implementation detail, not a public arbitrary-precision API, a correctly-rounded guarantee, or a cross-device reproducibility claim.

## Conservation compiler integration

- **Structured finite volume:** jointly accumulates cell-rate, negative source, and raw outward-boundary contributions in `reduction_dtype`.
- **Triangle and unstructured finite volume:** uses the same signed content balance over cell and boundary terms.
- **Spectral conservation:** casts physical, residual, source, and quadrature terms through `SpectralPrecisionPolicy.reduction` before compensated accumulation.
- **Periodic SBP flux differencing:** compensates the quadrature-weighted conservation rate while preserving the antisymmetric pairwise flux construction.

Backend-specific diagnostic result types and precision evidence remain intact.

## Conservative transfer accounting

The same convention now covers:

- small-cell redistribution failure evidence and returned defects
- conforming and nested multiblock interface fluxes
- accepted source, boundary, and net-cell flux-integral ledger totals
- cell-average and direct-content conservative remap defects
- overset donor/receptor and periodic sliding seam balances
- conservative diffusion global-balance certification

AMR synchronization values that are elementwise identical remain zero by construction and are intentionally unchanged.

## Compatibility

- no public constructor, policy, result-schema, or checkpoint changes
- no integration or Krylov reduction changes
- existing finite-volume and spectral precision policies remain authoritative
- documentation distinguishes roundoff accounting from discretization error, entropy stability, and distributed reproducibility