### PR TITLE
Add nonassociative algebra operations and G2 geometry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@
   resource-bounded sparse/dense products, shared real-coordinate maps, algebra-valued
   spaces and operators, Diffrax algebra state policies, and unit complex/quaternion
   state geometries.
+- Added exact and numerical commutator, Jordan-product, and associator operations;
+  explicit left/right regular-action operators; resource-bounded algebra derivation
+  spaces; and an octonion-derived G2 bridge with local metric, torsion, Ricci, and
+  infinitesimal invariance diagnostics.
 - Added canonical-complex holomorphic construction dependencies, spectrally
   initialized low-rank complex-affine layers, per-layer factorized
   `HolomorphicMLP` plans, certified independent branch bundles, same-coordinate

--- a/docs/all-of-phydrax.md
+++ b/docs/all-of-phydrax.md
@@ -398,13 +398,17 @@ are rejected rather than clipped or repaired.
 
 `phydrax.metrix` supplies charts and differentiable maps; tensors and compressed
 differential forms; positive and signed metrics; affine connections and curvature;
-Lie groups; symplectic, Poisson, and horizontal structures; metric-aware stochastic
-kernels; and immutable, measure-orthonormal Laplacian spectra. Graph and cochain
-constructors bind those spectra to explicit topology, metric, boundary, and entity
-provenance. Positive norms, Lorentzian wave operators, Poisson brackets, and
-sub-Laplacians remain distinct named operations rather than overloads with hidden
-defaults. Bounds, seams, sampling, and admissibility remain domain concerns. See
-[API → Metrix](api/metrix/index.md).
+finite real algebras; Lie groups; symplectic, Poisson, horizontal, complex, and G2
+structures; metric-aware stochastic kernels; and immutable, measure-orthonormal
+Laplacian spectra. Exact rational multiplication tables keep commutators, Jordan
+products, associators, and left/right regular actions explicit. The canonical octonion
+bridge derives the seven-dimensional cross product and G2 three-form from that same
+table, while derivation preparation exposes numerical infinitesimal-symmetry evidence.
+Graph and cochain constructors bind spectra to explicit topology, metric, boundary,
+and entity provenance. Positive norms, Lorentzian wave operators, Poisson brackets,
+sub-Laplacians, and nonassociative bracket trees remain distinct named operations
+rather than overloads with hidden defaults. Bounds, seams, sampling, and admissibility
+remain domain concerns. See [API → Metrix](api/metrix/index.md).
 
 For trainable arrays on spheres, hyperbolic spaces, probability simplices, matrix
 manifolds, SO(n), or SPD(n), `ParameterGeometry` binds exact PyTree leaf paths to

--- a/docs/api/linalg/algebra_coordinates.md
+++ b/docs/api/linalg/algebra_coordinates.md
@@ -26,6 +26,30 @@
 
 ::: phydrax.linalg.AlgebraCoefficientPairing
 
+
+::: phydrax.linalg.algebra_regular_action_operator
+
+---
+
+::: phydrax.linalg.AlgebraDerivationPolicy
+
+---
+
+::: phydrax.linalg.AlgebraDerivationPlan
+
+---
+
+::: phydrax.linalg.PreparedAlgebraDerivations
+
+---
+
+::: phydrax.linalg.plan_algebra_derivations
+
+---
+
+::: phydrax.linalg.prepare_algebra_derivations
+
+---
 ---
 
 ::: phydrax.linalg.lift_real_operator_to_algebra

--- a/docs/api/metrix/algebra.md
+++ b/docs/api/metrix/algebra.md
@@ -38,6 +38,18 @@
 
 ::: phydrax.metrix.algebra.AlgebraProductPlan
 
+
+::: phydrax.metrix.algebra.AlgebraDerivationConstraint
+
+---
+
+::: phydrax.metrix.algebra.AlgebraSymmetryBudget
+
+---
+
+::: phydrax.metrix.algebra.AlgebraSymmetryResourceEvidence
+
+---
 ---
 
 ::: phydrax.metrix.algebra.AlgebraPropertyEvidence

--- a/docs/api/metrix/index.md
+++ b/docs/api/metrix/index.md
@@ -3,8 +3,9 @@
 `phydrax.metrix` is Phydrax's differentiable geometry layer. It represents charts,
 atlases, differentiable maps and immersions, tensors and forms, positive and signed
 metrics, affine and bundle connections, curvature, metric measures, Lie groups,
-symplectic and Poisson structures, horizontal cometrics, complex/Kähler structures,
-and real or complex array manifolds as ordinary JAX programs.
+symplectic and Poisson structures, horizontal cometrics, finite real algebras,
+complex/Kähler and G2 structures, and real or complex array manifolds as ordinary
+JAX programs.
 
 Metrix is intentionally below the domain and solver layers:
 
@@ -96,6 +97,8 @@ point coordinates or replace domain admissibility rules.
 - [General affine connections](affine_connections.md)
 - [Curvature](curvature.md)
 - [Differential forms](forms.md)
+- [Finite real algebras](algebra.md)
+- [Special holonomy and G2 geometry](special_holonomy.md)
 - [Embedded geometry](embedded.md)
 - [Array manifolds](manifolds.md)
 - [Intrinsic endpoint geometry](intrinsic_geometry.md)
@@ -136,6 +139,13 @@ Run representative metric-jet, form, Poisson, Lorentzian, and horizontal kernels
 
 ```bash
 python -m tools.geometric_benchmarks --smoke
+```
+
+Octonion-derived G2 cross products and local compatibility/torsion diagnostics are
+included in:
+
+```bash
+python -m tools.exotic_geometry_benchmarks --smoke
 ```
 
 The report separates compilation-plus-first-call time from steady execution time and

--- a/docs/api/metrix/special_holonomy.md
+++ b/docs/api/metrix/special_holonomy.md
@@ -1,0 +1,52 @@
+# Special holonomy structures
+
+## Octonion bridge
+
+::: phydrax.metrix.OctonionG2Bridge
+
+`OctonionG2Bridge` owns the canonical flat identification between the seven ordered
+imaginary octonion coordinates and a seven-dimensional chart. Its cross product and
+associative three-form are derived from the exact `OctonionAlgebraSpec` structure table.
+The bridge does not infer a moving octonion frame on a curved manifold.
+
+---
+
+## Local G2 structures
+
+::: phydrax.metrix.LocalG2Structure
+
+---
+
+::: phydrax.metrix.LocalG2ValidationReport
+
+---
+
+::: phydrax.metrix.validate_local_g2_structure
+
+A local G2 structure supplies both its Riemannian metric and degree-three associative
+form. Validation checks their algebraic compatibility and reports closure, coclosure,
+torsion freedom, and Ricci-flatness independently. It does not claim global holonomy,
+completeness, compactness, or topology.
+
+---
+
+## Infinitesimal automorphisms
+
+::: phydrax.metrix.G2DerivationInvarianceReport
+
+---
+
+::: phydrax.metrix.validate_g2_derivations
+
+The derivation validator checks whether a prepared octonion derivation subspace fixes
+the scalar coordinate, is skew with respect to the canonical metric, and
+infinitesimally preserves the associative three-form. The prepared subspace is
+numerical evidence derived from exact Leibniz constraints; it is not a full G2 group
+implementation.
+
+## Boundary
+
+Unit octonions form a smooth Moufang loop, not a Lie group. This API neither enables
+Lie-group integrators for unit octonions nor introduces Moufang-loop exponential,
+logarithm, or composition methods. Unconstrained octonion states remain real coordinate
+arrays, and unit-norm states can use `SphereManifold(8)` independently of multiplication.

--- a/docs/guides_finite_real_algebras.md
+++ b/docs/guides_finite_real_algebras.md
@@ -45,6 +45,23 @@ audits establish finite polynomial identities such as associativity, alternativi
 flexibility, and conjugation anti-automorphism. Division and norm claims require family
 construction evidence or an explicit witness; finite samples do not mint proofs.
 
+## Derived nonassociative operations
+
+Exact specifications and prepared products expose the same commutator, symmetrized
+Jordan product, and associator. The associator retains both bracket trees:
+
+```python
+octonion = phx.metrix.algebra.OctonionAlgebraSpec()
+product = octonion.prepare_product(backend="sparse")
+associator = product.associator(left, middle, right)
+```
+
+`product.associator(left, middle, right)` evaluates
+`product(product(left, middle), right) - product(left, product(middle, right))`.
+No compiler path flattens that expression. `commutator` and `jordan_product` are
+defined for every algebra; calculating them does not assert commutativity or the
+Jordan identity.
+
 ## Family boundaries
 
 - complex values are commutative associative division-algebra values;
@@ -75,6 +92,18 @@ complex action without duplicating real/imaginary logic. Generic quaternion or
 octonion matrices require explicit real-, left-, right-, or bimodule semantics; no
 ambiguous algebra-valued matrix multiplication is inferred.
 
+`algebra_regular_action_operator` binds multiplication by one fixed algebra value as
+a Phydrax-native real-linear operator. The required `side="left"` or `side="right"`
+is part of the operator identity. Composing two left actions remains ordinary operator
+composition and is not collapsed to multiplication by one element.
+
+Derivation constraints encode the exact Leibniz equations from the rational structure
+table. `plan_algebra_derivations` and `prepare_algebra_derivations` then compute a
+resource-bounded numerical nullspace with explicit rank-gap and residual evidence.
+The canonical quaternion and octonion derivation spaces have dimensions three and
+fourteen, respectively. This is numerical subspace evidence, not an exact nullspace
+proof.
+
 ## Differential solvers
 
 `DiffraxAlgebraStatePolicy` binds prepared algebra coordinates to ordinary Diffrax
@@ -94,6 +123,21 @@ Nontrivial geometry remains family-specific. Unit complex and unit quaternion
 geometries are provided over real coordinates. Unit octonions are not assigned a Lie
 group geometry: their multiplication is nonassociative and their unit sphere is a
 Moufang loop.
+
+## Octonions and local G2 geometry
+
+`OctonionG2Bridge` derives the seven-dimensional cross product and canonical
+associative three-form directly from the configured octonion multiplication table.
+It therefore cannot drift to a second Fano-plane sign convention. `LocalG2Structure`
+couples a degree-three form to an explicit seven-dimensional Riemannian metric.
+`validate_local_g2_structure` reports metric compatibility, volume normalization,
+closure, coclosure, torsion freedom, and Ricci-flatness separately.
+
+Prepared octonion derivations can be checked with `validate_g2_derivations`; the
+fourteen-dimensional derivation space infinitesimally preserves the G2 three-form.
+This does not make unit octonions a Lie group. Unit-norm octonion states use the
+ordinary `SphereManifold(8)` geometry, while multiplication-aware Moufang-loop
+integrators remain outside this contract.
 
 ## Clifford relationship
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -226,6 +226,7 @@ nav:
             - Intrinsic endpoint geometry: "api/metrix/intrinsic_geometry.md"
             - Hessian and information geometry: "api/metrix/information_geometry.md"
             - Complex and Kähler geometry: "api/metrix/complex_geometry.md"
+            - Special holonomy and G2 geometry: "api/metrix/special_holonomy.md"
             - Global projective and Ricci-flat geometry: "api/metrix/global_complex.md"
             - Calabi-Yau campaigns: "api/metrix/calabi_yau_campaigns.md"
             - Bures and quantum density geometry: "api/metrix/quantum_density.md"

--- a/phydrax/linalg/__init__.py
+++ b/phydrax/linalg/__init__.py
@@ -12,10 +12,19 @@ from ._adaptive_spectral import (
     AdaptiveStochasticEstimate,
     AdaptiveStochasticPolicy,
 )
+from ._algebra_actions import algebra_regular_action_operator, AlgebraActionSide
 from ._algebra_coordinates import (
     AlgebraCoordinatePlan,
     AlgebraCoordinateStorage,
     PreparedAlgebraCoordinates,
+)
+from ._algebra_derivations import (
+    AlgebraDerivationPlan,
+    AlgebraDerivationPolicy,
+    AlgebraDerivationStatus,
+    plan_algebra_derivations,
+    prepare_algebra_derivations,
+    PreparedAlgebraDerivations,
 )
 from ._algebra_operators import (
     apply_real_map_componentwise,
@@ -522,10 +531,18 @@ __all__ = [
     "AbstractPreconditionerBuilder",
     "AbstractVectorSpace",
     "AbstractRealCoordinateMap",
+    "AlgebraActionSide",
+    "AlgebraDerivationPlan",
+    "AlgebraDerivationPolicy",
+    "AlgebraDerivationStatus",
     "AlgebraArraySpace",
     "AlgebraCoefficientPairing",
     "AlgebraCoordinatePlan",
     "AlgebraCoordinateStorage",
+    "algebra_regular_action_operator",
+    "plan_algebra_derivations",
+    "prepare_algebra_derivations",
+    "PreparedAlgebraDerivations",
     "AdditiveSubspaceCorrectionBuilder",
     "AdditiveSubspaceCorrectionPreconditioner",
     "AdjointLinearOperator",

--- a/phydrax/linalg/_algebra_actions.py
+++ b/phydrax/linalg/_algebra_actions.py
@@ -1,0 +1,113 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from typing import Any, Literal, TypeAlias
+
+import equinox as eqx
+import jax.numpy as jnp
+import numpy as np
+from jaxtyping import Array, ArrayLike
+
+from .._fingerprint import array_tree_fingerprint, canonical_fingerprint
+from .._strict import StrictModule
+from ._algebra_spaces import AlgebraArraySpace
+from ._operators import FunctionLinearOperator
+
+
+AlgebraActionSide: TypeAlias = Literal["left", "right"]
+
+
+class _BoundAlgebraAction(StrictModule):
+    product: Any
+    multiplier: Array
+    side: AlgebraActionSide = eqx.field(static=True)
+
+    def __init__(self, product: Any, multiplier: Array, side: AlgebraActionSide, /):
+        self.product = product
+        self.multiplier = multiplier
+        self.side = side
+
+    def __call__(self, value: Array, /) -> Array:
+        if self.side == "left":
+            return self.product(self.multiplier, value)
+        return self.product(value, self.multiplier)
+
+
+def _broadcast_multiplier(
+    multiplier: ArrayLike,
+    space: AlgebraArraySpace,
+    /,
+) -> Array:
+    value = jnp.asarray(multiplier)
+    if jnp.iscomplexobj(value):
+        raise TypeError("Algebra regular-action multipliers must use real coordinates.")
+    if not np.issubdtype(np.dtype(value.dtype), np.floating):
+        raise TypeError("Algebra regular-action multipliers must use floating dtype.")
+    if np.dtype(value.dtype) != space.dtype:
+        raise TypeError(
+            f"Algebra regular-action multiplier must have dtype {space.dtype}; "
+            f"got {value.dtype}."
+        )
+    dimension = space.algebra.coordinate_dimension
+    if value.shape == (dimension,):
+        shape = [1] * len(space.shape)
+        shape[space.algebra_axis] = dimension
+        value = value.reshape(tuple(shape))
+    elif value.ndim != len(space.shape) or value.shape[space.algebra_axis] != dimension:
+        raise ValueError(
+            "Algebra regular-action multiplier must be one algebra element or expose "
+            "the space's declared algebra axis."
+        )
+    if jnp.broadcast_shapes(value.shape, space.shape) != space.shape:
+        raise ValueError(
+            "Algebra regular-action multiplier does not broadcast to the declared space."
+        )
+    return value
+
+
+def algebra_regular_action_operator(
+    product: Any,
+    multiplier: ArrayLike,
+    space: AlgebraArraySpace,
+    /,
+    *,
+    side: AlgebraActionSide,
+) -> FunctionLinearOperator:
+    """Bind left or right pointwise multiplication as a real-linear operator."""
+    from ..metrix.algebra import AlgebraProductPlan
+
+    if not isinstance(product, AlgebraProductPlan):
+        raise TypeError("product must be an AlgebraProductPlan.")
+    if not isinstance(space, AlgebraArraySpace):
+        raise TypeError("space must be an AlgebraArraySpace.")
+    if side not in ("left", "right"):
+        raise ValueError("side must be 'left' or 'right'.")
+    product.algebra.require_compatible(space.algebra)
+    product_axis = product.layout.algebra_axis
+    if product_axis < 0:
+        product_axis += len(space.shape)
+    if product_axis != space.algebra_axis:
+        raise ValueError("Product layout and algebra space use different algebra axes.")
+    multiplier_ = _broadcast_multiplier(multiplier, space)
+    action = _BoundAlgebraAction(product, multiplier_, side)
+    operator_id = canonical_fingerprint(
+        {
+            "kind": "algebra-regular-action-v1",
+            "product": product.plan_id,
+            "space": space.space_id,
+            "side": side,
+            "multiplier": array_tree_fingerprint(multiplier_),
+        }
+    )
+    return FunctionLinearOperator(
+        action,
+        source=space,
+        target=space,
+        operator_id=operator_id,
+    )
+
+
+__all__ = ["AlgebraActionSide", "algebra_regular_action_operator"]

--- a/phydrax/linalg/_algebra_derivations.py
+++ b/phydrax/linalg/_algebra_derivations.py
@@ -1,0 +1,342 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from enum import IntEnum
+from math import isfinite
+from typing import Any
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import numpy as np
+import opt_einsum as oe
+from jaxtyping import Array
+
+from .._fingerprint import array_tree_fingerprint, canonical_fingerprint
+from .._strict import StrictModule
+from .._trainable import NonTrainableState
+from ._spaces import ArraySpace
+from ._subspaces import LinearSubspace
+
+
+class AlgebraDerivationStatus(IntEnum):
+    SUCCESS = 0
+    NONFINITE = 1
+    AMBIGUOUS_RANK = 2
+    RESIDUAL_FAILURE = 3
+
+
+class AlgebraDerivationPolicy(StrictModule, NonTrainableState):
+    absolute_cutoff: float = eqx.field(static=True)
+    relative_cutoff: float = eqx.field(static=True)
+    minimum_singular_gap: float = eqx.field(static=True)
+    residual_tolerance: float = eqx.field(static=True)
+    dtype: np.dtype = eqx.field(static=True)
+    policy_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        absolute_cutoff: float = 1e-12,
+        relative_cutoff: float = 1e-10,
+        minimum_singular_gap: float = 1e4,
+        residual_tolerance: float = 1e-10,
+        dtype: Any = np.float64,
+    ):
+        values = tuple(
+            float(value)
+            for value in (
+                absolute_cutoff,
+                relative_cutoff,
+                minimum_singular_gap,
+                residual_tolerance,
+            )
+        )
+        if any(not isfinite(value) or value < 0.0 for value in values):
+            raise ValueError(
+                "Algebra derivation policy values must be finite and nonnegative."
+            )
+        if values[2] < 1.0:
+            raise ValueError("minimum_singular_gap must be at least one.")
+        dtype_ = np.dtype(dtype)
+        if not np.issubdtype(dtype_, np.floating):
+            raise TypeError("Algebra derivation preparation requires floating dtype.")
+        (
+            self.absolute_cutoff,
+            self.relative_cutoff,
+            self.minimum_singular_gap,
+            self.residual_tolerance,
+        ) = values
+        self.dtype = dtype_
+        self.policy_id = canonical_fingerprint(
+            {
+                "kind": "algebra-derivation-policy-v1",
+                "absolute_cutoff": values[0].hex(),
+                "relative_cutoff": values[1].hex(),
+                "minimum_singular_gap": values[2].hex(),
+                "residual_tolerance": values[3].hex(),
+                "dtype": dtype_.str,
+            }
+        )
+
+
+class AlgebraDerivationPlan(StrictModule, NonTrainableState):
+    constraint: Any
+    policy: AlgebraDerivationPolicy
+    plan_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        constraint: Any,
+        /,
+        *,
+        policy: AlgebraDerivationPolicy | None = None,
+    ):
+        from ..metrix.algebra import AlgebraDerivationConstraint
+
+        if not isinstance(constraint, AlgebraDerivationConstraint):
+            raise TypeError("constraint must be an AlgebraDerivationConstraint.")
+        policy_ = AlgebraDerivationPolicy() if policy is None else policy
+        if not isinstance(policy_, AlgebraDerivationPolicy):
+            raise TypeError("policy must be AlgebraDerivationPolicy or None.")
+        self.constraint = constraint
+        self.policy = policy_
+        self.plan_id = canonical_fingerprint(
+            {
+                "kind": "algebra-derivation-plan-v1",
+                "constraint": constraint.constraint_id,
+                "policy": policy_.policy_id,
+            }
+        )
+
+
+class PreparedAlgebraDerivations(StrictModule):
+    plan: AlgebraDerivationPlan
+    subspace: LinearSubspace
+    singular_values: Array
+    cutoff: Array
+    singular_gap: Array
+    maximum_leibniz_residual: Array
+    maximum_unit_fixing_residual: Array
+    maximum_commutator_closure_residual: Array
+    converged: Array
+    status: Array
+    constraint_matrix_bytes: int = eqx.field(static=True)
+    workspace_bytes: int = eqx.field(static=True)
+    basis_bytes: int = eqx.field(static=True)
+    prepared_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        plan: AlgebraDerivationPlan,
+        subspace: LinearSubspace,
+        singular_values: Array,
+        cutoff: Array,
+        singular_gap: Array,
+        maximum_leibniz_residual: Array,
+        maximum_unit_fixing_residual: Array,
+        maximum_commutator_closure_residual: Array,
+        converged: Array,
+        status: Array,
+        /,
+        *,
+        constraint_matrix_bytes: int,
+        workspace_bytes: int,
+        basis_bytes: int,
+    ):
+        self.plan = plan
+        self.subspace = subspace
+        self.singular_values = jnp.asarray(singular_values)
+        self.cutoff = jnp.asarray(cutoff)
+        self.singular_gap = jnp.asarray(singular_gap)
+        self.maximum_leibniz_residual = jnp.asarray(maximum_leibniz_residual)
+        self.maximum_unit_fixing_residual = jnp.asarray(maximum_unit_fixing_residual)
+        self.maximum_commutator_closure_residual = jnp.asarray(
+            maximum_commutator_closure_residual
+        )
+        self.converged = jnp.asarray(converged, dtype=bool)
+        self.status = jnp.asarray(status, dtype=jnp.int32)
+        self.constraint_matrix_bytes = int(constraint_matrix_bytes)
+        self.workspace_bytes = int(workspace_bytes)
+        self.basis_bytes = int(basis_bytes)
+        self.prepared_id = canonical_fingerprint(
+            {
+                "kind": "prepared-algebra-derivations-v1",
+                "plan": plan.plan_id,
+                "subspace": subspace.subspace_id,
+                "basis": array_tree_fingerprint(subspace.basis),
+                "constraint_matrix_bytes": int(constraint_matrix_bytes),
+                "workspace_bytes": int(workspace_bytes),
+                "basis_bytes": int(basis_bytes),
+            }
+        )
+
+    @property
+    def dimension(self) -> Array:
+        return self.subspace.dimension
+
+    def project(self, matrix: Array, /) -> Array:
+        return self.subspace.project(matrix)
+
+
+def plan_algebra_derivations(
+    algebra: Any,
+    /,
+    *,
+    budget: Any | None = None,
+    policy: AlgebraDerivationPolicy | None = None,
+) -> AlgebraDerivationPlan:
+    from ..metrix.algebra import AlgebraDerivationConstraint
+
+    return AlgebraDerivationPlan(
+        AlgebraDerivationConstraint(algebra, budget=budget),
+        policy=policy,
+    )
+
+
+def _maximum_or_zero(value: Array, /) -> Array:
+    if value.size == 0:
+        return jnp.asarray(0.0, dtype=value.dtype)
+    return jnp.max(jnp.abs(value))
+
+
+def prepare_algebra_derivations(
+    plan: AlgebraDerivationPlan,
+    /,
+) -> PreparedAlgebraDerivations:
+    """Prepare a numerically certified derivation nullspace from exact constraints."""
+    if not isinstance(plan, AlgebraDerivationPlan):
+        raise TypeError("plan must be an AlgebraDerivationPlan.")
+    constraint = plan.constraint
+    policy = plan.policy
+    dimension = constraint.algebra.coordinate_dimension
+    itemsize = policy.dtype.itemsize
+    matrix_bytes = constraint.equation_count * constraint.variable_count * itemsize
+    workspace_bytes = (
+        constraint.equation_count * constraint.variable_count
+        + constraint.variable_count**2
+        + constraint.variable_count
+    ) * itemsize
+    maximum_basis_bytes = constraint.variable_count**2 * itemsize
+    constraint.budget.admit_materialization(
+        matrix_bytes,
+        workspace_bytes,
+        maximum_basis_bytes,
+    )
+    matrix = constraint.materialize(policy.dtype)
+    _, singular_values, right_adjoint = jnp.linalg.svd(matrix, full_matrices=False)
+    maximum = jnp.max(singular_values)
+    cutoff = jnp.maximum(
+        jnp.asarray(policy.absolute_cutoff, dtype=singular_values.dtype),
+        jnp.asarray(policy.relative_cutoff, dtype=singular_values.dtype) * maximum,
+    )
+    retained = singular_values > cutoff
+    rank = int(jax.device_get(jnp.sum(retained, dtype=jnp.int32)))
+    nullity = constraint.variable_count - rank
+    right_vectors = jnp.swapaxes(jnp.conj(right_adjoint), -1, -2)
+    basis = right_vectors[:, rank:]
+    space = ArraySpace((dimension, dimension), dtype=policy.dtype)
+    subspace = LinearSubspace(
+        space,
+        basis,
+        dimension=nullity,
+        orthonormal=True,
+        subspace_id=canonical_fingerprint(
+            {
+                "kind": "algebra-derivation-subspace-v1",
+                "plan": plan.plan_id,
+                "capacity": nullity,
+            }
+        ),
+    )
+
+    leibniz_residual = _maximum_or_zero(matrix @ basis)
+    unit = jnp.asarray(
+        [
+            numerator / denominator
+            for numerator, denominator in constraint.algebra.unit.entries
+        ],
+        dtype=policy.dtype,
+    )
+    matrices = jnp.swapaxes(basis, 0, 1).reshape((nullity, dimension, dimension))
+    unit_residual = _maximum_or_zero(oe.contract("nij,j->ni", matrices, unit))
+    if nullity:
+        commutators = oe.contract("aij,bjk->abik", matrices, matrices) - oe.contract(
+            "bij,ajk->abik",
+            matrices,
+            matrices,
+        )
+        flattened = commutators.reshape((nullity, nullity, constraint.variable_count))
+        projector = basis @ jnp.swapaxes(jnp.conj(basis), -1, -2)
+        projected = oe.contract("...v,vw->...w", flattened, projector)
+        closure_residual = _maximum_or_zero(flattened - projected)
+    else:
+        closure_residual = jnp.asarray(0.0, dtype=policy.dtype)
+
+    tiny = jnp.finfo(singular_values.dtype).tiny
+    retained_margin = (
+        singular_values[rank - 1] / jnp.maximum(cutoff, tiny)
+        if rank
+        else jnp.asarray(jnp.inf, dtype=policy.dtype)
+    )
+    discarded_margin = (
+        cutoff / jnp.maximum(singular_values[rank], tiny)
+        if rank < constraint.variable_count
+        else jnp.asarray(jnp.inf, dtype=policy.dtype)
+    )
+    singular_gap = jnp.minimum(retained_margin, discarded_margin)
+    finite = (
+        jnp.all(jnp.isfinite(singular_values))
+        & jnp.isfinite(leibniz_residual)
+        & jnp.isfinite(unit_residual)
+        & jnp.isfinite(closure_residual)
+    )
+    gap_resolved = singular_gap >= policy.minimum_singular_gap
+    residual_ok = (
+        (leibniz_residual <= policy.residual_tolerance)
+        & (unit_residual <= policy.residual_tolerance)
+        & (closure_residual <= policy.residual_tolerance)
+    )
+    converged = finite & gap_resolved & residual_ok
+    status = jnp.where(
+        ~finite,
+        int(AlgebraDerivationStatus.NONFINITE),
+        jnp.where(
+            ~gap_resolved,
+            int(AlgebraDerivationStatus.AMBIGUOUS_RANK),
+            jnp.where(
+                ~residual_ok,
+                int(AlgebraDerivationStatus.RESIDUAL_FAILURE),
+                int(AlgebraDerivationStatus.SUCCESS),
+            ),
+        ),
+    )
+    basis_bytes = constraint.variable_count * nullity * itemsize
+    return PreparedAlgebraDerivations(
+        plan,
+        subspace,
+        singular_values,
+        cutoff,
+        singular_gap,
+        leibniz_residual,
+        unit_residual,
+        closure_residual,
+        converged,
+        status,
+        constraint_matrix_bytes=matrix_bytes,
+        workspace_bytes=workspace_bytes,
+        basis_bytes=basis_bytes,
+    )
+
+
+__all__ = [
+    "AlgebraDerivationPlan",
+    "AlgebraDerivationPolicy",
+    "AlgebraDerivationStatus",
+    "PreparedAlgebraDerivations",
+    "plan_algebra_derivations",
+    "prepare_algebra_derivations",
+]

--- a/phydrax/metrix/__init__.py
+++ b/phydrax/metrix/__init__.py
@@ -244,8 +244,14 @@ from ._signed_validation import (
     validate_semi_riemannian_metric,
 )
 from ._special_holonomy import (
+    G2DerivationInvarianceReport,
+    LocalG2Structure,
+    LocalG2ValidationReport,
     LocalSUNStructure,
     LocalSUNValidationReport,
+    OctonionG2Bridge,
+    validate_g2_derivations,
+    validate_local_g2_structure,
     validate_local_su_structure,
 )
 from ._state_geometry import (
@@ -364,8 +370,12 @@ __all__ = [
     "LorentzianMetric",
     "KahlerStructure",
     "KahlerValidationReport",
+    "G2DerivationInvarianceReport",
+    "LocalG2Structure",
+    "LocalG2ValidationReport",
     "LocalSUNStructure",
     "LocalSUNValidationReport",
+    "OctonionG2Bridge",
     "ManifoldValidationReport",
     "MetricGeodesicResult",
     "MetricJet",
@@ -479,6 +489,8 @@ __all__ = [
     "validate_coordinate_atlas",
     "validate_hermitian_structure",
     "validate_kahler_structure",
+    "validate_g2_derivations",
+    "validate_local_g2_structure",
     "validate_local_su_structure",
     "validate_hessian_geometry",
     "validate_legendre_geometry",

--- a/phydrax/metrix/_special_holonomy.py
+++ b/phydrax/metrix/_special_holonomy.py
@@ -4,17 +4,24 @@
 
 from __future__ import annotations
 
-from math import factorial
+from itertools import permutations
+from math import factorial, isfinite
 
 import equinox as eqx
 import jax
 import jax.numpy as jnp
+import opt_einsum as oe
 from jaxtyping import Array, ArrayLike
 
+from .._fingerprint import canonical_fingerprint
 from .._strict import StrictModule
+from ._chart import CoordinateChart
 from ._curvature import ricci_tensor
-from ._forms import DifferentialForm, exterior_derivative, wedge
+from ._exterior_basis import exterior_indices
+from ._forms import DifferentialForm, exterior_derivative, hodge_star, wedge
 from ._kahler import KahlerStructure, validate_kahler_structure
+from ._metric import euclidean_metric, RiemannianMetric
+from .algebra import AlgebraProductPlan, OctonionAlgebraSpec
 
 
 class _ConjugateFormCoefficients(StrictModule):
@@ -207,8 +214,499 @@ def validate_local_su_structure(
     return report
 
 
+def _permutation_sign(values: tuple[int, ...], /) -> int:
+    inversions = sum(
+        values[left] > values[right]
+        for left in range(len(values))
+        for right in range(left + 1, len(values))
+    )
+    return -1 if inversions % 2 else 1
+
+
+def _dense_three_form(coefficients: Array, /) -> Array:
+    indices = exterior_indices(7, 3)
+    source_positions: list[int] = []
+    output_positions: list[int] = []
+    signs: list[int] = []
+    for source, axes in enumerate(indices):
+        for ordered in permutations(axes):
+            source_positions.append(source)
+            output_positions.append(ordered[0] * 49 + ordered[1] * 7 + ordered[2])
+            signs.append(_permutation_sign(ordered))
+    source_array = jnp.asarray(source_positions, dtype=jnp.int32)
+    output_array = jnp.asarray(output_positions, dtype=jnp.int32)
+    sign_array = jnp.asarray(signs, dtype=coefficients.dtype)
+    values = coefficients[..., source_array] * sign_array
+    flat = (
+        jnp.zeros(coefficients.shape[:-1] + (7**3,), dtype=coefficients.dtype)
+        .at[..., output_array]
+        .set(values)
+    )
+    return flat.reshape(coefficients.shape[:-1] + (7, 7, 7))
+
+
+def _maximum_or_zero(value: Array, /) -> Array:
+    if value.size == 0:
+        return jnp.asarray(0.0, dtype=value.dtype)
+    return jnp.max(jnp.abs(value))
+
+
+class _ConstantG2FormCoefficients(StrictModule):
+    coefficients: Array
+
+    def __init__(self, coefficients: Array, /):
+        self.coefficients = jnp.asarray(coefficients)
+
+    def __call__(self, coordinates: Array, /) -> Array:
+        return self.coefficients.astype(coordinates.dtype)
+
+
+class LocalG2Structure(StrictModule):
+    """Local seven-dimensional G2 candidate with an explicit metric and three-form."""
+
+    metric: RiemannianMetric
+    associative_form: DifferentialForm
+    orientation: int = eqx.field(static=True)
+
+    def __init__(
+        self,
+        metric: RiemannianMetric,
+        associative_form: DifferentialForm,
+        /,
+        *,
+        orientation: int = 1,
+    ):
+        if not isinstance(metric, RiemannianMetric):
+            raise TypeError("LocalG2Structure requires a RiemannianMetric.")
+        if not isinstance(associative_form, DifferentialForm):
+            raise TypeError("associative_form must be a DifferentialForm.")
+        if metric.chart.dimension != 7:
+            raise ValueError("A local G2 structure requires a seven-dimensional chart.")
+        if associative_form.degree != 3:
+            raise ValueError("A local G2 associative form must have degree three.")
+        if not metric.chart.compatible_with(associative_form.chart):
+            raise ValueError("G2 metric and associative-form charts must match.")
+        if orientation not in (-1, 1):
+            raise ValueError("G2 orientation must be +1 or -1.")
+        self.metric = metric
+        self.associative_form = associative_form
+        self.orientation = int(orientation)
+
+    def coassociative_form(self) -> DifferentialForm:
+        return hodge_star(
+            self.associative_form,
+            self.metric,
+            orientation=self.orientation,
+        )
+
+
+class OctonionG2Bridge(StrictModule):
+    """Canonical flat G2 data induced by the declared octonion convention."""
+
+    algebra: OctonionAlgebraSpec
+    chart: CoordinateChart
+    metric: RiemannianMetric
+    product: AlgebraProductPlan
+    coefficients: Array
+    imaginary_basis_indices: tuple[int, ...] = eqx.field(static=True)
+    orientation: int = eqx.field(static=True)
+    bridge_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        algebra: OctonionAlgebraSpec,
+        chart: CoordinateChart,
+        /,
+        *,
+        orientation: int = 1,
+    ):
+        if not isinstance(algebra, OctonionAlgebraSpec):
+            raise TypeError("OctonionG2Bridge requires an OctonionAlgebraSpec.")
+        if not isinstance(chart, CoordinateChart):
+            raise TypeError("OctonionG2Bridge requires a CoordinateChart.")
+        if chart.dimension != 7:
+            raise ValueError("Octonion G2 coordinates require a seven-dimensional chart.")
+        if orientation not in (-1, 1):
+            raise ValueError("G2 orientation must be +1 or -1.")
+        imaginary = tuple(
+            basis
+            for basis in range(algebra.coordinate_dimension)
+            if basis != algebra.scalar_basis_index
+        )
+        if len(imaginary) != 7:
+            raise ValueError(
+                "The octonion algebra must expose seven imaginary coordinates."
+            )
+        coefficients = []
+        for left, middle, right in exterior_indices(7, 3):
+            product = algebra.structure.basis_product(
+                imaginary[left],
+                imaginary[middle],
+            )
+            coefficients.append(orientation * product[imaginary[right]])
+        self.algebra = algebra
+        self.chart = chart
+        self.metric = euclidean_metric(chart)
+        self.product = algebra.prepare_product(backend="sparse")
+        self.coefficients = jnp.asarray(
+            [float(value) for value in coefficients],
+            dtype=float,
+        )
+        self.imaginary_basis_indices = imaginary
+        self.orientation = int(orientation)
+        self.bridge_id = canonical_fingerprint(
+            {
+                "kind": "octonion-g2-bridge-v1",
+                "algebra": algebra.algebra_id,
+                "basis": list(imaginary),
+                "chart": {
+                    "name": chart.name,
+                    "coordinates": list(chart.coordinates),
+                },
+                "orientation": int(orientation),
+            }
+        )
+
+    def _imaginary_value(self, value: ArrayLike, owner: str, /) -> Array:
+        array = jnp.asarray(value)
+        if array.shape[-1:] != (7,):
+            raise ValueError(f"{owner} must have trailing shape (7,).")
+        if jnp.iscomplexobj(array):
+            raise TypeError(f"{owner} must use real coordinates.")
+        if not jnp.issubdtype(array.dtype, jnp.floating):
+            raise TypeError(f"{owner} must use floating coordinates.")
+        return array
+
+    def embed_imaginary(self, value: ArrayLike, /) -> Array:
+        imaginary = self._imaginary_value(value, "Imaginary octonion value")
+        return (
+            jnp.zeros(
+                imaginary.shape[:-1] + (self.algebra.coordinate_dimension,),
+                dtype=imaginary.dtype,
+            )
+            .at[..., jnp.asarray(self.imaginary_basis_indices, dtype=jnp.int32)]
+            .set(imaginary)
+        )
+
+    def extract_imaginary(self, value: ArrayLike, /) -> Array:
+        array = jnp.asarray(value)
+        if array.shape[-1:] != (self.algebra.coordinate_dimension,):
+            raise ValueError("Octonion value must have trailing shape (8,).")
+        if jnp.iscomplexobj(array):
+            raise TypeError("Octonion value must use real coordinates.")
+        return array[..., jnp.asarray(self.imaginary_basis_indices, dtype=jnp.int32)]
+
+    def cross(self, left: ArrayLike, right: ArrayLike, /) -> Array:
+        left_ = self.embed_imaginary(left)
+        right_ = self.embed_imaginary(right)
+        return self.extract_imaginary(self.product(left_, right_))
+
+    def associative_tensor(self) -> Array:
+        """Return the canonical alternating G2 three-tensor."""
+        return _dense_three_form(self.coefficients)
+
+    def associative_differential_form(self) -> DifferentialForm:
+        return DifferentialForm(
+            _ConstantG2FormCoefficients(self.coefficients),
+            chart=self.chart,
+            degree=3,
+        )
+
+    def coassociative_differential_form(self) -> DifferentialForm:
+        return hodge_star(
+            self.associative_differential_form(),
+            self.metric,
+            orientation=self.orientation,
+        )
+
+    def local_structure(self) -> LocalG2Structure:
+        return LocalG2Structure(
+            self.metric,
+            self.associative_differential_form(),
+            orientation=self.orientation,
+        )
+
+
+class LocalG2ValidationReport(StrictModule):
+    valid: Array
+    algebraically_compatible: Array
+    closed: Array
+    coclosed: Array
+    torsion_free: Array
+    ricci_flat: Array
+    maximum_metric_compatibility_residual: Array
+    maximum_volume_normalization_residual: Array
+    maximum_closure_residual: Array
+    maximum_coclosure_residual: Array
+    maximum_ricci_residual: Array
+    required_torsion_free: bool = eqx.field(static=True)
+    required_ricci_flat: bool = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        valid: ArrayLike,
+        algebraically_compatible: ArrayLike,
+        closed: ArrayLike,
+        coclosed: ArrayLike,
+        torsion_free: ArrayLike,
+        ricci_flat: ArrayLike,
+        maximum_metric_compatibility_residual: ArrayLike,
+        maximum_volume_normalization_residual: ArrayLike,
+        maximum_closure_residual: ArrayLike,
+        maximum_coclosure_residual: ArrayLike,
+        maximum_ricci_residual: ArrayLike,
+        required_torsion_free: bool,
+        required_ricci_flat: bool,
+    ):
+        self.valid = jnp.asarray(valid, dtype=bool)
+        self.algebraically_compatible = jnp.asarray(
+            algebraically_compatible,
+            dtype=bool,
+        )
+        self.closed = jnp.asarray(closed, dtype=bool)
+        self.coclosed = jnp.asarray(coclosed, dtype=bool)
+        self.torsion_free = jnp.asarray(torsion_free, dtype=bool)
+        self.ricci_flat = jnp.asarray(ricci_flat, dtype=bool)
+        self.maximum_metric_compatibility_residual = jnp.asarray(
+            maximum_metric_compatibility_residual
+        )
+        self.maximum_volume_normalization_residual = jnp.asarray(
+            maximum_volume_normalization_residual
+        )
+        self.maximum_closure_residual = jnp.asarray(maximum_closure_residual)
+        self.maximum_coclosure_residual = jnp.asarray(maximum_coclosure_residual)
+        self.maximum_ricci_residual = jnp.asarray(maximum_ricci_residual)
+        self.required_torsion_free = bool(required_torsion_free)
+        self.required_ricci_flat = bool(required_ricci_flat)
+
+
+def validate_local_g2_structure(
+    structure: LocalG2Structure,
+    points: ArrayLike,
+    /,
+    *,
+    compatibility_tolerance: float = 1e-8,
+    normalization_tolerance: float = 1e-8,
+    closure_tolerance: float = 1e-8,
+    coclosure_tolerance: float = 1e-8,
+    ricci_tolerance: float = 1e-7,
+    require_torsion_free: bool = True,
+    require_ricci_flat: bool = False,
+    raise_on_error: bool = True,
+) -> LocalG2ValidationReport:
+    """Validate local metric compatibility and requested torsion/Ricci conditions."""
+    if not isinstance(structure, LocalG2Structure):
+        raise TypeError("structure must be a LocalG2Structure.")
+    tolerances = (
+        compatibility_tolerance,
+        normalization_tolerance,
+        closure_tolerance,
+        coclosure_tolerance,
+        ricci_tolerance,
+    )
+    if any(not isfinite(value) or value < 0.0 for value in tolerances):
+        raise ValueError("G2 validation tolerances must be finite and nonnegative.")
+    if not isinstance(require_torsion_free, bool) or not isinstance(
+        require_ricci_flat,
+        bool,
+    ):
+        raise TypeError("G2 validation requirement flags must be Boolean.")
+
+    point_values = jnp.asarray(points)
+    coefficients = structure.associative_form(point_values)
+    phi = _dense_three_form(coefficients)
+    metric = structure.metric(point_values)
+    inverse_metric = structure.metric.inverse(point_values)
+    contraction = oe.contract(
+        "...ikl,...ka,...lb,...jab->...ij",
+        phi,
+        inverse_metric,
+        inverse_metric,
+        phi,
+        backend="jax",
+    )
+    metric_residual = jnp.max(jnp.abs(contraction - 6.0 * metric))
+
+    coassociative = structure.coassociative_form()
+    volume = wedge(structure.associative_form, coassociative)(point_values)[..., 0]
+    expected_volume = (
+        7.0 * structure.orientation * structure.metric.volume_density(point_values)
+    )
+    normalization_residual = jnp.max(jnp.abs(volume - expected_volume))
+    algebraically_compatible = (
+        (metric_residual <= compatibility_tolerance)
+        & (normalization_residual <= normalization_tolerance)
+        & jnp.isfinite(metric_residual)
+        & jnp.isfinite(normalization_residual)
+    )
+
+    closure_residual = jnp.max(
+        jnp.abs(exterior_derivative(structure.associative_form)(point_values))
+    )
+    coclosure_residual = jnp.max(
+        jnp.abs(exterior_derivative(coassociative)(point_values))
+    )
+    closed = jnp.isfinite(closure_residual) & (closure_residual <= closure_tolerance)
+    coclosed = jnp.isfinite(coclosure_residual) & (
+        coclosure_residual <= coclosure_tolerance
+    )
+    torsion_free = closed & coclosed
+
+    ricci_residual = jnp.max(jnp.abs(ricci_tensor(structure.metric, point_values)))
+    ricci_flat = jnp.isfinite(ricci_residual) & (ricci_residual <= ricci_tolerance)
+    valid = algebraically_compatible
+    if require_torsion_free:
+        valid = valid & torsion_free
+    if require_ricci_flat:
+        valid = valid & ricci_flat
+    report = LocalG2ValidationReport(
+        valid=valid,
+        algebraically_compatible=algebraically_compatible,
+        closed=closed,
+        coclosed=coclosed,
+        torsion_free=torsion_free,
+        ricci_flat=ricci_flat,
+        maximum_metric_compatibility_residual=metric_residual,
+        maximum_volume_normalization_residual=normalization_residual,
+        maximum_closure_residual=closure_residual,
+        maximum_coclosure_residual=coclosure_residual,
+        maximum_ricci_residual=ricci_residual,
+        required_torsion_free=require_torsion_free,
+        required_ricci_flat=require_ricci_flat,
+    )
+    if raise_on_error and not bool(jax.device_get(valid)):
+        raise ValueError(
+            "Local G2 validation failed: "
+            f"compatibility={float(jax.device_get(metric_residual))}, "
+            f"normalization={float(jax.device_get(normalization_residual))}, "
+            f"closure={float(jax.device_get(closure_residual))}, "
+            f"coclosure={float(jax.device_get(coclosure_residual))}, "
+            f"ricci={float(jax.device_get(ricci_residual))}."
+        )
+    return report
+
+
+class G2DerivationInvarianceReport(StrictModule):
+    valid: Array
+    derivation_dimension: Array
+    maximum_form_invariance_residual: Array
+    maximum_metric_skew_residual: Array
+    maximum_scalar_mixing_residual: Array
+    algebra_id: str = eqx.field(static=True)
+    derivation_plan_id: str = eqx.field(static=True)
+    tolerance: float = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        valid: ArrayLike,
+        derivation_dimension: ArrayLike,
+        maximum_form_invariance_residual: ArrayLike,
+        maximum_metric_skew_residual: ArrayLike,
+        maximum_scalar_mixing_residual: ArrayLike,
+        algebra_id: str,
+        derivation_plan_id: str,
+        tolerance: float,
+    ):
+        self.valid = jnp.asarray(valid, dtype=bool)
+        self.derivation_dimension = jnp.asarray(
+            derivation_dimension,
+            dtype=jnp.int32,
+        )
+        self.maximum_form_invariance_residual = jnp.asarray(
+            maximum_form_invariance_residual
+        )
+        self.maximum_metric_skew_residual = jnp.asarray(maximum_metric_skew_residual)
+        self.maximum_scalar_mixing_residual = jnp.asarray(maximum_scalar_mixing_residual)
+        self.algebra_id = str(algebra_id)
+        self.derivation_plan_id = str(derivation_plan_id)
+        self.tolerance = float(tolerance)
+
+
+def validate_g2_derivations(
+    bridge: OctonionG2Bridge,
+    derivations,
+    /,
+    *,
+    tolerance: float = 1e-9,
+    raise_on_error: bool = True,
+) -> G2DerivationInvarianceReport:
+    """Validate that prepared octonion derivations infinitesimally preserve G2."""
+    from ..linalg import PreparedAlgebraDerivations
+
+    if not isinstance(bridge, OctonionG2Bridge):
+        raise TypeError("bridge must be an OctonionG2Bridge.")
+    if not isinstance(derivations, PreparedAlgebraDerivations):
+        raise TypeError("derivations must be PreparedAlgebraDerivations.")
+    tolerance_ = float(tolerance)
+    if not isfinite(tolerance_) or tolerance_ < 0.0:
+        raise ValueError("G2 derivation tolerance must be finite and nonnegative.")
+    bridge.algebra.require_compatible(derivations.plan.constraint.algebra)
+
+    dimension = bridge.algebra.coordinate_dimension
+    basis = derivations.subspace.basis
+    capacity = derivations.subspace.capacity
+    matrices = jnp.swapaxes(basis, 0, 1).reshape((capacity, dimension, dimension))
+    imaginary = jnp.asarray(bridge.imaginary_basis_indices, dtype=jnp.int32)
+    restricted = matrices[:, imaginary, :][:, :, imaginary]
+    phi = bridge.associative_tensor().astype(basis.dtype)
+    action = (
+        oe.contract("nai,ajk->nijk", restricted, phi, backend="jax")
+        + oe.contract("naj,iak->nijk", restricted, phi, backend="jax")
+        + oe.contract("nak,ija->nijk", restricted, phi, backend="jax")
+    )
+    form_residual = _maximum_or_zero(action)
+    skew_residual = _maximum_or_zero(restricted + jnp.swapaxes(restricted, -1, -2))
+    scalar = bridge.algebra.scalar_basis_index
+    scalar_mixing = jnp.concatenate(
+        (
+            matrices[:, scalar, :],
+            matrices[:, :, scalar],
+        ),
+        axis=-1,
+    )
+    scalar_residual = _maximum_or_zero(scalar_mixing)
+    finite = (
+        jnp.isfinite(form_residual)
+        & jnp.isfinite(skew_residual)
+        & jnp.isfinite(scalar_residual)
+    )
+    valid = (
+        derivations.converged
+        & finite
+        & (form_residual <= tolerance_)
+        & (skew_residual <= tolerance_)
+        & (scalar_residual <= tolerance_)
+    )
+    report = G2DerivationInvarianceReport(
+        valid=valid,
+        derivation_dimension=derivations.dimension,
+        maximum_form_invariance_residual=form_residual,
+        maximum_metric_skew_residual=skew_residual,
+        maximum_scalar_mixing_residual=scalar_residual,
+        algebra_id=bridge.algebra.algebra_id,
+        derivation_plan_id=derivations.plan.plan_id,
+        tolerance=tolerance_,
+    )
+    if raise_on_error and not bool(jax.device_get(valid)):
+        raise ValueError(
+            "G2 derivation invariance failed: "
+            f"form={float(jax.device_get(form_residual))}, "
+            f"metric={float(jax.device_get(skew_residual))}, "
+            f"scalar={float(jax.device_get(scalar_residual))}."
+        )
+    return report
+
+
 __all__ = [
+    "G2DerivationInvarianceReport",
+    "LocalG2Structure",
+    "LocalG2ValidationReport",
     "LocalSUNStructure",
     "LocalSUNValidationReport",
+    "OctonionG2Bridge",
+    "validate_g2_derivations",
+    "validate_local_g2_structure",
     "validate_local_su_structure",
 ]

--- a/phydrax/metrix/algebra/__init__.py
+++ b/phydrax/metrix/algebra/__init__.py
@@ -5,6 +5,11 @@
 """Exact finite-dimensional real algebras and prepared coordinate products."""
 
 from ._core import AbstractFiniteRealAlgebraSpec, FiniteRealAlgebraSpec
+from ._derivations import (
+    AlgebraDerivationConstraint,
+    AlgebraSymmetryBudget,
+    AlgebraSymmetryResourceEvidence,
+)
 from ._families import (
     CayleyDicksonAlgebraSpec,
     ComplexAlgebraSpec,
@@ -42,6 +47,7 @@ __all__ = [
     "FiniteRealAlgebraProvider",
     "AlgebraClaimSource",
     "AlgebraClaimStatus",
+    "AlgebraDerivationConstraint",
     "AlgebraElementLayout",
     "AlgebraProductBackend",
     "AlgebraProductEvidence",
@@ -51,6 +57,8 @@ __all__ = [
     "AlgebraRationalVector",
     "AlgebraResourceBudget",
     "AlgebraResourceEvidence",
+    "AlgebraSymmetryBudget",
+    "AlgebraSymmetryResourceEvidence",
     "AlgebraStructureTable",
     "CayleyDicksonAlgebraSpec",
     "ComplexAlgebraSpec",

--- a/phydrax/metrix/algebra/_core.py
+++ b/phydrax/metrix/algebra/_core.py
@@ -165,6 +165,31 @@ class AbstractFiniteRealAlgebraSpec(StrictModule, NonTrainableState):
     ) -> tuple[Fraction, ...]:
         return self.structure.multiply(left, right)
 
+    def commutator_exact(
+        self,
+        left: Sequence[Fraction],
+        right: Sequence[Fraction],
+        /,
+    ) -> tuple[Fraction, ...]:
+        return self.structure.commutator(left, right)
+
+    def jordan_product_exact(
+        self,
+        left: Sequence[Fraction],
+        right: Sequence[Fraction],
+        /,
+    ) -> tuple[Fraction, ...]:
+        return self.structure.jordan_product(left, right)
+
+    def associator_exact(
+        self,
+        left: Sequence[Fraction],
+        middle: Sequence[Fraction],
+        right: Sequence[Fraction],
+        /,
+    ) -> tuple[Fraction, ...]:
+        return self.structure.associator(left, middle, right)
+
     def prepare_product(self, **kwargs):
         from ._product import AlgebraProductPlan
 

--- a/phydrax/metrix/algebra/_derivations.py
+++ b/phydrax/metrix/algebra/_derivations.py
@@ -1,0 +1,273 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from fractions import Fraction
+from operator import index
+from typing import Any
+
+import equinox as eqx
+import jax.numpy as jnp
+import numpy as np
+from jaxtyping import Array
+
+from ..._fingerprint import canonical_fingerprint
+from ..._strict import StrictModule
+from ..._trainable import NonTrainableState
+from ._core import AbstractFiniteRealAlgebraSpec
+
+
+class AlgebraSymmetryBudget(StrictModule, NonTrainableState):
+    maximum_constraint_equations: int = eqx.field(static=True)
+    maximum_constraint_nonzeros: int = eqx.field(static=True)
+    maximum_materialized_bytes: int = eqx.field(static=True)
+    maximum_workspace_bytes: int = eqx.field(static=True)
+    maximum_basis_bytes: int = eqx.field(static=True)
+    budget_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        maximum_constraint_equations: int = 32_768,
+        maximum_constraint_nonzeros: int = 1_000_000,
+        maximum_materialized_bytes: int = 64 * 1024**2,
+        maximum_workspace_bytes: int = 128 * 1024**2,
+        maximum_basis_bytes: int = 16 * 1024**2,
+    ):
+        names = (
+            "maximum_constraint_equations",
+            "maximum_constraint_nonzeros",
+            "maximum_materialized_bytes",
+            "maximum_workspace_bytes",
+            "maximum_basis_bytes",
+        )
+        raw = (
+            maximum_constraint_equations,
+            maximum_constraint_nonzeros,
+            maximum_materialized_bytes,
+            maximum_workspace_bytes,
+            maximum_basis_bytes,
+        )
+        if any(isinstance(value, bool) for value in raw):
+            raise TypeError("Algebra symmetry resource limits must be integers.")
+        values = tuple(index(value) for value in raw)
+        if any(value <= 0 for value in values):
+            raise ValueError("Algebra symmetry resource limits must be positive.")
+        for name, value in zip(names, values, strict=True):
+            setattr(self, name, value)
+        self.budget_id = canonical_fingerprint(
+            {
+                "kind": "algebra-symmetry-budget-v1",
+                **dict(zip(names, values, strict=True)),
+            }
+        )
+
+    def admit_constraint(self, equations: int, nonzeros: int, /) -> None:
+        equation_count = index(equations)
+        nonzero_count = index(nonzeros)
+        if equation_count < 0 or equation_count > self.maximum_constraint_equations:
+            raise ValueError("Algebra derivation equation budget exceeded.")
+        if nonzero_count < 0 or nonzero_count > self.maximum_constraint_nonzeros:
+            raise ValueError("Algebra derivation nonzero budget exceeded.")
+
+    def admit_materialization(
+        self,
+        matrix_bytes: int,
+        workspace_bytes: int,
+        basis_bytes: int,
+        /,
+    ) -> None:
+        matrix = index(matrix_bytes)
+        workspace = index(workspace_bytes)
+        basis = index(basis_bytes)
+        if matrix < 0 or matrix > self.maximum_materialized_bytes:
+            raise ValueError("Algebra derivation materialization budget exceeded.")
+        if workspace < 0 or workspace > self.maximum_workspace_bytes:
+            raise ValueError("Algebra derivation workspace budget exceeded.")
+        if basis < 0 or basis > self.maximum_basis_bytes:
+            raise ValueError("Algebra derivation basis budget exceeded.")
+
+
+class AlgebraSymmetryResourceEvidence(StrictModule, NonTrainableState):
+    equation_count: int = eqx.field(static=True)
+    variable_count: int = eqx.field(static=True)
+    nonzero_count: int = eqx.field(static=True)
+    sparse_bytes: int = eqx.field(static=True)
+    materialized_bytes: int = eqx.field(static=True)
+    budget_id: str = eqx.field(static=True)
+    evidence_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        equation_count: int,
+        variable_count: int,
+        nonzero_count: int,
+        sparse_bytes: int,
+        materialized_bytes: int,
+        budget: AlgebraSymmetryBudget,
+    ):
+        if not isinstance(budget, AlgebraSymmetryBudget):
+            raise TypeError("budget must be an AlgebraSymmetryBudget.")
+        values = tuple(
+            index(value)
+            for value in (
+                equation_count,
+                variable_count,
+                nonzero_count,
+                sparse_bytes,
+                materialized_bytes,
+            )
+        )
+        if any(value < 0 for value in values):
+            raise ValueError("Algebra symmetry resource evidence must be nonnegative.")
+        budget.admit_constraint(values[0], values[2])
+        if values[4] > budget.maximum_materialized_bytes:
+            raise ValueError("Algebra derivation materialization budget exceeded.")
+        (
+            self.equation_count,
+            self.variable_count,
+            self.nonzero_count,
+            self.sparse_bytes,
+            self.materialized_bytes,
+        ) = values
+        self.budget_id = budget.budget_id
+        self.evidence_id = canonical_fingerprint(
+            {
+                "kind": "algebra-symmetry-resources-v1",
+                "equations": values[0],
+                "variables": values[1],
+                "nonzeros": values[2],
+                "sparse_bytes": values[3],
+                "materialized_bytes": values[4],
+                "budget": budget.budget_id,
+            }
+        )
+
+
+class AlgebraDerivationConstraint(StrictModule, NonTrainableState):
+    """Exact sparse Leibniz constraints for real algebra derivation matrices."""
+
+    algebra: AbstractFiniteRealAlgebraSpec
+    budget: AlgebraSymmetryBudget
+    row_indices: tuple[int, ...] = eqx.field(static=True)
+    column_indices: tuple[int, ...] = eqx.field(static=True)
+    coefficient_numerators: tuple[int, ...] = eqx.field(static=True)
+    coefficient_denominators: tuple[int, ...] = eqx.field(static=True)
+    equation_count: int = eqx.field(static=True)
+    variable_count: int = eqx.field(static=True)
+    resources: AlgebraSymmetryResourceEvidence
+    constraint_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        algebra: AbstractFiniteRealAlgebraSpec,
+        /,
+        *,
+        budget: AlgebraSymmetryBudget | None = None,
+    ):
+        if not isinstance(algebra, AbstractFiniteRealAlgebraSpec):
+            raise TypeError("algebra must implement AbstractFiniteRealAlgebraSpec.")
+        budget_ = AlgebraSymmetryBudget() if budget is None else budget
+        if not isinstance(budget_, AlgebraSymmetryBudget):
+            raise TypeError("budget must be AlgebraSymmetryBudget or None.")
+        dimension = algebra.coordinate_dimension
+        equations = dimension**3
+        variables = dimension**2
+        coefficients: dict[tuple[int, int], Fraction] = {}
+
+        def add(row: int, column: int, value: Fraction) -> None:
+            key = (row, column)
+            coefficients[key] = coefficients.get(key, Fraction(0)) + value
+
+        for left, right, output, numerator, denominator in algebra.structure.terms:
+            coefficient = Fraction(numerator, denominator)
+            for result in range(dimension):
+                first_row = (left * dimension + right) * dimension + result
+                first_column = result * dimension + output
+                add(first_row, first_column, coefficient)
+
+                second_row = (result * dimension + right) * dimension + output
+                second_column = left * dimension + result
+                add(second_row, second_column, -coefficient)
+
+                third_row = (left * dimension + result) * dimension + output
+                third_column = right * dimension + result
+                add(third_row, third_column, -coefficient)
+
+        normalized = tuple(
+            (row, column, value)
+            for (row, column), value in sorted(coefficients.items())
+            if value
+        )
+        budget_.admit_constraint(equations, len(normalized))
+        sparse_bytes = len(normalized) * 4 * 8
+        materialized_bytes = equations * variables * 8
+        resources = AlgebraSymmetryResourceEvidence(
+            equation_count=equations,
+            variable_count=variables,
+            nonzero_count=len(normalized),
+            sparse_bytes=sparse_bytes,
+            materialized_bytes=materialized_bytes,
+            budget=budget_,
+        )
+        self.algebra = algebra
+        self.budget = budget_
+        self.row_indices = tuple(row for row, _, _ in normalized)
+        self.column_indices = tuple(column for _, column, _ in normalized)
+        self.coefficient_numerators = tuple(value.numerator for _, _, value in normalized)
+        self.coefficient_denominators = tuple(
+            value.denominator for _, _, value in normalized
+        )
+        self.equation_count = equations
+        self.variable_count = variables
+        self.resources = resources
+        self.constraint_id = canonical_fingerprint(
+            {
+                "kind": "algebra-derivation-constraint-v1",
+                "algebra": algebra.algebra_id,
+                "rows": self.row_indices,
+                "columns": self.column_indices,
+                "numerators": self.coefficient_numerators,
+                "denominators": self.coefficient_denominators,
+                "resources": resources.evidence_id,
+            }
+        )
+
+    @property
+    def matrix_shape(self) -> tuple[int, int]:
+        dimension = self.algebra.coordinate_dimension
+        return dimension, dimension
+
+    def materialize(self, dtype: Any = np.float64, /) -> Array:
+        dtype_ = np.dtype(dtype)
+        if not np.issubdtype(dtype_, np.floating):
+            raise TypeError("Algebra derivation constraints require floating dtype.")
+        itemsize = dtype_.itemsize
+        matrix_bytes = self.equation_count * self.variable_count * itemsize
+        self.budget.admit_materialization(matrix_bytes, 0, 0)
+        rows = jnp.asarray(self.row_indices, dtype=jnp.int32)
+        columns = jnp.asarray(self.column_indices, dtype=jnp.int32)
+        coefficients = jnp.asarray(
+            self.coefficient_numerators, dtype=dtype_
+        ) / jnp.asarray(
+            self.coefficient_denominators,
+            dtype=dtype_,
+        )
+        return (
+            jnp.zeros(
+                (self.equation_count, self.variable_count),
+                dtype=dtype_,
+            )
+            .at[rows, columns]
+            .add(coefficients)
+        )
+
+
+__all__ = [
+    "AlgebraDerivationConstraint",
+    "AlgebraSymmetryBudget",
+    "AlgebraSymmetryResourceEvidence",
+]

--- a/phydrax/metrix/algebra/_product.py
+++ b/phydrax/metrix/algebra/_product.py
@@ -204,9 +204,9 @@ class AlgebraProductPlan(StrictModule, NonTrainableState):
             )
         else:
             output = jnp.zeros(leading + (dimension,), dtype=dtype)
-            coefficients = self.coefficient_numerators.astype(
-                dtype
-            ) / self.coefficient_denominators.astype(dtype)
+            coefficients = self.coefficient_numerators.astype(dtype)
+            if self.fractional_coefficients:
+                coefficients = coefficients / self.coefficient_denominators.astype(dtype)
             terms = (
                 left_[..., self.left_indices]
                 * right_[..., self.right_indices]
@@ -217,6 +217,32 @@ class AlgebraProductPlan(StrictModule, NonTrainableState):
         if target_axis < 0:
             target_axis += output.ndim
         return jnp.moveaxis(output, -1, target_axis)
+
+    def commutator(self, left: ArrayLike, right: ArrayLike, /) -> Array:
+        """Return ``left * right - right * left`` under this product plan."""
+        return self(left, right) - self(right, left)
+
+    def jordan_product(self, left: ArrayLike, right: ArrayLike, /) -> Array:
+        """Return the symmetrized product without integer truncation."""
+        left_right = self(left, right)
+        right_left = self(right, left)
+        dtype = jnp.result_type(left_right, right_left, 0.5)
+        return (left_right.astype(dtype) + right_left.astype(dtype)) * jnp.asarray(
+            0.5, dtype=dtype
+        )
+
+    def associator(
+        self,
+        left: ArrayLike,
+        middle: ArrayLike,
+        right: ArrayLike,
+        /,
+    ) -> Array:
+        """Return the explicit bracket defect ``(left * middle) * right - left * (middle * right)``."""
+        return self(self(left, middle), right) - self(
+            left,
+            self(middle, right),
+        )
 
     def lower(self, leading_shape: Sequence[int], dtype: Any, /):
         from ...discretization._lowered_operator import (

--- a/phydrax/metrix/algebra/_properties.py
+++ b/phydrax/metrix/algebra/_properties.py
@@ -121,19 +121,8 @@ def _add(left, right):
     return tuple(a + b for a, b in zip(left, right, strict=True))
 
 
-def _subtract(left, right):
-    return tuple(a - b for a, b in zip(left, right, strict=True))
-
-
 def _zero(value) -> bool:
     return all(entry == _ZERO for entry in value)
-
-
-def _associator(table, left, middle, right):
-    return _subtract(
-        table.multiply(table.multiply(left, middle), right),
-        table.multiply(left, table.multiply(middle, right)),
-    )
 
 
 def _claim_from_witness(name, witness, work):
@@ -201,14 +190,14 @@ def audit_algebra_properties(
     for left in range(dimension):
         for middle in range(dimension):
             for right in range(dimension):
-                associator = _associator(
-                    table, vectors[left], vectors[middle], vectors[right]
+                associator = table.associator(
+                    vectors[left], vectors[middle], vectors[right]
                 )
                 if associative_witness is None and not _zero(associator):
                     associative_witness = (labels[left], labels[middle], labels[right])
                 if left_alternative_witness is None:
-                    swapped = _associator(
-                        table, vectors[middle], vectors[left], vectors[right]
+                    swapped = table.associator(
+                        vectors[middle], vectors[left], vectors[right]
                     )
                     if not _zero(_add(associator, swapped)):
                         left_alternative_witness = (
@@ -217,8 +206,8 @@ def audit_algebra_properties(
                             labels[right],
                         )
                 if right_alternative_witness is None:
-                    swapped = _associator(
-                        table, vectors[left], vectors[right], vectors[middle]
+                    swapped = table.associator(
+                        vectors[left], vectors[right], vectors[middle]
                     )
                     if not _zero(_add(associator, swapped)):
                         right_alternative_witness = (
@@ -227,8 +216,8 @@ def audit_algebra_properties(
                             labels[right],
                         )
                 if flexible_witness is None:
-                    reversed_outer = _associator(
-                        table, vectors[right], vectors[middle], vectors[left]
+                    reversed_outer = table.associator(
+                        vectors[right], vectors[middle], vectors[left]
                     )
                     if not _zero(_add(associator, reversed_outer)):
                         flexible_witness = (labels[left], labels[middle], labels[right])

--- a/phydrax/metrix/algebra/_structure.py
+++ b/phydrax/metrix/algebra/_structure.py
@@ -191,6 +191,49 @@ class AlgebraStructureTable(StrictModule, NonTrainableState):
             )
         return tuple(output)
 
+    def commutator(
+        self,
+        left: Sequence[Fraction],
+        right: Sequence[Fraction],
+        /,
+    ) -> tuple[Fraction, ...]:
+        """Return the exact commutator ``left * right - right * left``."""
+        left_right = self.multiply(left, right)
+        right_left = self.multiply(right, left)
+        return tuple(
+            forward - reverse
+            for forward, reverse in zip(left_right, right_left, strict=True)
+        )
+
+    def jordan_product(
+        self,
+        left: Sequence[Fraction],
+        right: Sequence[Fraction],
+        /,
+    ) -> tuple[Fraction, ...]:
+        """Return the exact symmetrized product."""
+        left_right = self.multiply(left, right)
+        right_left = self.multiply(right, left)
+        return tuple(
+            (forward + reverse) / 2
+            for forward, reverse in zip(left_right, right_left, strict=True)
+        )
+
+    def associator(
+        self,
+        left: Sequence[Fraction],
+        middle: Sequence[Fraction],
+        right: Sequence[Fraction],
+        /,
+    ) -> tuple[Fraction, ...]:
+        """Return the exact bracket defect ``(left * middle) * right - left * (middle * right)``."""
+        left_bracket = self.multiply(self.multiply(left, middle), right)
+        right_bracket = self.multiply(left, self.multiply(middle, right))
+        return tuple(
+            first - second
+            for first, second in zip(left_bracket, right_bracket, strict=True)
+        )
+
 
 __all__ = [
     "AlgebraRationalMap",

--- a/tests/unit/metrix/test_g2_geometry.py
+++ b/tests/unit/metrix/test_g2_geometry.py
@@ -1,0 +1,124 @@
+import equinox as eqx
+import jax.numpy as jnp
+import pytest
+
+import phydrax as phx
+
+
+def _chart(name="g2"):
+    return phx.metrix.CoordinateChart(name, tuple(f"x{index}" for index in range(7)))
+
+
+def test_octonion_bridge_cross_product_and_forms_share_one_convention():
+    algebra = phx.metrix.algebra.OctonionAlgebraSpec()
+    bridge = phx.metrix.OctonionG2Bridge(algebra, _chart())
+    left = jnp.asarray([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+    right = jnp.asarray([0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+    embedded_product = bridge.product(
+        bridge.embed_imaginary(left), bridge.embed_imaginary(right)
+    )
+    coefficients = bridge.associative_differential_form()(jnp.zeros((7,)))
+
+    assert jnp.array_equal(
+        bridge.cross(left, right), bridge.extract_imaginary(embedded_product)
+    )
+    assert jnp.array_equal(coefficients, bridge.coefficients)
+    assert bridge.associative_tensor().shape == (7, 7, 7)
+
+
+def test_canonical_flat_g2_structure_is_compatible_closed_and_ricci_flat():
+    bridge = phx.metrix.OctonionG2Bridge(
+        phx.metrix.algebra.OctonionAlgebraSpec(), _chart()
+    )
+    points = jnp.stack((jnp.zeros((7,)), jnp.linspace(-0.2, 0.3, 7)))
+    report = phx.metrix.validate_local_g2_structure(
+        bridge.local_structure(),
+        points,
+        require_ricci_flat=True,
+    )
+    phi = bridge.associative_differential_form()
+    psi = bridge.coassociative_differential_form()
+    volume = phx.metrix.wedge(phi, psi)(points)
+
+    assert bool(report.valid)
+    assert bool(report.algebraically_compatible)
+    assert bool(report.torsion_free)
+    assert bool(report.ricci_flat)
+    assert report.maximum_metric_compatibility_residual < 1e-12
+    assert report.maximum_volume_normalization_residual < 1e-12
+    assert jnp.allclose(volume[..., 0], 7.0, atol=1e-12)
+
+
+def test_g2_validation_separates_algebraic_and_torsion_failures():
+    chart = _chart()
+    bridge = phx.metrix.OctonionG2Bridge(phx.metrix.algebra.OctonionAlgebraSpec(), chart)
+    perturbed = bridge.coefficients.at[0].add(0.1)
+    incompatible_form = phx.metrix.DifferentialForm(
+        lambda point: perturbed.astype(point.dtype),
+        chart=chart,
+        degree=3,
+    )
+    incompatible = phx.metrix.validate_local_g2_structure(
+        phx.metrix.LocalG2Structure(bridge.metric, incompatible_form),
+        jnp.zeros((7,)),
+        require_torsion_free=False,
+        raise_on_error=False,
+    )
+    varying_form = phx.metrix.DifferentialForm(
+        lambda point: bridge.coefficients.at[0].set(
+            bridge.coefficients[0] * (1.0 + point[6])
+        ),
+        chart=chart,
+        degree=3,
+    )
+    torsion = phx.metrix.validate_local_g2_structure(
+        phx.metrix.LocalG2Structure(bridge.metric, varying_form),
+        jnp.zeros((7,)),
+        require_torsion_free=True,
+        raise_on_error=False,
+    )
+
+    assert not bool(incompatible.algebraically_compatible)
+    assert not bool(incompatible.valid)
+    assert bool(torsion.algebraically_compatible)
+    assert not bool(torsion.closed)
+    assert not bool(torsion.torsion_free)
+    assert not bool(torsion.valid)
+
+
+def test_g2_validation_is_jittable_when_runtime_errors_are_disabled():
+    bridge = phx.metrix.OctonionG2Bridge(
+        phx.metrix.algebra.OctonionAlgebraSpec(), _chart()
+    )
+    validate = eqx.filter_jit(
+        lambda point: (
+            phx.metrix.validate_local_g2_structure(
+                bridge.local_structure(), point, raise_on_error=False
+            ).maximum_metric_compatibility_residual
+        )
+    )
+
+    assert validate(jnp.zeros((7,))) < 1e-12
+
+
+def test_g2_geometry_rejects_invalid_charts_forms_and_lie_group_inference():
+    algebra = phx.metrix.algebra.OctonionAlgebraSpec()
+    chart = _chart()
+    bridge = phx.metrix.OctonionG2Bridge(algebra, chart)
+
+    with pytest.raises(ValueError, match="seven-dimensional"):
+        phx.metrix.OctonionG2Bridge(
+            algebra,
+            phx.metrix.CoordinateChart("wrong", ("x", "y")),
+        )
+    with pytest.raises(ValueError, match="degree three"):
+        phx.metrix.LocalG2Structure(
+            bridge.metric,
+            phx.metrix.DifferentialForm(
+                lambda point: jnp.zeros((21,), dtype=point.dtype),
+                chart=chart,
+                degree=2,
+            ),
+        )
+    with pytest.raises(ValueError, match="Lie-group"):
+        phx.metrix.algebra.unit_algebra_state_geometry(algebra)

--- a/tests/unit/metrix/test_nonassociative_algebra.py
+++ b/tests/unit/metrix/test_nonassociative_algebra.py
@@ -1,0 +1,107 @@
+from fractions import Fraction
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+
+import phydrax as phx
+
+
+def _exact_basis(dimension, position):
+    return tuple(Fraction(int(index == position)) for index in range(dimension))
+
+
+def test_exact_derived_products_distinguish_quaternion_and_octonion_bracketing():
+    quaternion = phx.metrix.algebra.QuaternionAlgebraSpec()
+    octonion = phx.metrix.algebra.OctonionAlgebraSpec()
+    quaternion_basis = tuple(_exact_basis(4, index) for index in range(4))
+    witness = octonion.properties.claim("associative").witness
+    octonion_basis = tuple(_exact_basis(8, index) for index in range(8))
+    positions = tuple(octonion.basis_index(label) for label in witness)
+
+    assert (
+        quaternion.associator_exact(
+            quaternion_basis[1], quaternion_basis[2], quaternion_basis[3]
+        )
+        == (Fraction(0),) * 4
+    )
+    assert quaternion.commutator_exact(quaternion_basis[1], quaternion_basis[2]) == tuple(
+        2 * value for value in quaternion_basis[3]
+    )
+    assert (
+        octonion.associator_exact(*(octonion_basis[position] for position in positions))
+        != (Fraction(0),) * 8
+    )
+
+
+def test_octonion_associator_is_alternating_for_exact_linear_combinations():
+    algebra = phx.metrix.algebra.OctonionAlgebraSpec()
+    left = tuple(Fraction(value) for value in (1, 2, -1, 3, 0, 1, -2, 4))
+    right = tuple(Fraction(value) for value in (0, -1, 2, 1, 3, -2, 1, 0))
+    third = tuple(Fraction(value) for value in (2, 0, 1, -1, 4, 3, 0, -2))
+    zero = (Fraction(0),) * 8
+
+    assert algebra.associator_exact(left, left, right) == zero
+    assert algebra.associator_exact(right, left, left) == zero
+    forward = algebra.associator_exact(left, right, third)
+    reverse = algebra.associator_exact(right, left, third)
+    assert forward == tuple(-value for value in reverse)
+
+
+def test_numeric_derived_products_preserve_bracketing_jit_and_jvp():
+    algebra = phx.metrix.algebra.OctonionAlgebraSpec()
+    product = algebra.prepare_product(backend="sparse")
+    left = jnp.asarray([0.3, -0.2, 0.7, 0.1, -0.4, 0.8, 0.5, -0.6])
+    middle = jnp.asarray([-0.1, 0.4, 0.2, -0.8, 0.3, 0.6, -0.5, 0.7])
+    right = jnp.asarray([0.2, 0.5, -0.3, 0.9, -0.7, 0.1, 0.4, -0.2])
+
+    expected = product(product(left, middle), right) - product(
+        left, product(middle, right)
+    )
+    compiled = eqx.filter_jit(product.associator)(left, middle, right)
+    tangent = jax.jvp(
+        lambda value: product.associator(value, middle, right),
+        (left,),
+        (jnp.ones_like(left),),
+    )[1]
+
+    assert jnp.allclose(compiled, expected, atol=1e-12)
+    assert jnp.all(jnp.isfinite(tangent))
+    assert jnp.linalg.norm(compiled) > 0.0
+
+
+def test_jordan_product_promotes_integer_coordinates_without_truncation():
+    algebra = phx.metrix.algebra.FiniteRealAlgebraSpec(
+        "rational-product",
+        ("1", "u"),
+        (
+            (0, 0, 0, 1, 1),
+            (0, 1, 1, 1, 1),
+            (1, 0, 0, 1, 1),
+        ),
+        (1, 0),
+        ((1, 0), (0, 1)),
+    )
+    product = algebra.prepare_product(backend="sparse")
+    left = jnp.asarray([0, 1], dtype=jnp.int32)
+    right = jnp.asarray([1, 0], dtype=jnp.int32)
+
+    value = product.jordan_product(left, right)
+
+    assert jnp.issubdtype(value.dtype, jnp.floating)
+    assert jnp.array_equal(value, jnp.asarray([0.5, 0.5]))
+
+
+def test_higher_cayley_dickson_does_not_inherit_octonion_alternation():
+    algebra = phx.metrix.algebra.CayleyDicksonAlgebraSpec(4)
+    witness = algebra.properties.claim("left_alternative").witness
+    basis = jnp.eye(algebra.coordinate_dimension)
+    positions = tuple(algebra.basis_index(label) for label in witness)
+    product = algebra.prepare_product(backend="sparse")
+    left, middle, right = (basis[position] for position in positions)
+
+    polarized = product.associator(left, middle, right) + product.associator(
+        middle, left, right
+    )
+
+    assert jnp.linalg.norm(polarized) > 0.0

--- a/tests/unit/test_algebra_derivations.py
+++ b/tests/unit/test_algebra_derivations.py
@@ -1,0 +1,97 @@
+import jax.numpy as jnp
+import jax.scipy as jsp
+import pytest
+
+import phydrax as phx
+
+
+def _prepare(algebra, **policy_kwargs):
+    policy = phx.linalg.AlgebraDerivationPolicy(**policy_kwargs)
+    return phx.linalg.prepare_algebra_derivations(
+        phx.linalg.plan_algebra_derivations(algebra, policy=policy)
+    )
+
+
+def test_canonical_composition_algebras_have_expected_derivation_dimensions():
+    complex_derivations = _prepare(phx.metrix.algebra.ComplexAlgebraSpec())
+    quaternion_derivations = _prepare(phx.metrix.algebra.QuaternionAlgebraSpec())
+    octonion_derivations = _prepare(phx.metrix.algebra.OctonionAlgebraSpec())
+
+    assert int(complex_derivations.dimension) == 0
+    assert int(quaternion_derivations.dimension) == 3
+    assert int(octonion_derivations.dimension) == 14
+    assert bool(complex_derivations.converged)
+    assert bool(quaternion_derivations.converged)
+    assert bool(octonion_derivations.converged)
+    assert octonion_derivations.maximum_leibniz_residual < 1e-10
+    assert octonion_derivations.maximum_unit_fixing_residual < 1e-10
+    assert octonion_derivations.maximum_commutator_closure_residual < 1e-10
+
+
+def test_octonion_derivations_infinitesimally_preserve_the_g2_structure():
+    algebra = phx.metrix.algebra.OctonionAlgebraSpec()
+    derivations = _prepare(algebra)
+    bridge = phx.metrix.OctonionG2Bridge(
+        algebra,
+        phx.metrix.CoordinateChart("g2", tuple(f"x{i}" for i in range(7))),
+    )
+    report = phx.metrix.validate_g2_derivations(bridge, derivations)
+
+    assert bool(report.valid)
+    assert int(report.derivation_dimension) == 14
+    assert report.maximum_form_invariance_residual < 1e-9
+    assert report.maximum_metric_skew_residual < 1e-9
+    assert report.maximum_scalar_mixing_residual < 1e-9
+
+
+def test_exponentiated_small_derivation_preserves_octonion_multiplication():
+    algebra = phx.metrix.algebra.OctonionAlgebraSpec()
+    product = algebra.prepare_product(backend="sparse")
+    derivations = _prepare(algebra)
+    generator = derivations.subspace.basis[:, 0].reshape((8, 8))
+    automorphism = jsp.linalg.expm(0.05 * generator)
+    left = jnp.linspace(-0.4, 0.6, 8)
+    right = jnp.linspace(0.7, -0.3, 8)
+
+    transformed_product = automorphism @ product(left, right)
+    product_of_transforms = product(automorphism @ left, automorphism @ right)
+
+    assert jnp.allclose(transformed_product, product_of_transforms, atol=1e-10)
+
+
+def test_derivation_projector_returns_a_leibniz_matrix():
+    algebra = phx.metrix.algebra.QuaternionAlgebraSpec()
+    derivations = _prepare(algebra)
+    candidate = jnp.arange(16, dtype=jnp.float64).reshape((4, 4)) / 7.0
+    projected = derivations.project(candidate)
+    constraint = derivations.plan.constraint.materialize(jnp.float64)
+
+    assert projected.shape == (4, 4)
+    assert jnp.linalg.norm(constraint @ projected.reshape((-1,))) < 1e-10
+
+
+def test_derivation_rank_ambiguity_and_resource_failures_are_explicit():
+    algebra = phx.metrix.algebra.QuaternionAlgebraSpec()
+    ambiguous = _prepare(algebra, minimum_singular_gap=1e30)
+
+    assert not bool(ambiguous.converged)
+    assert int(ambiguous.status) == int(phx.linalg.AlgebraDerivationStatus.AMBIGUOUS_RANK)
+    with pytest.raises(ValueError, match="materialization"):
+        phx.metrix.algebra.AlgebraDerivationConstraint(
+            algebra,
+            budget=phx.metrix.algebra.AlgebraSymmetryBudget(maximum_materialized_bytes=1),
+        )
+
+
+def test_derivation_plan_id_records_exact_constraints_and_numeric_policy():
+    algebra = phx.metrix.algebra.QuaternionAlgebraSpec()
+    first = phx.linalg.plan_algebra_derivations(algebra)
+    second = phx.linalg.plan_algebra_derivations(algebra)
+    relaxed = phx.linalg.plan_algebra_derivations(
+        algebra,
+        policy=phx.linalg.AlgebraDerivationPolicy(relative_cutoff=1e-8),
+    )
+
+    assert first.constraint.constraint_id == second.constraint.constraint_id
+    assert first.plan_id == second.plan_id
+    assert first.plan_id != relaxed.plan_id

--- a/tests/unit/test_algebra_regular_actions.py
+++ b/tests/unit/test_algebra_regular_actions.py
@@ -1,0 +1,107 @@
+import jax.numpy as jnp
+import pytest
+
+import phydrax as phx
+
+
+def test_left_and_right_quaternion_actions_are_distinct_native_operators():
+    algebra = phx.metrix.algebra.QuaternionAlgebraSpec()
+    product = algebra.prepare_product(backend="sparse")
+    space = phx.linalg.AlgebraArraySpace((), algebra, dtype=jnp.float64)
+    multiplier = jnp.asarray([0.0, 1.0, 0.0, 0.0])
+    value = jnp.asarray([0.0, 0.0, 1.0, 0.0])
+    left = phx.linalg.algebra_regular_action_operator(
+        product, multiplier, space, side="left"
+    )
+    right = phx.linalg.algebra_regular_action_operator(
+        product, multiplier, space, side="right"
+    )
+
+    assert jnp.array_equal(left.mv(value), jnp.asarray([0.0, 0.0, 0.0, 1.0]))
+    assert jnp.array_equal(right.mv(value), jnp.asarray([0.0, 0.0, 0.0, -1.0]))
+    assert left.operator_id != right.operator_id
+
+
+def test_octonion_action_composition_does_not_collapse_to_one_multiplier():
+    algebra = phx.metrix.algebra.OctonionAlgebraSpec()
+    product = algebra.prepare_product(backend="sparse")
+    space = phx.linalg.AlgebraArraySpace((), algebra, dtype=jnp.float64)
+    witness = algebra.properties.claim("associative").witness
+    positions = tuple(algebra.basis_index(label) for label in witness)
+    basis = jnp.eye(8)
+    left, middle, value = (basis[position] for position in positions)
+    left_action = phx.linalg.algebra_regular_action_operator(
+        product, left, space, side="left"
+    )
+    middle_action = phx.linalg.algebra_regular_action_operator(
+        product, middle, space, side="left"
+    )
+    collapsed = phx.linalg.algebra_regular_action_operator(
+        product, product(left, middle), space, side="left"
+    )
+
+    composed_value = (left_action @ middle_action).mv(value)
+
+    assert not jnp.array_equal(composed_value, collapsed.mv(value))
+    assert jnp.array_equal(
+        composed_value - collapsed.mv(value),
+        -product.associator(left, middle, value),
+    )
+
+
+def test_regular_action_materialization_and_transpose_match_pairing():
+    algebra = phx.metrix.algebra.OctonionAlgebraSpec()
+    product = algebra.prepare_product(backend="sparse")
+    space = phx.linalg.AlgebraArraySpace((), algebra, dtype=jnp.float64)
+    multiplier = jnp.linspace(-0.4, 0.6, 8)
+    value = jnp.linspace(0.2, 0.9, 8)
+    probe = jnp.linspace(-0.7, 0.3, 8)
+    action = phx.linalg.algebra_regular_action_operator(
+        product, multiplier, space, side="right"
+    )
+    matrix = phx.linalg.materialize(action, phx.linalg.MaterializationPolicy())
+
+    assert jnp.allclose(action.mv(value), matrix @ value, atol=1e-12)
+    assert jnp.allclose(
+        space.inner(action.mv(value), probe),
+        space.inner(value, action.transpose_mv(probe)),
+        atol=1e-12,
+    )
+
+
+def test_regular_actions_support_nonfinal_axes_and_base_shaped_multipliers():
+    algebra = phx.metrix.algebra.QuaternionAlgebraSpec()
+    layout = phx.metrix.algebra.AlgebraElementLayout(algebra, algebra_axis=0)
+    product = algebra.prepare_product(layout=layout, backend="sparse")
+    space = phx.linalg.AlgebraArraySpace((2,), algebra, algebra_axis=0, dtype=jnp.float64)
+    multiplier = jnp.asarray([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [0.0, 0.0]])
+    value = jnp.asarray([[1.0, 1.0], [0.0, 0.0], [1.0, 1.0], [0.0, 0.0]])
+    action = phx.linalg.algebra_regular_action_operator(
+        product, multiplier, space, side="left"
+    )
+
+    assert jnp.array_equal(action.mv(value), product(multiplier, value))
+
+
+def test_regular_action_rejects_ambiguous_layout_dtype_and_side():
+    quaternion = phx.metrix.algebra.QuaternionAlgebraSpec()
+    octonion = phx.metrix.algebra.OctonionAlgebraSpec()
+    product = quaternion.prepare_product(backend="sparse")
+    space = phx.linalg.AlgebraArraySpace((), quaternion, dtype=jnp.float64)
+    multiplier = jnp.asarray([0.0, 1.0, 0.0, 0.0])
+
+    with pytest.raises(ValueError, match="side"):
+        phx.linalg.algebra_regular_action_operator(
+            product, multiplier, space, side="center"
+        )
+    with pytest.raises(TypeError, match="dtype"):
+        phx.linalg.algebra_regular_action_operator(
+            product, multiplier.astype(jnp.float32), space, side="left"
+        )
+    with pytest.raises(ValueError, match="match"):
+        phx.linalg.algebra_regular_action_operator(
+            product,
+            multiplier,
+            phx.linalg.AlgebraArraySpace((), octonion, dtype=jnp.float64),
+            side="left",
+        )

--- a/tools/algebra_benchmarks.py
+++ b/tools/algebra_benchmarks.py
@@ -28,11 +28,29 @@ class AlgebraBenchmarkRecord:
     first_jit_ms: float
     steady_wall_ms: float
     sparse_dense_defect: float
+    associator_first_jit_ms: float
+    associator_steady_wall_ms: float
+    associator_norm: float
+    associator_classification_passed: bool
+    regular_action_defect: float
+    derivation_preparation_wall_ms: float | None
+    derivation_dimension: int | None
+    derivation_leibniz_residual: float | None
+    derivation_converged: bool | None
     finite: bool
 
     @property
     def passed(self) -> bool:
-        return self.finite and self.sparse_dense_defect <= 1e-12
+        derivations_passed = (
+            self.derivation_converged if self.derivation_converged is not None else True
+        )
+        return (
+            self.finite
+            and self.sparse_dense_defect <= 1e-12
+            and self.regular_action_defect <= 1e-12
+            and self.associator_classification_passed
+            and derivations_passed
+        )
 
 
 def _measure(function, left, right, repeats):
@@ -49,6 +67,20 @@ def _measure(function, left, right, repeats):
     return value, first, steady
 
 
+def _measure_three(function, left, middle, right, repeats):
+    compiled = eqx.filter_jit(function)
+    started = time.perf_counter()
+    value = compiled(left, middle, right)
+    jax.block_until_ready(value)
+    first = 1e3 * (time.perf_counter() - started)
+    started = time.perf_counter()
+    for _ in range(repeats):
+        value = compiled(left, middle, right)
+        jax.block_until_ready(value)
+    steady = 1e3 * (time.perf_counter() - started) / repeats
+    return value, first, steady
+
+
 def run_algebra_benchmark(level: int, /, *, repeats: int = 5) -> AlgebraBenchmarkRecord:
     started = time.perf_counter()
     algebra = phx.metrix.algebra.CayleyDicksonAlgebraSpec(level)
@@ -58,21 +90,90 @@ def run_algebra_benchmark(level: int, /, *, repeats: int = 5) -> AlgebraBenchmar
     dimension = algebra.coordinate_dimension
     left = jnp.sin(jnp.arange(8 * dimension, dtype=float)).reshape((8, dimension))
     right = jnp.cos(jnp.arange(dimension, dtype=float))
+    middle = jnp.sin(0.3 + jnp.arange(dimension, dtype=float))
+    associator_left = jnp.sin(0.7 + jnp.arange(dimension, dtype=float))
+    right_associator = right
+    if algebra.properties.claim("associative").status == "disproven":
+        witness = algebra.properties.claim("associative").witness
+        positions = tuple(algebra.basis_index(label) for label in witness)
+        basis = jnp.eye(dimension)
+        associator_left, middle, right_associator = (
+            basis[position] for position in positions
+        )
     sparse_value, first, steady = _measure(sparse, left, right, repeats)
     dense_value = dense(left, right)
     defect = jnp.max(jnp.abs(sparse_value - dense_value))
-    finite = bool(jnp.all(jnp.isfinite(sparse_value)) & jnp.isfinite(defect))
+    associator_value, associator_first, associator_steady = _measure_three(
+        sparse.associator,
+        associator_left,
+        middle,
+        right_associator,
+        repeats,
+    )
+    associator_norm = jnp.linalg.norm(associator_value)
+    associative_status = algebra.properties.claim("associative").status
+    associator_classification_passed = (
+        bool(associator_norm <= 1e-12)
+        if associative_status == "proven"
+        else bool(associator_norm > 1e-12)
+        if associative_status == "disproven"
+        else True
+    )
+    space = phx.linalg.AlgebraArraySpace((), algebra, dtype=jnp.float64)
+    multiplier = jnp.sin(jnp.arange(dimension, dtype=float))
+    action_value = jnp.cos(jnp.arange(dimension, dtype=float))
+    action = phx.linalg.algebra_regular_action_operator(
+        sparse,
+        multiplier,
+        space,
+        side="left",
+    )
+    action_matrix = phx.linalg.materialize(
+        action,
+        phx.linalg.MaterializationPolicy(),
+    )
+    action_defect = jnp.max(
+        jnp.abs(action.mv(action_value) - action_matrix @ action_value)
+    )
+    derivation_preparation = None
+    derivation_dimension = None
+    derivation_residual = None
+    derivation_converged = None
+    if level <= 3:
+        derivation_started = time.perf_counter()
+        derivations = phx.linalg.prepare_algebra_derivations(
+            phx.linalg.plan_algebra_derivations(algebra)
+        )
+        derivation_preparation = 1e3 * (time.perf_counter() - derivation_started)
+        derivation_dimension = int(derivations.dimension)
+        derivation_residual = float(derivations.maximum_leibniz_residual)
+        derivation_converged = bool(derivations.converged)
+    finite = bool(
+        jnp.all(jnp.isfinite(sparse_value))
+        & jnp.all(jnp.isfinite(associator_value))
+        & jnp.isfinite(defect)
+        & jnp.isfinite(action_defect)
+    )
     return AlgebraBenchmarkRecord(
         family=algebra.family,
         coordinate_dimension=dimension,
         product_terms=algebra.structure.term_count,
         plan_bytes=sparse.evidence.resource_evidence.plan_bytes,
-        associative_status=algebra.properties.claim("associative").status,
+        associative_status=associative_status,
         alternative_status=algebra.properties.claim("alternative").status,
         preparation_wall_ms=float(preparation),
         first_jit_ms=float(first),
         steady_wall_ms=float(steady),
         sparse_dense_defect=float(defect),
+        associator_first_jit_ms=float(associator_first),
+        associator_steady_wall_ms=float(associator_steady),
+        associator_norm=float(associator_norm),
+        associator_classification_passed=associator_classification_passed,
+        regular_action_defect=float(action_defect),
+        derivation_preparation_wall_ms=derivation_preparation,
+        derivation_dimension=derivation_dimension,
+        derivation_leibniz_residual=derivation_residual,
+        derivation_converged=derivation_converged,
         finite=finite,
     )
 

--- a/tools/exotic_geometry_benchmarks.py
+++ b/tools/exotic_geometry_benchmarks.py
@@ -52,6 +52,34 @@ def run_benchmarks(*, dimension=2, repeats=10):
     )
     point = jnp.linspace(0.1, 0.4, 2 * dimension)
     projective = phx.geometry.complex.ComplexProjectiveAtlas(dimension)
+    g2_chart = phx.metrix.CoordinateChart(
+        "g2-benchmark",
+        tuple(f"z{index}" for index in range(7)),
+    )
+    g2_bridge = phx.metrix.OctonionG2Bridge(
+        phx.metrix.algebra.OctonionAlgebraSpec(),
+        g2_chart,
+    )
+    g2_point = jnp.linspace(-0.3, 0.4, 7)
+    g2_right = jnp.cos(jnp.arange(7, dtype=float))
+
+    def g2_validation(value):
+        report = phx.metrix.validate_local_g2_structure(
+            g2_bridge.local_structure(),
+            value,
+            require_ricci_flat=True,
+            raise_on_error=False,
+        )
+        return jnp.stack(
+            (
+                report.maximum_metric_compatibility_residual,
+                report.maximum_volume_normalization_residual,
+                report.maximum_closure_residual,
+                report.maximum_coclosure_residual,
+                report.maximum_ricci_residual,
+            )
+        )
+
     records = {
         "weighted_laplacian": _benchmark(
             lambda value: measure.laplacian(lambda q: jnp.dot(q, q), value),
@@ -73,6 +101,16 @@ def run_benchmarks(*, dimension=2, repeats=10):
             point,
             repeats=repeats,
         ),
+        "g2_cross_product": _benchmark(
+            lambda value: g2_bridge.cross(value, g2_right),
+            g2_point,
+            repeats=repeats,
+        ),
+        "g2_validation": _benchmark(
+            g2_validation,
+            g2_point,
+            repeats=repeats,
+        ),
     }
     return {
         "backend": jax.default_backend(),
@@ -80,6 +118,13 @@ def run_benchmarks(*, dimension=2, repeats=10):
         "dimension": dimension,
         "repeats": repeats,
         "records": records,
+        "g2_valid": bool(
+            phx.metrix.validate_local_g2_structure(
+                g2_bridge.local_structure(),
+                g2_point,
+                require_ricci_flat=True,
+            ).valid
+        ),
     }
 
 


### PR DESCRIPTION
## Summary

Extend the finite-real-algebra substrate with explicit nonassociative operations, native left/right regular actions, resource-bounded derivation spaces, and an octonion-derived G2 geometry vertical. The implementation preserves binary product bracketing and continues to execute through ordinary real coordinate arrays.

## Derived algebra operations

- Add exact commutator, symmetrized Jordan product, and associator operations to `AlgebraStructureTable` and finite-algebra specifications.
- Add matching prepared numerical operations to `AlgebraProductPlan` with broadcasting, declared algebra-axis, and JAX transformation support.
- Route associativity and alternativity audits through the canonical exact associator instead of retaining a private duplicate implementation.
- Preserve explicit bracket trees: `(ab)c` and `a(bc)` remain separate calls and are never reassociated.
- Keep integral sparse products integral when all structure denominators are one, avoiding unsafe float-to-integer scatter conversion; fractional Jordan products promote before symmetrization.

## Left and right regular actions

- Add `algebra_regular_action_operator` as a Phydrax-native `FunctionLinearOperator` over `AlgebraArraySpace`.
- Require an explicit `side="left"` or `side="right"`; the side, product plan, space, and multiplier are all bound into operator identity.
- Support one algebra element or a base-shaped pointwise multiplier without materializing broadcast copies.
- Reuse the existing real pairing, materialization, transpose, adjoint, and composition substrate.
- Do not collapse composed left actions into multiplication by one element, which would be invalid for nonassociative algebras.

## Derivation spaces

- Add exact sparse Leibniz constraints directly from rational structure constants.
- Add independent symmetry budgets for constraint equations, sparse terms, dense materialization, workspace, and basis storage without changing existing algebra specification identities.
- Add plan/prepared derivation artifacts with explicit absolute and relative rank cutoffs, singular-gap evidence, and reusable `LinearSubspace` projectors.
- Record Leibniz, unit-fixing, and matrix-commutator closure residuals together with explicit success, nonfinite, ambiguous-rank, and residual-failure statuses.
- Recover the canonical zero-, three-, and fourteen-dimensional derivation spaces for complex numbers, quaternions, and octonions while keeping the prepared nullspace a numerical artifact rather than claiming an exact basis proof.

## Octonion and G2 geometry

- Add `OctonionG2Bridge`, deriving the seven-dimensional cross product and associative three-form from the exact configured octonion multiplication table rather than a second Fano-plane sign table.
- Expose the canonical Euclidean metric, coassociative four-form, imaginary-coordinate embedding, and local G2 structure.
- Add `LocalG2Structure` and a report that separates metric compatibility, volume normalization, closure, coclosure, torsion freedom, and Ricci-flatness.
- Add infinitesimal G2 derivation evidence covering scalar-coordinate preservation, metric skew-adjointness, and associative-form invariance.
- Retain explicit orientation and chart identities throughout bridge and differential-form construction.

## Mathematical boundaries

- Unit octonions are not exposed as a Lie group; their multiplication remains a smooth Moufang-loop concern outside this change.
- Unit-norm octonion states can continue to use the ordinary `SphereManifold(8)` geometry independently of multiplication.
- No generic algebra-valued matrix multiplication, inversion, eigenproblem, or solver semantics are inferred.
- Complex scalar extension, split octonions, higher Cayley-Dickson geometry, Moufang-loop integrators, and a full G2 group implementation remain separate capabilities.

## Documentation and tooling

- Expand the finite-algebra guide and API references with derived products, regular actions, derivation evidence, and nonassociative boundaries.
- Add a special-holonomy API page for local G2 geometry and infinitesimal automorphisms.
- Extend algebra benchmarks with associator classification, regular-action parity, and derivation preparation.
- Extend exotic-geometry benchmarks with canonical G2 cross-product and local-structure diagnostics.
- Update the Metrix overview, high-level library map, navigation, and changelog.