### PR TITLE
Add native low-rank model adaptation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## Unreleased
 
 ### Added
+- Added native low-rank adaptation for exact real `Linear` weight paths,
+  factor-only `ParameterSubspace` training through `fit_operator` and Optax
+  `FunctionalSolver`, safe scan fallback, explicit KFAC rejection, pure dense
+  deployment merging, and checksum-validated adapter artifacts bound to the
+  complete base model content and structure.
 - Added `phydrax.topology`: compact active subcomplexes and relative pairs,
   exact prime-field homology with cycle/cocycle representatives, exact rational
   Betti dimensions, explicit cell-vertex supports, lower/upper-star filtrations,

--- a/NOTICE
+++ b/NOTICE
@@ -119,6 +119,14 @@ contracts. See LICENSES/SPINEAX-MIT.txt.
 
 Research and design acknowledgments
 
+The low-rank adaptation design study considered Davis Yoshida's Lorax at commit
+1ebd0efa6c467974357bb9f73fe4a4967b487622, Copyright (c) 2023
+davisyoshida, licensed under the MIT License, together with Hu et al.,
+“LoRA: Low-Rank Adaptation of Large Language Models” (2021). Phydrax
+independently implements explicit native affine updates, exact parameter
+subspaces, trainer integration, base-bound artifacts, and deployment merging;
+no Lorax or Qax source or runtime dependency is copied or redistributed.
+
 The direct-collocation design study considered csu-hmc/opty at commit
 fdad07d0f0ae149e2eedb479e7a87298fd6722ef, Copyright (c) 2014-2025,
 opty authors, licensed under the BSD 2-Clause License, together with Moore and

--- a/benchmarks/low_rank_adaptation.json
+++ b/benchmarks/low_rank_adaptation.json
@@ -1,0 +1,31 @@
+{
+  "operator_transfer": {
+    "adapted_site_count": 4,
+    "base_coefficient": 2.0,
+    "frozen_loss": 4.137572759070361,
+    "full_finetune_loss": 3.8108540773391724,
+    "full_trainable_parameters": 197,
+    "low_rank_loss": 4.121539354324341,
+    "low_rank_trainable_parameters": 53,
+    "rank": 1,
+    "target_coefficient": 3.0
+  },
+  "resource": {
+    "adapter_artifact_bytes": 67809,
+    "adapter_compile_seconds": 1.3081609159708023,
+    "adapter_optimizer_state_bytes": 131076,
+    "adapter_parameter_bytes": 65536,
+    "adapter_parameter_count": 8192,
+    "adapter_step_seconds": 0.010808233404532075,
+    "batch_size": 16,
+    "dense_compile_seconds": 0.6263532909797505,
+    "dense_optimizer_state_bytes": 4194308,
+    "dense_parameter_bytes": 2097152,
+    "dense_parameter_count": 262144,
+    "dense_step_seconds": 0.027233225002419204,
+    "dimension": 512,
+    "merged_output_max_abs_error": 6.661338147750939e-15,
+    "rank": 8,
+    "reported_adapter_parameter_count": 8192
+  }
+}

--- a/docs/all-of-phydrax.md
+++ b/docs/all-of-phydrax.md
@@ -187,6 +187,16 @@ factorization, stability, and orthogonality maps live in
 are constructed on demand. The same package owns explicit model-PyTree
 selection through `ParameterSubspace`.
 
+Exact native `Linear` paths can instead carry factorized low-rank updates over
+a shared dense base. The factor-only `ParameterSubspace` is the complete
+gradient and optimizer-state boundary for `fit_operator` and Optax
+`FunctionalSolver` runs; merging returns an ordinary dense deployment model,
+while adapter-only archives verify the complete base content before loading.
+The checked transfer campaign improves its frozen baseline with 53 selected
+parameters versus 197 for full fine-tuning, and the resource campaign reduces
+Adam state from 4,194,308 to 131,076 bytes with merged/factorized disagreement
+below \(7\times10^{-15}\).
+
 ### Native ML: fitted array models, not mutable estimators
 
 `phydrax.ml` covers preprocessing and composition; linear, generalized-linear,

--- a/docs/api/nn/architectures.md
+++ b/docs/api/nn/architectures.md
@@ -2559,6 +2559,14 @@ output pipeline. `OperatorFitResult.execution_model` and
 and all callable schedules require stable identities for exact-resume
 compatibility.
 
+`parameter_subspace=` restricts differentiation, gradient accumulation, and
+optimizer state to exact selected model leaves. The subspace is validated
+against the caller model, then rebased after parameter-dtype casting and model
+replication. Its effective paths, shapes, dtypes, and total dimension are part
+of the exact-resume fit contract. Low-rank adapted models require
+`low_rank_parameter_subspace(model)`; omitting it or selecting anything other
+than every adapter factor fails before optimizer initialization.
+
 Operator fit checkpoints use a versioned semantic fit schema rather than the
 concrete shape of the batch used to construct the fit. On resume, PhydraX
 validates manifest fields, format version, state checksum, loader content and

--- a/docs/api/nn/parameters.md
+++ b/docs/api/nn/parameters.md
@@ -108,6 +108,108 @@ spd = phx.nn.parameters.PositiveDefiniteTransform()(raw)
             - value
             - __call__
 
+
+## Low-rank adaptation
+
+`LowRankUpdate` represents a real affine weight as
+`W_eff = W_0 + (alpha / rank) * left @ right`. The base has shape
+`(out, in)`, `left` has shape `(out, rank)`, and `right` has shape
+`(rank, in)`. `Linear` evaluates the two factor contractions directly; it does
+not construct the dense update during training. `merge_low_rank(...)` performs
+that construction explicitly for deployment.
+
+`adapt_low_rank(...)` accepts exact native `Linear.weight` paths only. It
+initializes `left` to zero and `right` from a Gaussian, so the adapted model is
+exactly the base model before optimization. `alpha=None` resolves to
+`alpha=rank`, giving unit effective scaling. RWF, weight transforms, complex
+weights, aliased layers, and already adapted weights fail before model surgery.
+
+```python
+import jax.random as jr
+import phydrax as phx
+
+paths = phx.nn.parameters.low_rank_sites(model)
+specs = {
+    path: phx.nn.parameters.LowRankSpec(rank=8)
+    for path in paths
+}
+adapted, report = phx.nn.parameters.adapt_low_rank(
+    model,
+    specs,
+    key=jr.key(0),
+)
+subspace = phx.nn.parameters.low_rank_parameter_subspace(adapted)
+
+fit = phx.nn.operator.training.fit_operator(
+    adapted,
+    training_data,
+    parameter_subspace=subspace,
+    epochs=10,
+)
+deployed = phx.nn.parameters.merge_low_rank(fit.execution_model)
+```
+
+The explicit subspace is mandatory for low-rank training through
+`fit_operator` and `FunctionalSolver.solve`. It prevents gradients, optimizer
+moments, and decoupled weight decay from reaching the dense base or unrelated
+model leaves. The initial implementation supports standard and
+extra-argument Optax transformations. KFAC and Phydrax geometric/iterative
+optimizers reject explicit subspaces.
+
+Adapter-only artifacts are content-bound to the complete dense base:
+
+```python
+phx.nn.parameters.save_low_rank_adapter("task.phxadapter", trained_model)
+restored = phx.nn.parameters.read_low_rank_adapter(
+    "task.phxadapter",
+    exact_base_model,
+)
+```
+
+Loading verifies the model type, static structure, every base array, site
+path, shape, dtype, rank, and factor checksum before reconstruction. A wrong
+base fails rather than accepting shape compatibility alone.
+
+The factorization is not identifiable: for invertible `Q`, the pairs
+`(left, right)` and `(left @ Q, inverse(Q) @ right)` represent the same dense
+update. Deterministic optimization remains valid, but factor-space Hessians,
+KFAC blocks, Laplace approximations, and MCMC require a separate gauge-aware
+contract and are not claimed here.
+
+::: phydrax.nn.parameters.LowRankSpec
+
+---
+
+::: phydrax.nn.parameters.LowRankUpdate
+
+---
+
+::: phydrax.nn.parameters.LowRankAdaptationReport
+
+---
+
+::: phydrax.nn.parameters.adapt_low_rank
+
+---
+
+::: phydrax.nn.parameters.low_rank_sites
+
+---
+
+::: phydrax.nn.parameters.low_rank_parameter_subspace
+
+---
+
+::: phydrax.nn.parameters.merge_low_rank
+
+---
+
+::: phydrax.nn.parameters.save_low_rank_adapter
+
+---
+
+::: phydrax.nn.parameters.read_low_rank_adapter
+
 ## Explicit model subspaces
 
 `ParameterSubspace` partitions selected inexact array leaves from a frozen complement and reconstructs the original model topology exactly. It also records deterministic leaf paths, shapes, exact dtypes, and total dimension. `pack()` and `unpack()` provide the canonical vector coordinate system; `reconstruct_vector()` rebuilds a complete model directly from that vector. Use exact leaf paths or named subtree paths for branched architectures. `last_layer(...)` means the globally final array leaves in deterministic PyTree order; it is not architecture-aware and does not select one output head per branch.
@@ -130,6 +232,8 @@ reconstructed = subspace.reconstruct(selected)
         members:
             - __init__
             - reconstruct
+            - validate_root
+            - rebase
             - array_leaf_paths
             - pack
             - unpack

--- a/docs/api/optim.md
+++ b/docs/api/optim.md
@@ -1700,6 +1700,12 @@ iterative methods. Operator fitting accepts supplied Optax transformations.
 Resumable `fit_operator` runs require a stable `optimizer_id` whenever the transformation
 is supplied externally so checkpoint identity does not depend on an opaque Python object.
 
+An explicit `ParameterSubspace` may be supplied to `FunctionalSolver.solve` or
+`fit_operator`. In the initial contract this restriction is supported only by
+standard and extra-argument Optax transformations. KFAC, Evosax, mirror,
+Riemannian, scalar, least-squares, and composite backends reject it rather than
+silently optimizing the complete ambient PyTree.
+
 Evosax distribution-based algorithms remain accepted by `FunctionalSolver`; its
 population-based algorithms require an explicit finite search-space contract and are
 rejected there. Optimistix interoperation is deliberately explicit and standalone:

--- a/docs/cookbook/operator_learning.md
+++ b/docs/cookbook/operator_learning.md
@@ -1428,6 +1428,46 @@ training_model = fit_result.execution_model
 assert fit_result.completed_steps == 1
 ```
 
+For parameter-efficient transfer, adapt explicit native affine sites and pass
+only their factors to the same production fitting control plane:
+
+```python
+base_model = training_model
+paths = phx.nn.parameters.low_rank_sites(base_model)
+adapted, adaptation = phx.nn.parameters.adapt_low_rank(
+    base_model,
+    {
+        path: phx.nn.parameters.LowRankSpec(rank=8)
+        for path in paths
+    },
+    key=jr.key(12),
+)
+adapter_parameters = phx.nn.parameters.low_rank_parameter_subspace(adapted)
+adapted_fit = phx.nn.operator.training.fit_operator(
+    adapted,
+    split.train,
+    validation=split.validation,
+    parameter_subspace=adapter_parameters,
+    epochs=10,
+    batch_size=16,
+)
+phx.nn.parameters.save_low_rank_adapter(
+    "adapted-task.phxadapter",
+    adapted_fit.execution_model,
+    provenance={"task": "downstream-operator"},
+)
+restored = phx.nn.parameters.read_low_rank_adapter(
+    "adapted-task.phxadapter",
+    base_model,
+)
+deployment_model = phx.nn.parameters.merge_low_rank(restored.model)
+```
+
+The adapter archive contains no base arrays. Loading binds it to the exact base
+model content and static architecture, not merely compatible shapes. Keep the
+factorized model while training or swapping tasks; merge only when ordinary
+dense deployment and zero adapter inference overhead are required.
+
 Pass an `OperatorTask` plus matching `OperatorTrainingEvidence` to bind physical
 dimensions, source/query roles, output fields, and the admissible deployment
 regime. The task contract separates the structural source/query relation

--- a/phydrax/_model/_kfac.py
+++ b/phydrax/_model/_kfac.py
@@ -16,7 +16,9 @@ class KFACAffineBlock:
     name: str
     weight: Any
     bias: Any | None
-    parameterization: Literal["direct", "rwf", "transformed"] = "direct"
+    parameterization: Literal["direct", "low_rank_update", "rwf", "transformed"] = (
+        "direct"
+    )
 
 
 class KFACLayoutProvider(abc.ABC):

--- a/phydrax/nn/__init__.py
+++ b/phydrax/nn/__init__.py
@@ -4,7 +4,7 @@ Ownership is explicit:
 
 - :mod:`phydrax.nn.models` contains pointwise and structured finite-dimensional models.
 - :mod:`phydrax.nn.layers` contains reusable tensor-to-tensor layers.
-- :mod:`phydrax.nn.parameters` contains physical parameter transforms and selections.
+- :mod:`phydrax.nn.parameters` contains transforms, subspaces, and adaptations.
 - :mod:`phydrax.nn.operator` contains operator data, engines, adapters, and runtime policy.
 """
 

--- a/phydrax/nn/_scan.py
+++ b/phydrax/nn/_scan.py
@@ -71,12 +71,31 @@ def pack_scan_modules(modules: Sequence[Any]) -> tuple[Any | None, Any | None, b
     return stacked_dynamic, static0, True
 
 
-def stack_scan_dynamics(modules: Sequence[Any]) -> Any | None:
-    """Stack dynamic leaves across compatible modules along a new scan axis."""
-    if len(modules) == 0:
+def stack_scan_dynamics(
+    modules: Sequence[Any],
+    expected_static: Any | None = None,
+    /,
+) -> Any | None:
+    """Stack compatible dynamics or decline when cached static structure is stale."""
+    dynamic, current_static, enabled = pack_scan_modules(modules)
+    if not enabled or dynamic is None or current_static is None:
         return None
-    dynamics = [eqx.partition(module, eqx.is_array)[0] for module in modules]
-    return jtu.tree_map(lambda *xs: jnp.stack(xs, axis=0), *dynamics)
+    if expected_static is None:
+        return dynamic
+    if jtu.tree_structure(current_static) != jtu.tree_structure(expected_static):
+        return None
+    current_leaves = jtu.tree_leaves(current_static)
+    expected_leaves = jtu.tree_leaves(expected_static)
+    if any(
+        not _leaf_static_equal(current, expected)
+        for current, expected in zip(
+            current_leaves,
+            expected_leaves,
+            strict=True,
+        )
+    ):
+        return None
+    return dynamic
 
 
 def scan_apply(

--- a/phydrax/nn/layers/_linear.py
+++ b/phydrax/nn/layers/_linear.py
@@ -21,7 +21,7 @@ from .._utils import (
     _identity,
     SizeLike,
 )
-from ..parameters import AbstractParameterTransform
+from ..parameters import AbstractParameterTransform, LowRankUpdate
 
 
 _key = DOC_KEY0
@@ -46,10 +46,12 @@ class Linear(_AbstractBaseModel):
     $$
 
     A shape-preserving `weight_transform` may map raw trainable weights to
-    physically constrained effective weights at evaluation time.
+    physically constrained effective weights at evaluation time. A
+    `LowRankUpdate` instead applies a frozen-base adaptation without
+    materializing its dense update.
     """
 
-    weight: Array  # In RWF mode, this stores V (unscaled weights)
+    weight: Array | LowRankUpdate  # In RWF mode, this stores V (unscaled weights)
     bias: Array | None
     activation: Callable
     weight_transform: AbstractParameterTransform | None
@@ -175,18 +177,25 @@ class Linear(_AbstractBaseModel):
                 leading_shape = x_arr.shape
                 x_flat = x_arr.reshape(leading_shape + (1,))
 
-        # Map raw weights into their physical parameter space when requested.
-        w = (
-            self.weight
-            if self.weight_transform is None
-            else self.weight_transform(self.weight)
-        )
-        # Support both vector input (in,) and batched input (..., in).
-        # Weight is shaped (out, in); contract over the last dim of x.
-        x_flat = contract("oi,...i->...o", w, x_flat)
-        if self.random_weight_factorization and self.rwf_log_scales is not None:
-            # Equivalent to (diag(exp(s)) @ (weight @ x)) = exp(s) * (weight @ x)
-            x_flat = jnp.exp(self.rwf_log_scales) * x_flat
+        if isinstance(self.weight, LowRankUpdate):
+            if self.weight_transform is not None or self.random_weight_factorization:
+                raise ValueError(
+                    "Low-rank weights are incompatible with weight transforms and RWF."
+                )
+            x_flat = self.weight.apply(x_flat)
+        else:
+            # Map raw weights into their physical parameter space when requested.
+            w = (
+                self.weight
+                if self.weight_transform is None
+                else self.weight_transform(self.weight)
+            )
+            # Support both vector input (in,) and batched input (..., in).
+            # Weight is shaped (out, in); contract over the last dim of x.
+            x_flat = contract("oi,...i->...o", w, x_flat)
+            if self.random_weight_factorization and self.rwf_log_scales is not None:
+                # Equivalent to (diag(exp(s)) @ (weight @ x)) = exp(s) * (weight @ x)
+                x_flat = jnp.exp(self.rwf_log_scales) * x_flat
         if self.bias is not None:
             x_flat = x_flat + self.bias
 

--- a/phydrax/nn/models/_feynmann.py
+++ b/phydrax/nn/models/_feynmann.py
@@ -401,7 +401,7 @@ class FeynmaNN(_AbstractBaseModel):
                 _FeynBlockStep(block=b, activation=a)
                 for b, a in zip(self.blocks[1:], self.activs[1:], strict=True)
             )
-            dynamic = stack_scan_dynamics(repeated_steps)
+            dynamic = stack_scan_dynamics(repeated_steps, self._scan_static)
             if dynamic is not None:
                 z = self.activs[0](self.blocks[0](z))
                 z = scan_apply(

--- a/phydrax/nn/models/_kan.py
+++ b/phydrax/nn/models/_kan.py
@@ -425,7 +425,7 @@ class KAN(_AbstractBaseModel):
         out = None
         if self._scan_enabled and self._scan_static is not None:
             repeated_layers = self.layers[1:-1]
-            dynamic = stack_scan_dynamics(repeated_layers)
+            dynamic = stack_scan_dynamics(repeated_layers, self._scan_static)
             if dynamic is not None:
                 y = self.layers[0](y)
                 y = scan_apply(

--- a/phydrax/nn/models/_mlp.py
+++ b/phydrax/nn/models/_mlp.py
@@ -22,6 +22,19 @@ from .._scan import (
 from .._utils import _canonical_size, _get_value_shape, _identity, SizeLike
 from ..layers._dropout import _dropout_probabilities, Dropout
 from ..layers._linear import Linear
+from ..parameters import LowRankUpdate
+
+
+def _kfac_parameterization(
+    layer: Linear,
+) -> Literal["direct", "low_rank_update", "rwf", "transformed"]:
+    if isinstance(layer.weight, LowRankUpdate):
+        return "low_rank_update"
+    if layer.random_weight_factorization:
+        return "rwf"
+    if layer.weight_transform is not None:
+        return "transformed"
+    return "direct"
 
 
 class MLP(_AbstractBaseModel, KFACLayoutProvider):
@@ -240,13 +253,7 @@ class MLP(_AbstractBaseModel, KFACLayoutProvider):
                 name=f"layers/{index}",
                 weight=layer.weight,
                 bias=layer.bias,
-                parameterization=(
-                    "rwf"
-                    if layer.random_weight_factorization
-                    else "transformed"
-                    if layer.weight_transform is not None
-                    else "direct"
-                ),
+                parameterization=_kfac_parameterization(layer),
             )
             for index, layer in enumerate(self.layers)
         )
@@ -258,13 +265,7 @@ class MLP(_AbstractBaseModel, KFACLayoutProvider):
                 name="residual_projection",
                 weight=residual.weight,
                 bias=residual.bias,
-                parameterization=(
-                    "rwf"
-                    if residual.random_weight_factorization
-                    else "transformed"
-                    if residual.weight_transform is not None
-                    else "direct"
-                ),
+                parameterization=_kfac_parameterization(residual),
             ),
         )
 
@@ -294,7 +295,7 @@ class MLP(_AbstractBaseModel, KFACLayoutProvider):
             repeated_blocks = tuple(
                 zip(self.layers[1:-1], self.dropouts[1:], strict=True)
             )
-            dynamic = stack_scan_dynamics(repeated_blocks)
+            dynamic = stack_scan_dynamics(repeated_blocks, self._scan_static)
             if dynamic is not None:
                 site_key = fold_in_eval_key(key, 0)
                 x = self.layers[0](x, key=site_key)

--- a/phydrax/nn/models/_modified_mlp.py
+++ b/phydrax/nn/models/_modified_mlp.py
@@ -204,7 +204,7 @@ class ModifiedMLP(_AbstractBaseModel):
             repeated_blocks = tuple(
                 zip(self.layers[1:-1], self.dropouts[1:], strict=True)
             )
-            dynamic = stack_scan_dynamics(repeated_blocks)
+            dynamic = stack_scan_dynamics(repeated_blocks, self._scan_static)
             if dynamic is not None:
                 sites = jnp.arange(3, len(self.dropouts) + 2, dtype=jnp.uint32)
                 hidden = scan_apply_with_data(

--- a/phydrax/nn/models/wrappers/_separable_wrappers.py
+++ b/phydrax/nn/models/wrappers/_separable_wrappers.py
@@ -626,7 +626,10 @@ class LatentContractionModel(
                 name=self.factor_names[0],
                 key=keys[0],
             )
-            dynamic = stack_scan_dynamics(self.factor_models[1:])
+            dynamic = stack_scan_dynamics(
+                self.factor_models[1:],
+                self._scan_static_aligned,
+            )
             if dynamic is not None:
                 scan_inputs = jnp.stack(
                     tuple(jnp.asarray(pts) for pts in factor_inputs[1:]), axis=0
@@ -1061,7 +1064,10 @@ class Separable(_AbstractStructuredInputModel):
                 or len(self.models) <= 1
             ):
                 return None
-            dynamic = stack_scan_dynamics(self.models[1:])
+            dynamic = stack_scan_dynamics(
+                self.models[1:],
+                self._scan_static_regular,
+            )
             if dynamic is None:
                 return None
 
@@ -1299,7 +1305,7 @@ class Separable(_AbstractStructuredInputModel):
                 static_group = self._scan_static_clone_groups[i]
                 first = jax.vmap(ft.partial(group_models[0], key=group_keys[0]))(xi)
                 group_lat = self._reshape_latents(first)
-                dynamic = stack_scan_dynamics(group_models[1:])
+                dynamic = stack_scan_dynamics(group_models[1:], static_group)
                 if dynamic is not None and static_group is not None:
                     scan_x = jnp.broadcast_to(xi, (clones - 1, int(xi.shape[0])))
 

--- a/phydrax/nn/operator/architectures/spectral/_fno.py
+++ b/phydrax/nn/operator/architectures/spectral/_fno.py
@@ -898,7 +898,7 @@ def _execute_explicit_fno(
     key: EvalKey,
 ) -> Array:
     if model._scan_enabled and model._scan_static is not None:
-        dynamic = stack_scan_dynamics(model.blocks)
+        dynamic = stack_scan_dynamics(model.blocks, model._scan_static)
         if dynamic is not None:
             sites = jnp.arange(len(model.blocks), dtype=jnp.uint32)
             return scan_apply_with_data(

--- a/phydrax/nn/operator/architectures/spectral/_hofno.py
+++ b/phydrax/nn/operator/architectures/spectral/_hofno.py
@@ -702,7 +702,7 @@ class HOFNO(AbstractOperatorModel):
         key: EvalKey,
     ) -> Array:
         if self._scan_enabled and self._scan_static is not None:
-            dynamic = stack_scan_dynamics(self.blocks)
+            dynamic = stack_scan_dynamics(self.blocks, self._scan_static)
             if dynamic is not None:
                 sites = jnp.arange(len(self.blocks), dtype=jnp.uint32)
                 return scan_apply_with_data(

--- a/phydrax/nn/operator/training/_fit.py
+++ b/phydrax/nn/operator/training/_fit.py
@@ -34,6 +34,11 @@ from ...._training import (
 from ..._keys import split_eval_key
 from ..._loss import model_loss_labels, model_loss_values
 from ...layers._dropout import inference_mode
+from ...parameters import ParameterSubspace
+from ...parameters._low_rank import (
+    contains_low_rank_updates,
+    validate_low_rank_subspace,
+)
 from ..capabilities import OperatorTrainingEvidence
 from ..data import OperatorBatch, OperatorTargetBatch
 from ..engine import AbstractOperatorModel
@@ -397,6 +402,7 @@ def fit_operator(
     optimizer_id: str | None = None,
     evaluation_parameters: EvaluationParametersFn | None = None,
     evaluation_parameters_id: str | None = None,
+    parameter_subspace: ParameterSubspace | None = None,
     learning_rate: float = 1e-3,
     epochs: int = 1,
     steps: int | None = None,
@@ -429,11 +435,27 @@ def fit_operator(
 
     ``evaluation_parameters`` maps ``(optimizer_state, training_parameters)`` to
     the parameter view used for validation, best-model selection, and returned
-    execution models. Checkpointed fits require ``evaluation_parameters_id`` so
-    resume cannot silently change that lifecycle contract.
+    execution models. ``parameter_subspace`` restricts differentiation and
+    optimizer state to exact model leaves. Checkpointed fits require
+    ``evaluation_parameters_id`` so resume cannot silently change that lifecycle
+    contract.
     """
     if not isinstance(model, AbstractOperatorModel):
         raise TypeError("fit_operator requires a PhydraX operator model.")
+    if parameter_subspace is None:
+        parameter_paths: tuple[str, ...] | None = None
+        if contains_low_rank_updates(model):
+            raise ValueError(
+                "Low-rank operator fitting requires an explicit parameter_subspace."
+            )
+    else:
+        if not isinstance(parameter_subspace, ParameterSubspace):
+            raise TypeError(
+                "parameter_subspace must be a ParameterSubspace or None."
+            )
+        parameter_subspace.validate_root(model)
+        validate_low_rank_subspace(model, parameter_subspace)
+        parameter_paths = parameter_subspace.leaf_paths
     if int(epochs) < 0:
         raise ValueError("epochs must be non-negative.")
     if steps is not None and int(steps) < 0:
@@ -561,6 +583,36 @@ def fit_operator(
     model = resolved_dtype.cast_model(model)
     if sharding_policy is not None:
         model = replicate_operator_model(model, sharding_policy)
+    if parameter_paths is None:
+        effective_parameter_shapes: tuple[tuple[int, ...], ...] = ()
+        effective_parameter_dtypes: tuple[str, ...] = ()
+        effective_parameter_dimension = None
+    else:
+        assert parameter_subspace is not None
+        effective_subspace = parameter_subspace.rebase(model, exact_dtype=False)
+        validate_low_rank_subspace(model, effective_subspace)
+        effective_parameter_shapes = effective_subspace.leaf_shapes
+        effective_parameter_dtypes = effective_subspace.leaf_dtypes
+        effective_parameter_dimension = effective_subspace.total_dimension
+
+    def partition_fit_model(current_model):
+        if parameter_paths is None:
+            return partition_trainable(current_model)
+        current_subspace = ParameterSubspace.from_leaf_paths(
+            current_model,
+            parameter_paths,
+        )
+        if current_subspace.leaf_shapes != effective_parameter_shapes:
+            raise ValueError("Operator fit parameter-subspace shapes changed.")
+        if current_subspace.leaf_dtypes != effective_parameter_dtypes:
+            raise ValueError("Operator fit parameter-subspace dtypes changed.")
+        validate_low_rank_subspace(current_model, current_subspace)
+        return current_subspace.initial, current_subspace.frozen
+
+    def reconstruct_fit_model(current_parameters, current_fixed):
+        if parameter_paths is None:
+            return combine_trainable(current_parameters, current_fixed)
+        return eqx.combine(current_parameters, current_fixed)
 
     if normalization == "fit":
         if not isinstance(train, OperatorDataset):
@@ -738,14 +790,14 @@ def fit_operator(
             jr.key(seed),
         )
 
-    parameters, fixed = partition_trainable(model)
+    parameters, fixed = partition_fit_model(model)
     optimizer_state = optimizer.init(parameters)
     evaluated_parameters = resolve_evaluation_parameters(
         evaluation_parameters,
         optimizer_state,
         parameters,
     )
-    evaluation_model = combine_trainable(evaluated_parameters, fixed)
+    evaluation_model = reconstruct_fit_model(evaluated_parameters, fixed)
     gradient_accumulator = _tree_zeros(parameters)
     accumulated_cases = 0.0
     accumulated_microsteps = 0
@@ -828,7 +880,7 @@ def fit_operator(
         loss_scale_state_,
     ):
         def objective(candidate):
-            current_model = combine_trainable(candidate, fixed)
+            current_model = reconstruct_fit_model(candidate, fixed)
             total, components = loss_components(
                 current_model,
                 batch,
@@ -980,6 +1032,16 @@ def fit_operator(
         "include_model_losses": bool(include_model_losses),
         "optimizer_id": resolved_optimizer_id,
         "gradient_accumulation": int(gradient_accumulation),
+        "parameter_subspace": (
+            None
+            if parameter_paths is None
+            else {
+                "paths": list(parameter_paths),
+                "shapes": [list(shape) for shape in effective_parameter_shapes],
+                "dtypes": list(effective_parameter_dtypes),
+                "total_dimension": effective_parameter_dimension,
+            }
+        ),
         "normalization": (
             None if resolved_normalization is None else resolved_normalization.to_dict()
         ),
@@ -1073,13 +1135,13 @@ def fit_operator(
         accumulated_metrics = [float(value) for value in metadata["accumulated_metrics"]]
         prior_training_seconds = float(metadata["training_seconds"])
         resumed_from_step = progress.update_step
-        parameters, fixed = partition_trainable(model)
+        parameters, fixed = partition_fit_model(model)
         evaluated_parameters = resolve_evaluation_parameters(
             evaluation_parameters,
             optimizer_state,
             parameters,
         )
-        evaluation_model = combine_trainable(evaluated_parameters, fixed)
+        evaluation_model = reconstruct_fit_model(evaluated_parameters, fixed)
     else:
         initial_metrics = evaluate(evaluation_model, raw_train_loader, 0)
         if raw_validation_loader is not None:
@@ -1308,7 +1370,7 @@ def fit_operator(
                         )
                     parameters = candidate_parameters
                     optimizer_state = candidate_optimizer_state
-                    model = combine_trainable(parameters, fixed)
+                    model = reconstruct_fit_model(parameters, fixed)
                     update_step = control.progress.update_step + 1
                     control.complete_update(update_step)
                     metrics = {
@@ -1351,7 +1413,7 @@ def fit_operator(
                             optimizer_state,
                             parameters,
                         )
-                        evaluation_model = combine_trainable(
+                        evaluation_model = reconstruct_fit_model(
                             evaluated_parameters,
                             fixed,
                         )
@@ -1402,7 +1464,7 @@ def fit_operator(
         optimizer_state,
         parameters,
     )
-    evaluation_model = combine_trainable(evaluated_parameters, fixed)
+    evaluation_model = reconstruct_fit_model(evaluated_parameters, fixed)
     if (
         raw_validation_loader is not None
         and validation_config is not None

--- a/phydrax/nn/parameters/__init__.py
+++ b/phydrax/nn/parameters/__init__.py
@@ -1,5 +1,22 @@
 """Parameter transformations and explicit model-PyTree selection."""
 
+from ._low_rank import (
+    adapt_low_rank,
+    contains_low_rank_updates,
+    low_rank_parameter_subspace,
+    low_rank_sites,
+    LowRankAdaptationReport,
+    LowRankAdaptationSite,
+    LowRankSpec,
+    LowRankUpdate,
+    merge_low_rank,
+)
+from ._low_rank_artifact import (
+    LowRankAdapterArtifact,
+    LowRankAdapterManifest,
+    read_low_rank_adapter,
+    save_low_rank_adapter,
+)
 from ._parameter import TransformedParameter
 from ._selection import ParameterSubspace
 from ._transforms import (
@@ -24,6 +41,12 @@ __all__ = [
     "HurwitzTransform",
     "IdentityTransform",
     "IntervalTransform",
+    "LowRankAdaptationReport",
+    "LowRankAdaptationSite",
+    "LowRankAdapterArtifact",
+    "LowRankAdapterManifest",
+    "LowRankSpec",
+    "LowRankUpdate",
     "PackedSkewSymmetricTransform",
     "ParameterSubspace",
     "PositiveDefiniteTransform",
@@ -35,4 +58,11 @@ __all__ = [
     "StiefelTransform",
     "SymmetricTransform",
     "TransformedParameter",
+    "adapt_low_rank",
+    "contains_low_rank_updates",
+    "low_rank_parameter_subspace",
+    "low_rank_sites",
+    "merge_low_rank",
+    "read_low_rank_adapter",
+    "save_low_rank_adapter",
 ]

--- a/phydrax/nn/parameters/_low_rank.py
+++ b/phydrax/nn/parameters/_low_rank.py
@@ -1,0 +1,429 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from math import isfinite
+from numbers import Integral
+from typing import Any
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+from jaxtyping import Array, Key, PyTree
+from opt_einsum import contract
+
+from ..._doc import DOC_KEY0
+from ..._strict import StrictModule
+from ._selection import ParameterSubspace
+
+
+@dataclass(frozen=True, slots=True)
+class LowRankSpec:
+    """Construction policy for one low-rank affine weight update."""
+
+    rank: int
+    alpha: float | None = None
+    stddev: float = 0.01
+
+    def __post_init__(self) -> None:
+        if isinstance(self.rank, bool) or not isinstance(self.rank, Integral):
+            raise TypeError("Low-rank adaptation rank must be an integer.")
+        rank = int(self.rank)
+        if rank <= 0:
+            raise ValueError("Low-rank adaptation rank must be positive.")
+        alpha = float(rank if self.alpha is None else self.alpha)
+        stddev = float(self.stddev)
+        if not isfinite(alpha) or alpha <= 0.0:
+            raise ValueError("Low-rank adaptation alpha must be finite and positive.")
+        if not isfinite(stddev) or stddev <= 0.0:
+            raise ValueError("Low-rank initialization stddev must be finite and positive.")
+        object.__setattr__(self, "rank", rank)
+        object.__setattr__(self, "alpha", alpha)
+        object.__setattr__(self, "stddev", stddev)
+
+
+class LowRankUpdate(StrictModule):
+    """Dense base weight plus one trainable low-rank update.
+
+    For a base weight with shape ``(out, in)``, ``left`` has shape
+    ``(out, rank)`` and ``right`` has shape ``(rank, in)``. Evaluation keeps the
+    update factorized; :meth:`materialize` is reserved for diagnostics, export,
+    and deployment merging.
+    """
+
+    base: Array
+    left: Array
+    right: Array
+    alpha: float = eqx.field(static=True)
+
+    def __init__(
+        self,
+        base: Array,
+        /,
+        *,
+        rank: int,
+        alpha: float | None = None,
+        stddev: float = 0.01,
+        key: Key[Array, ""] = DOC_KEY0,
+    ):
+        value = jnp.asarray(base)
+        if not eqx.is_inexact_array(value) or jnp.iscomplexobj(value):
+            raise TypeError("Low-rank base weights must be real inexact JAX arrays.")
+        if value.ndim != 2:
+            raise ValueError("Low-rank base weights must be rank-two arrays.")
+        spec = LowRankSpec(rank=rank, alpha=alpha, stddev=stddev)
+        output_size, input_size = (int(size) for size in value.shape)
+        if spec.rank > min(output_size, input_size):
+            raise ValueError(
+                "Low-rank adaptation rank must not exceed either weight dimension."
+            )
+        self.base = value
+        self.left = jnp.zeros((output_size, spec.rank), dtype=value.dtype)
+        self.right = (
+            jr.normal(key, (spec.rank, input_size), dtype=value.dtype) * spec.stddev
+        )
+        assert spec.alpha is not None
+        self.alpha = spec.alpha
+
+    @classmethod
+    def from_factors(
+        cls,
+        base: Array,
+        left: Array,
+        right: Array,
+        /,
+        *,
+        alpha: float,
+    ) -> LowRankUpdate:
+        """Construct an update from validated persisted factors without randomness."""
+        base_ = jnp.asarray(base)
+        left_ = jnp.asarray(left)
+        right_ = jnp.asarray(right)
+        if not eqx.is_inexact_array(base_) or jnp.iscomplexobj(base_):
+            raise TypeError("Low-rank base weights must be real inexact JAX arrays.")
+        if base_.ndim != 2 or left_.ndim != 2 or right_.ndim != 2:
+            raise ValueError("Low-rank bases and factors must be rank-two arrays.")
+        if left_.shape[0] != base_.shape[0] or right_.shape[1] != base_.shape[1]:
+            raise ValueError("Low-rank factor outer dimensions must match the base.")
+        if left_.shape[1] != right_.shape[0]:
+            raise ValueError("Low-rank factors must share one positive rank dimension.")
+        rank = int(left_.shape[1])
+        if rank <= 0 or rank > min(base_.shape):
+            raise ValueError("Low-rank factor rank is invalid for the base weight.")
+        if left_.dtype != base_.dtype or right_.dtype != base_.dtype:
+            raise TypeError("Low-rank factors must have the exact base dtype.")
+        alpha_ = float(alpha)
+        if not isfinite(alpha_) or alpha_ <= 0.0:
+            raise ValueError("Low-rank adaptation alpha must be finite and positive.")
+        instance = object.__new__(cls)
+        object.__setattr__(instance, "base", base_)
+        object.__setattr__(instance, "left", left_)
+        object.__setattr__(instance, "right", right_)
+        object.__setattr__(instance, "alpha", alpha_)
+        object.__setattr__(instance, "_strict_initialized", True)
+        return instance
+
+    @property
+    def shape(self) -> tuple[int, int]:
+        return int(self.base.shape[0]), int(self.base.shape[1])
+
+    @property
+    def dtype(self):
+        return self.base.dtype
+
+    @property
+    def rank(self) -> int:
+        return int(self.left.shape[1])
+
+    @property
+    def scale(self) -> float:
+        return self.alpha / self.rank
+
+    @property
+    def base_parameter_count(self) -> int:
+        return int(self.base.size)
+
+    @property
+    def adapter_parameter_count(self) -> int:
+        return int(self.left.size + self.right.size)
+
+    def apply(self, value: Array, /) -> Array:
+        """Apply the effective weight without materializing its dense update."""
+        argument = jnp.asarray(value)
+        base_output = contract("oi,...i->...o", jax.lax.stop_gradient(self.base), argument)
+        latent = contract("ri,...i->...r", self.right, argument)
+        update = contract("or,...r->...o", self.left, latent)
+        return (base_output + self.scale * update).astype(base_output.dtype)
+
+    def materialize(self) -> Array:
+        """Return the dense effective weight for diagnostics, export, or deployment."""
+        update = contract("or,ri->oi", self.left, self.right)
+        return (self.base + self.scale * update).astype(self.base.dtype)
+
+
+@dataclass(frozen=True, slots=True)
+class LowRankAdaptationSite:
+    """Static accounting for one adapted affine weight path."""
+
+    path: str
+    shape: tuple[int, int]
+    dtype: str
+    rank: int
+    alpha: float
+    scale: float
+    base_parameter_count: int
+    adapter_parameter_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class LowRankAdaptationReport:
+    """Deterministic site and parameter accounting for one adaptation operation."""
+
+    sites: tuple[LowRankAdaptationSite, ...]
+    base_parameter_count: int
+    adapter_parameter_count: int
+
+    @property
+    def parameter_ratio(self) -> float:
+        return self.adapter_parameter_count / self.base_parameter_count
+
+
+@dataclass(frozen=True, slots=True)
+class _LinearSite:
+    path: str
+    layer: Any
+
+
+def _linear_sites(tree: PyTree[Any], /) -> tuple[_LinearSite, ...]:
+    from ..layers._linear import Linear
+
+    sites: list[_LinearSite] = []
+    aliases: dict[int, str] = {}
+    leaves = jax.tree_util.tree_flatten_with_path(
+        tree,
+        is_leaf=lambda value: isinstance(value, Linear),
+    )[0]
+    for path, leaf in leaves:
+        if not isinstance(leaf, Linear):
+            continue
+        prefix = jax.tree_util.keystr(path)
+        weight_path = f"{prefix}.weight" if prefix else ".weight"
+        previous = aliases.get(id(leaf))
+        if previous is not None:
+            raise ValueError(
+                "Low-rank adaptation does not support aliased Linear modules at "
+                f"{previous!r} and {weight_path!r}."
+            )
+        aliases[id(leaf)] = weight_path
+        sites.append(_LinearSite(weight_path, leaf))
+    return tuple(sites)
+
+
+def _is_adaptable(site: _LinearSite, /) -> bool:
+    layer = site.layer
+    weight = layer.weight
+    return bool(
+        not isinstance(weight, LowRankUpdate)
+        and not layer.random_weight_factorization
+        and layer.weight_transform is None
+        and eqx.is_inexact_array(weight)
+        and not jnp.iscomplexobj(weight)
+        and weight.ndim == 2
+    )
+
+
+def _validate_adaptable(site: _LinearSite, /) -> Array:
+    layer = site.layer
+    if isinstance(layer.weight, LowRankUpdate):
+        raise TypeError(f"Linear weight {site.path!r} is already low-rank adapted.")
+    if layer.random_weight_factorization:
+        raise ValueError(
+            f"Linear weight {site.path!r} uses random weight factorization."
+        )
+    if layer.weight_transform is not None:
+        raise ValueError(f"Linear weight {site.path!r} uses a weight transform.")
+    weight = jnp.asarray(layer.weight)
+    if not eqx.is_inexact_array(weight) or jnp.iscomplexobj(weight) or weight.ndim != 2:
+        raise TypeError(
+            f"Linear weight {site.path!r} must be a real inexact rank-two array."
+        )
+    return weight
+
+
+def low_rank_sites(tree: PyTree[Any], /) -> tuple[str, ...]:
+    """Return deterministic paths of native Linear weights eligible for adaptation."""
+    return tuple(site.path for site in _linear_sites(tree) if _is_adaptable(site))
+
+
+def adapt_low_rank(
+    tree: PyTree[Any],
+    specs: Mapping[str, LowRankSpec],
+    /,
+    *,
+    key: Key[Array, ""] = DOC_KEY0,
+) -> tuple[PyTree[Any], LowRankAdaptationReport]:
+    """Adapt exact native Linear weight paths and return immutable accounting."""
+    from ..layers._linear import Linear
+
+    requested = {str(path): spec for path, spec in specs.items()}
+    if not requested:
+        raise ValueError("Low-rank adaptation requires at least one weight path.")
+    if any(not isinstance(spec, LowRankSpec) for spec in requested.values()):
+        raise TypeError("Every low-rank adaptation value must be a LowRankSpec.")
+    sites = _linear_sites(tree)
+    sites_by_path = {site.path: site for site in sites}
+    missing = tuple(path for path in requested if path not in sites_by_path)
+    if missing:
+        raise ValueError(f"Unknown native Linear weight paths: {missing!r}.")
+
+    ordered = tuple(site for site in sites if site.path in requested)
+    weights: dict[str, Array] = {}
+    for site in ordered:
+        weight = _validate_adaptable(site)
+        spec = requested[site.path]
+        if spec.rank > min(weight.shape):
+            raise ValueError(
+                f"Low-rank rank {spec.rank} exceeds weight shape {weight.shape} "
+                f"at {site.path!r}."
+            )
+        weights[site.path] = weight
+
+    keys = jr.split(key, len(ordered))
+    replacements: dict[str, LowRankUpdate] = {}
+    records: list[LowRankAdaptationSite] = []
+    for site, site_key in zip(ordered, keys, strict=True):
+        spec = requested[site.path]
+        weight = weights[site.path]
+        update = LowRankUpdate(
+            weight,
+            rank=spec.rank,
+            alpha=spec.alpha,
+            stddev=spec.stddev,
+            key=site_key,
+        )
+        replacements[site.path] = update
+        records.append(
+            LowRankAdaptationSite(
+                path=site.path,
+                shape=update.shape,
+                dtype=jnp.dtype(update.dtype).str,
+                rank=update.rank,
+                alpha=update.alpha,
+                scale=update.scale,
+                base_parameter_count=update.base_parameter_count,
+                adapter_parameter_count=update.adapter_parameter_count,
+            )
+        )
+
+    def replace(path, value):
+        if not isinstance(value, Linear):
+            return value
+        prefix = jax.tree_util.keystr(path)
+        weight_path = f"{prefix}.weight" if prefix else ".weight"
+        update = replacements.get(weight_path)
+        if update is None:
+            return value
+        return eqx.tree_at(lambda layer: layer.weight, value, update)
+
+    adapted = jax.tree_util.tree_map_with_path(
+        replace,
+        tree,
+        is_leaf=lambda value: isinstance(value, Linear),
+    )
+    records_ = tuple(records)
+    return adapted, LowRankAdaptationReport(
+        sites=records_,
+        base_parameter_count=sum(site.base_parameter_count for site in records_),
+        adapter_parameter_count=sum(site.adapter_parameter_count for site in records_),
+    )
+
+
+def _low_rank_nodes(tree: PyTree[Any], /) -> tuple[tuple[str, LowRankUpdate], ...]:
+    nodes: list[tuple[str, LowRankUpdate]] = []
+    leaves = jax.tree_util.tree_flatten_with_path(
+        tree,
+        is_leaf=lambda value: isinstance(value, LowRankUpdate),
+    )[0]
+    for path, leaf in leaves:
+        if isinstance(leaf, LowRankUpdate):
+            nodes.append((jax.tree_util.keystr(path), leaf))
+    return tuple(nodes)
+
+
+def _low_rank_factor_paths(tree: PyTree[Any], /) -> tuple[str, ...]:
+    paths: list[str] = []
+    for prefix, _ in _low_rank_nodes(tree):
+        paths.extend(
+            (
+                f"{prefix}.left" if prefix else ".left",
+                f"{prefix}.right" if prefix else ".right",
+            )
+        )
+    return tuple(paths)
+
+
+def contains_low_rank_updates(tree: PyTree[Any], /) -> bool:
+    """Return whether a PyTree contains at least one low-rank update."""
+    return bool(_low_rank_nodes(tree))
+
+
+def low_rank_parameter_subspace(tree: PyTree[Any], /) -> ParameterSubspace:
+    """Select exactly the trainable factors of every low-rank update in a PyTree."""
+    paths = _low_rank_factor_paths(tree)
+    if not paths:
+        raise ValueError("The supplied PyTree contains no low-rank updates.")
+    return ParameterSubspace.from_leaf_paths(tree, paths)
+
+
+def validate_low_rank_subspace(
+    tree: PyTree[Any],
+    subspace: ParameterSubspace,
+    /,
+) -> None:
+    """Require all and only low-rank factor leaves in a training subspace."""
+    expected = _low_rank_factor_paths(tree)
+    if not expected:
+        return
+    if subspace.leaf_paths != expected:
+        raise ValueError(
+            "Low-rank training requires a ParameterSubspace selecting exactly every "
+            "left and right adapter factor."
+        )
+
+
+def merge_low_rank(tree: PyTree[Any], /) -> PyTree[Any]:
+    """Return a dense model with every low-rank update merged into its base."""
+    return jax.tree_util.tree_map(
+        lambda value: (
+            value.materialize() if isinstance(value, LowRankUpdate) else value
+        ),
+        tree,
+        is_leaf=lambda value: isinstance(value, LowRankUpdate),
+    )
+
+
+def _strip_low_rank(tree: PyTree[Any], /) -> PyTree[Any]:
+    return jax.tree_util.tree_map(
+        lambda value: value.base if isinstance(value, LowRankUpdate) else value,
+        tree,
+        is_leaf=lambda value: isinstance(value, LowRankUpdate),
+    )
+
+
+__all__ = [
+    "LowRankAdaptationReport",
+    "LowRankAdaptationSite",
+    "LowRankSpec",
+    "LowRankUpdate",
+    "adapt_low_rank",
+    "contains_low_rank_updates",
+    "low_rank_parameter_subspace",
+    "low_rank_sites",
+    "merge_low_rank",
+    "validate_low_rank_subspace",
+]

--- a/phydrax/nn/parameters/_low_rank_artifact.py
+++ b/phydrax/nn/parameters/_low_rank_artifact.py
@@ -1,0 +1,299 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from ..._array_archive import (
+    ArrayArchiveCorruptionError,
+    read_array_archive,
+    write_array_archive,
+)
+from ..._fingerprint import (
+    array_tree_fingerprint,
+    canonical_fingerprint,
+    canonical_mapping,
+)
+from ..._model import artifact_value_id
+from ..._model._structure import model_structure_recipe
+from ._low_rank import (
+    _low_rank_nodes,
+    _strip_low_rank,
+    LowRankAdaptationSite,
+    LowRankUpdate,
+)
+
+
+_LOW_RANK_ADAPTER_FORMAT = "phydrax-low-rank-adapter"
+
+
+@dataclass(frozen=True, slots=True)
+class LowRankAdapterManifest:
+    """Verified identity and site metadata for one adapter-only artifact."""
+
+    base_model_type: str
+    base_structure_sha256: str
+    base_array_sha256: str
+    base_array_signature: tuple[Mapping[str, Any], ...]
+    sites: tuple[LowRankAdaptationSite, ...]
+    provenance: Mapping[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class LowRankAdapterArtifact:
+    """A restored adapted model and its verified base-binding manifest."""
+
+    model: Any
+    manifest: LowRankAdapterManifest
+
+
+def _base_identity(model: Any, /) -> tuple[str, str, dict[str, Any]]:
+    recipe = model_structure_recipe(model)
+    return (
+        artifact_value_id(type(model)),
+        canonical_fingerprint(recipe),
+        array_tree_fingerprint(model),
+    )
+
+
+def save_low_rank_adapter(
+    path: str | Path,
+    model: Any,
+    /,
+    *,
+    provenance: Mapping[str, Any] | None = None,
+) -> Path:
+    """Write only low-rank factors, bound to the exact dense base model."""
+    nodes = _low_rank_nodes(model)
+    if not nodes:
+        raise ValueError("Cannot save a low-rank adapter from a model without adapters.")
+    base_model = _strip_low_rank(model)
+    base_type, structure_sha256, array_fingerprint = _base_identity(base_model)
+    arrays: dict[str, Any] = {}
+    sites: list[dict[str, Any]] = []
+    for index, (weight_path, update) in enumerate(nodes):
+        left_name = f"site/{index:06d}/left"
+        right_name = f"site/{index:06d}/right"
+        arrays[left_name] = update.left
+        arrays[right_name] = update.right
+        sites.append(
+            {
+                "path": weight_path,
+                "shape": list(update.shape),
+                "dtype": jnp.dtype(update.dtype).str,
+                "rank": update.rank,
+                "alpha": update.alpha,
+                "scale": update.scale,
+                "left": left_name,
+                "right": right_name,
+            }
+        )
+    manifest = {
+        "format": _LOW_RANK_ADAPTER_FORMAT,
+        "base_model_type": base_type,
+        "base_structure_sha256": structure_sha256,
+        "base_arrays": array_fingerprint,
+        "sites": sites,
+        "provenance": canonical_mapping({} if provenance is None else provenance),
+    }
+    return write_array_archive(path, manifest=manifest, arrays=arrays)
+
+
+def _validated_sites(
+    value: Any,
+    arrays: Mapping[str, np.ndarray],
+    /,
+) -> tuple[dict[str, Any], ...]:
+    if not isinstance(value, list) or not value:
+        raise ArrayArchiveCorruptionError("Low-rank adapter sites are missing.")
+    expected_fields = {
+        "path",
+        "shape",
+        "dtype",
+        "rank",
+        "alpha",
+        "scale",
+        "left",
+        "right",
+    }
+    records: list[dict[str, Any]] = []
+    seen_paths: set[str] = set()
+    seen_arrays: set[str] = set()
+    for record in value:
+        if not isinstance(record, dict) or set(record) != expected_fields:
+            raise ArrayArchiveCorruptionError("Low-rank adapter site metadata is invalid.")
+        path = record["path"]
+        if not isinstance(path, str) or not path or path in seen_paths:
+            raise ArrayArchiveCorruptionError("Low-rank adapter paths are invalid.")
+        left_name = record["left"]
+        right_name = record["right"]
+        if (
+            not isinstance(left_name, str)
+            or not isinstance(right_name, str)
+            or left_name in seen_arrays
+            or right_name in seen_arrays
+            or left_name == right_name
+            or left_name not in arrays
+            or right_name not in arrays
+        ):
+            raise ArrayArchiveCorruptionError(
+                "Low-rank adapter factor inventory is invalid."
+            )
+        shape = record["shape"]
+        rank = record["rank"]
+        alpha = record["alpha"]
+        scale = record["scale"]
+        dtype = record["dtype"]
+        if (
+            not isinstance(shape, list)
+            or len(shape) != 2
+            or any(isinstance(size, bool) or not isinstance(size, int) or size <= 0 for size in shape)
+            or isinstance(rank, bool)
+            or not isinstance(rank, int)
+            or rank <= 0
+            or not isinstance(dtype, str)
+            or not isinstance(alpha, (int, float))
+            or not isinstance(scale, (int, float))
+            or not np.isfinite(alpha)
+            or not np.isfinite(scale)
+            or alpha <= 0.0
+            or scale <= 0.0
+            or float(scale) != float(alpha) / rank
+        ):
+            raise ArrayArchiveCorruptionError("Low-rank adapter site values are invalid.")
+        seen_paths.add(path)
+        seen_arrays.update((left_name, right_name))
+        records.append(record)
+    if seen_arrays != set(arrays):
+        raise ArrayArchiveCorruptionError(
+            "Low-rank adapter contains unreferenced factor arrays."
+        )
+    return tuple(records)
+
+
+def read_low_rank_adapter(
+    path: str | Path,
+    base_model: Any,
+    /,
+) -> LowRankAdapterArtifact:
+    """Restore an adapter only after verifying the exact supplied base model."""
+    manifest, arrays = read_array_archive(path)
+    expected_fields = {
+        "format",
+        "base_model_type",
+        "base_structure_sha256",
+        "base_arrays",
+        "sites",
+        "provenance",
+        "arrays",
+    }
+    if set(manifest) != expected_fields or manifest["format"] != _LOW_RANK_ADAPTER_FORMAT:
+        raise ArrayArchiveCorruptionError(
+            "Archive is not a canonical Phydrax low-rank adapter."
+        )
+    base_type, structure_sha256, array_fingerprint = _base_identity(base_model)
+    if manifest["base_model_type"] != base_type:
+        raise ValueError("Low-rank adapter base model type mismatch.")
+    if manifest["base_structure_sha256"] != structure_sha256:
+        raise ValueError("Low-rank adapter base model structure mismatch.")
+    if manifest["base_arrays"] != array_fingerprint:
+        raise ValueError("Low-rank adapter base model content mismatch.")
+    provenance = manifest["provenance"]
+    if not isinstance(provenance, dict):
+        raise ArrayArchiveCorruptionError("Low-rank adapter provenance is invalid.")
+    records = _validated_sites(manifest["sites"], arrays)
+    records_by_path = {record["path"]: record for record in records}
+
+    from ..layers._linear import Linear
+
+    restored_paths: list[str] = []
+
+    def restore(path_, value):
+        if not isinstance(value, Linear):
+            return value
+        prefix = jax.tree_util.keystr(path_)
+        weight_path = f"{prefix}.weight" if prefix else ".weight"
+        record = records_by_path.get(weight_path)
+        if record is None:
+            return value
+        if isinstance(value.weight, LowRankUpdate):
+            raise TypeError("Low-rank adapters require a dense supplied base model.")
+        if value.random_weight_factorization or value.weight_transform is not None:
+            raise ValueError(
+                f"Low-rank adapter site {weight_path!r} is no longer adaptable."
+            )
+        weight = jnp.asarray(value.weight)
+        shape = tuple(int(size) for size in record["shape"])
+        dtype = str(record["dtype"])
+        if tuple(weight.shape) != shape or jnp.dtype(weight.dtype).str != dtype:
+            raise ValueError(
+                f"Low-rank adapter site {weight_path!r} shape or dtype mismatch."
+            )
+        left = jnp.asarray(arrays[record["left"]])
+        right = jnp.asarray(arrays[record["right"]])
+        update = LowRankUpdate.from_factors(
+            weight,
+            left,
+            right,
+            alpha=float(record["alpha"]),
+        )
+        if update.rank != int(record["rank"]) or update.scale != float(record["scale"]):
+            raise ArrayArchiveCorruptionError(
+                f"Low-rank adapter site {weight_path!r} factors are inconsistent."
+            )
+        restored_paths.append(weight_path)
+        return eqx.tree_at(lambda layer: layer.weight, value, update)
+
+    restored = jax.tree_util.tree_map_with_path(
+        restore,
+        base_model,
+        is_leaf=lambda value: isinstance(value, Linear),
+    )
+    if tuple(restored_paths) != tuple(record["path"] for record in records):
+        raise ValueError("Low-rank adapter contains unknown or reordered weight paths.")
+    sites = tuple(
+        LowRankAdaptationSite(
+            path=record["path"],
+            shape=tuple(record["shape"]),
+            dtype=record["dtype"],
+            rank=int(record["rank"]),
+            alpha=float(record["alpha"]),
+            scale=float(record["scale"]),
+            base_parameter_count=int(np.prod(record["shape"])),
+            adapter_parameter_count=int(
+                np.prod(arrays[record["left"]].shape)
+                + np.prod(arrays[record["right"]].shape)
+            ),
+        )
+        for record in records
+    )
+    parsed = LowRankAdapterManifest(
+        base_model_type=base_type,
+        base_structure_sha256=structure_sha256,
+        base_array_sha256=array_fingerprint["sha256"],
+        base_array_signature=tuple(
+            MappingProxyType(dict(item)) for item in array_fingerprint["signature"]
+        ),
+        sites=sites,
+        provenance=MappingProxyType(dict(provenance)),
+    )
+    return LowRankAdapterArtifact(model=restored, manifest=parsed)
+
+
+__all__ = [
+    "LowRankAdapterArtifact",
+    "LowRankAdapterManifest",
+    "read_low_rank_adapter",
+    "save_low_rank_adapter",
+]

--- a/phydrax/nn/parameters/_selection.py
+++ b/phydrax/nn/parameters/_selection.py
@@ -127,6 +127,31 @@ class ParameterSubspace(StrictModule):
             [path for path in available if path in selected],
         )
 
+    def validate_root(self, tree: PyTree[Any], /) -> None:
+        """Require the exact root tree used to construct this parameter subspace."""
+        equal = eqx.tree_equal(self.reconstruct(self.initial), tree)
+        matched = equal if isinstance(equal, bool) else bool(jax.device_get(equal))
+        if not matched:
+            raise ValueError(
+                "ParameterSubspace does not describe the supplied root PyTree."
+            )
+
+    def rebase(
+        self,
+        tree: PyTree[Any],
+        /,
+        *,
+        exact_dtype: bool = True,
+    ) -> ParameterSubspace:
+        """Apply the same exact leaf paths to a compatible updated root tree."""
+        rebased = type(self).from_leaf_paths(tree, self.leaf_paths)
+        if rebased.leaf_shapes != self.leaf_shapes:
+            raise ValueError("Rebased parameter leaves changed shape.")
+        if exact_dtype and rebased.leaf_dtypes != self.leaf_dtypes:
+            raise ValueError("Rebased parameter leaves changed dtype.")
+        return rebased
+
+
     def pack(self, selected: PyTree[Any] | None = None, /) -> Array:
         """Flatten a selected parameter position in deterministic leaf order."""
         position = self.initial if selected is None else selected

--- a/phydrax/solver/_functional_backend.py
+++ b/phydrax/solver/_functional_backend.py
@@ -54,6 +54,9 @@ class _GradientBackend:
             num_iter=config.num_iter,
             optim=self.optimizer,
             evaluation_parameters=config.evaluation_parameters,
+            parameter_paths=config.parameter_paths,
+            parameter_shapes=config.parameter_shapes,
+            parameter_dtypes=config.parameter_dtypes,
             seed=config.seed,
             jit=config.jit,
             keep_best=config.keep_best,
@@ -79,6 +82,10 @@ class _EvosaxBackend:
         config: FunctionalSolveConfig,
         /,
     ) -> "FunctionalSolver":
+        if config.parameter_paths is not None:
+            raise ValueError(
+                "Explicit parameter subspaces are unsupported by Evosax backends."
+            )
         return _solve_evosax_distribution(
             solver,
             num_iter=config.num_iter,
@@ -107,6 +114,10 @@ class _KFACBackend:
         config: FunctionalSolveConfig,
         /,
     ) -> "FunctionalSolver":
+        if config.parameter_paths is not None:
+            raise ValueError(
+                "Explicit parameter subspaces are unsupported by KFAC."
+            )
         from ._kfac_solver import solve_kfac
 
         return solve_kfac(

--- a/phydrax/solver/_functional_gradient.py
+++ b/phydrax/solver/_functional_gradient.py
@@ -27,6 +27,8 @@ from .._training import (
     TrainingProgress,
     TrainingSignalGuard as _TrainingSignalGuard,
 )
+from ..nn.parameters import ParameterSubspace
+from ..nn.parameters._low_rank import validate_low_rank_subspace
 from ..optim._composite import CompositeLeastSquaresProblem
 from ..optim._iterative import (
     AbstractCompositeLeastSquaresMethod,
@@ -85,6 +87,9 @@ def solve_gradient(
     | optax.GradientTransformationExtraArgs
     | Any = optax.rprop(1e-3),
     evaluation_parameters: EvaluationParametersFn | None = None,
+    parameter_paths: tuple[str, ...] | None = None,
+    parameter_shapes: tuple[tuple[int, ...], ...] = (),
+    parameter_dtypes: tuple[str, ...] = (),
     seed: int = 0,
     jit: bool = True,
     keep_best: bool = True,
@@ -144,6 +149,15 @@ def solve_gradient(
             "optim must be a Phydrax least-squares, iterative, mirror, or "
             "Riemannian optimizer, or an Optax transformation."
         )
+    if (
+        parameter_paths is not None
+        and _opt_standard is None
+        and _opt_linesearch is None
+    ):
+        raise ValueError(
+            "Explicit parameter subspaces are supported only by Optax "
+            "transformations."
+        )
     if precision is not None and not isinstance(precision, FunctionalPrecisionPolicy):
         raise TypeError("precision must be a FunctionalPrecisionPolicy or None.")
     optimizer_label = (
@@ -173,7 +187,26 @@ def solve_gradient(
     )
 
     with log_ctx as log_fp, tb_ctx as tb_writer, _TrainingSignalGuard() as signal_guard:
-        params, non_trainable = partition_trainable(self.functions)
+        if parameter_paths is None:
+            params, non_trainable = partition_trainable(self.functions)
+            explicit_subspace = False
+        else:
+            subspace = ParameterSubspace.from_leaf_paths(
+                self.functions,
+                parameter_paths,
+            )
+            if subspace.leaf_shapes != parameter_shapes:
+                raise ValueError("FunctionalSolver parameter-subspace shapes changed.")
+            if subspace.leaf_dtypes != parameter_dtypes:
+                raise ValueError("FunctionalSolver parameter-subspace dtypes changed.")
+            validate_low_rank_subspace(self.functions, subspace)
+            params, non_trainable = subspace.initial, subspace.frozen
+            explicit_subspace = True
+
+        def reconstruct_functions(current, fixed):
+            if explicit_subspace:
+                return eqx.combine(current, fixed)
+            return combine_trainable(current, fixed)
         preinitialized_opt_state = None
         if _opt_linesearch is not None:
             preinitialized_opt_state = _opt_linesearch.init(params)
@@ -194,14 +227,14 @@ def solve_gradient(
             raise ValueError(
                 "Functional precision currently supports standard Optax transforms only."
             )
-        parameter_dtypes = {
+        trainable_dtypes = {
             leaf.dtype for leaf in jax.tree.leaves(params) if eqx.is_inexact_array(leaf)
         }
-        if precision is not None and len(parameter_dtypes) != 1:
+        if precision is not None and len(trainable_dtypes) != 1:
             raise ValueError(
                 "Functional precision requires one uniform trainable parameter dtype."
             )
-        precision_dtype = None if precision is None else next(iter(parameter_dtypes))
+        precision_dtype = None if precision is None else next(iter(trainable_dtypes))
         log_every_ = int(log_every)
         if log_every_ < 0:
             raise ValueError("log_every must be >= 0.")
@@ -235,13 +268,13 @@ def solve_gradient(
             )
 
         def _loss_wrt_params(params_, non_trainable_, prepared_):
-            functions = combine_trainable(params_, non_trainable_)
+            functions = reconstruct_functions(params_, non_trainable_)
             with _precision_context():
                 values = evaluate_prepared_objective(prepared_, functions)
             return values.total, values.flat_values
 
         def _term_values_wrt_params(params_, non_trainable_, prepared_):
-            functions = combine_trainable(params_, non_trainable_)
+            functions = reconstruct_functions(params_, non_trainable_)
             with _precision_context():
                 return evaluate_prepared_objective(
                     prepared_,
@@ -250,7 +283,7 @@ def solve_gradient(
                 ).term_values
 
         def _data_metrics_wrt_terms(params_, non_trainable_, prepared_):
-            functions = combine_trainable(params_, non_trainable_)
+            functions = reconstruct_functions(params_, non_trainable_)
             with _precision_context():
                 return prepared_data_metrics(prepared_, functions)
 
@@ -296,7 +329,7 @@ def solve_gradient(
                     return jnp.concatenate(pieces, axis=0)
 
                 def _scalar_fn(p, _):
-                    functions = combine_trainable(p, non_trainable_)
+                    functions = reconstruct_functions(p, non_trainable_)
                     return evaluate_prepared_scalar_remainder(
                         prepared_,
                         functions,
@@ -548,7 +581,7 @@ def solve_gradient(
                 iter_start = time.perf_counter()
                 subkey = control.split_key()
                 iter_ = jnp.asarray(epoch + 1, dtype=float)
-                functions_snapshot = combine_trainable(params, non_trainable)
+                functions_snapshot = reconstruct_functions(params, non_trainable)
                 refresh_started = time.perf_counter() if profile_adaptive else 0.0
                 objective = objective.refresh(
                     functions_snapshot,
@@ -1244,7 +1277,7 @@ def solve_gradient(
                         opt_state.direction_fallbacks
                     ),
                 }
-        functions = combine_trainable(chosen, non_trainable)
+        functions = reconstruct_functions(chosen, non_trainable)
         settle_started = time.perf_counter() if profile_adaptive else 0.0
         with _precision_context():
             objective = objective.settle(

--- a/phydrax/solver/_functional_run.py
+++ b/phydrax/solver/_functional_run.py
@@ -24,6 +24,9 @@ class FunctionalSolveConfig:
 
     num_iter: int
     evaluation_parameters: EvaluationParametersFn | None = None
+    parameter_paths: tuple[str, ...] | None = None
+    parameter_shapes: tuple[tuple[int, ...], ...] = ()
+    parameter_dtypes: tuple[str, ...] = ()
     seed: int = 0
     jit: bool = True
     keep_best: bool = True
@@ -51,6 +54,18 @@ class FunctionalSolveConfig:
             self.precision, FunctionalPrecisionPolicy
         ):
             raise TypeError("precision must be a FunctionalPrecisionPolicy or None.")
+        if self.parameter_paths is None:
+            if self.parameter_shapes or self.parameter_dtypes:
+                raise ValueError(
+                    "Parameter shapes and dtypes require parameter_paths."
+                )
+        elif (
+            len(self.parameter_paths) != len(self.parameter_shapes)
+            or len(self.parameter_paths) != len(self.parameter_dtypes)
+        ):
+            raise ValueError(
+                "Parameter paths, shapes, and dtypes must have equal lengths."
+            )
         object.__setattr__(self, "num_iter", iterations)
         object.__setattr__(self, "log_every", log_every)
         object.__setattr__(self, "tensorboard_flush_every", flush_every)

--- a/phydrax/solver/_functional_solver.py
+++ b/phydrax/solver/_functional_solver.py
@@ -33,6 +33,11 @@ from ..discretization import (
 )
 from ..enforcement import EnforcementProgram
 from ..equations.trefftz import TrialSpaceCertificate
+from ..nn.parameters import ParameterSubspace
+from ..nn.parameters._low_rank import (
+    contains_low_rank_updates,
+    validate_low_rank_subspace,
+)
 from ..optim._kfac._config import KFAC
 from ..optim._mirror_descent import AbstractMirrorOptimizer
 from ..optim._riemannian import AbstractRiemannianOptimizer
@@ -374,6 +379,7 @@ class FunctionalSolver(StrictModule):
         | AbstractRiemannianOptimizer
         | None = None,
         evaluation_parameters: EvaluationParametersFn | None = None,
+        parameter_subspace: ParameterSubspace | None = None,
         seed: int = 0,
         jit: bool = True,
         keep_best: bool = True,
@@ -390,7 +396,8 @@ class FunctionalSolver(StrictModule):
         """Run the training loop and return an updated solver.
 
         The optimization updates trainable inexact-array leaves of `self.functions`.
-        Domains and fixed observed-data state are kept non-trainable.
+        Domains and fixed observed-data state are kept non-trainable. An explicit
+        `parameter_subspace` restricts supported Optax runs to exact selected leaves.
 
         - Standard and extra-argument Optax transformations are accepted.
         - `phydrax.optim.kfac(...)` configurations are accepted and receive frozen
@@ -408,6 +415,8 @@ class FunctionalSolver(StrictModule):
           selection, and the returned solver. Mirror and Riemannian optimizers reject
           ambient evaluation transforms because they need not preserve geometric
           membership.
+        - Explicit parameter subspaces are initially supported only by standard and
+          extra-argument Optax transformations.
 
         During training, each term receives the one-based iteration index as the
         JAX scalar keyword `iter_`, enabling scheduled coefficients.
@@ -437,6 +446,25 @@ class FunctionalSolver(StrictModule):
             raise ValueError("num_iter must be non-negative.")
         if num_iter == 0:
             return self
+        if parameter_subspace is None:
+            parameter_paths: tuple[str, ...] | None = None
+            parameter_shapes: tuple[tuple[int, ...], ...] = ()
+            parameter_dtypes: tuple[str, ...] = ()
+            if contains_low_rank_updates(self.functions):
+                raise ValueError(
+                    "Low-rank FunctionalSolver training requires an explicit "
+                    "parameter_subspace."
+                )
+        else:
+            if not isinstance(parameter_subspace, ParameterSubspace):
+                raise TypeError(
+                    "parameter_subspace must be a ParameterSubspace or None."
+                )
+            parameter_subspace.validate_root(self.functions)
+            validate_low_rank_subspace(self.functions, parameter_subspace)
+            parameter_paths = parameter_subspace.leaf_paths
+            parameter_shapes = parameter_subspace.leaf_shapes
+            parameter_dtypes = parameter_subspace.leaf_dtypes
         if keep_best and _has_signed_randomized_objective(self.terms):
             raise ValueError(
                 "Signed unbiased randomized terms require keep_best=False; "
@@ -450,6 +478,9 @@ class FunctionalSolver(StrictModule):
         config = FunctionalSolveConfig(
             num_iter=num_iter,
             evaluation_parameters=evaluation_parameters,
+            parameter_paths=parameter_paths,
+            parameter_shapes=parameter_shapes,
+            parameter_dtypes=parameter_dtypes,
             seed=seed,
             jit=jit,
             keep_best=keep_best,

--- a/tests/unit/nn/test_low_rank_adaptation.py
+++ b/tests/unit/nn/test_low_rank_adaptation.py
@@ -1,0 +1,220 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+import phydrax as phx
+from phydrax.nn.parameters import LowRankUpdate
+
+
+_KEY0 = jr.key(0)
+_KEY1 = jr.key(1)
+
+@pytest.mark.parametrize(
+    ("kwargs", "error"),
+    [
+        ({"rank": True}, TypeError),
+        ({"rank": 0}, ValueError),
+        ({"rank": -1}, ValueError),
+        ({"rank": 1, "alpha": 0.0}, ValueError),
+        ({"rank": 1, "alpha": jnp.inf}, ValueError),
+        ({"rank": 1, "stddev": 0.0}, ValueError),
+    ],
+)
+def test_low_rank_spec_rejects_invalid_coordinates(kwargs, error):
+    with pytest.raises(error):
+        phx.nn.parameters.LowRankSpec(**kwargs)
+
+
+def _linear(*, key=_KEY0, rwf=False, weight_transform=None):
+    return phx.nn.layers.Linear(
+        in_size=3,
+        out_size=2,
+        rwf=rwf,
+        weight_transform=weight_transform,
+        key=key,
+    )
+
+
+def _adapt(model, *, rank=2, key=_KEY1):
+    paths = phx.nn.parameters.low_rank_sites(model)
+    specs = {
+        path: phx.nn.parameters.LowRankSpec(rank=rank, alpha=rank)
+        for path in paths
+    }
+    return phx.nn.parameters.adapt_low_rank(model, specs, key=key)
+
+
+def test_low_rank_linear_preserves_initial_function_and_factorizes_batches():
+    base = _linear()
+    adapted, report = _adapt(base)
+    assert isinstance(adapted.weight, LowRankUpdate)
+    assert report.sites[0].path == ".weight"
+    assert report.base_parameter_count == 6
+    assert report.adapter_parameter_count == 10
+    assert report.parameter_ratio == pytest.approx(10.0 / 6.0)
+
+    inputs = jnp.arange(24.0).reshape((2, 4, 3))
+    assert jnp.array_equal(adapted(inputs), base(inputs))
+    assert jnp.array_equal(jax.jit(adapted)(inputs), base(inputs))
+    assert jnp.allclose(jax.vmap(adapted)(inputs[0]), base(inputs[0]))
+
+    update = adapted.weight
+    nonzero = LowRankUpdate.from_factors(
+        update.base,
+        jnp.arange(4.0, dtype=update.dtype).reshape((2, 2)) / 7.0,
+        jnp.arange(6.0, dtype=update.dtype).reshape((2, 3)) / 5.0,
+        alpha=update.alpha,
+    )
+    changed = eqx.tree_at(lambda model: model.weight, adapted, nonzero)
+    merged = phx.nn.parameters.merge_low_rank(changed)
+    assert isinstance(changed.weight, LowRankUpdate)
+    assert isinstance(merged.weight, jax.Array)
+    assert jnp.allclose(changed(inputs), merged(inputs), rtol=1e-12, atol=1e-12)
+    assert jnp.array_equal(base.weight, changed.weight.base)
+
+
+def test_low_rank_gradients_stop_base_and_reach_both_nonzero_factors():
+    adapted, _ = _adapt(_linear())
+    update = adapted.weight
+    changed_update = LowRankUpdate.from_factors(
+        update.base,
+        jnp.full_like(update.left, 0.2),
+        jnp.full_like(update.right, -0.1),
+        alpha=update.alpha,
+    )
+    changed = eqx.tree_at(lambda model: model.weight, adapted, changed_update)
+    inputs = jnp.arange(6.0).reshape((2, 3))
+
+    gradients = eqx.filter_grad(lambda model: jnp.sum(model(inputs) ** 2))(changed)
+    assert jnp.array_equal(gradients.weight.base, jnp.zeros_like(update.base))
+    assert jnp.any(gradients.weight.left != 0.0)
+    assert jnp.any(gradients.weight.right != 0.0)
+
+
+def test_low_rank_paths_keys_and_subspace_are_deterministic():
+    model = phx.nn.models.MLP(
+        in_size=3,
+        out_size=2,
+        width_size=4,
+        depth=3,
+        rwf=False,
+        key=jr.key(4),
+    )
+    paths = phx.nn.parameters.low_rank_sites(model)
+    assert paths == tuple(f".layers[{index}].weight" for index in range(4))
+    specs = {path: phx.nn.parameters.LowRankSpec(2) for path in reversed(paths)}
+    first, first_report = phx.nn.parameters.adapt_low_rank(
+        model, specs, key=jr.key(5)
+    )
+    second, second_report = phx.nn.parameters.adapt_low_rank(
+        model, specs, key=jr.key(5)
+    )
+    assert first_report == second_report
+    for left, right in zip(first.layers, second.layers, strict=True):
+        assert jnp.array_equal(left.weight.right, right.weight.right)
+    assert not jnp.array_equal(
+        first.layers[1].weight.right,
+        first.layers[2].weight.right,
+    )
+
+    subspace = phx.nn.parameters.low_rank_parameter_subspace(first)
+    expected_factor_paths = tuple(
+        factor_path
+        for weight_path in paths
+        for factor_path in (f"{weight_path}.left", f"{weight_path}.right")
+    )
+    assert subspace.leaf_paths == expected_factor_paths
+    subspace.validate_root(first)
+    moved = eqx.tree_at(
+        lambda adapted: adapted.layers[0].weight.left,
+        first,
+        first.layers[0].weight.left + 0.5,
+    )
+    rebased = subspace.rebase(moved)
+    assert jnp.array_equal(
+        rebased.reconstruct(rebased.initial).layers[0].weight.left,
+        moved.layers[0].weight.left,
+    )
+    with pytest.raises(ValueError, match="does not describe"):
+        subspace.validate_root(moved)
+
+
+def test_low_rank_scan_cache_safely_falls_back_after_model_surgery():
+    scanned = phx.nn.models.MLP(
+        in_size=3,
+        out_size=2,
+        width_size=4,
+        depth=4,
+        rwf=False,
+        scan=True,
+        key=jr.key(6),
+    )
+    unrolled = eqx.tree_at(
+        lambda model: (model.scan, model._scan_enabled, model._scan_static),
+        scanned,
+        (False, False, None),
+        is_leaf=lambda value: value is None,
+    )
+    adapted_scan, _ = _adapt(scanned, key=jr.key(7))
+    adapted_loop, _ = _adapt(unrolled, key=jr.key(7))
+    value = jnp.arange(3.0)
+    assert jnp.allclose(adapted_scan(value), adapted_loop(value))
+    scan_grad = eqx.filter_grad(lambda model: jnp.sum(model(value)))(adapted_scan)
+    loop_grad = eqx.filter_grad(lambda model: jnp.sum(model(value)))(adapted_loop)
+    assert jnp.allclose(
+        scan_grad.layers[1].weight.left,
+        loop_grad.layers[1].weight.left,
+    )
+
+
+def test_low_rank_adaptation_rejects_unsupported_or_ambiguous_sites():
+    with pytest.raises(ValueError, match="random weight factorization"):
+        phx.nn.parameters.adapt_low_rank(
+            _linear(rwf=True),
+            {".weight": phx.nn.parameters.LowRankSpec(1)},
+        )
+    with pytest.raises(ValueError, match="weight transform"):
+        phx.nn.parameters.adapt_low_rank(
+            _linear(
+                weight_transform=phx.nn.parameters.PositiveTransform(),
+            ),
+            {".weight": phx.nn.parameters.LowRankSpec(1)},
+        )
+    complex_layer = eqx.tree_at(
+        lambda layer: layer.weight,
+        _linear(),
+        _linear().weight.astype(jnp.complex128),
+    )
+    with pytest.raises(TypeError, match="real inexact"):
+        phx.nn.parameters.adapt_low_rank(
+            complex_layer,
+            {".weight": phx.nn.parameters.LowRankSpec(1)},
+        )
+    layer = _linear()
+    with pytest.raises(ValueError, match="aliased"):
+        phx.nn.parameters.low_rank_sites((layer, layer))
+    with pytest.raises(ValueError, match="Unknown"):
+        phx.nn.parameters.adapt_low_rank(
+            layer,
+            {".missing": phx.nn.parameters.LowRankSpec(1)},
+        )
+
+
+def test_mlp_kfac_metadata_rejects_adapter_until_merged():
+    model = phx.nn.models.MLP(
+        in_size=2,
+        out_size=1,
+        hidden_sizes=(),
+        rwf=False,
+        key=jr.key(8),
+    )
+    adapted, _ = _adapt(model, rank=1, key=jr.key(9))
+    assert adapted.kfac_affine_blocks()[0].parameterization == "low_rank_update"
+    merged = phx.nn.parameters.merge_low_rank(adapted)
+    assert merged.kfac_affine_blocks()[0].parameterization == "direct"

--- a/tests/unit/nn/test_low_rank_adapter_artifact.py
+++ b/tests/unit/nn/test_low_rank_adapter_artifact.py
@@ -1,0 +1,118 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import equinox as eqx
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+import phydrax as phx
+from phydrax._array_archive import ArrayArchiveCorruptionError
+
+
+_KEY0 = jr.key(0)
+
+
+def _base(*, key=_KEY0):
+    return phx.nn.models.MLP(
+        in_size=3,
+        out_size=2,
+        width_size=4,
+        depth=2,
+        rwf=False,
+        key=key,
+    )
+
+
+def _adapted(base):
+    paths = phx.nn.parameters.low_rank_sites(base)
+    model, _ = phx.nn.parameters.adapt_low_rank(
+        base,
+        {path: phx.nn.parameters.LowRankSpec(2) for path in paths},
+        key=jr.key(1),
+    )
+    first = model.layers[0].weight
+    changed = phx.nn.parameters.LowRankUpdate.from_factors(
+        first.base,
+        jnp.full_like(first.left, 0.125),
+        jnp.full_like(first.right, -0.25),
+        alpha=first.alpha,
+    )
+    return eqx.tree_at(lambda value: value.layers[0].weight, model, changed)
+
+
+def test_low_rank_adapter_round_trip_binds_base_and_preserves_merge(tmp_path):
+    base = _base()
+    adapted = _adapted(base)
+    destination = tmp_path / "adapter.phx"
+    phx.nn.parameters.save_low_rank_adapter(
+        destination,
+        adapted,
+        provenance={"task": "unit"},
+    )
+    restored = phx.nn.parameters.read_low_rank_adapter(destination, base)
+    inputs = jnp.arange(18.0).reshape((2, 3, 3))
+
+    assert jnp.allclose(restored.model(inputs), adapted(inputs))
+    assert jnp.allclose(
+        phx.nn.parameters.merge_low_rank(restored.model)(inputs),
+        phx.nn.parameters.merge_low_rank(adapted)(inputs),
+    )
+    assert restored.manifest.provenance == {"task": "unit"}
+    assert tuple(site.path for site in restored.manifest.sites) == (
+        ".layers[0].weight",
+        ".layers[1].weight",
+        ".layers[2].weight",
+    )
+    subspace = phx.nn.parameters.low_rank_parameter_subspace(restored.model)
+    assert subspace.total_dimension == sum(
+        site.adapter_parameter_count for site in restored.manifest.sites
+    )
+
+
+def test_low_rank_adapter_rejects_wrong_base_content_or_structure(tmp_path):
+    base = _base()
+    destination = tmp_path / "adapter.phx"
+    phx.nn.parameters.save_low_rank_adapter(destination, _adapted(base))
+    wrong_content = _base(key=jr.key(2))
+    with pytest.raises(ValueError, match="content mismatch"):
+        phx.nn.parameters.read_low_rank_adapter(destination, wrong_content)
+    wrong_structure = phx.nn.models.MLP(
+        in_size=4,
+        out_size=2,
+        width_size=4,
+        depth=2,
+        rwf=False,
+        key=jr.key(0),
+    )
+    with pytest.raises(ValueError, match="structure mismatch"):
+        phx.nn.parameters.read_low_rank_adapter(destination, wrong_structure)
+
+
+def test_low_rank_adapter_rejects_payload_corruption_and_dense_save(tmp_path):
+    with pytest.raises(ValueError, match="without adapters"):
+        phx.nn.parameters.save_low_rank_adapter(tmp_path / "dense.phx", _base())
+
+    destination = tmp_path / "adapter.phx"
+    phx.nn.parameters.save_low_rank_adapter(destination, _adapted(_base()))
+    payload = bytearray(destination.read_bytes())
+    payload[len(payload) // 2] ^= 0xFF
+    destination.write_bytes(payload)
+    with pytest.raises(ArrayArchiveCorruptionError):
+        phx.nn.parameters.read_low_rank_adapter(destination, _base())
+
+
+def test_adapted_model_round_trips_through_native_ml_artifact(tmp_path):
+    adapted = _adapted(_base())
+    destination = tmp_path / "adapted.phxml"
+    phx.ml.artifacts.save_ml_artifact(destination, adapted)
+    restored = phx.ml.artifacts.read_ml_artifact(destination).model
+    inputs = jnp.arange(9.0).reshape((3, 3))
+
+    assert isinstance(restored.layers[0].weight, phx.nn.parameters.LowRankUpdate)
+    assert jnp.allclose(restored(inputs), adapted(inputs))
+    assert jnp.allclose(
+        phx.nn.parameters.merge_low_rank(restored)(inputs),
+        phx.nn.parameters.merge_low_rank(adapted)(inputs),
+    )

--- a/tests/unit/nn/test_low_rank_operator_training.py
+++ b/tests/unit/nn/test_low_rank_operator_training.py
@@ -1,0 +1,147 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+import phydrax as phx
+
+
+_FLOAT64_POLICY = phx.nn.operator.training.OperatorDTypePolicy(
+    parameter_dtype="float64",
+    compute_dtype="float64",
+    reduction_dtype="float64",
+)
+
+
+def _dataset(cases=4, resolution=6):
+    axis = phx.nn.operator.OperatorAxis(
+        "x",
+        jnp.linspace(0.0, 1.0, resolution),
+        quadrature_weights=jnp.full((resolution,), 1.0 / resolution),
+    )
+    offsets = jnp.arange(cases, dtype=float)[:, None]
+    values = offsets + axis.nodes[None, :]
+    return phx.nn.operator.training.operator_dataset_from_arrays(
+        {"state": values},
+        {"solution": 2.0 * values},
+        source_axes={"state": (axis,)},
+        query_axes=(axis,),
+    )
+
+
+def _adapted_operator(seed=0, *, resolution=6):
+    latent = 4
+    branch = phx.nn.models.MLP(
+        in_size=resolution,
+        out_size=latent,
+        width_size=5,
+        depth=1,
+        rwf=False,
+        key=jr.key(seed),
+    )
+    trunk = phx.nn.models.MLP(
+        in_size="scalar",
+        out_size=latent,
+        width_size=5,
+        depth=1,
+        rwf=False,
+        key=jr.key(seed + 1),
+    )
+    base = phx.nn.operator.architectures.DeepONet(
+        branch=phx.nn.operator.architectures.FixedBranchEncoder(branch, latent),
+        trunk=trunk,
+        coord_dim=1,
+        latent_size=latent,
+        out_size="scalar",
+        in_size=resolution,
+        source_key="state",
+    )
+    paths = phx.nn.parameters.low_rank_sites(base)
+    adapted, _ = phx.nn.parameters.adapt_low_rank(
+        base,
+        {path: phx.nn.parameters.LowRankSpec(1) for path in paths},
+        key=jr.key(seed + 100),
+    )
+    return adapted, phx.nn.parameters.low_rank_parameter_subspace(adapted)
+
+
+def test_fit_operator_updates_only_low_rank_factor_subspace():
+    model, subspace = _adapted_operator()
+    initial_factors = tuple(jax.tree.leaves(subspace.initial))
+    result = phx.nn.operator.training.fit_operator(
+        model,
+        _dataset(),
+        epochs=1,
+        steps=2,
+        batch_size=2,
+        learning_rate=2e-2,
+        parameter_subspace=subspace,
+        dtype_policy=_FLOAT64_POLICY,
+    )
+    rebased = subspace.rebase(result.last_execution_model)
+    final_factors = tuple(jax.tree.leaves(rebased.initial))
+
+    assert any(
+        not jnp.array_equal(initial, final)
+        for initial, final in zip(initial_factors, final_factors, strict=True)
+    )
+    assert bool(eqx.tree_equal(subspace.frozen, rebased.frozen))
+    assert jnp.isfinite(result.final_loss)
+
+
+def test_fit_operator_requires_explicit_low_rank_subspace():
+    model, _ = _adapted_operator()
+    with pytest.raises(ValueError, match="requires an explicit"):
+        phx.nn.operator.training.fit_operator(
+            model,
+            _dataset(),
+            epochs=1,
+            steps=1,
+        )
+
+
+def test_low_rank_operator_resume_matches_uninterrupted(tmp_path):
+    model, subspace = _adapted_operator(seed=2)
+    dataset = _dataset()
+    common = {
+        "epochs": 2,
+        "batch_size": 2,
+        "seed": 11,
+        "checkpoint_every": 1,
+        "parameter_subspace": subspace,
+        "dtype_policy": _FLOAT64_POLICY,
+    }
+    uninterrupted = phx.nn.operator.training.fit_operator(
+        model,
+        dataset,
+        steps=2,
+        **common,
+    )
+    checkpoint = tmp_path / "low-rank-fit"
+    phx.nn.operator.training.fit_operator(
+        model,
+        dataset,
+        steps=1,
+        checkpoint_path=checkpoint,
+        **common,
+    )
+    resumed = phx.nn.operator.training.fit_operator(
+        model,
+        dataset,
+        steps=2,
+        checkpoint_path=checkpoint,
+        resume=True,
+        **common,
+    )
+
+    assert eqx.tree_equal(
+        uninterrupted.last_execution_model,
+        resumed.last_execution_model,
+    )
+    assert uninterrupted.history == resumed.history
+    assert resumed.resumed_from_step == 1

--- a/tests/unit/solver/test_parameter_subspace_training.py
+++ b/tests/unit/solver/test_parameter_subspace_training.py
@@ -1,0 +1,95 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import optax
+import pytest
+
+import phydrax as phx
+
+
+def _output_target(model, *, key=None, iter_=None):
+    del key, iter_
+    return (model(jnp.asarray([1.0])) - 2.0) ** 2
+
+
+def _solver():
+    base = phx.nn.models.MLP(
+        in_size=1,
+        out_size="scalar",
+        hidden_sizes=(),
+        rwf=False,
+        key=jr.key(0),
+    )
+    adapted, _ = phx.nn.parameters.adapt_low_rank(
+        base,
+        {".layers[0].weight": phx.nn.parameters.LowRankSpec(1)},
+        key=jr.key(1),
+    )
+    model = adapted.add_model_loss(_output_target, label="output_target")
+    domain = phx.domain.Interval1d(0.0, 1.0)
+    return phx.solver.FunctionalSolver(
+        functions={"u": domain.Model("x")(model)},
+        terms=(),
+    )
+
+
+def test_functional_solver_optimizes_only_explicit_low_rank_factors():
+    solver = _solver()
+    subspace = phx.nn.parameters.low_rank_parameter_subspace(solver.functions)
+    initial_loss = solver.loss(key=jr.key(2))
+    initial_factors = tuple(jax.tree.leaves(subspace.initial))
+
+    trained = solver.solve(
+        num_iter=20,
+        optim=optax.adamw(5e-2, weight_decay=0.1),
+        parameter_subspace=subspace,
+        keep_best=False,
+        log_every=0,
+    )
+    final_loss = trained.loss(key=jr.key(2))
+    rebased = subspace.rebase(trained.functions)
+    final_factors = tuple(jax.tree.leaves(rebased.initial))
+
+    assert final_loss < initial_loss
+    assert any(
+        not jnp.array_equal(initial, final)
+        for initial, final in zip(initial_factors, final_factors, strict=True)
+    )
+    frozen_equal = eqx.tree_equal(subspace.frozen, rebased.frozen)
+    assert bool(frozen_equal)
+
+
+def test_functional_solver_requires_matching_low_rank_subspace():
+    solver = _solver()
+    with pytest.raises(ValueError, match="requires an explicit"):
+        solver.solve(num_iter=1, optim=optax.sgd(1e-2), log_every=0)
+
+    unrelated = phx.nn.parameters.ParameterSubspace(
+        {"weight": jnp.ones((1,))},
+        eqx.is_inexact_array,
+    )
+    with pytest.raises(ValueError, match="does not describe"):
+        solver.solve(
+            num_iter=1,
+            optim=optax.sgd(1e-2),
+            parameter_subspace=unrelated,
+            log_every=0,
+        )
+
+
+def test_functional_solver_rejects_non_optax_subspace_backend():
+    solver = _solver()
+    subspace = phx.nn.parameters.low_rank_parameter_subspace(solver.functions)
+    with pytest.raises(ValueError, match="unsupported by KFAC"):
+        solver.solve(
+            num_iter=1,
+            optim=phx.optim.kfac(damping=1e-2),
+            parameter_subspace=subspace,
+            keep_best=False,
+            log_every=0,
+        )

--- a/tools/low_rank_adaptation_benchmarks.py
+++ b/tools/low_rank_adaptation_benchmarks.py
@@ -1,0 +1,261 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import argparse
+import json
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import optax
+
+import phydrax as phx
+from phydrax._trainable import partition_trainable
+
+
+def _array_count(tree: Any, /) -> int:
+    return sum(int(leaf.size) for leaf in jax.tree.leaves(tree) if eqx.is_array(leaf))
+
+
+def _array_bytes(tree: Any, /) -> int:
+    return sum(
+        int(leaf.size * leaf.dtype.itemsize)
+        for leaf in jax.tree.leaves(tree)
+        if eqx.is_array(leaf)
+    )
+
+
+def _resource_benchmark(*, dimension: int, rank: int, batch_size: int) -> dict[str, Any]:
+    base = phx.nn.layers.Linear(
+        in_size=dimension,
+        out_size=dimension,
+        rwf=False,
+        use_bias=False,
+        key=jr.key(0),
+    )
+    adapted, report = phx.nn.parameters.adapt_low_rank(
+        base,
+        {".weight": phx.nn.parameters.LowRankSpec(rank)},
+        key=jr.key(1),
+    )
+    subspace = phx.nn.parameters.low_rank_parameter_subspace(adapted)
+    dense_parameters, dense_fixed = partition_trainable(base)
+    adapter_parameters = subspace.initial
+    adapter_fixed = subspace.frozen
+    inputs = jr.normal(jr.key(2), (batch_size, dimension))
+    targets = jr.normal(jr.key(3), (batch_size, dimension))
+    dense_optimizer = optax.adam(1e-3)
+    adapter_optimizer = optax.adam(1e-3)
+    dense_state = dense_optimizer.init(dense_parameters)
+    adapter_state = adapter_optimizer.init(adapter_parameters)
+
+    def dense_step(parameters, state):
+        def objective(candidate):
+            model = eqx.combine(candidate, dense_fixed)
+            return jnp.mean((model(inputs) - targets) ** 2)
+
+        loss, gradient = eqx.filter_value_and_grad(objective)(parameters)
+        updates, state = dense_optimizer.update(gradient, state, parameters)
+        return optax.apply_updates(parameters, updates), state, loss
+
+    def adapter_step(parameters, state):
+        def objective(candidate):
+            model = eqx.combine(candidate, adapter_fixed)
+            return jnp.mean((model(inputs) - targets) ** 2)
+
+        loss, gradient = eqx.filter_value_and_grad(objective)(parameters)
+        updates, state = adapter_optimizer.update(gradient, state, parameters)
+        return optax.apply_updates(parameters, updates), state, loss
+
+    dense_jit = eqx.filter_jit(dense_step)
+    adapter_jit = eqx.filter_jit(adapter_step)
+    started = time.perf_counter()
+    dense_parameters, dense_state, dense_loss = dense_jit(dense_parameters, dense_state)
+    jax.block_until_ready(dense_loss)
+    dense_compile_seconds = time.perf_counter() - started
+    started = time.perf_counter()
+    adapter_parameters, adapter_state, adapter_loss = adapter_jit(
+        adapter_parameters, adapter_state
+    )
+    jax.block_until_ready(adapter_loss)
+    adapter_compile_seconds = time.perf_counter() - started
+
+    repeats = 5
+    started = time.perf_counter()
+    for _ in range(repeats):
+        dense_parameters, dense_state, dense_loss = dense_jit(
+            dense_parameters, dense_state
+        )
+    jax.block_until_ready(dense_loss)
+    dense_step_seconds = (time.perf_counter() - started) / repeats
+    started = time.perf_counter()
+    for _ in range(repeats):
+        adapter_parameters, adapter_state, adapter_loss = adapter_jit(
+            adapter_parameters, adapter_state
+        )
+    jax.block_until_ready(adapter_loss)
+    adapter_step_seconds = (time.perf_counter() - started) / repeats
+
+    trained_adapter = eqx.combine(adapter_parameters, adapter_fixed)
+    merged = phx.nn.parameters.merge_low_rank(trained_adapter)
+    unmerged_output = trained_adapter(inputs)
+    merged_output = merged(inputs)
+    with tempfile.TemporaryDirectory() as directory:
+        adapter_path = Path(directory) / "adapter.phx"
+        phx.nn.parameters.save_low_rank_adapter(adapter_path, trained_adapter)
+        artifact_bytes = adapter_path.stat().st_size
+
+    return {
+        "dimension": dimension,
+        "rank": rank,
+        "batch_size": batch_size,
+        "dense_parameter_count": _array_count(dense_parameters),
+        "adapter_parameter_count": _array_count(adapter_parameters),
+        "reported_adapter_parameter_count": report.adapter_parameter_count,
+        "dense_parameter_bytes": _array_bytes(dense_parameters),
+        "adapter_parameter_bytes": _array_bytes(adapter_parameters),
+        "dense_optimizer_state_bytes": _array_bytes(dense_state),
+        "adapter_optimizer_state_bytes": _array_bytes(adapter_state),
+        "dense_compile_seconds": dense_compile_seconds,
+        "adapter_compile_seconds": adapter_compile_seconds,
+        "dense_step_seconds": dense_step_seconds,
+        "adapter_step_seconds": adapter_step_seconds,
+        "adapter_artifact_bytes": artifact_bytes,
+        "merged_output_max_abs_error": float(
+            jax.device_get(jnp.max(jnp.abs(unmerged_output - merged_output)))
+        ),
+    }
+
+
+def _operator_dataset(*, coefficient: float, cases: int = 8, resolution: int = 8):
+    axis = phx.nn.operator.OperatorAxis(
+        "x",
+        jnp.linspace(0.0, 1.0, resolution),
+        quadrature_weights=jnp.full((resolution,), 1.0 / resolution),
+    )
+    offsets = jnp.arange(cases, dtype=float)[:, None]
+    values = jnp.sin((offsets + 1.0) * jnp.pi * axis.nodes[None, :])
+    return phx.nn.operator.training.operator_dataset_from_arrays(
+        {"state": values},
+        {"solution": coefficient * values},
+        source_axes={"state": (axis,)},
+        query_axes=(axis,),
+    )
+
+
+def _operator_loss(model, dataset) -> float:
+    prediction = model(dataset.batch)
+    target = dataset.targets.field("solution").values
+    return float(jax.device_get(jnp.mean((prediction - target) ** 2)))
+
+
+def _transfer_benchmark() -> dict[str, Any]:
+    source = _operator_dataset(coefficient=2.0)
+    target = _operator_dataset(coefficient=3.0)
+    latent = 6
+    branch = phx.nn.models.MLP(
+        in_size=8,
+        out_size=latent,
+        width_size=8,
+        depth=1,
+        rwf=False,
+        key=jr.key(10),
+    )
+    trunk = phx.nn.models.MLP(
+        in_size="scalar",
+        out_size=latent,
+        width_size=8,
+        depth=1,
+        rwf=False,
+        key=jr.key(11),
+    )
+    base = phx.nn.operator.architectures.DeepONet(
+        branch=phx.nn.operator.architectures.FixedBranchEncoder(branch, latent),
+        trunk=trunk,
+        coord_dim=1,
+        latent_size=latent,
+        out_size="scalar",
+        in_size=8,
+        source_key="state",
+    )
+    pretrained = phx.nn.operator.training.fit_operator(
+        base,
+        source,
+        epochs=1,
+        steps=4,
+        batch_size=4,
+        learning_rate=2e-2,
+    ).last_execution_model
+    frozen_loss = _operator_loss(pretrained, target)
+    full_result = phx.nn.operator.training.fit_operator(
+        pretrained,
+        target,
+        epochs=1,
+        steps=4,
+        batch_size=4,
+        learning_rate=2e-2,
+    )
+    paths = phx.nn.parameters.low_rank_sites(pretrained)
+    adapted, report = phx.nn.parameters.adapt_low_rank(
+        pretrained,
+        {path: phx.nn.parameters.LowRankSpec(1) for path in paths},
+        key=jr.key(11),
+    )
+    subspace = phx.nn.parameters.low_rank_parameter_subspace(adapted)
+    adapter_result = phx.nn.operator.training.fit_operator(
+        adapted,
+        target,
+        epochs=1,
+        steps=4,
+        batch_size=4,
+        learning_rate=2e-2,
+        parameter_subspace=subspace,
+    )
+    full_parameters, _ = partition_trainable(pretrained)
+    return {
+        "base_coefficient": 2.0,
+        "target_coefficient": 3.0,
+        "frozen_loss": frozen_loss,
+        "full_finetune_loss": float(full_result.final_loss),
+        "low_rank_loss": float(adapter_result.final_loss),
+        "full_trainable_parameters": _array_count(full_parameters),
+        "low_rank_trainable_parameters": subspace.total_dimension,
+        "adapted_site_count": len(report.sites),
+        "rank": 1,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("benchmarks/low_rank_adaptation.json"),
+    )
+    parser.add_argument("--dimension", type=int, default=512)
+    parser.add_argument("--rank", type=int, default=8)
+    parser.add_argument("--batch-size", type=int, default=16)
+    args = parser.parse_args()
+    result = {
+        "resource": _resource_benchmark(
+            dimension=args.dimension,
+            rank=args.rank,
+            batch_size=args.batch_size,
+        ),
+        "operator_transfer": _transfer_benchmark(),
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a native parameter-efficient adaptation substrate for real Phydrax `Linear` weights. The implementation represents each selected affine weight as a dense shared base plus a trainable factorized update, evaluates the factors without constructing a dense delta, and merges them purely for ordinary deployment.

No Lorax, Qax, Quax, or additional runtime dependency is introduced.

## Public parameter API

- Adds `LowRankSpec`, `LowRankUpdate`, deterministic site accounting, and adaptation reports.
- Adds exact native `Linear.weight` discovery and path-addressed heterogeneous adaptation.
- Initializes one factor to zero so adapted models exactly preserve the base function before optimization.
- Adds factor-only `ParameterSubspace` discovery and pure dense merging.
- Extends `ParameterSubspace` with exact-root validation and compatible-state rebasing.
- Rejects RWF, transformed, complex, aliased, unknown, and already-adapted sites before model surgery.

## Training integration

- Adds `parameter_subspace=` to `fit_operator`.
- Restricts differentiation, accumulation, optimizer state, evaluation views, selection, and returned models to exact selected leaves.
- Rebases selected paths after dtype casting, model replication, and checkpoint restoration.
- Includes effective selected paths, shapes, dtypes, and dimension in the resume contract.
- Adds `parameter_subspace=` to Optax-backed `FunctionalSolver.solve` while rejecting unsupported optimizer families explicitly.
- Requires complete factor-only subspaces for low-rank models; omission fails before optimizer initialization.

## Persistence and deployment

- Adds checksum-validated adapter-only archives containing factors rather than shared base arrays.
- Binds each archive to the exact base model type, static structure, array paths, shapes, dtypes, and contents.
- Rejects wrong bases, corrupted factors, unknown sites, and inconsistent rank or scaling metadata.
- Keeps merge non-destructive and returns ordinary dense models suitable for existing inference and artifact paths.

## Execution compatibility

- Integrates factorized execution directly into native `Linear` using `opt_einsum.contract`.
- Marks adapted affine blocks as `low_rank_update` so KFAC rejects them before treating structured state as a direct dense block.
- Hardens scan packing against stale cached static structures introduced by model surgery; affected models use their existing serial fallback rather than failing or combining incompatible PyTrees.

## Qualification evidence

The checked resource campaign for a 512 by 512 affine map at rank 8 records:

- 262,144 dense trainable parameters versus 8,192 adapter parameters.
- 4,194,308 dense Adam-state bytes versus 131,076 adapter-state bytes.
- 0.02723 second dense steady steps versus 0.01081 second adapter steps.
- Maximum merged versus factorized output disagreement of 6.66e-15.

The operator-transfer campaign improves the frozen baseline from 4.13757 to 4.12154 using 53 trainable adapter parameters; full fine-tuning reaches 3.81085 with 197 parameters. The documentation preserves that accuracy tradeoff rather than claiming parity.

## Documentation and provenance

Updates the parameter API, operator-fitting contract, optimizer compatibility matrix, operator-learning cookbook, all-of-Phydrax overview, changelog, benchmark evidence, and independent-implementation attribution.