### PR TITLE
Harden finite element IR foundations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,14 @@
   conservative fixed-h summation-density SPH, complete conservation and step
   diagnostics, and native separable-Hamiltonian compilation through
   `StormerVerlet`.
-- Added a typed finite-element local-action IR and compiled worksets; arbitrary-
-  order tensor-product nodal tabulation and sum factorization; mixed elasticity,
-  Darcy, Maxwell, advection, and penalty proof-form builders; bounded implicit
-  local materials; time laws and accepted/rejected solve schedules; uniform T3
-  refinement; and source-specific Q4 plate/shell, ES-FEM, NS-FEM, selective
-  ES/NS, and fully smoothed axisymmetric patch/moment operators with explicit
-  stabilization and certification evidence.
+- Added typed finite-element local-action IR identities, workset planning, eager
+  differential operators, element/partial operator utilities, quadrilateral
+  nodal tabulation and p-transfer prototypes, bounded implicit-material and time
+  schedule foundations, uniform T3 refinement, and source-specific Q4
+  plate/shell, ES-FEM, NS-FEM, selective ES/NS, and fully smoothed
+  axisymmetric patch/moment operators. The IR and proof builders remain
+  developmental planning/front-end surfaces until the authoritative executor
+  cutover; smoothed elasticity now defaults to matrix-free patch action.
 - Added first-class exact-sampling round-sphere spectral discretizations with
   explicit S2FFT mode layouts, physical area measures, matrix-free
   Laplace--Beltrami actions, complete-degree real eigenbases and spatial noise,

--- a/docs/guides_fem_smoothing.md
+++ b/docs/guides_fem_smoothing.md
@@ -63,7 +63,8 @@ mesh = phx.discretization.CellMesh.from_triangles(vertices, cells)
 smoothed = phx.discretization.fem.smoothing
 constitutive = smoothed.plane_stress_matrix(1.0, 0.3)
 edge_plan = smoothed.SmoothedElasticityPlan("ES", mesh, constitutive)
-stiffness = edge_plan.stiffness(vertices)
+operator = edge_plan.operator(vertices)
+residual = operator.mv(jnp.zeros((10,)))
 ```
 
 ## Node smoothing

--- a/docs/guides_finite_elements.md
+++ b/docs/guides_finite_elements.md
@@ -118,20 +118,21 @@ sum/average/update semantics.
 
 ## Local-action IR and high order
 
-Every compiled weak form lowers to `phydrax.equations.fem.LocalActionIR` and a
-typed `WorksetProgram`. Field slots, differential operators, region/rule
-identities, and workset gathers therefore have one canonical fingerprint even
-when the existing variational frontend is used.
+Weak forms can be lowered to `phydrax.equations.fem.LocalActionIR` and a typed
+`WorksetProgram` for identity, validation, and executor development. The
+production residual still uses the existing variational executor; the IR is not
+yet the authoritative evaluation path.
 
-`ReferenceNodalFamily` supplies arbitrary-order quadrilateral Lagrange elements
-with equispaced or Gauss-Lobatto nodes. `TensorProductTabulation` and
-`SumFactorizationPlan` retain one-dimensional factors for high-order
-interpolation and gradients. `QuadratureChunkPolicy` makes memory/chunking
-decisions explicit.
+`ReferenceNodalFamily` currently supplies arbitrary-order quadrilateral
+Lagrange tabulation with equispaced or Gauss-Lobatto nodes.
+`TensorProductTabulation` and `SumFactorizationPlan` provide prototype
+factorized interpolation/gradient utilities; they are not yet the physical
+high-order multi-cell operator backend.
 
-Proof-form builders under `phydrax.equations.fem` provide linear elasticity,
-upwind advection, interior penalty, mixed Darcy, and curl-curl Maxwell
-configurations over the common compiler contracts.
+Proof builders under `phydrax.equations.fem` currently provide semantic or
+small-problem configurations. In particular, SIPG is an IR declaration, HDG
+solves caller-supplied local systems, and mixed Darcy/Maxwell require the future
+authoritative mixed IR executor before being production solve paths.
 
 ## Smoothed finite elements
 

--- a/phydrax/discretization/fem/_high_order.py
+++ b/phydrax/discretization/fem/_high_order.py
@@ -198,17 +198,17 @@ class SumFactorizationPlan(StrictModule, NonTrainableState):
     def gradient(self, coefficients: ArrayLike, /) -> Array:
         values = jnp.asarray(coefficients)
         dx = oe.contract(
-            "pi,...ij,qj->...pqi",
+            "pi,...ij,qj->...pq",
             self.tabulation.gradient_x,
             values,
             self.tabulation.basis_y,
-        )[..., 0]
+        )
         dy = oe.contract(
-            "pi,...ij,qj->...pqi",
+            "pi,...ij,qj->...pq",
             self.tabulation.basis_x,
             values,
             self.tabulation.gradient_y,
-        )[..., 0]
+        )
         return jnp.stack((dx, dy), axis=-1)
 
 

--- a/phydrax/discretization/fem/smoothing/__init__.py
+++ b/phydrax/discretization/fem/smoothing/__init__.py
@@ -14,9 +14,9 @@ from ._common import (
 )
 from ._edge import edge_smoothing_layout
 from ._elasticity import (
-    assemble_smoothing_stiffness,
     plane_strain_matrix,
     plane_stress_matrix,
+    SmoothedElasticityOperator,
     smoothing_internal_force,
     smoothing_local_stiffness,
     smoothing_strain_matrix,
@@ -47,6 +47,7 @@ __all__ = [
     "Q4FSDTSmoothingPlan",
     "SelectiveESNSPlan",
     "SmoothedElasticityPlan",
+    "SmoothedElasticityOperator",
     "SmoothingEnergyEvidence",
     "SmoothingEvidence",
     "SmoothingPatchGeometry",
@@ -54,7 +55,6 @@ __all__ = [
     "SmoothingPatchLayout",
     "SmoothingStabilizationKind",
     "SmoothingStabilizationPolicy",
-    "assemble_smoothing_stiffness",
     "certify_smoothing_operator",
     "boundary_moment",
     "edge_smoothing_layout",

--- a/phydrax/discretization/fem/smoothing/_certification.py
+++ b/phydrax/discretization/fem/smoothing/_certification.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import jax.numpy as jnp
+import opt_einsum as oe
 from jaxtyping import ArrayLike
 
 from ._common import (
@@ -19,6 +20,7 @@ from ._moments import boundary_moment
 def certify_smoothing_operator(
     layout: SmoothingPatchLayout,
     geometry: SmoothingPatchGeometry,
+    dof_coordinates: ArrayLike,
     stiffness: ArrayLike,
     constrained_dofs: ArrayLike,
     expected_total_measure: ArrayLike,
@@ -40,6 +42,24 @@ def certify_smoothing_operator(
     eigenvalues = jnp.linalg.eigvalsh(0.5 * (reduced + reduced.T))
     scale = jnp.maximum(jnp.max(jnp.abs(eigenvalues)), 1.0)
     near_zero = int(jnp.sum(jnp.abs(eigenvalues) <= eigen_tolerance * scale))
+    coordinates = jnp.asarray(dof_coordinates)
+    if coordinates.ndim != 2:
+        raise ValueError("Smoothing DOF coordinates must be rank-2.")
+    safe_routes = jnp.where(layout.dof_valid, layout.dof_routes, 0)
+    gathered_coordinates = coordinates[safe_routes]
+    gathered_coordinates = jnp.where(
+        layout.dof_valid[..., None],
+        gathered_coordinates,
+        0.0,
+    )
+    moments = boundary_moment(layout, geometry)
+    affine_tensor = oe.contract(
+        "plc,pld->pcd",
+        gathered_coordinates,
+        moments,
+    )
+    identity = jnp.eye(coordinates.shape[-1], dtype=affine_tensor.dtype)
+    affine = affine_tensor - identity[None, :, :]
     closure = jnp.sum(
         geometry.boundary_lengths[..., None] * geometry.boundary_normals,
         axis=1,
@@ -51,7 +71,7 @@ def certify_smoothing_operator(
         geometry.valid,
         jnp.sqrt(jnp.sum(closure**2, axis=-1)),
         partition_defect,
-        jnp.sqrt(jnp.sum(affine**2, axis=-1)),
+        jnp.sqrt(jnp.sum(affine**2, axis=(-2, -1))),
         expected_rigid_modes,
         max(near_zero - expected_rigid_modes, 0),
         jnp.min(eigenvalues),

--- a/phydrax/discretization/fem/smoothing/_elasticity.py
+++ b/phydrax/discretization/fem/smoothing/_elasticity.py
@@ -4,10 +4,15 @@
 
 from __future__ import annotations
 
+import equinox as eqx
 import jax.numpy as jnp
 import opt_einsum as oe
 from jaxtyping import Array, ArrayLike
 
+from ...._fingerprint import canonical_fingerprint
+from ...._strict import StrictModule
+from ...._trainable import NonTrainableState
+from ....linalg import ArraySpace, FunctionLinearOperator
 from ._common import SmoothingPatchGeometry, SmoothingPatchLayout
 from ._moments import boundary_moment, smoothed_symmetric_gradient_matrix
 from ._stabilization import SmoothingStabilizationPolicy
@@ -54,6 +59,99 @@ def smoothing_local_stiffness(
             "Active smoothing stabilization needs compatible local stiffness."
         )
     return stabilization.apply(local, compatible_local_stiffness)
+
+
+class SmoothedElasticityOperator(StrictModule, NonTrainableState):
+    """Matrix-free patch gather/action/scatter for 2-D smoothed elasticity."""
+
+    layout: SmoothingPatchLayout
+    local_stiffness: Array
+    global_node_count: int = eqx.field(static=True)
+    operator_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        layout: SmoothingPatchLayout,
+        local_stiffness: ArrayLike,
+        global_node_count: int,
+        /,
+    ):
+        local = jnp.asarray(local_stiffness)
+        count = int(global_node_count)
+        local_width = 2 * int(layout.dof_routes.shape[1])
+        if local.shape != (
+            layout.dof_routes.shape[0],
+            local_width,
+            local_width,
+        ):
+            raise ValueError("Smoothed local stiffness shape is incompatible.")
+        if count <= 0:
+            raise ValueError("global_node_count must be positive.")
+        self.layout = layout
+        self.local_stiffness = local
+        self.global_node_count = count
+        self.operator_id = canonical_fingerprint(
+            {
+                "kind": "smoothed-elasticity-operator",
+                "layout": layout.layout_id,
+                "patches": int(local.shape[0]),
+                "local_width": local_width,
+                "global_nodes": count,
+            }
+        )
+
+    def mv(self, displacement: ArrayLike, /) -> Array:
+        value = jnp.asarray(displacement)
+        original_shape = value.shape
+        flat_value = value.reshape((-1,))
+        if flat_value.shape != (2 * self.global_node_count,):
+            raise ValueError("Smoothed displacement has invalid global shape.")
+        nodes = self.layout.dof_routes
+        valid = self.layout.dof_valid
+        flat_routes = (2 * nodes[..., None] + jnp.arange(2)).reshape((nodes.shape[0], -1))
+        flat_valid = jnp.repeat(valid, 2, axis=1)
+        safe = jnp.where(flat_valid, flat_routes, 0)
+        local_value = jnp.where(flat_valid, flat_value[safe], 0.0)
+        local_result = oe.contract("pij,pj->pi", self.local_stiffness, local_value)
+        local_result = jnp.where(flat_valid, local_result, 0.0)
+        result = jnp.zeros_like(flat_value).at[safe].add(local_result)
+        return result.reshape(original_shape)
+
+    def diagonal(self, /) -> Array:
+        nodes = self.layout.dof_routes
+        valid = self.layout.dof_valid
+        flat_routes = (2 * nodes[..., None] + jnp.arange(2)).reshape((nodes.shape[0], -1))
+        flat_valid = jnp.repeat(valid, 2, axis=1)
+        safe = jnp.where(flat_valid, flat_routes, 0)
+        local = jnp.diagonal(self.local_stiffness, axis1=-2, axis2=-1)
+        return (
+            jnp.zeros((2 * self.global_node_count,), dtype=local.dtype)
+            .at[safe]
+            .add(jnp.where(flat_valid, local, 0.0))
+        )
+
+    def materialize(self, /, *, max_entries: int = 4_000_000) -> Array:
+        size = 2 * self.global_node_count
+        if size * size > int(max_entries):
+            raise ValueError(
+                "Dense smoothing materialization exceeds the explicit entry budget."
+            )
+        return assemble_smoothing_stiffness(
+            self.layout,
+            self.local_stiffness,
+            self.global_node_count,
+        )
+
+    def as_linear_operator(self, /) -> FunctionLinearOperator:
+        space = ArraySpace(
+            (2 * self.global_node_count,), dtype=self.local_stiffness.dtype
+        )
+        return FunctionLinearOperator(
+            self.mv,
+            source=space,
+            target=space,
+            operator_id=self.operator_id,
+        )
 
 
 def assemble_smoothing_stiffness(

--- a/phydrax/discretization/fem/smoothing/_methods.py
+++ b/phydrax/discretization/fem/smoothing/_methods.py
@@ -14,6 +14,7 @@ from jaxtyping import Array, ArrayLike
 from ...._fingerprint import canonical_fingerprint
 from ...._strict import StrictModule
 from ...._trainable import NonTrainableState
+from ....linalg import ArraySpace, FunctionLinearOperator
 from ..._cell_mesh import CellMesh
 from ._cell import q4_cell_smoothing_layout
 from ._common import (
@@ -22,10 +23,7 @@ from ._common import (
     SmoothingPatchLayout,
 )
 from ._edge import edge_smoothing_layout
-from ._elasticity import (
-    assemble_smoothing_stiffness,
-    smoothing_local_stiffness,
-)
+from ._elasticity import SmoothedElasticityOperator, smoothing_local_stiffness
 from ._moments import boundary_moment, primitive_volume_moment, shape_average
 from ._node import node_smoothing_layout
 from ._stabilization import SmoothingStabilizationPolicy
@@ -93,14 +91,14 @@ class SmoothedElasticityPlan(StrictModule, NonTrainableState):
             stabilization=self.stabilization,
         )
 
-    def stiffness(
+    def operator(
         self,
         coordinates: ArrayLike,
         /,
         *,
         compatible_local_stiffness: ArrayLike | None = None,
-    ) -> Array:
-        return assemble_smoothing_stiffness(
+    ) -> SmoothedElasticityOperator:
+        return SmoothedElasticityOperator(
             self.layout,
             self.local_stiffness(
                 coordinates,
@@ -108,6 +106,19 @@ class SmoothedElasticityPlan(StrictModule, NonTrainableState):
             ),
             self.global_node_count,
         )
+
+    def materialize_stiffness(
+        self,
+        coordinates: ArrayLike,
+        /,
+        *,
+        compatible_local_stiffness: ArrayLike | None = None,
+        max_entries: int = 4_000_000,
+    ) -> Array:
+        return self.operator(
+            coordinates,
+            compatible_local_stiffness=compatible_local_stiffness,
+        ).materialize(max_entries=max_entries)
 
 
 class SelectiveESNSPlan(StrictModule, NonTrainableState):
@@ -134,10 +145,28 @@ class SelectiveESNSPlan(StrictModule, NonTrainableState):
             }
         )
 
-    def stiffness(self, coordinates: ArrayLike, /) -> Array:
-        return self.edge_plan.stiffness(coordinates) + self.node_plan.stiffness(
-            coordinates
+    def operator(self, coordinates: ArrayLike, /) -> FunctionLinearOperator:
+        edge = self.edge_plan.operator(coordinates)
+        node = self.node_plan.operator(coordinates)
+        size = 2 * self.edge_plan.global_node_count
+        space = ArraySpace((size,), dtype=edge.local_stiffness.dtype)
+        return FunctionLinearOperator(
+            lambda value: edge.mv(value) + node.mv(value),
+            source=space,
+            target=space,
+            operator_id=self.plan_id,
         )
+
+    def materialize_stiffness(
+        self,
+        coordinates: ArrayLike,
+        /,
+        *,
+        max_entries: int = 4_000_000,
+    ) -> Array:
+        edge = self.edge_plan.operator(coordinates).materialize(max_entries=max_entries)
+        node = self.node_plan.operator(coordinates).materialize(max_entries=max_entries)
+        return edge + node
 
 
 class Q4FSDTChannels(StrictModule):

--- a/phydrax/equations/_finite_element_variational.py
+++ b/phydrax/equations/_finite_element_variational.py
@@ -883,8 +883,8 @@ class CompiledFiniteElementProblem(StrictModule, NonTrainableState):
     discretization: FiniteElementDiscretization
     constraint: FiniteElementDirichletConstraint | None
     execution_policy: FiniteElementExecutionPolicy
-    action_ir: object
-    workset_program: object
+    _action_ir: object
+    _workset_program: object
     work_blocks: tuple[_FiniteElementWorkBlock, ...]
     lift: Array
     discretization_bundle: DiscretizationBundle
@@ -1010,8 +1010,8 @@ class CompiledFiniteElementProblem(StrictModule, NonTrainableState):
         self.discretization = discretization
         self.constraint = constraint
         self.execution_policy = policy
-        self.action_ir = action_ir
-        self.workset_program = workset_program
+        self._action_ir = action_ir
+        self._workset_program = workset_program
         self.lift = lift
         self.work_blocks = work_blocks
         self.discretization_bundle = DiscretizationBundle(

--- a/phydrax/equations/fem/__init__.py
+++ b/phydrax/equations/fem/__init__.py
@@ -36,16 +36,6 @@ from ._operators import (
     symmetric_gradient,
     tangential_trace,
 )
-from ._proofs import (
-    darcy_form,
-    HDGPoissonSolution,
-    interior_penalty_form,
-    linear_elasticity_form,
-    maxwell_form,
-    sipg_poisson_ir,
-    solve_hdg_poisson,
-    upwind_advection_form,
-)
 from ._worksets import CompiledWorkset, WorksetProgram, WorksetSignature
 
 
@@ -75,14 +65,6 @@ __all__ = [
     "WorksetProgram",
     "WorksetSignature",
     "average",
-    "HDGPoissonSolution",
-    "darcy_form",
-    "interior_penalty_form",
-    "linear_elasticity_form",
-    "maxwell_form",
-    "sipg_poisson_ir",
-    "solve_hdg_poisson",
-    "upwind_advection_form",
     "compile_workset_program",
     "curl",
     "divergence",

--- a/phydrax/equations/fem/_materials.py
+++ b/phydrax/equations/fem/_materials.py
@@ -120,8 +120,7 @@ class LocalImplicitMaterial(StrictModule, NonTrainableState):
         args: object,
         /,
     ) -> tuple[Array, LocalImplicitDiagnostics]:
-        initial = jnp.asarray(initial_state)
-        root = self._newton_solve(self.residual, initial, args)
+        root = self.solve(initial_state, args)
         residual = jnp.asarray(self.residual(root, args))
         norm = jnp.linalg.norm(residual.reshape((-1,)))
         finite = jnp.all(jnp.isfinite(root)) & jnp.all(jnp.isfinite(residual))

--- a/phydrax/solver/_schedule.py
+++ b/phydrax/solver/_schedule.py
@@ -141,7 +141,7 @@ class SolveStage(StrictModule, NonTrainableState):
         /,
         *,
         commit: Callable = lambda state, diagnostics: state,
-        rollback: Callable = lambda state, diagnostics: state,
+        rollback: Callable = lambda committed, candidate, diagnostics: committed,
     ):
         identifier = str(stage_id)
         start = float(start_time)
@@ -171,7 +171,7 @@ class SolveStage(StrictModule, NonTrainableState):
         accepted_state = (
             self.commit(result.state, result.diagnostics)
             if bool(jnp.asarray(result.accepted))
-            else self.rollback(result.state, result.diagnostics)
+            else self.rollback(state, result.state, result.diagnostics)
         )
         return ScheduleStepResult(
             state=accepted_state,

--- a/tests/unit/discretization/test_fem_action_ir_smoothing.py
+++ b/tests/unit/discretization/test_fem_action_ir_smoothing.py
@@ -28,15 +28,16 @@ def test_weak_form_lowers_to_typed_ir_and_worksets():
         "u",
         (phx.equations.DiffusionTerm("u"), phx.equations.SourceTerm("u", 1.0)),
     )
-    compiled = phx.equations.compile_finite_element_problem(form, discretization)
 
-    assert compiled.action_ir.ir_id
-    assert tuple(slot.name for slot in compiled.action_ir.slots) == ("u",)
-    assert len(compiled.action_ir.terms) == 2
-    assert compiled.workset_program.program_id
-    assert all(
-        workset.entity_indices.size for workset in compiled.workset_program.worksets
+    action_ir = phx.equations.fem.lower_weak_form(form, discretization)
+    workset_program = phx.equations.fem.compile_workset_program(
+        action_ir, form, discretization
     )
+    assert action_ir.ir_id
+    assert tuple(slot.name for slot in action_ir.slots) == ("u",)
+    assert len(action_ir.terms) == 2
+    assert workset_program.program_id
+    assert all(workset.entity_indices.size for workset in workset_program.worksets)
 
 
 def test_high_order_tensor_family_partition_unity_and_sum_factorization():
@@ -73,8 +74,8 @@ def test_edge_and_node_smoothing_partition_patch_and_rigid_modes():
     node = smoothing.SmoothedElasticityPlan("NS", mesh, constitutive)
     edge_geometry = edge.geometry(mesh.coordinates)
     node_geometry = node.geometry(mesh.coordinates)
-    edge_stiffness = edge.stiffness(mesh.coordinates)
-    node_stiffness = node.stiffness(mesh.coordinates)
+    edge_stiffness = edge.operator(mesh.coordinates).materialize()
+    node_stiffness = node.operator(mesh.coordinates).materialize()
     translation_x = jnp.tile(jnp.asarray([1.0, 0.0]), (5, 1)).reshape((-1,))
     rotation = jnp.stack(
         (-mesh.coordinates[:, 1], mesh.coordinates[:, 0]), axis=-1
@@ -191,11 +192,7 @@ def test_element_partial_and_p_transfer_operators_are_consistent():
     assert jnp.allclose(transfer.prolong(constant), 1.0)
 
 
-def test_proof_form_and_application_models_are_executable():
-    elasticity = phx.equations.fem.linear_elasticity_form("u", 1.0, 1.0)
-    assert elasticity.form_id
-    upwind = phx.equations.fem.upwind_advection_form("c", jnp.asarray([1.0, 0.0]))
-    assert upwind.form_id
+def test_application_model_primitives_are_executable():
     parameters = phx.equations.fem.J2PlasticityParameters(1.0, 2.0, 0.1, 0.2)
     response = phx.equations.fem.j2_radial_return(
         jnp.asarray([0.2, -0.1, -0.1, 0.0, 0.0, 0.0]),

--- a/tests/unit/discretization/test_fem_ir_foundation_repairs.py
+++ b/tests/unit/discretization/test_fem_ir_foundation_repairs.py
@@ -1,0 +1,141 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax
+import jax.numpy as jnp
+import opt_einsum as oe
+import pytest
+
+import phydrax as phx
+
+
+def _tri_mesh():
+    vertices = jnp.asarray([[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [0.5, 0.5]])
+    cells = jnp.asarray(
+        [[0, 1, 4], [1, 2, 4], [2, 3, 4], [3, 0, 4]],
+        dtype=jnp.int32,
+    )
+    return phx.discretization.CellMesh.from_triangles(vertices, cells)
+
+
+def test_sum_factorized_gradient_contracts_every_nodal_axis():
+    family = phx.discretization.fem.ReferenceNodalFamily("quadrilateral", 2)
+    tabulation = phx.discretization.fem.TensorProductTabulation(
+        family,
+        jnp.asarray([0.2, 0.8]),
+        jnp.asarray([0.3, 0.7]),
+    )
+    plan = phx.discretization.fem.SumFactorizationPlan(tabulation)
+    coefficients = jnp.zeros((3, 3)).at[2, 1].set(1.0)
+    gradient = plan.gradient(coefficients)
+    points = jnp.stack(
+        jnp.meshgrid(
+            jnp.asarray([0.2, 0.8]),
+            jnp.asarray([0.3, 0.7]),
+            indexing="ij",
+        ),
+        axis=-1,
+    ).reshape((-1, 2))
+    _, dense_gradient = family.tabulate(points)
+    expected = oe.contract("qia,i->qa", dense_gradient, coefficients.reshape((-1,)))
+
+    assert gradient.shape == (2, 2, 2)
+    assert jnp.linalg.norm(gradient) > 0.0
+    assert jnp.allclose(gradient.reshape((-1, 2)), expected)
+
+
+def test_smoothed_elasticity_defaults_to_budgeted_matrix_free_operator():
+    mesh = _tri_mesh()
+    smoothing = phx.discretization.fem.smoothing
+    plan = smoothing.SmoothedElasticityPlan(
+        "ES", mesh, smoothing.plane_stress_matrix(1.0, 0.3)
+    )
+    operator = plan.operator(mesh.coordinates)
+    displacement = jnp.arange(10.0).reshape((5, 2))
+
+    assert operator.mv(displacement).shape == displacement.shape
+    assert operator.diagonal().shape == (10,)
+    with pytest.raises(ValueError, match="entry budget"):
+        operator.materialize(max_entries=10)
+    assert operator.materialize(max_entries=100).shape == (10, 10)
+
+
+def test_rejected_schedule_stage_restores_committed_state():
+    law = phx.solver.TimeLaw.constant(1.0)
+
+    def solve(state, start, end, time_law, args):
+        return phx.solver.ScheduleStepResult(
+            state=state + 10.0,
+            accepted=jnp.asarray(False),
+            diagnostics=jnp.asarray(1.0),
+        )
+
+    stage = phx.solver.SolveStage("reject", 0.0, 1.0, law, solve)
+    final, results = phx.solver.SolveSchedule((stage,)).run(jnp.asarray(2.0))
+
+    assert jnp.allclose(final, 2.0)
+    assert jnp.allclose(results[0].state, 2.0)
+
+
+def test_material_evaluate_uses_implicit_root_derivative():
+    material = phx.equations.fem.LocalImplicitMaterial(
+        lambda state, target: state**2 - target,
+        lambda state, target: phx.equations.ConstitutiveResponse(state, state),
+        state_shape=(1,),
+        model_id="implicit-square-root",
+    )
+    initial = jnp.asarray([1.0])
+    response, tangent = jax.jvp(
+        lambda target: material.evaluate(initial, target).response,
+        (jnp.asarray([4.0]),),
+        (jnp.asarray([1.0]),),
+    )
+
+    assert jnp.allclose(response, 2.0)
+    assert jnp.allclose(tangent, 0.25, atol=1.0e-8)
+
+
+def test_smoothing_certificate_checks_full_affine_identity():
+    mesh = _tri_mesh()
+    smoothing = phx.discretization.fem.smoothing
+    plan = smoothing.SmoothedElasticityPlan(
+        "ES", mesh, smoothing.plane_stress_matrix(1.0, 0.3)
+    )
+    operator = plan.operator(mesh.coordinates)
+    matrix = operator.materialize(max_entries=100)
+    constrained = jnp.asarray(
+        [True, True, False, True, False, False, False, False, False, False]
+    )
+    evidence = smoothing.certify_smoothing_operator(
+        plan.layout,
+        plan.geometry(mesh.coordinates),
+        mesh.coordinates,
+        matrix,
+        constrained,
+        1.0,
+        0,
+    )
+
+    assert jnp.max(evidence.affine_reproduction_defect) < 1.0e-12
+    assert jnp.max(evidence.closure_defect) < 1.0e-12
+
+
+def test_ir_is_explicitly_lowered_but_not_advertised_as_executor():
+    mesh = _tri_mesh()
+    field = phx.discretization.FiniteElementFieldSpec(
+        "u", phx.discretization.lagrange_element("triangle", 1)
+    )
+    discretization = phx.discretization.FiniteElementPlan(mesh, field).prepare()
+    form = phx.equations.WeakForm(
+        "poisson",
+        "u",
+        (phx.equations.DiffusionTerm("u"),),
+    )
+    compiled = phx.equations.compile_finite_element_problem(form, discretization)
+    action_ir = phx.equations.fem.lower_weak_form(form, discretization)
+
+    assert action_ir.ir_id
+    assert "action_ir" not in compiled.__dataclass_fields__
+    assert "darcy_form" not in phx.equations.fem.__all__
+    assert "sipg_poisson_ir" not in phx.equations.fem.__all__

--- a/tools/discretization_benchmarks.py
+++ b/tools/discretization_benchmarks.py
@@ -112,21 +112,30 @@ def _smoothing_case(width, repeats):
     started = time.perf_counter()
     edge = smoothing.SmoothedElasticityPlan("ES", mesh, constitutive)
     node = smoothing.SmoothedElasticityPlan("NS", mesh, constitutive)
+    edge_operator = edge.operator(vertices)
+    node_operator = node.operator(vertices)
     preparation = time.perf_counter() - started
-    edge_action = eqx.filter_jit(edge.stiffness)
-    node_action = eqx.filter_jit(node.stiffness)
-    edge_action(vertices).block_until_ready()
-    node_action(vertices).block_until_ready()
-    edge_stiffness, edge_steady = _timed(lambda: edge_action(vertices), repeats)
-    node_stiffness, node_steady = _timed(lambda: node_action(vertices), repeats)
+    displacement = jnp.stack(
+        (
+            jnp.sin(jnp.pi * vertices[:, 0]),
+            jnp.sin(jnp.pi * vertices[:, 1]),
+        ),
+        axis=-1,
+    ).reshape((-1,))
+    edge_action = eqx.filter_jit(edge_operator.mv)
+    node_action = eqx.filter_jit(node_operator.mv)
+    edge_action(displacement).block_until_ready()
+    node_action(displacement).block_until_ready()
+    edge_residual, edge_steady = _timed(lambda: edge_action(displacement), repeats)
+    node_residual, node_steady = _timed(lambda: node_action(displacement), repeats)
     return {
         "preparation_seconds": preparation,
         "edge_steady_seconds": edge_steady,
         "node_steady_seconds": node_steady,
         "edge_patches": int(edge.layout.owner_entities.size),
         "node_patches": int(node.layout.owner_entities.size),
-        "edge_matrix_norm": float(jnp.linalg.norm(edge_stiffness)),
-        "node_matrix_norm": float(jnp.linalg.norm(node_stiffness)),
+        "edge_action_norm": float(jnp.linalg.norm(edge_residual)),
+        "node_action_norm": float(jnp.linalg.norm(node_residual)),
     }
 
 


### PR DESCRIPTION
## Summary

Harden the finite-element IR and smoothed-method foundations before the authoritative executor cutover. This repair removes correctness blockers and public overclaims that would otherwise propagate into the mixed-method, high-order, material, smoothing, and application phases.

## Sum-factorized gradients

- Correct `SumFactorizationPlan.gradient()` so both nodal axes are fully contracted.
- Remove the accidental residual nodal axis/index-zero selection.
- Restore dense-versus-factorized polynomial derivative equivalence.

## Matrix-free smoothed elasticity

- Add `SmoothedElasticityOperator` with patch gather/action/scatter.
- Add matrix-free `mv`, diagonal extraction, and native `FunctionLinearOperator` lowering.
- Make `SmoothedElasticityPlan.operator(...)` the default execution surface.
- Restrict dense materialization to an explicit entry budget through `materialize_stiffness(...)`.
- Compose selective ES/NS through matrix-free operators.
- Update smoothing benchmarks to measure residual action rather than dense global assembly.

## Accepted-state rollback

- Change rejected `SolveStage` semantics to `rollback(committed_state, candidate_state, diagnostics)`.
- Make the default rollback preserve the committed state.
- Prevent rejected trial state from becoming the next schedule state.

## Implicit material derivatives

- Route `LocalImplicitMaterial.evaluate()` through the `custom_root` solution path.
- Compute diagnostics at the implicit root without replacing its derivative by differentiation through the bounded Newton loop.

## Smoothing certification

- Extend affine reproduction evidence from `sum_a Gbar_a = 0` to the full identity `sum_a x_a tensor Gbar_a = I`.
- Bind nodal coordinates explicitly into smoothing certification.

## Capability and API honesty

- Make compiled IR/workset planning objects private rather than advertising them as the production executor.
- Remove non-executable proof builders from the public `phydrax.equations.fem` namespace.
- Update guides and changelog to state that:
  - the IR is currently a lowering/planning surface;
  - the production residual still uses the current variational executor;
  - SIPG is semantic IR;
  - HDG consumes caller-supplied local systems;
  - arbitrary-order support is quadrilateral-focused.

## Regression coverage

- Add dedicated coverage for high-order gradient contraction, matrix-free smoothing and materialization budget, rejected-state rollback, implicit material differentiation, full smoothing affine identity, and the non-public status of incomplete IR/method surfaces.