### PR TITLE
feat: add fixed-mesh FEM solver acceleration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,13 @@
   marking/refinement/coarsening and transfer data, local DWR indicators, and
   executable phase-field, CPFEM, persistent-pair contact, fracture, and fixed-
   crack XFEM application workflows. Distributed execution remains out of scope.
+- Added accepted linear-solve histories, exact FEM diagonal data, pairing-aware
+  p-transfer roles and p-level planning, collocated tensor-product actions,
+  staged DG traces, explicit quadrature evidence, one-ring patch and low-order
+  auxiliary preconditioners, an incompressible pressure-correction workflow, and
+  conservative multirate DG traces. The execution and preconditioning design is
+  informed by libParanumal and its published high-order solver algorithms while
+  remaining Phydrax-native.
 - Added first-class exact-sampling round-sphere spectral discretizations with
   explicit S2FFT mode layouts, physical area measures, matrix-free
   Laplace--Beltrami actions, complete-degree real eigenbases and spatial noise,

--- a/docs/guides_fem_solver_acceleration.md
+++ b/docs/guides_fem_solver_acceleration.md
@@ -1,0 +1,125 @@
+# Fixed-mesh FEM solver acceleration
+
+This guide covers linear-history initial guesses, exact FEM diagonals,
+p-transfer, p-multigrid, collocated tensor kernels, staged DG traces,
+quadrature policies, one-ring Schwarz, and low-order auxiliary operators.
+
+The algorithms are Phydrax-native. The design was informed by
+[libParanumal](https://github.com/paranumal/libparanumal), its matrix-free
+[p-multigrid implementation](https://github.com/paranumal/libparanumal/blob/main/solvers/elliptic/src/ellipticPreconMultiGrid.cpp),
+[multigrid smoothers](https://github.com/paranumal/libparanumal/blob/main/solvers/elliptic/src/ellipticPreconMultiGridLevel.cpp),
+[overlapping Schwarz preconditioner](https://github.com/paranumal/libparanumal/blob/main/solvers/elliptic/src/ellipticPreconOAS.cpp), and
+[tensor-product kernels](https://github.com/paranumal/libparanumal/blob/main/solvers/elliptic/okl/ellipticAxQuad2D.okl).
+
+## Linear solve histories
+
+`LinearSolveHistory` stores accepted solution vectors and their operator images.
+For projection strategies it chooses coefficients that minimize the represented
+RHS residual and reconstructs an initial solution from the paired solution
+basis. Histories carry explicit operator-family, constraint, and nullspace
+identities. Incompatible histories are rejected rather than reused by shape.
+
+Updates are immutable and require an explicit acceptance decision. Initial
+guesses are treated as algorithmic data and stop gradients by default; the
+converged solve retains its existing differentiation policy.
+
+Available strategies are:
+
+- zero;
+- last accepted solution;
+- paired RHS/solution projection;
+- fixed-capacity rolling history;
+- stabilized polynomial extrapolation from accepted times.
+
+The history design follows ideas described in
+[Initial Guesses for Sequences of Linear Systems](https://arxiv.org/abs/2009.10863).
+
+## Exact diagonal data
+
+`CompiledFiniteElementProblem.exact_diagonal()` returns
+`FiniteElementDiagonalData` with construction provenance and zero/negative
+masks. Structurally sparse affine operators use direct coordinate storage. A
+bounded coordinate-linearization fallback is available only when explicitly
+enabled with a dimension cap.
+
+No diagonal floor, absolute value, or regularization is applied implicitly.
+
+## p-transfer
+
+`FiniteElementPTransfer` separates:
+
+- primal prolongation;
+- raw dual pullback;
+- pairing-aware adjoint;
+- mass projection.
+
+The generic transfer factory supports matching element cell/conformity families
+with increasing degree. Supplied mass matrices are solved through Phydrax dense
+factorization to construct a pairing-aware adjoint.
+
+## p-level planning
+
+`FiniteElementPMultigridPolicy` supports:
+
+- every degree;
+- approximately half degree;
+- approximately half local DOFs;
+- explicit decreasing orders.
+
+`finite_element_p_multigrid_plan` validates level operators, smoothers, and
+transfer spaces before creating the generic Phydrax multigrid hierarchy. Fine
+levels may remain matrix-free; the caller supplies the coarse sparse operator
+and preconditioner.
+
+## Collocated tensor path
+
+`CollocatedTensorProductOperator` implements quad/hex mass-diffusion actions
+when nodal and quadrature axes coincide. It stores one-dimensional derivatives,
+weighted mass data, and packed symmetric metric components. Unsupported or
+overintegrated actions should use the generic tensor partial-assembly path.
+
+The execution strategy follows the dataflow studied in
+[Acceleration of tensor-product operations for high-order finite element methods](https://arxiv.org/abs/1711.00903),
+but is implemented through JAX and `opt_einsum`, not translated OCCA kernels.
+
+## DG derivative and trace staging
+
+`CellDerivativeBatch` evaluates one set of local values/gradients.
+`DGTraceBatch` constructs plus/minus `FacetJet` traces from packed side data so
+multiple facet actions can share one staged derivative representation within an
+operator invocation. Staged state-dependent data must never survive into a
+later nonlinear residual evaluation.
+
+## Quadrature accuracy
+
+`QuadratureAccuracyPolicy` distinguishes:
+
+- declared polynomial exactness;
+- collocation;
+- overintegration;
+- explicit rule degree.
+
+Polynomial-exactness mode rejects unknown coefficient or kernel degree.
+`QuadratureEvidence` records role, selected degree, exactness, and aliasing
+status. Nonpolynomial material laws require explicit integration evidence.
+
+## One-ring Schwarz
+
+`one_ring_patch_plan` builds fixed-mesh cell patches from interior-facet
+adjacency. It computes reciprocal overlap weights so valid patch weights form a
+partition of unity. `FiniteElementPatchPreconditioner` applies supplied local
+inverse matrices and weighted additive scatter. Local matrix construction and
+factorization remain explicit preparation responsibilities.
+
+## Low-order auxiliary action
+
+`LowOrderAuxiliaryOperatorPlan` binds high-to-low interpolation,
+low-to-high anterpolation, and positive multiplicity weights.
+`LowOrderAuxiliaryPreconditioner` transforms the residual, invokes any prepared
+low-order Phydrax preconditioner, maps the correction back, and reapplies the
+weights. The plan does not create or expose a mesh-generation API.
+
+## Current scope
+
+These paths are fixed-mesh and single-device. They do not add MPI/OGS,
+partitioning, OCCA, parAlmond, mesh loaders, or a duplicate Krylov stack.

--- a/docs/guides_incompressible_multirate.md
+++ b/docs/guides_incompressible_multirate.md
@@ -1,0 +1,63 @@
+# Incompressible and multirate workflows
+
+## Pressure correction
+
+`phydrax.applications.incompressible_flow` wires supplied advection, velocity
+Helmholtz, divergence, pressure Poisson, and gradient operators into an accepted
+pressure-correction step. Both pressure and pressure-increment forms are
+explicit policies.
+
+A nonincremental step performs:
+
+```text
+advection RHS
+→ velocity Helmholtz solve
+→ divergence
+→ pressure Poisson solve
+→ velocity gradient correction
+→ assessment
+```
+
+An incremental step includes the accepted pressure gradient in the velocity
+RHS, solves for a pressure increment, updates pressure, and corrects velocity
+with the increment gradient.
+
+The application package does not define another linear or nonlinear solver.
+`IncompressibleFlowOperators` receives prepared callable actions and
+`incompressible_flow_schedule` connects them to the accepted-step runtime.
+
+The schedule was informed by libParanumal's
+[incompressible split step](https://github.com/paranumal/libparanumal/blob/main/solvers/ins/src/insStep.cpp)
+and [advection subcycling](https://github.com/paranumal/libparanumal/blob/main/solvers/ins/src/insSubcycle.cpp).
+
+## OIFS history combination
+
+`oifs_history_combination` forms the normalized partial history sum from oldest
+to newest contributions. A supplied subcycle action may evolve the combined
+state while evaluating time-dependent boundary data consistently. Time
+integration remains an explicit application policy.
+
+## Multirate DG traces
+
+`DGMultirateTracePlan` declares power-of-two side-rate levels.
+`DGTraceHistory` stores accepted trace values and predicts traces at intermediate
+times with polynomial interpolation. Rejected updates leave history unchanged.
+
+`conservative_multirate_flux` evaluates one shared numerical flux and returns
+exactly opposite plus/minus contributions together with a conservation defect.
+This follows the interface-history concept in libParanumal's
+[multirate AB3 implementation](https://github.com/paranumal/libparanumal/blob/main/libs/timeStepper/timeStepperMRAB3.cpp)
+without adding a duplicate MRAB integrator.
+
+## Derivative scope
+
+Pressure-correction and subcycle branching describe the executed algorithm.
+Initial-guess histories, rate categories, history eviction, and acceptance
+branches are algorithmic decisions and are not smooth model parameters.
+Differentiable workflows must choose between executed-schedule differentiation
+and an independently compiled monolithic implicit formulation.
+
+## Current scope
+
+The workflow is fixed-mesh and single-device. Distributed trace exchange,
+partitioning, and mesh adaptation are not introduced.

--- a/examples/fem_solver_acceleration.py
+++ b/examples/fem_solver_acceleration.py
@@ -1,0 +1,67 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax.numpy as jnp
+
+import phydrax as phx
+
+
+space = phx.linalg.ArraySpace((2,))
+operator = phx.linalg.DenseLinearOperator(
+    jnp.asarray([[2.0, 0.0], [0.0, 3.0]]), source=space, target=space
+)
+history = phx.linalg.LinearSolveHistory.empty(
+    operator,
+    phx.linalg.LinearSolveHistoryPolicy("projection", capacity=3),
+    "example-shifted-family",
+)
+history = history.update(operator, jnp.asarray([1.0, 0.0]), time=0.0)
+history = history.update(operator, jnp.asarray([0.0, 2.0]), time=1.0)
+guess, history_diagnostics = history.initial_guess(operator.mv(jnp.asarray([2.0, 6.0])))
+
+derivative = jnp.zeros((2, 2))
+metric = jnp.ones((1, 2, 2, 3))
+mass = jnp.ones((1, 2, 2))
+gathers = jnp.asarray([[0, 1, 2, 3]], dtype=jnp.int32)
+tensor = phx.equations.fem.CollocatedTensorProductOperator(
+    derivative, metric, mass, gathers, 4
+)
+tensor_value = jnp.arange(1.0, 5.0)
+tensor_defect = jnp.linalg.norm(tensor.mv(tensor_value) - tensor_value)
+
+flow = phx.applications.incompressible_flow
+flow_operators = flow.IncompressibleFlowOperators(
+    lambda velocity, time, args: jnp.zeros_like(velocity),
+    lambda rhs, gamma, time, args: rhs / gamma,
+    lambda velocity, time, args: velocity,
+    lambda rhs, time, args: -rhs,
+    lambda pressure, time, args: pressure,
+)
+flow_state, flow_diagnostics = flow.pressure_correction_step(
+    flow.IncompressibleFlowState(jnp.asarray([1.0, 2.0]), jnp.zeros((2,))),
+    1.0,
+    flow_operators,
+    flow.IncompressibleFlowPolicy(pressure_increment=False),
+    0.0,
+)
+
+if (
+    not jnp.allclose(guess, jnp.asarray([2.0, 6.0]))
+    or history_diagnostics.projection_residual_norm > 1.0e-12
+    or tensor_defect > 1.0e-12
+    or flow_diagnostics.divergence_after > 1.0e-12
+):
+    raise RuntimeError("FEM solver-acceleration smoke failed.")
+
+print(
+    {
+        "history_guess": guess.tolist(),
+        "history_projection_residual": float(
+            history_diagnostics.projection_residual_norm
+        ),
+        "collocated_tensor_defect": float(tensor_defect),
+        "corrected_velocity": flow_state.velocity.tolist(),
+        "corrected_divergence": float(flow_diagnostics.divergence_after),
+    }
+)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -138,6 +138,8 @@ nav:
         - Multiphase and incompressible SPH: "guides_multiphase_incompressible_sph.md"
         - Finite elements: "guides_finite_elements.md"
         - Finite-element applications: "guides_fem_applications.md"
+        - FEM solver acceleration: "guides_fem_solver_acceleration.md"
+        - Incompressible and multirate workflows: "guides_incompressible_multirate.md"
         - Smoothed finite elements: "guides_fem_smoothing.md"
         - Global spectral methods: "guides_spectral_methods.md"
         - Finite real algebras: "guides_finite_real_algebras.md"

--- a/phydrax/applications/__init__.py
+++ b/phydrax/applications/__init__.py
@@ -9,6 +9,7 @@ from . import (
     crystal_plasticity,
     fracture,
     free_boundary,
+    incompressible_flow,
     phase_field,
     solid_mechanics,
 )
@@ -19,6 +20,7 @@ __all__ = [
     "crystal_plasticity",
     "fracture",
     "free_boundary",
+    "incompressible_flow",
     "phase_field",
     "solid_mechanics",
 ]

--- a/phydrax/applications/incompressible_flow/__init__.py
+++ b/phydrax/applications/incompressible_flow/__init__.py
@@ -1,0 +1,24 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from ._workflow import (
+    incompressible_flow_schedule,
+    IncompressibleFlowDiagnostics,
+    IncompressibleFlowOperators,
+    IncompressibleFlowPolicy,
+    IncompressibleFlowState,
+    oifs_history_combination,
+    pressure_correction_step,
+)
+
+
+__all__ = [
+    "IncompressibleFlowDiagnostics",
+    "IncompressibleFlowOperators",
+    "IncompressibleFlowPolicy",
+    "IncompressibleFlowState",
+    "incompressible_flow_schedule",
+    "oifs_history_combination",
+    "pressure_correction_step",
+]

--- a/phydrax/applications/incompressible_flow/_workflow.py
+++ b/phydrax/applications/incompressible_flow/_workflow.py
@@ -1,0 +1,270 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+
+import equinox as eqx
+import jax.numpy as jnp
+from jaxtyping import Array, ArrayLike
+
+from ..._fingerprint import canonical_fingerprint
+from ..._strict import StrictModule
+from ..._trainable import NonTrainableState
+from ...solver import (
+    FiniteElementAcceptedStepSchedule,
+    FiniteElementAttemptResult,
+    FiniteElementStepPolicy,
+)
+
+
+class IncompressibleFlowOperators(StrictModule, NonTrainableState):
+    advection: Callable
+    velocity_solve: Callable
+    divergence: Callable
+    pressure_solve: Callable
+    gradient: Callable
+    subcycle: Callable | None
+    operators_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        advection: Callable,
+        velocity_solve: Callable,
+        divergence: Callable,
+        pressure_solve: Callable,
+        gradient: Callable,
+        /,
+        *,
+        subcycle: Callable | None = None,
+        operators_id: str = "incompressible-flow-operators",
+    ):
+        callables = (advection, velocity_solve, divergence, pressure_solve, gradient)
+        if not all(callable(value) for value in callables):
+            raise TypeError("Every incompressible-flow operator must be callable.")
+        if subcycle is not None and not callable(subcycle):
+            raise TypeError("subcycle must be callable or None.")
+        identifier = str(operators_id)
+        if not identifier:
+            raise ValueError("operators_id must be non-empty.")
+        self.advection = advection
+        self.velocity_solve = velocity_solve
+        self.divergence = divergence
+        self.pressure_solve = pressure_solve
+        self.gradient = gradient
+        self.subcycle = subcycle
+        self.operators_id = canonical_fingerprint(
+            {
+                "kind": "incompressible-flow-operators",
+                "declared_id": identifier,
+                "has_subcycle": subcycle is not None,
+            }
+        )
+
+
+class IncompressibleFlowPolicy(StrictModule, NonTrainableState):
+    pressure_increment: bool = eqx.field(static=True)
+    advection_subcycles: int = eqx.field(static=True)
+    policy_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        /,
+        *,
+        pressure_increment: bool = True,
+        advection_subcycles: int = 1,
+    ):
+        subcycles = int(advection_subcycles)
+        if subcycles < 1:
+            raise ValueError("Advection subcycles must be positive.")
+        self.pressure_increment = bool(pressure_increment)
+        self.advection_subcycles = subcycles
+        self.policy_id = canonical_fingerprint(
+            {
+                "kind": "incompressible-flow-policy",
+                "pressure_increment": bool(pressure_increment),
+                "advection_subcycles": subcycles,
+            }
+        )
+
+
+class IncompressibleFlowState(StrictModule):
+    velocity: Array
+    pressure: Array
+    velocity_history: tuple[Array, ...]
+
+    def __init__(
+        self,
+        velocity: ArrayLike,
+        pressure: ArrayLike,
+        /,
+        *,
+        velocity_history: Sequence[ArrayLike] = (),
+    ):
+        velocity_ = jnp.asarray(velocity)
+        pressure_ = jnp.asarray(pressure)
+        history = tuple(jnp.asarray(value) for value in velocity_history)
+        if not jnp.issubdtype(velocity_.dtype, jnp.inexact) or not jnp.issubdtype(
+            pressure_.dtype, jnp.inexact
+        ):
+            raise TypeError("Incompressible-flow state must use inexact arrays.")
+        if any(value.shape != velocity_.shape for value in history):
+            raise ValueError("Velocity history must preserve velocity shape.")
+        self.velocity = velocity_
+        self.pressure = pressure_
+        self.velocity_history = history
+
+
+class IncompressibleFlowDiagnostics(StrictModule):
+    divergence_before: Array
+    divergence_after: Array
+    pressure_increment_norm: Array
+    successful: Array
+
+
+def oifs_history_combination(
+    history: Sequence[ArrayLike],
+    coefficients: ArrayLike,
+    /,
+) -> Array:
+    values = tuple(jnp.asarray(value) for value in history)
+    weights = jnp.asarray(coefficients)
+    if not values or weights.shape != (len(values),):
+        raise ValueError("OIFS history and coefficients are incompatible.")
+    if any(value.shape != values[0].shape for value in values):
+        raise ValueError("OIFS history values must share one shape.")
+    combined = jnp.zeros_like(values[0])
+    accumulated = jnp.asarray(0.0, dtype=weights.dtype)
+    for value, weight in zip(reversed(values), reversed(weights), strict=True):
+        denominator = weight + accumulated
+        combined = jnp.where(
+            denominator != 0.0,
+            weight / denominator * value + accumulated / denominator * combined,
+            combined,
+        )
+        accumulated = denominator
+    return combined
+
+
+def pressure_correction_step(
+    state: IncompressibleFlowState,
+    step_size: ArrayLike,
+    operators: IncompressibleFlowOperators,
+    policy: IncompressibleFlowPolicy,
+    time: ArrayLike,
+    args: object = None,
+    /,
+) -> tuple[IncompressibleFlowState, IncompressibleFlowDiagnostics]:
+    if (
+        not isinstance(state, IncompressibleFlowState)
+        or not isinstance(operators, IncompressibleFlowOperators)
+        or not isinstance(policy, IncompressibleFlowPolicy)
+    ):
+        raise TypeError("Pressure-correction step inputs are invalid.")
+    dt = jnp.asarray(step_size)
+    time_ = jnp.asarray(time)
+    if dt.shape != () or time_.shape != () or bool(dt <= 0.0):
+        raise ValueError("Pressure-correction time data are invalid.")
+    if policy.advection_subcycles > 1:
+        if operators.subcycle is None:
+            raise ValueError("Advection subcycling requires a subcycle operator.")
+        advected = operators.subcycle(
+            state.velocity,
+            time_,
+            dt,
+            policy.advection_subcycles,
+            args,
+        )
+        advection = (state.velocity - advected) / dt
+    else:
+        advection = operators.advection(state.velocity, time_, args)
+    right_hand_side = state.velocity / dt - advection
+    if policy.pressure_increment:
+        right_hand_side = right_hand_side - operators.gradient(
+            state.pressure, time_, args
+        )
+    predictor = operators.velocity_solve(right_hand_side, 1.0 / dt, time_, args)
+    divergence_before = operators.divergence(predictor, time_, args)
+    pressure_correction = operators.pressure_solve(
+        -divergence_before / dt,
+        time_,
+        args,
+    )
+    if policy.pressure_increment:
+        pressure = state.pressure + pressure_correction
+        correction_gradient = operators.gradient(pressure_correction, time_, args)
+    else:
+        pressure = pressure_correction
+        correction_gradient = operators.gradient(pressure, time_, args)
+    velocity = predictor - dt * correction_gradient
+    divergence_after = operators.divergence(velocity, time_ + dt, args)
+    finite = (
+        jnp.all(jnp.isfinite(velocity))
+        & jnp.all(jnp.isfinite(pressure))
+        & jnp.all(jnp.isfinite(divergence_after))
+    )
+    next_history = (state.velocity, *state.velocity_history[:2])
+    return IncompressibleFlowState(
+        velocity,
+        pressure,
+        velocity_history=next_history,
+    ), IncompressibleFlowDiagnostics(
+        divergence_before=jnp.sqrt(jnp.sum(jnp.abs(divergence_before) ** 2)),
+        divergence_after=jnp.sqrt(jnp.sum(jnp.abs(divergence_after) ** 2)),
+        pressure_increment_norm=jnp.sqrt(jnp.sum(jnp.abs(pressure_correction) ** 2)),
+        successful=finite,
+    )
+
+
+def incompressible_flow_schedule(
+    operators: IncompressibleFlowOperators,
+    flow_policy: IncompressibleFlowPolicy | None = None,
+    /,
+    *,
+    step_policy: FiniteElementStepPolicy | None = None,
+) -> FiniteElementAcceptedStepSchedule:
+    selected = IncompressibleFlowPolicy() if flow_policy is None else flow_policy
+    if not isinstance(selected, IncompressibleFlowPolicy):
+        raise TypeError("flow_policy must be IncompressibleFlowPolicy or None.")
+
+    def attempt(accepted, start, end, time_law, args):
+        state = IncompressibleFlowState(
+            accepted.fields[0],
+            accepted.fields[1],
+            velocity_history=accepted.fields[2:],
+        )
+        updated, diagnostics = pressure_correction_step(
+            state,
+            end - start,
+            operators,
+            selected,
+            start,
+            args,
+        )
+        fields = (updated.velocity, updated.pressure, *updated.velocity_history)
+        return FiniteElementAttemptResult(
+            fields,
+            diagnostics.successful,
+            retry_requested=~diagnostics.successful,
+            suggested_step=0.5 * (end - start),
+            diagnostics=diagnostics,
+        )
+
+    return FiniteElementAcceptedStepSchedule(
+        attempt,
+        policy=step_policy,
+        schedule_id="incompressible-flow-pressure-correction",
+    )
+
+
+__all__ = [
+    "IncompressibleFlowDiagnostics",
+    "IncompressibleFlowOperators",
+    "IncompressibleFlowPolicy",
+    "IncompressibleFlowState",
+    "incompressible_flow_schedule",
+    "oifs_history_combination",
+    "pressure_correction_step",
+]

--- a/phydrax/discretization/fem/__init__.py
+++ b/phydrax/discretization/fem/__init__.py
@@ -66,7 +66,28 @@ from ._local_elimination import (
     FiniteElementLocalEliminationPlan,
     LocalEliminationResult,
 )
-from ._multigrid import PTransferData, quadrilateral_p_transfer
+from ._low_order_auxiliary import (
+    LowOrderAuxiliaryOperatorPlan,
+    LowOrderAuxiliaryPreconditioner,
+)
+from ._multigrid import (
+    finite_element_p_transfer,
+    FiniteElementPTransfer,
+    PTransferData,
+    PTransferRole,
+    quadrilateral_p_transfer,
+)
+from ._p_multigrid import (
+    finite_element_p_multigrid_plan,
+    FiniteElementPMultigridPlan,
+    FiniteElementPMultigridPolicy,
+    PDegreeCoarsening,
+)
+from ._patch_preconditioning import (
+    FiniteElementPatchPlan,
+    FiniteElementPatchPreconditioner,
+    one_ring_patch_plan,
+)
 from ._precision import FiniteElementPrecisionPolicy
 from ._reference import (
     discontinuous_element,
@@ -103,12 +124,24 @@ __all__ = [
     "local_diagonal",
     "FiniteElementTransferRole",
     "coarsen_triangles_local",
+    "LowOrderAuxiliaryOperatorPlan",
+    "LowOrderAuxiliaryPreconditioner",
     "dorfler_mark",
     "local_dual_weighted_residual",
     "maximum_mark",
     "refine_triangles_local",
+    "finite_element_p_transfer",
+    "FiniteElementPTransfer",
     "PTransferData",
+    "PTransferRole",
     "quadrilateral_p_transfer",
+    "finite_element_p_multigrid_plan",
+    "FiniteElementPMultigridPlan",
+    "FiniteElementPMultigridPolicy",
+    "PDegreeCoarsening",
+    "FiniteElementPatchPlan",
+    "FiniteElementPatchPreconditioner",
+    "one_ring_patch_plan",
     "refine_triangles_uniform",
     "affine_dof_constraint",
     "dual_weighted_residual_estimate",

--- a/phydrax/discretization/fem/_low_order_auxiliary.py
+++ b/phydrax/discretization/fem/_low_order_auxiliary.py
@@ -1,0 +1,132 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jaxtyping import ArrayLike, PyTree
+
+from ..._fingerprint import canonical_fingerprint
+from ..._strict import StrictModule
+from ..._trainable import NonTrainableState
+from ...linalg import (
+    AbstractLinearOperator,
+    AbstractPreconditioner,
+    PreconditionerProperties,
+)
+
+
+class LowOrderAuxiliaryOperatorPlan(StrictModule, NonTrainableState):
+    interpolation: AbstractLinearOperator
+    anterpolation: AbstractLinearOperator
+    multiplicity_weight: object
+    plan_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        interpolation: AbstractLinearOperator,
+        anterpolation: AbstractLinearOperator,
+        multiplicity_weight: object,
+        /,
+    ):
+        if not isinstance(interpolation, AbstractLinearOperator) or not isinstance(
+            anterpolation, AbstractLinearOperator
+        ):
+            raise TypeError("Auxiliary transfers must be linear operators.")
+        if not interpolation.source.compatible(
+            anterpolation.target
+        ) or not interpolation.target.compatible(anterpolation.source):
+            raise ValueError(
+                "Auxiliary interpolation/anterpolation spaces are incompatible."
+            )
+        weight = interpolation.source.validate(multiplicity_weight)
+        leaves = jax.tree.leaves(weight)
+        if any(bool(jnp.any(~jnp.isfinite(value) | (value <= 0.0))) for value in leaves):
+            raise ValueError(
+                "Auxiliary multiplicity weights must be positive and finite."
+            )
+        self.interpolation = interpolation
+        self.anterpolation = anterpolation
+        self.multiplicity_weight = weight
+        self.plan_id = canonical_fingerprint(
+            {
+                "kind": "low-order-auxiliary-operator-plan",
+                "interpolation": interpolation.operator_id,
+                "anterpolation": anterpolation.operator_id,
+                "high_space": interpolation.source.space_id,
+                "low_space": interpolation.target.space_id,
+            }
+        )
+
+
+class LowOrderAuxiliaryPreconditioner(AbstractPreconditioner):
+    plan: LowOrderAuxiliaryOperatorPlan
+    low_order_preconditioner: AbstractPreconditioner
+
+    def __init__(
+        self,
+        plan: LowOrderAuxiliaryOperatorPlan,
+        low_order_preconditioner: AbstractPreconditioner,
+        /,
+    ):
+        if not isinstance(plan, LowOrderAuxiliaryOperatorPlan) or not isinstance(
+            low_order_preconditioner, AbstractPreconditioner
+        ):
+            raise TypeError("Auxiliary preconditioner inputs are invalid.")
+        if not low_order_preconditioner.space.compatible(plan.interpolation.target):
+            raise ValueError("Low-order preconditioner acts on the wrong space.")
+        self.plan = plan
+        self.low_order_preconditioner = low_order_preconditioner
+        self.space = plan.interpolation.source
+        self.properties = PreconditionerProperties(
+            linear=low_order_preconditioner.properties.certifies("linear"),
+            stationary=low_order_preconditioner.properties.certifies("stationary"),
+            evidence={
+                name: "transformed"
+                for name in ("linear", "stationary")
+                if low_order_preconditioner.properties.certifies(name)
+            },
+        )
+        self.preconditioner_id = canonical_fingerprint(
+            {
+                "kind": "low-order-auxiliary-preconditioner",
+                "plan": plan.plan_id,
+                "inner": low_order_preconditioner.preconditioner_id,
+            }
+        )
+
+    def apply(
+        self,
+        residual: PyTree,
+        /,
+        *,
+        iteration: ArrayLike | None = None,
+    ):
+        checked = self.space.validate(residual)
+        weighted = jax.tree.map(
+            lambda value, weight: value * weight,
+            checked,
+            self.plan.multiplicity_weight,
+        )
+        low_residual = self.plan.interpolation.mv(weighted)
+        low_correction = self.low_order_preconditioner.apply(
+            low_residual,
+            iteration=iteration,
+        )
+        high_correction = self.plan.anterpolation.mv(low_correction)
+        return self.space.validate(
+            jax.tree.map(
+                lambda value, weight: value * weight,
+                high_correction,
+                self.plan.multiplicity_weight,
+            )
+        )
+
+
+__all__ = [
+    "LowOrderAuxiliaryOperatorPlan",
+    "LowOrderAuxiliaryPreconditioner",
+]

--- a/phydrax/discretization/fem/_multigrid.py
+++ b/phydrax/discretization/fem/_multigrid.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 import equinox as eqx
 import jax.numpy as jnp
 import opt_einsum as oe
@@ -12,7 +14,15 @@ from jaxtyping import Array, ArrayLike
 from ..._fingerprint import canonical_fingerprint
 from ..._strict import StrictModule
 from ..._trainable import NonTrainableState
+from ...linalg import (
+    ArraySpace,
+    DenseLinearOperator,
+    FactorizationPolicy,
+    factorize,
+    OperatorProperties,
+)
 from ._high_order import ReferenceNodalFamily
+from ._reference import FiniteElementSpec
 
 
 class PTransferData(StrictModule, NonTrainableState):
@@ -78,18 +88,150 @@ def quadrilateral_p_transfer(
         raise TypeError("p-transfer requires ReferenceNodalFamily values.")
     if coarse.cell_kind != fine.cell_kind or fine.order <= coarse.order:
         raise ValueError("p-transfer families require one cell and increasing order.")
-    fine_nodes = jnp.stack(
-        jnp.meshgrid(fine.axis_nodes, fine.axis_nodes, indexing="ij"), axis=-1
-    ).reshape((-1, 2))
-    prolongation, _ = coarse.tabulate(fine_nodes)
-    mass = prolongation.T @ prolongation
-    restriction = jnp.linalg.solve(mass, prolongation.T)
+    transfer = finite_element_p_transfer(
+        coarse.finite_element(),
+        fine.finite_element(),
+    )
     return PTransferData(
-        prolongation,
-        restriction,
+        transfer.primal_prolongation,
+        transfer.mass_projection,
         coarse.order,
         fine.order,
     )
 
 
-__all__ = ["PTransferData", "quadrilateral_p_transfer"]
+PTransferRole = Literal[
+    "primal-prolongation",
+    "dual-pullback",
+    "pairing-adjoint",
+    "mass-projection",
+]
+
+
+class FiniteElementPTransfer(StrictModule, NonTrainableState):
+    """Local fixed-mesh p-transfer with explicit primal and dual roles."""
+
+    primal_prolongation: Array
+    dual_pullback: Array
+    pairing_adjoint: Array
+    mass_projection: Array
+    coarse_element_id: str = eqx.field(static=True)
+    fine_element_id: str = eqx.field(static=True)
+    transfer_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        primal_prolongation: ArrayLike,
+        pairing_adjoint: ArrayLike,
+        coarse_element_id: str,
+        fine_element_id: str,
+        /,
+    ):
+        prolongation = jnp.asarray(primal_prolongation)
+        adjoint = jnp.asarray(pairing_adjoint)
+        if prolongation.ndim != 2 or adjoint.shape != prolongation.T.shape:
+            raise ValueError("Finite-element p-transfer shapes are incompatible.")
+        identifiers = (str(coarse_element_id), str(fine_element_id))
+        if any(not value for value in identifiers):
+            raise ValueError("Finite-element p-transfer identities must be non-empty.")
+        self.primal_prolongation = prolongation
+        self.dual_pullback = prolongation.T
+        self.pairing_adjoint = adjoint
+        self.mass_projection = adjoint
+        self.coarse_element_id, self.fine_element_id = identifiers
+        self.transfer_id = canonical_fingerprint(
+            {
+                "kind": "finite-element-p-transfer-roles",
+                "coarse": identifiers[0],
+                "fine": identifiers[1],
+                "shape": list(prolongation.shape),
+            }
+        )
+
+    def apply(self, role: PTransferRole, value: ArrayLike, /) -> Array:
+        value_ = jnp.asarray(value)
+        if role == "primal-prolongation":
+            return self.primal_prolongation @ value_
+        if role == "dual-pullback":
+            return self.dual_pullback @ value_
+        if role == "pairing-adjoint":
+            return self.pairing_adjoint @ value_
+        if role == "mass-projection":
+            return self.mass_projection @ value_
+        raise ValueError("Unknown p-transfer role.")
+
+
+def finite_element_p_transfer(
+    coarse: FiniteElementSpec,
+    fine: FiniteElementSpec,
+    /,
+    *,
+    coarse_mass: ArrayLike | None = None,
+    fine_mass: ArrayLike | None = None,
+) -> FiniteElementPTransfer:
+    if not isinstance(coarse, FiniteElementSpec) or not isinstance(
+        fine, FiniteElementSpec
+    ):
+        raise TypeError("p-transfer requires FiniteElementSpec values.")
+    if (
+        coarse.cell_kind != fine.cell_kind
+        or coarse.conformity != fine.conformity
+        or fine.degree <= coarse.degree
+    ):
+        raise ValueError(
+            "p-transfer elements require one cell/conformity and increasing degree."
+        )
+    prolongation, _ = coarse.tabulate(fine.reference_nodes)
+    if coarse_mass is None and fine_mass is None:
+        pairing_adjoint = prolongation.T
+    elif coarse_mass is None or fine_mass is None:
+        raise ValueError("Pairing-aware p-transfer requires both mass matrices.")
+    else:
+        coarse_mass_ = jnp.asarray(coarse_mass)
+        fine_mass_ = jnp.asarray(fine_mass)
+        if coarse_mass_.shape != (
+            coarse.local_dof_count,
+            coarse.local_dof_count,
+        ) or fine_mass_.shape != (fine.local_dof_count, fine.local_dof_count):
+            raise ValueError("p-transfer mass matrix shapes are incompatible.")
+        coarse_space = ArraySpace((coarse.local_dof_count,), dtype=coarse_mass_.dtype)
+        coarse_operator = DenseLinearOperator(
+            coarse_mass_,
+            source=coarse_space,
+            target=coarse_space,
+            properties=OperatorProperties(
+                self_adjoint=True,
+                positive_definite=True,
+                evidence={
+                    "self_adjoint": "supplied mass matrix",
+                    "positive_definite": "supplied mass matrix",
+                },
+            ),
+        )
+        prepared = factorize(
+            coarse_operator,
+            FactorizationPolicy(kind="cholesky"),
+        )
+        right_hand_side = prolongation.T @ fine_mass_
+        result = prepared.solve(right_hand_side)
+        pairing_adjoint = result.value
+        pairing_adjoint = eqx.error_if(
+            pairing_adjoint,
+            ~jnp.all(result.successful),
+            "Pairing-aware p-transfer mass solve failed.",
+        )
+    return FiniteElementPTransfer(
+        prolongation,
+        pairing_adjoint,
+        coarse.element_id,
+        fine.element_id,
+    )
+
+
+__all__ = [
+    "FiniteElementPTransfer",
+    "PTransferData",
+    "PTransferRole",
+    "finite_element_p_transfer",
+    "quadrilateral_p_transfer",
+]

--- a/phydrax/discretization/fem/_p_multigrid.py
+++ b/phydrax/discretization/fem/_p_multigrid.py
@@ -1,0 +1,214 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from typing import Literal
+
+import equinox as eqx
+
+from ..._fingerprint import canonical_fingerprint
+from ..._strict import StrictModule
+from ..._trainable import NonTrainableState
+from ...linalg import (
+    AbstractLinearOperator,
+    AbstractPreconditioner,
+    AbstractPreconditionerBuilder,
+    MultigridCyclePolicy,
+    MultigridHierarchyBuilder,
+    MultigridLevelBuilder,
+    PreconditionerProperties,
+)
+
+
+PDegreeCoarsening = Literal[
+    "all-degrees",
+    "half-degrees",
+    "half-dofs",
+    "explicit",
+]
+
+
+def _local_dof_count(cell_kind: str, order: int) -> int:
+    if cell_kind == "triangle":
+        return (order + 1) * (order + 2) // 2
+    if cell_kind == "quadrilateral":
+        return (order + 1) ** 2
+    if cell_kind == "tetrahedron":
+        return (order + 1) * (order + 2) * (order + 3) // 6
+    if cell_kind == "hexahedron":
+        return (order + 1) ** 3
+    raise ValueError("Unknown finite-element cell kind.")
+
+
+class FiniteElementPMultigridPolicy(StrictModule, NonTrainableState):
+    degree_coarsening: PDegreeCoarsening = eqx.field(static=True)
+    explicit_orders: tuple[int, ...] = eqx.field(static=True)
+    pre_smoothing: int = eqx.field(static=True)
+    post_smoothing: int = eqx.field(static=True)
+    cycle: str = eqx.field(static=True)
+    policy_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        degree_coarsening: PDegreeCoarsening = "half-dofs",
+        /,
+        *,
+        explicit_orders: tuple[int, ...] = (),
+        pre_smoothing: int = 1,
+        post_smoothing: int = 1,
+        cycle: str = "v",
+    ):
+        coarsening = str(degree_coarsening)
+        orders = tuple(int(value) for value in explicit_orders)
+        pre = int(pre_smoothing)
+        post = int(post_smoothing)
+        cycle_ = str(cycle)
+        if coarsening not in (
+            "all-degrees",
+            "half-degrees",
+            "half-dofs",
+            "explicit",
+        ):
+            raise ValueError("Unknown p-multigrid degree coarsening policy.")
+        if coarsening == "explicit" and (
+            not orders
+            or orders[-1] != 1
+            or any(left <= right for left, right in zip(orders, orders[1:], strict=True))
+        ):
+            raise ValueError("Explicit p-level orders must decrease strictly to one.")
+        if coarsening != "explicit" and orders:
+            raise ValueError("explicit_orders require explicit degree coarsening.")
+        if pre < 0 or post < 0 or cycle_ not in ("v", "w", "f", "full"):
+            raise ValueError("p-multigrid smoothing/cycle policy is invalid.")
+        self.degree_coarsening = coarsening
+        self.explicit_orders = orders
+        self.pre_smoothing = pre
+        self.post_smoothing = post
+        self.cycle = cycle_
+        self.policy_id = canonical_fingerprint(
+            {
+                "kind": "finite-element-p-multigrid-policy",
+                "degree_coarsening": coarsening,
+                "explicit_orders": list(orders),
+                "pre_smoothing": pre,
+                "post_smoothing": post,
+                "cycle": cycle_,
+            }
+        )
+
+    def degree_sequence(self, cell_kind: str, fine_order: int, /) -> tuple[int, ...]:
+        fine = int(fine_order)
+        if fine < 1:
+            raise ValueError("Fine polynomial order must be positive.")
+        if self.degree_coarsening == "explicit":
+            if self.explicit_orders[0] != fine:
+                raise ValueError("Explicit p-level sequence must start at fine_order.")
+            return self.explicit_orders
+        orders = [fine]
+        current = fine
+        while current > 1:
+            if self.degree_coarsening == "all-degrees":
+                coarse = current - 1
+            elif self.degree_coarsening == "half-degrees":
+                coarse = max(1, (current + 1) // 2)
+            else:
+                fine_count = _local_dof_count(cell_kind, current)
+                coarse = current - 1
+                while coarse > 1 and _local_dof_count(cell_kind, coarse) > fine_count / 2:
+                    coarse -= 1
+            if coarse >= current:
+                raise ValueError("p-level coarsening failed to reduce polynomial order.")
+            orders.append(coarse)
+            current = coarse
+        return tuple(orders)
+
+
+class FiniteElementPMultigridPlan(StrictModule, NonTrainableState):
+    level_orders: tuple[int, ...] = eqx.field(static=True)
+    hierarchy_builder: MultigridHierarchyBuilder
+    policy: FiniteElementPMultigridPolicy
+    plan_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        level_orders: tuple[int, ...],
+        hierarchy_builder: MultigridHierarchyBuilder,
+        policy: FiniteElementPMultigridPolicy,
+        /,
+    ):
+        if not isinstance(hierarchy_builder, MultigridHierarchyBuilder) or not isinstance(
+            policy, FiniteElementPMultigridPolicy
+        ):
+            raise TypeError("p-multigrid plan requires hierarchy builder and policy.")
+        orders = tuple(int(value) for value in level_orders)
+        if len(orders) != len(hierarchy_builder.levels):
+            raise ValueError("p-level orders must match hierarchy levels.")
+        self.level_orders = orders
+        self.hierarchy_builder = hierarchy_builder
+        self.policy = policy
+        self.plan_id = canonical_fingerprint(
+            {
+                "kind": "finite-element-p-multigrid-plan",
+                "orders": list(orders),
+                "hierarchy": hierarchy_builder.builder_id,
+                "policy": policy.policy_id,
+            }
+        )
+
+
+def finite_element_p_multigrid_plan(
+    cell_kind: str,
+    fine_order: int,
+    operators: tuple[AbstractLinearOperator, ...],
+    smoothers: tuple[AbstractPreconditioner | AbstractPreconditionerBuilder, ...],
+    restrictions: tuple[AbstractLinearOperator, ...],
+    prolongations: tuple[AbstractLinearOperator, ...],
+    /,
+    *,
+    policy: FiniteElementPMultigridPolicy | None = None,
+    properties: PreconditionerProperties | None = None,
+) -> FiniteElementPMultigridPlan:
+    selected = FiniteElementPMultigridPolicy() if policy is None else policy
+    if not isinstance(selected, FiniteElementPMultigridPolicy):
+        raise TypeError("policy must be FiniteElementPMultigridPolicy or None.")
+    orders = selected.degree_sequence(cell_kind, fine_order)
+    if (
+        len(operators) != len(orders)
+        or len(smoothers) != len(orders)
+        or len(restrictions) != len(orders) - 1
+        or len(prolongations) != len(orders) - 1
+    ):
+        raise ValueError(
+            "p-multigrid operators, smoothers, and transfers are incomplete."
+        )
+    levels = []
+    for index, (operator, smoother) in enumerate(zip(operators, smoothers, strict=True)):
+        if index == len(orders) - 1:
+            levels.append(MultigridLevelBuilder(operator, smoother))
+        else:
+            levels.append(
+                MultigridLevelBuilder(
+                    operator,
+                    smoother,
+                    restriction=restrictions[index],
+                    prolongation=prolongations[index],
+                    pre_smoothing=selected.pre_smoothing,
+                    post_smoothing=selected.post_smoothing,
+                )
+            )
+    builder = MultigridHierarchyBuilder(
+        tuple(levels),
+        properties=properties,
+        cycle_policy=MultigridCyclePolicy(selected.cycle),
+    )
+    return FiniteElementPMultigridPlan(orders, builder, selected)
+
+
+__all__ = [
+    "FiniteElementPMultigridPlan",
+    "FiniteElementPMultigridPolicy",
+    "PDegreeCoarsening",
+    "finite_element_p_multigrid_plan",
+]

--- a/phydrax/discretization/fem/_patch_preconditioning.py
+++ b/phydrax/discretization/fem/_patch_preconditioning.py
@@ -1,0 +1,182 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import equinox as eqx
+import jax.numpy as jnp
+import numpy as np
+import opt_einsum as oe
+from jaxtyping import Array, ArrayLike, PyTree
+
+from ..._fingerprint import canonical_fingerprint
+from ..._strict import StrictModule
+from ..._trainable import NonTrainableState
+from ...linalg import AbstractPreconditioner, PreconditionerProperties
+from ._generic import FiniteElementDiscretization
+
+
+class FiniteElementPatchPlan(StrictModule, NonTrainableState):
+    gathers: Array
+    valid: Array
+    partition_weights: Array
+    global_size: int = eqx.field(static=True)
+    patch_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        gathers: ArrayLike,
+        valid: ArrayLike,
+        partition_weights: ArrayLike,
+        global_size: int,
+        /,
+    ):
+        routes = jnp.asarray(gathers, dtype=jnp.int32)
+        valid_ = jnp.asarray(valid, dtype=bool)
+        weights = jnp.asarray(partition_weights)
+        size = int(global_size)
+        if (
+            routes.ndim != 2
+            or valid_.shape != routes.shape
+            or weights.shape != routes.shape
+        ):
+            raise ValueError(
+                "Patch gather, validity, and weight layouts are incompatible."
+            )
+        if size <= 0 or bool(jnp.any(valid_ & ((routes < 0) | (routes >= size)))):
+            raise ValueError("Patch routes/global size are invalid.")
+        if bool(jnp.any(jnp.where(valid_, weights <= 0.0, weights != 0.0))):
+            raise ValueError(
+                "Patch partition weights must be positive only on valid routes."
+            )
+        self.gathers = routes
+        self.valid = valid_
+        self.partition_weights = weights
+        self.global_size = size
+        self.patch_id = canonical_fingerprint(
+            {
+                "kind": "finite-element-one-ring-patch-plan",
+                "patches": int(routes.shape[0]),
+                "width": int(routes.shape[1]),
+                "global_size": size,
+            }
+        )
+
+
+def one_ring_patch_plan(
+    discretization: FiniteElementDiscretization,
+    field_name: str,
+    /,
+) -> FiniteElementPatchPlan:
+    if not isinstance(discretization, FiniteElementDiscretization):
+        raise TypeError("discretization must be FiniteElementDiscretization.")
+    field_index = discretization._field_index(field_name)
+    dof_map = discretization.dof_maps[field_index]
+    cell_count = sum(block.cell_count for block in discretization.mesh.blocks)
+    block_by_cell = []
+    local_by_cell = []
+    for block_index, block in enumerate(discretization.mesh.blocks):
+        block_by_cell.extend((block_index,) * block.cell_count)
+        local_by_cell.extend(range(block.cell_count))
+    neighbours = [set((cell,)) for cell in range(cell_count)]
+    for owner, neighbour in zip(
+        np.asarray(discretization.interior_facet_domain.owner_cells),
+        np.asarray(discretization.interior_facet_domain.neighbour_cells),
+        strict=True,
+    ):
+        neighbours[int(owner)].add(int(neighbour))
+        neighbours[int(neighbour)].add(int(owner))
+    patches = []
+    for cells in neighbours:
+        dofs = set()
+        for cell in sorted(cells):
+            block = block_by_cell[cell]
+            local = local_by_cell[cell]
+            dofs.update(np.asarray(dof_map.cell_dofs[block][local]).tolist())
+        patches.append(tuple(sorted(dofs)))
+    width = max(len(patch) for patch in patches)
+    routes = np.zeros((cell_count, width), dtype=np.int32)
+    valid = np.zeros((cell_count, width), dtype=bool)
+    for patch, values in enumerate(patches):
+        routes[patch, : len(values)] = values
+        valid[patch, : len(values)] = True
+    coverage = np.zeros((dof_map.global_dof_count,), dtype=np.int32)
+    np.add.at(coverage, routes[valid], 1)
+    weights = np.zeros_like(
+        routes, dtype=np.asarray(discretization.mesh.coordinates).dtype
+    )
+    weights[valid] = 1.0 / coverage[routes[valid]]
+    return FiniteElementPatchPlan(
+        routes,
+        valid,
+        weights,
+        dof_map.global_dof_count,
+    )
+
+
+class FiniteElementPatchPreconditioner(AbstractPreconditioner):
+    plan: FiniteElementPatchPlan
+    local_inverse: Array
+
+    def __init__(
+        self,
+        plan: FiniteElementPatchPlan,
+        local_inverse: ArrayLike,
+        space,
+        /,
+    ):
+        if not isinstance(plan, FiniteElementPatchPlan):
+            raise TypeError("plan must be FiniteElementPatchPlan.")
+        inverse = jnp.asarray(local_inverse)
+        if inverse.shape != plan.gathers.shape + (plan.gathers.shape[1],):
+            raise ValueError("Patch inverse matrices have an incompatible shape.")
+        if space.size != plan.global_size:
+            raise ValueError("Patch preconditioner space does not match patch plan.")
+        self.plan = plan
+        self.local_inverse = inverse
+        self.space = space
+        self.properties = PreconditionerProperties(
+            linear=True,
+            stationary=True,
+            evidence={"linear": "construction", "stationary": "construction"},
+        )
+        self.preconditioner_id = canonical_fingerprint(
+            {
+                "kind": "finite-element-one-ring-preconditioner",
+                "patch": plan.patch_id,
+                "space": space.space_id,
+                "inverse_shape": list(inverse.shape),
+            }
+        )
+
+    def apply(
+        self,
+        residual: PyTree,
+        /,
+        *,
+        iteration: ArrayLike | None = None,
+    ):
+        coordinates = self.space.flatten(self.space.validate(residual))
+        safe_routes = jnp.maximum(self.plan.gathers, 0)
+        local = coordinates[safe_routes]
+        local = jnp.where(self.plan.valid, local, 0.0)
+        correction = oe.contract("pij,pj->pi", self.local_inverse, local)
+        correction = jnp.where(
+            self.plan.valid,
+            correction * self.plan.partition_weights,
+            0.0,
+        )
+        assembled = (
+            jnp.zeros((self.plan.global_size,), dtype=correction.dtype)
+            .at[safe_routes]
+            .add(correction)
+        )
+        return self.space.unflatten(assembled)
+
+
+__all__ = [
+    "FiniteElementPatchPlan",
+    "FiniteElementPatchPreconditioner",
+    "one_ring_patch_plan",
+]

--- a/phydrax/equations/_finite_element_variational.py
+++ b/phydrax/equations/_finite_element_variational.py
@@ -1763,6 +1763,67 @@ class CompiledFiniteElementProblem(StrictModule, NonTrainableState):
             else compiled.linearization_operator(state, args)
         )
 
+    def exact_diagonal(
+        self,
+        state: object | None = None,
+        args: object = None,
+        /,
+        *,
+        allow_coordinate_fallback: bool = False,
+        maximum_coordinate_size: int = 4096,
+    ):
+        from .fem import FiniteElementDiagonalData
+
+        raw = (
+            self.affine_operator(args)
+            if state is None
+            else self.operator_function(self.state_space.validate(state), args)
+        )
+        method = "workset"
+        if isinstance(raw, SparseCoordinateOperator) and isinstance(
+            raw.relation, EdgeRelation
+        ):
+            relation = raw.relation
+            on_diagonal = relation.valid & (
+                relation.source_indices == relation.target_indices
+            )
+            diagonal = (
+                jnp.zeros((relation.source_size,), dtype=raw.coefficients.dtype)
+                .at[relation.source_indices]
+                .add(jnp.where(on_diagonal, raw.coefficients, 0.0))
+            )
+            method = "sparse-coordinate"
+        elif raw.capabilities.diagonal_assembly:
+            diagonal = assemble_diagonal(raw)
+        else:
+            if not allow_coordinate_fallback:
+                raise ValueError(
+                    "Exact diagonal lowering is unavailable; explicitly enable the "
+                    "bounded coordinate-linearization fallback."
+                )
+            limit = int(maximum_coordinate_size)
+            if limit < 1 or self.state_space.size > limit:
+                raise ValueError(
+                    "Coordinate diagonal fallback exceeds its explicit dimension cap."
+                )
+            coordinates = jnp.eye(
+                self.state_space.size,
+                dtype=self.state_space.flatten(self.state_space.zeros()).dtype,
+            )
+
+            def column(direction):
+                image = raw.mv(self.state_space.unflatten(direction))
+                return self.residual_space.flatten(image)
+
+            matrix_columns = jax.vmap(column)(coordinates)
+            diagonal = self.state_space.unflatten(jnp.diag(matrix_columns))
+            method = "coordinate-linearization"
+        return FiniteElementDiagonalData(
+            diagonal,
+            method,
+            raw.operator_id,
+        )
+
     def preconditioner_data(
         self,
         state: object | None = None,
@@ -1771,39 +1832,12 @@ class CompiledFiniteElementProblem(StrictModule, NonTrainableState):
     ):
         from .fem import FiniteElementPreconditionerData
 
-        raw = (
-            self.affine_operator(args)
-            if state is None
-            else self.operator_function(self.state_space.validate(state), args)
+        diagonal_data = self.exact_diagonal(
+            state,
+            args,
+            allow_coordinate_fallback=False,
         )
-        if isinstance(raw, BlockLinearOperator):
-            diagonal = tuple(
-                (
-                    jnp.zeros(space.structure().shape, dtype=space.structure().dtype)
-                    if raw.blocks[index][index] is None
-                    else assemble_diagonal(raw.blocks[index][index])
-                )
-                for index, space in enumerate(self.state_space.spaces)
-            )
-        else:
-            if isinstance(raw, SparseCoordinateOperator) and isinstance(
-                raw.relation, EdgeRelation
-            ):
-                relation = raw.relation
-                on_diagonal = relation.valid & (
-                    relation.source_indices == relation.target_indices
-                )
-                diagonal = (
-                    jnp.zeros((relation.source_size,), dtype=raw.coefficients.dtype)
-                    .at[relation.source_indices]
-                    .add(jnp.where(on_diagonal, raw.coefficients, 0.0))
-                )
-            else:
-                if not raw.capabilities.diagonal_assembly:
-                    raise ValueError(
-                        "Exact FE preconditioner data require diagonal-capable lowering."
-                    )
-                diagonal = assemble_diagonal(raw)
+        diagonal = diagonal_data.diagonal
         graph = (
             self.block_dependency_graph()
             if len(self.form.field_names) > 1

--- a/phydrax/equations/fem/__init__.py
+++ b/phydrax/equations/fem/__init__.py
@@ -3,7 +3,9 @@
 #
 
 from ._execution import (
+    CollocatedTensorProductOperator,
     ElementTensorOperator,
+    FiniteElementDiagonalData,
     FiniteElementPreconditionerData,
     PartialAssemblyOperator,
     TensorProductAction,
@@ -40,7 +42,9 @@ from ._observations import (
 )
 from ._operators import (
     average,
+    CellDerivativeBatch,
     curl,
+    DGTraceBatch,
     divergence,
     FacetJet,
     FieldJet,
@@ -65,17 +69,27 @@ from ._proofs import (
     stokes_form,
     upwind_advection_form,
 )
+from ._quadrature import (
+    QuadratureAccuracyKind,
+    QuadratureAccuracyPolicy,
+    QuadratureEvidence,
+    QuadratureRole,
+)
 from ._worksets import CompiledWorkset, WorksetProgram, WorksetSignature
 
 
 __all__ = [
     "ElementTensorOperator",
+    "CollocatedTensorProductOperator",
     "PartialAssemblyOperator",
     "CoordinateObservation",
     "ActionKind",
+    "CellDerivativeBatch",
+    "DGTraceBatch",
     "CompiledWorkset",
     "HDGPoissonSolution",
     "DifferentialOperator",
+    "FiniteElementDiagonalData",
     "FiniteElementPreconditionerData",
     "FiniteElementAuxiliaryEvaluation",
     "FiniteElementAdjointResult",
@@ -98,6 +112,10 @@ __all__ = [
     "WorksetSignature",
     "average",
     "darcy_form",
+    "QuadratureAccuracyKind",
+    "QuadratureAccuracyPolicy",
+    "QuadratureEvidence",
+    "QuadratureRole",
     "linear_elasticity_form",
     "maxwell_form",
     "SIPGBoundaryCondition",

--- a/phydrax/equations/fem/_execution.py
+++ b/phydrax/equations/fem/_execution.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from typing import Literal
 
 import equinox as eqx
+import jax
 import jax.numpy as jnp
 import opt_einsum as oe
 from jaxtyping import Array, ArrayLike
@@ -324,6 +325,56 @@ class PartialAssemblyOperator(StrictModule, NonTrainableState):
 TensorProductAction = Literal["mass", "diffusion"]
 
 
+class FiniteElementDiagonalData(StrictModule, NonTrainableState):
+    """Exact coordinate diagonal with explicit construction provenance."""
+
+    diagonal: object
+    zero_mask: object
+    negative_mask: object
+    method: str = eqx.field(static=True)
+    operator_id: str = eqx.field(static=True)
+    numeric_version: Array
+    diagonal_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        diagonal: object,
+        method: str,
+        operator_id: str,
+        /,
+        *,
+        numeric_version: ArrayLike = 0,
+    ):
+        method_ = str(method)
+        operator = str(operator_id)
+        version = jnp.asarray(numeric_version, dtype=jnp.int32)
+        if method_ not in ("sparse-coordinate", "workset", "coordinate-linearization"):
+            raise ValueError("Unknown finite-element diagonal construction method.")
+        if not operator or version.shape != () or version < 0:
+            raise ValueError("Diagonal operator identity/version are invalid.")
+        leaves = jax.tree.leaves(diagonal)
+        if not leaves or any(
+            not jnp.issubdtype(jnp.asarray(value).dtype, jnp.inexact) for value in leaves
+        ):
+            raise TypeError("Finite-element diagonal must contain inexact arrays.")
+        self.diagonal = diagonal
+        self.zero_mask = jax.tree.map(lambda value: jnp.asarray(value) == 0, diagonal)
+        self.negative_mask = jax.tree.map(
+            lambda value: jnp.real(jnp.asarray(value)) < 0, diagonal
+        )
+        self.method = method_
+        self.operator_id = operator
+        self.numeric_version = version
+        self.diagonal_id = canonical_fingerprint(
+            {
+                "kind": "finite-element-diagonal-data",
+                "method": method_,
+                "operator": operator,
+                "shape": [list(jnp.asarray(value).shape) for value in leaves],
+            }
+        )
+
+
 class FiniteElementPreconditionerData(StrictModule, NonTrainableState):
     """Prepared diagonal/block/workset evidence for generic preconditioner builders."""
 
@@ -483,7 +534,150 @@ class TensorProductPartialAssemblyOperator(StrictModule, NonTrainableState):
         )
 
 
+class CollocatedTensorProductOperator(StrictModule, NonTrainableState):
+    """Collocated quad/hex mass-diffusion action with packed metric entries."""
+
+    derivative: Array
+    weighted_metric: Array
+    weighted_mass: Array
+    gathers: Array
+    valid: Array
+    dimension: int = eqx.field(static=True)
+    global_size: int = eqx.field(static=True)
+    properties: OperatorProperties
+    operator_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        derivative: ArrayLike,
+        weighted_metric: ArrayLike,
+        weighted_mass: ArrayLike,
+        gathers: ArrayLike,
+        global_size: int,
+        /,
+        *,
+        valid: ArrayLike | None = None,
+    ):
+        derivative_ = jnp.asarray(derivative)
+        metric = jnp.asarray(weighted_metric)
+        mass = jnp.asarray(weighted_mass)
+        routes = jnp.asarray(gathers, dtype=jnp.int32)
+        size = int(global_size)
+        if derivative_.ndim != 2 or derivative_.shape[0] != derivative_.shape[1]:
+            raise ValueError("Collocated derivative must be one square matrix.")
+        points = int(derivative_.shape[0])
+        if metric.ndim == 4 and metric.shape[-1] == 3:
+            dimension = 2
+            expected_grid = (points, points)
+        elif metric.ndim == 5 and metric.shape[-1] == 6:
+            dimension = 3
+            expected_grid = (points, points, points)
+        else:
+            raise ValueError("Collocated metric must pack 2-D or 3-D symmetric entries.")
+        if metric.shape[1:-1] != expected_grid or mass.shape != metric.shape[:-1]:
+            raise ValueError("Collocated metric/mass grids are incompatible.")
+        if routes.shape != (metric.shape[0], points**dimension):
+            raise ValueError("Collocated gathers do not match tensor grid size.")
+        if size <= 0 or bool(jnp.any((routes < 0) | (routes >= size))):
+            raise ValueError("Collocated tensor routes/global size are invalid.")
+        valid_ = (
+            jnp.ones((routes.shape[0],), dtype=bool)
+            if valid is None
+            else jnp.asarray(valid, dtype=bool)
+        )
+        if valid_.shape != (routes.shape[0],):
+            raise ValueError("Collocated validity must match element count.")
+        self.derivative = derivative_
+        self.weighted_metric = metric
+        self.weighted_mass = mass
+        self.gathers = routes
+        self.valid = valid_
+        self.dimension = dimension
+        self.global_size = size
+        self.properties = OperatorProperties(
+            self_adjoint=True,
+            positive_semidefinite=True,
+            evidence={
+                "self_adjoint": "construction",
+                "positive_semidefinite": "construction",
+            },
+        )
+        self.operator_id = canonical_fingerprint(
+            {
+                "kind": "collocated-tensor-product-operator",
+                "dimension": dimension,
+                "points": points,
+                "elements": int(routes.shape[0]),
+                "global_size": size,
+            }
+        )
+
+    def mv(self, value: ArrayLike, /) -> Array:
+        value_ = jnp.asarray(value)
+        if value_.shape != (self.global_size,):
+            raise ValueError("Collocated tensor input shape is incompatible.")
+        points = self.derivative.shape[0]
+        local = value_[self.gathers]
+        if self.dimension == 2:
+            q = local.reshape((-1, points, points))
+            qx = oe.contract("ia,eaj->eij", self.derivative, q)
+            qy = oe.contract("ja,eia->eij", self.derivative, q)
+            g00, g01, g11 = (
+                self.weighted_metric[..., 0],
+                self.weighted_metric[..., 1],
+                self.weighted_metric[..., 2],
+            )
+            flux_x = g00 * qx + g01 * qy
+            flux_y = g01 * qx + g11 * qy
+            output = (
+                oe.contract("ia,eij->eaj", self.derivative, flux_x)
+                + oe.contract("ja,eij->eia", self.derivative, flux_y)
+                + self.weighted_mass * q
+            )
+        else:
+            q = local.reshape((-1, points, points, points))
+            qx = oe.contract("ia,eajk->eijk", self.derivative, q)
+            qy = oe.contract("ja,eiak->eijk", self.derivative, q)
+            qz = oe.contract("ka,eija->eijk", self.derivative, q)
+            g00, g01, g02, g11, g12, g22 = tuple(
+                self.weighted_metric[..., index] for index in range(6)
+            )
+            flux_x = g00 * qx + g01 * qy + g02 * qz
+            flux_y = g01 * qx + g11 * qy + g12 * qz
+            flux_z = g02 * qx + g12 * qy + g22 * qz
+            output = (
+                oe.contract("ia,eijk->eajk", self.derivative, flux_x)
+                + oe.contract("ja,eijk->eiak", self.derivative, flux_y)
+                + oe.contract("ka,eijk->eija", self.derivative, flux_z)
+                + self.weighted_mass * q
+            )
+        contribution = output.reshape(self.gathers.shape)
+        contribution = jnp.where(self.valid[:, None], contribution, 0.0)
+        return (
+            jnp.zeros((self.global_size,), dtype=contribution.dtype)
+            .at[self.gathers]
+            .add(contribution)
+        )
+
+    def transpose_mv(self, value: ArrayLike, /) -> Array:
+        return self.mv(value)
+
+    def as_linear_operator(self, /) -> FunctionLinearOperator:
+        space = ArraySpace((self.global_size,), dtype=self.weighted_metric.dtype)
+        return FunctionLinearOperator(
+            self.mv,
+            source=space,
+            target=space,
+            transpose_action=self.transpose_mv,
+            properties=self.properties,
+            operator_id=self.operator_id,
+            closure_convert=False,
+        )
+
+
 __all__ = [
+    "CollocatedTensorProductOperator",
+    "FiniteElementDiagonalData",
     "ElementTensorOperator",
     "FiniteElementPreconditionerData",
     "PartialAssemblyOperator",

--- a/phydrax/equations/fem/_operators.py
+++ b/phydrax/equations/fem/_operators.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import jax.numpy as jnp
+import opt_einsum as oe
 from jaxtyping import Array, ArrayLike
 
 from ..._strict import StrictModule
@@ -83,6 +84,82 @@ class FacetJet(StrictModule):
         self.measure = measure_
 
 
+class CellDerivativeBatch(StrictModule):
+    """Cell-local coefficients and evaluated values/gradients for one action."""
+
+    local_coefficients: Array
+    value: Array
+    gradient: Array
+
+    def __init__(
+        self,
+        local_coefficients: ArrayLike,
+        basis_values: ArrayLike,
+        physical_gradients: ArrayLike,
+        /,
+    ):
+        coefficients = jnp.asarray(local_coefficients)
+        basis = jnp.asarray(basis_values)
+        gradients = jnp.asarray(physical_gradients)
+        if coefficients.ndim != 2 or gradients.ndim != 4:
+            raise ValueError("Scalar cell derivative staging requires rank-2/4 data.")
+        if (
+            gradients.shape[0] != coefficients.shape[0]
+            or gradients.shape[2] != coefficients.shape[1]
+        ):
+            raise ValueError("Cell derivative staging local layouts are incompatible.")
+        if basis.ndim == 2:
+            value = oe.contract("qi,ei->eq", basis, coefficients)
+        elif basis.ndim == 3 and basis.shape[:1] == coefficients.shape[:1]:
+            value = oe.contract("eqi,ei->eq", basis, coefficients)
+        else:
+            raise ValueError("Cell derivative basis values have an invalid layout.")
+        self.local_coefficients = coefficients
+        self.value = value
+        self.gradient = oe.contract("eqid,ei->eqd", gradients, coefficients)
+
+
+class DGTraceBatch(StrictModule):
+    """Packed plus/minus DG traces computed once for a facet action group."""
+
+    jet: FacetJet
+    plus_local_coefficients: Array
+    minus_local_coefficients: Array
+
+    def __init__(
+        self,
+        plus_local_coefficients: ArrayLike,
+        minus_local_coefficients: ArrayLike,
+        plus_basis_values: ArrayLike,
+        minus_basis_values: ArrayLike,
+        plus_physical_gradients: ArrayLike,
+        minus_physical_gradients: ArrayLike,
+        normal: ArrayLike,
+        measure: ArrayLike,
+        /,
+    ):
+        plus = CellDerivativeBatch(
+            plus_local_coefficients,
+            plus_basis_values,
+            plus_physical_gradients,
+        )
+        minus = CellDerivativeBatch(
+            minus_local_coefficients,
+            minus_basis_values,
+            minus_physical_gradients,
+        )
+        self.jet = FacetJet(
+            plus.value,
+            minus.value,
+            plus.gradient,
+            minus.gradient,
+            normal,
+            measure,
+        )
+        self.plus_local_coefficients = plus.local_coefficients
+        self.minus_local_coefficients = minus.local_coefficients
+
+
 def symmetric_gradient(gradient: ArrayLike, /) -> Array:
     gradient_ = jnp.asarray(gradient)
     if gradient_.shape[-1] != gradient_.shape[-2]:
@@ -149,6 +226,8 @@ def average(plus: ArrayLike, minus: ArrayLike, /) -> Array:
 
 
 __all__ = [
+    "CellDerivativeBatch",
+    "DGTraceBatch",
     "FacetJet",
     "FieldJet",
     "average",

--- a/phydrax/equations/fem/_quadrature.py
+++ b/phydrax/equations/fem/_quadrature.py
@@ -1,0 +1,158 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from typing import Literal
+
+import equinox as eqx
+
+from ..._fingerprint import canonical_fingerprint
+from ..._strict import StrictModule
+from ..._trainable import NonTrainableState
+
+
+QuadratureAccuracyKind = Literal[
+    "exact-polynomial",
+    "collocated",
+    "overintegrated",
+    "explicit-rule",
+]
+QuadratureRole = Literal[
+    "volume",
+    "interior-facet",
+    "exterior-facet",
+    "projection",
+    "observation",
+]
+
+
+class QuadratureAccuracyPolicy(StrictModule, NonTrainableState):
+    kind: QuadratureAccuracyKind = eqx.field(static=True)
+    overintegration_factor: float = eqx.field(static=True)
+    explicit_degree: int | None = eqx.field(static=True)
+    policy_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        kind: QuadratureAccuracyKind = "exact-polynomial",
+        /,
+        *,
+        overintegration_factor: float = 1.5,
+        explicit_degree: int | None = None,
+    ):
+        kind_ = str(kind)
+        factor = float(overintegration_factor)
+        degree = None if explicit_degree is None else int(explicit_degree)
+        if kind_ not in (
+            "exact-polynomial",
+            "collocated",
+            "overintegrated",
+            "explicit-rule",
+        ):
+            raise ValueError("Unknown quadrature accuracy policy.")
+        if factor < 1.0:
+            raise ValueError("Quadrature overintegration factor must be at least one.")
+        if kind_ == "explicit-rule" and (degree is None or degree < 0):
+            raise ValueError("Explicit quadrature policy requires a nonnegative degree.")
+        if kind_ != "explicit-rule" and degree is not None:
+            raise ValueError("explicit_degree requires explicit-rule policy.")
+        self.kind = kind_
+        self.overintegration_factor = factor
+        self.explicit_degree = degree
+        self.policy_id = canonical_fingerprint(
+            {
+                "kind": "quadrature-accuracy-policy",
+                "policy": kind_,
+                "overintegration_factor": factor,
+                "explicit_degree": degree,
+            }
+        )
+
+    def resolve_degree(
+        self,
+        trial_order: int,
+        test_order: int,
+        /,
+        *,
+        coordinate_order: int = 1,
+        coefficient_order: int | None = 0,
+        kernel_polynomial_degree: int | None = 1,
+    ) -> int:
+        trial = int(trial_order)
+        test = int(test_order)
+        coordinate = int(coordinate_order)
+        if min(trial, test, coordinate) < 0:
+            raise ValueError("Quadrature polynomial orders must be nonnegative.")
+        if self.kind == "explicit-rule":
+            return int(self.explicit_degree)
+        if self.kind == "collocated":
+            return max(trial, test)
+        if coefficient_order is None or kernel_polynomial_degree is None:
+            raise ValueError(
+                "Polynomial exactness requires declared coefficient and kernel degrees."
+            )
+        coefficient = int(coefficient_order)
+        kernel = int(kernel_polynomial_degree)
+        if coefficient < 0 or kernel < 0:
+            raise ValueError("Coefficient/kernel polynomial degrees must be nonnegative.")
+        exact_degree = trial + test + coefficient + kernel + max(coordinate - 1, 0)
+        if self.kind == "overintegrated":
+            return int(self.overintegration_factor * exact_degree + 0.999999999)
+        return exact_degree
+
+
+class QuadratureEvidence(StrictModule, NonTrainableState):
+    role: QuadratureRole = eqx.field(static=True)
+    requested_policy: str = eqx.field(static=True)
+    selected_degree: int = eqx.field(static=True)
+    exact: bool = eqx.field(static=True)
+    aliasing_status: str = eqx.field(static=True)
+    evidence_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        role: QuadratureRole,
+        policy: QuadratureAccuracyPolicy,
+        selected_degree: int,
+        /,
+        *,
+        exact: bool,
+        aliasing_status: str,
+    ):
+        if role not in (
+            "volume",
+            "interior-facet",
+            "exterior-facet",
+            "projection",
+            "observation",
+        ) or not isinstance(policy, QuadratureAccuracyPolicy):
+            raise ValueError("Quadrature evidence role/policy is invalid.")
+        degree = int(selected_degree)
+        aliasing = str(aliasing_status)
+        if degree < 0 or not aliasing:
+            raise ValueError("Quadrature evidence degree/status are invalid.")
+        self.role = role
+        self.requested_policy = policy.kind
+        self.selected_degree = degree
+        self.exact = bool(exact)
+        self.aliasing_status = aliasing
+        self.evidence_id = canonical_fingerprint(
+            {
+                "kind": "quadrature-evidence",
+                "role": role,
+                "policy": policy.policy_id,
+                "selected_degree": degree,
+                "exact": bool(exact),
+                "aliasing_status": aliasing,
+            }
+        )
+
+
+__all__ = [
+    "QuadratureAccuracyKind",
+    "QuadratureAccuracyPolicy",
+    "QuadratureEvidence",
+    "QuadratureRole",
+]

--- a/phydrax/linalg/__init__.py
+++ b/phydrax/linalg/__init__.py
@@ -110,6 +110,14 @@ from ._incomplete_factorizations import (
     SparseFactorizationPreconditioner,
     SparseFactorizationPreconditionerBuilder,
 )
+from ._initial_guess import (
+    HistoryLinearSolveResult,
+    LinearInitialGuessDiagnostics,
+    LinearInitialGuessStrategy,
+    LinearSolveHistory,
+    LinearSolveHistoryPolicy,
+    solve_with_history,
+)
 from ._linear_transform import (
     AbstractLinearTransform,
     DenseLinearTransform,
@@ -708,6 +716,12 @@ __all__ = [
     "FactoredMatrixEquationStatus",
     "FactoredMatrixSolution",
     "FactoredMatrixSolutionForm",
+    "HistoryLinearSolveResult",
+    "LinearInitialGuessDiagnostics",
+    "LinearInitialGuessStrategy",
+    "LinearSolveHistory",
+    "LinearSolveHistoryPolicy",
+    "solve_with_history",
     "MatrixEquationCostEstimate",
     "MatrixEquationDiagnostics",
     "MatrixEquationKind",

--- a/phydrax/linalg/_initial_guess.py
+++ b/phydrax/linalg/_initial_guess.py
@@ -1,0 +1,504 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array, ArrayLike, PyTree
+
+from .._fingerprint import canonical_fingerprint
+from .._strict import StrictModule
+from .._trainable import NonTrainableState
+from ._operators import AbstractLinearOperator
+from ._spaces import AbstractVectorSpace
+
+
+LinearInitialGuessStrategy = Literal[
+    "zero",
+    "last-solution",
+    "projection",
+    "rolling-qr",
+    "stabilized-extrapolation",
+]
+
+
+class LinearSolveHistoryPolicy(StrictModule, NonTrainableState):
+    strategy: LinearInitialGuessStrategy = eqx.field(static=True)
+    capacity: int = eqx.field(static=True)
+    extrapolation_degree: int = eqx.field(static=True)
+    rank_tolerance: float = eqx.field(static=True)
+    reorthogonalizations: int = eqx.field(static=True)
+    policy_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        strategy: LinearInitialGuessStrategy = "projection",
+        /,
+        *,
+        capacity: int = 6,
+        extrapolation_degree: int = 2,
+        rank_tolerance: float = 1.0e-10,
+        reorthogonalizations: int = 2,
+    ):
+        strategy_ = str(strategy)
+        capacity_ = int(capacity)
+        degree = int(extrapolation_degree)
+        tolerance = float(rank_tolerance)
+        reorthogonalizations_ = int(reorthogonalizations)
+        if strategy_ not in (
+            "zero",
+            "last-solution",
+            "projection",
+            "rolling-qr",
+            "stabilized-extrapolation",
+        ):
+            raise ValueError("Unknown linear initial-guess strategy.")
+        if (
+            capacity_ < 1
+            or degree < 0
+            or (strategy_ == "stabilized-extrapolation" and degree >= capacity_)
+        ):
+            raise ValueError("History capacity/degree are incompatible.")
+        if tolerance <= 0.0 or reorthogonalizations_ < 1:
+            raise ValueError("History rank controls are invalid.")
+        self.strategy = strategy_
+        self.capacity = capacity_
+        self.extrapolation_degree = degree
+        self.rank_tolerance = tolerance
+        self.reorthogonalizations = reorthogonalizations_
+        self.policy_id = canonical_fingerprint(
+            {
+                "kind": "linear-solve-history-policy",
+                "strategy": strategy_,
+                "capacity": capacity_,
+                "extrapolation_degree": degree,
+                "rank_tolerance": tolerance,
+                "reorthogonalizations": reorthogonalizations_,
+            }
+        )
+
+
+class LinearInitialGuessDiagnostics(StrictModule):
+    effective_dimension: Array
+    rank: Array
+    projection_residual_norm: Array
+    reused: Array
+    strategy: str = eqx.field(static=True)
+
+
+class LinearSolveHistory(StrictModule):
+    source: AbstractVectorSpace
+    target: AbstractVectorSpace
+    solution_basis: Array
+    rhs_image_basis: Array
+    times: Array
+    effective_dimension: Array
+    update_count: Array
+    operator_family_id: str = eqx.field(static=True)
+    constraint_id: str = eqx.field(static=True)
+    nullspace_policy_id: str = eqx.field(static=True)
+    policy: LinearSolveHistoryPolicy
+    history_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        source: AbstractVectorSpace,
+        target: AbstractVectorSpace,
+        policy: LinearSolveHistoryPolicy,
+        operator_family_id: str,
+        /,
+        *,
+        constraint_id: str = "unconstrained",
+        nullspace_policy_id: str = "none",
+        solution_basis: ArrayLike | None = None,
+        rhs_image_basis: ArrayLike | None = None,
+        times: ArrayLike | None = None,
+        effective_dimension: ArrayLike = 0,
+        update_count: ArrayLike = 0,
+    ):
+        if not isinstance(source, AbstractVectorSpace) or not isinstance(
+            target, AbstractVectorSpace
+        ):
+            raise TypeError("History spaces must be AbstractVectorSpace values.")
+        if not isinstance(policy, LinearSolveHistoryPolicy):
+            raise TypeError("policy must be LinearSolveHistoryPolicy.")
+        identifiers = (
+            str(operator_family_id),
+            str(constraint_id),
+            str(nullspace_policy_id),
+        )
+        if any(not value for value in identifiers):
+            raise ValueError("History compatibility identities must be non-empty.")
+        source_dtype = source.flatten(source.zeros()).dtype
+        target_dtype = target.flatten(target.zeros()).dtype
+        solutions = (
+            jnp.zeros((source.size, policy.capacity), dtype=source_dtype)
+            if solution_basis is None
+            else jnp.asarray(solution_basis)
+        )
+        images = (
+            jnp.zeros((target.size, policy.capacity), dtype=target_dtype)
+            if rhs_image_basis is None
+            else jnp.asarray(rhs_image_basis)
+        )
+        times_ = (
+            jnp.full((policy.capacity,), jnp.nan, dtype=jnp.float64)
+            if times is None
+            else jnp.asarray(times)
+        )
+        effective = jnp.asarray(effective_dimension, dtype=jnp.int32)
+        updates = jnp.asarray(update_count, dtype=jnp.int32)
+        if solutions.shape != (source.size, policy.capacity):
+            raise ValueError("Solution history basis has an invalid shape.")
+        if images.shape != (target.size, policy.capacity):
+            raise ValueError("RHS-image history basis has an invalid shape.")
+        if (
+            times_.shape != (policy.capacity,)
+            or effective.shape != ()
+            or updates.shape != ()
+        ):
+            raise ValueError("History time/counter layouts are invalid.")
+        effective = eqx.error_if(
+            effective,
+            (effective < 0) | (effective > policy.capacity),
+            "History effective dimension is out of bounds.",
+        )
+        self.source = source
+        self.target = target
+        self.solution_basis = solutions
+        self.rhs_image_basis = images
+        self.times = times_
+        self.effective_dimension = effective
+        self.update_count = updates
+        self.operator_family_id, self.constraint_id, self.nullspace_policy_id = (
+            identifiers
+        )
+        self.policy = policy
+        self.history_id = canonical_fingerprint(
+            {
+                "kind": "linear-solve-history",
+                "source": source.space_id,
+                "target": target.space_id,
+                "policy": policy.policy_id,
+                "operator_family": identifiers[0],
+                "constraint": identifiers[1],
+                "nullspace": identifiers[2],
+            }
+        )
+
+    @classmethod
+    def empty(
+        cls,
+        operator: AbstractLinearOperator,
+        policy: LinearSolveHistoryPolicy,
+        operator_family_id: str,
+        /,
+        *,
+        constraint_id: str = "unconstrained",
+        nullspace_policy_id: str = "none",
+    ) -> LinearSolveHistory:
+        if not isinstance(operator, AbstractLinearOperator):
+            raise TypeError("operator must be AbstractLinearOperator.")
+        return cls(
+            operator.source,
+            operator.target,
+            policy,
+            operator_family_id,
+            constraint_id=constraint_id,
+            nullspace_policy_id=nullspace_policy_id,
+        )
+
+    def compatible(
+        self,
+        operator: AbstractLinearOperator,
+        operator_family_id: str,
+        /,
+        *,
+        constraint_id: str = "unconstrained",
+        nullspace_policy_id: str = "none",
+    ) -> bool:
+        return (
+            isinstance(operator, AbstractLinearOperator)
+            and self.source.compatible(operator.source)
+            and self.target.compatible(operator.target)
+            and self.operator_family_id == str(operator_family_id)
+            and self.constraint_id == str(constraint_id)
+            and self.nullspace_policy_id == str(nullspace_policy_id)
+        )
+
+    def _active_mask(self) -> Array:
+        return jnp.arange(self.policy.capacity) < self.effective_dimension
+
+    def initial_guess(
+        self,
+        rhs: PyTree[Any],
+        /,
+        *,
+        time: ArrayLike | None = None,
+    ) -> tuple[PyTree[Array], LinearInitialGuessDiagnostics]:
+        rhs_ = self.target.validate(rhs)
+        rhs_coordinates = self.target.flatten(rhs_)
+        mask = self._active_mask()
+        effective = self.effective_dimension
+        zero = self.source.zeros()
+        if self.policy.strategy == "zero":
+            return zero, LinearInitialGuessDiagnostics(
+                effective_dimension=effective,
+                rank=jnp.asarray(0, dtype=jnp.int32),
+                projection_residual_norm=self.target.norm(rhs_),
+                reused=jnp.asarray(False),
+                strategy=self.policy.strategy,
+            )
+        if self.policy.strategy == "last-solution":
+            index = jnp.maximum(effective - 1, 0)
+            coordinates = jnp.where(
+                effective > 0,
+                self.solution_basis[:, index],
+                jnp.zeros((self.source.size,), dtype=self.solution_basis.dtype),
+            )
+            return self.source.unflatten(
+                jax.lax.stop_gradient(coordinates)
+            ), LinearInitialGuessDiagnostics(
+                effective_dimension=effective,
+                rank=jnp.minimum(effective, 1),
+                projection_residual_norm=jnp.asarray(jnp.nan),
+                reused=effective > 0,
+                strategy=self.policy.strategy,
+            )
+        if self.policy.strategy == "stabilized-extrapolation":
+            if time is None:
+                raise ValueError("Extrapolation initial guesses require a target time.")
+            degree_count = min(self.policy.extrapolation_degree + 1, self.policy.capacity)
+            used = jnp.minimum(effective, degree_count)
+            start = jnp.maximum(effective - degree_count, 0)
+            recent_solutions = jnp.roll(self.solution_basis, -start, axis=1)[
+                :, :degree_count
+            ]
+            recent_times = jnp.roll(self.times, -start)[:degree_count]
+            valid = jnp.arange(degree_count) < used
+            scale = jnp.maximum(
+                jnp.max(jnp.where(valid, jnp.abs(recent_times), 0.0)), 1.0
+            )
+            nodes = recent_times / scale
+            target = jnp.asarray(time) / scale
+            powers = jnp.arange(degree_count)
+            vandermonde = nodes[:, None] ** powers[None, :]
+            system = jnp.where(valid[:, None], vandermonde, 0.0)
+            system = system + jnp.diag((~valid).astype(system.dtype))
+            target_values = target**powers
+            coefficients = jnp.linalg.solve(system.T, target_values)
+            coordinates = recent_solutions @ coefficients
+            coordinates = jnp.where(used > 0, coordinates, 0.0)
+            return self.source.unflatten(
+                jax.lax.stop_gradient(coordinates)
+            ), LinearInitialGuessDiagnostics(
+                effective_dimension=effective,
+                rank=used,
+                projection_residual_norm=jnp.asarray(jnp.nan),
+                reused=used > 0,
+                strategy=self.policy.strategy,
+            )
+        active_images = jnp.where(mask[None, :], self.rhs_image_basis, 0.0)
+        if self.policy.strategy == "rolling-qr":
+            q_basis, upper = jnp.linalg.qr(active_images, mode="reduced")
+            coefficients = jnp.linalg.pinv(upper, rtol=self.policy.rank_tolerance) @ (
+                jnp.conj(q_basis.T) @ rhs_coordinates
+            )
+            coefficients = jnp.where(mask, coefficients, 0.0)
+            coordinates = self.solution_basis @ coefficients
+            projected = active_images @ coefficients
+            residual = rhs_coordinates - projected
+            singular_values = jnp.linalg.svd(upper, compute_uv=False)
+            largest = jnp.maximum(jnp.max(singular_values), 1.0)
+            rank = jnp.sum(
+                singular_values > self.policy.rank_tolerance * largest,
+                dtype=jnp.int32,
+            )
+            return self.source.unflatten(
+                jax.lax.stop_gradient(coordinates)
+            ), LinearInitialGuessDiagnostics(
+                effective_dimension=effective,
+                rank=rank,
+                projection_residual_norm=jnp.sqrt(jnp.real(jnp.vdot(residual, residual))),
+                reused=effective > 0,
+                strategy=self.policy.strategy,
+            )
+        gram = jnp.conj(active_images.T) @ active_images
+        rhs_projection = jnp.conj(active_images.T) @ rhs_coordinates
+        inactive = (~mask).astype(gram.dtype)
+        gram = gram + jnp.diag(inactive)
+        eigenvalues = jnp.linalg.eigvalsh(0.5 * (gram + jnp.conj(gram.T)))
+        largest = jnp.maximum(jnp.max(jnp.abs(eigenvalues)), 1.0)
+        threshold = self.policy.rank_tolerance * largest
+        rank = jnp.sum((eigenvalues > threshold) & mask, dtype=jnp.int32)
+        coefficients = (
+            jnp.linalg.pinv(gram, rtol=self.policy.rank_tolerance) @ rhs_projection
+        )
+        coefficients = jnp.where(mask, coefficients, 0.0)
+        coordinates = self.solution_basis @ coefficients
+        projected = active_images @ coefficients
+        residual = rhs_coordinates - projected
+        return self.source.unflatten(
+            jax.lax.stop_gradient(coordinates)
+        ), LinearInitialGuessDiagnostics(
+            effective_dimension=effective,
+            rank=rank,
+            projection_residual_norm=jnp.sqrt(jnp.real(jnp.vdot(residual, residual))),
+            reused=effective > 0,
+            strategy=self.policy.strategy,
+        )
+
+    def update(
+        self,
+        operator: AbstractLinearOperator,
+        solution: PyTree[Any],
+        /,
+        *,
+        rhs: PyTree[Any] | None = None,
+        time: ArrayLike | None = None,
+        accepted: ArrayLike = True,
+    ) -> LinearSolveHistory:
+        if (
+            not isinstance(operator, AbstractLinearOperator)
+            or not self.source.compatible(operator.source)
+            or not self.target.compatible(operator.target)
+        ):
+            raise ValueError("History update operator is incompatible.")
+        solution_ = self.source.validate(solution)
+        image = operator.mv(solution_) if rhs is None else self.target.validate(rhs)
+        solution_coordinates = jax.lax.stop_gradient(self.source.flatten(solution_))
+        image_coordinates = jax.lax.stop_gradient(self.target.flatten(image))
+        time_ = jnp.asarray(jnp.nan if time is None else time, dtype=self.times.dtype)
+        accepted_ = jnp.asarray(accepted, dtype=bool)
+        if accepted_.shape != () or time_.shape != ():
+            raise ValueError("History acceptance/time must be scalar.")
+
+        def perform(history):
+            effective = history.effective_dimension
+            full = effective >= history.policy.capacity
+            solutions = jax.lax.cond(
+                full,
+                lambda value: jnp.concatenate(
+                    (value[:, 1:], solution_coordinates[:, None]), axis=1
+                ),
+                lambda value: value.at[:, effective].set(solution_coordinates),
+                history.solution_basis,
+            )
+            images = jax.lax.cond(
+                full,
+                lambda value: jnp.concatenate(
+                    (value[:, 1:], image_coordinates[:, None]), axis=1
+                ),
+                lambda value: value.at[:, effective].set(image_coordinates),
+                history.rhs_image_basis,
+            )
+            times = jax.lax.cond(
+                full,
+                lambda value: jnp.concatenate((value[1:], time_[None])),
+                lambda value: value.at[effective].set(time_),
+                history.times,
+            )
+            return LinearSolveHistory(
+                history.source,
+                history.target,
+                history.policy,
+                history.operator_family_id,
+                constraint_id=history.constraint_id,
+                nullspace_policy_id=history.nullspace_policy_id,
+                solution_basis=solutions,
+                rhs_image_basis=images,
+                times=times,
+                effective_dimension=jnp.minimum(effective + 1, history.policy.capacity),
+                update_count=history.update_count + 1,
+            )
+
+        return jax.lax.cond(accepted_, perform, lambda history: history, self)
+
+
+class HistoryLinearSolveResult(StrictModule):
+    result: object
+    history: LinearSolveHistory
+    initial_guess_diagnostics: LinearInitialGuessDiagnostics
+
+    def __init__(
+        self,
+        result: object,
+        history: LinearSolveHistory,
+        initial_guess_diagnostics: LinearInitialGuessDiagnostics,
+        /,
+    ):
+        if not isinstance(history, LinearSolveHistory):
+            raise TypeError("history must be LinearSolveHistory.")
+        if not isinstance(initial_guess_diagnostics, LinearInitialGuessDiagnostics):
+            raise TypeError(
+                "initial_guess_diagnostics must be LinearInitialGuessDiagnostics."
+            )
+        self.result = result
+        self.history = history
+        self.initial_guess_diagnostics = initial_guess_diagnostics
+
+
+def solve_with_history(
+    problem_or_prepared: object,
+    rhs: PyTree[Any],
+    history: LinearSolveHistory,
+    /,
+    *,
+    operator_family_id: str,
+    constraint_id: str = "unconstrained",
+    nullspace_policy_id: str = "none",
+    time: ArrayLike | None = None,
+    accepted: ArrayLike = True,
+    policy: object = None,
+    rhs_layout: object = None,
+    control: object = None,
+) -> HistoryLinearSolveResult:
+    from ._plans import PreparedLinearSolve
+    from ._problems import AbstractLinearProblem
+    from ._runtime import solve
+
+    if isinstance(problem_or_prepared, PreparedLinearSolve):
+        operator = problem_or_prepared.problem.operator
+    elif isinstance(problem_or_prepared, AbstractLinearProblem):
+        operator = problem_or_prepared.operator
+    else:
+        raise TypeError("Expected an AbstractLinearProblem or PreparedLinearSolve.")
+    if not isinstance(history, LinearSolveHistory) or not history.compatible(
+        operator,
+        operator_family_id,
+        constraint_id=constraint_id,
+        nullspace_policy_id=nullspace_policy_id,
+    ):
+        raise ValueError("Linear solve history is incompatible with this problem.")
+    guess, diagnostics = history.initial_guess(rhs, time=time)
+    result = solve(
+        problem_or_prepared,
+        rhs,
+        policy=policy,
+        rhs_layout=rhs_layout,
+        initial_guess=guess,
+        control=control,
+    )
+    accepted_ = jnp.asarray(accepted, dtype=bool) & result.successful
+    updated = history.update(
+        operator,
+        result.value,
+        time=time,
+        accepted=accepted_,
+    )
+    return HistoryLinearSolveResult(result, updated, diagnostics)
+
+
+__all__ = [
+    "HistoryLinearSolveResult",
+    "LinearInitialGuessDiagnostics",
+    "LinearInitialGuessStrategy",
+    "LinearSolveHistory",
+    "LinearSolveHistoryPolicy",
+    "solve_with_history",
+]

--- a/phydrax/solver/__init__.py
+++ b/phydrax/solver/__init__.py
@@ -253,6 +253,12 @@ from ._fbsde import (
     CoupledFBSDEResult,
     solve_coupled_fbsde_explicit,
 )
+from ._fem_multirate import (
+    conservative_multirate_flux,
+    DGInterfaceFluxResult,
+    DGMultirateTracePlan,
+    DGTraceHistory,
+)
 from ._fermionic_gaussian import (
     damped_fermionic_mode,
     FermionicGaussianProblem,
@@ -1012,6 +1018,10 @@ __all__ = [
     "DAEAttemptHistory",
     "DAEAttemptStatus",
     "DAEContinuation",
+    "conservative_multirate_flux",
+    "DGInterfaceFluxResult",
+    "DGMultirateTracePlan",
+    "DGTraceHistory",
     "DAEFailureMode",
     "DAERegularityEvidence",
     "DAERegularityFailureMode",

--- a/phydrax/solver/_fem_multirate.py
+++ b/phydrax/solver/_fem_multirate.py
@@ -1,0 +1,192 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array, ArrayLike
+
+from .._fingerprint import canonical_fingerprint
+from .._strict import StrictModule
+from .._trainable import NonTrainableState
+
+
+class DGMultirateTracePlan(StrictModule, NonTrainableState):
+    facet_levels: Array
+    maximum_level: int = eqx.field(static=True)
+    history_depth: int = eqx.field(static=True)
+    plan_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        facet_levels: ArrayLike,
+        /,
+        *,
+        history_depth: int = 3,
+    ):
+        levels = jnp.asarray(facet_levels, dtype=jnp.int32)
+        depth = int(history_depth)
+        if levels.ndim != 2 or levels.shape[1] != 2 or levels.size == 0:
+            raise ValueError("DG multirate facet levels require shape (facets, 2).")
+        if bool(jnp.any(levels < 0)) or depth < 1:
+            raise ValueError("DG multirate levels/history depth are invalid.")
+        maximum = int(jnp.max(levels))
+        self.facet_levels = levels
+        self.maximum_level = maximum
+        self.history_depth = depth
+        self.plan_id = canonical_fingerprint(
+            {
+                "kind": "dg-multirate-trace-plan",
+                "facet_shape": list(levels.shape),
+                "maximum_level": maximum,
+                "history_depth": depth,
+            }
+        )
+
+    @property
+    def ticks_per_macro_step(self) -> int:
+        return 1 << self.maximum_level
+
+    def active_level(self, tick: int, /) -> int:
+        tick_ = int(tick)
+        if tick_ < 0 or tick_ >= self.ticks_per_macro_step:
+            raise ValueError("DG multirate tick is out of bounds.")
+        level = 0
+        while level < self.maximum_level and tick_ % (1 << (level + 1)) == 0:
+            level += 1
+        return level
+
+
+class DGTraceHistory(StrictModule):
+    values: Array
+    times: Array
+    effective_depth: Array
+
+    def __init__(
+        self,
+        values: ArrayLike,
+        times: ArrayLike,
+        effective_depth: ArrayLike,
+        /,
+    ):
+        values_ = jnp.asarray(values)
+        times_ = jnp.asarray(times)
+        effective = jnp.asarray(effective_depth, dtype=jnp.int32)
+        if (
+            values_.ndim < 2
+            or times_.shape != (values_.shape[0],)
+            or effective.shape != ()
+        ):
+            raise ValueError("DG trace history layouts are incompatible.")
+        effective = eqx.error_if(
+            effective,
+            (effective < 0) | (effective > values_.shape[0]),
+            "DG trace history depth is out of bounds.",
+        )
+        self.values = values_
+        self.times = times_
+        self.effective_depth = effective
+
+    @classmethod
+    def empty(
+        cls,
+        depth: int,
+        trace_shape: tuple[int, ...],
+        dtype,
+        /,
+    ) -> DGTraceHistory:
+        return cls(
+            jnp.zeros((int(depth),) + tuple(trace_shape), dtype=dtype),
+            jnp.full((int(depth),), jnp.nan),
+            0,
+        )
+
+    def update(
+        self,
+        value: ArrayLike,
+        time: ArrayLike,
+        /,
+        *,
+        accepted: ArrayLike = True,
+    ) -> DGTraceHistory:
+        value_ = jnp.asarray(value)
+        time_ = jnp.asarray(time)
+        accepted_ = jnp.asarray(accepted, dtype=bool)
+        if (
+            value_.shape != self.values.shape[1:]
+            or time_.shape != ()
+            or accepted_.shape != ()
+        ):
+            raise ValueError("DG trace update value/time/acceptance are incompatible.")
+
+        def perform(history):
+            values = jnp.concatenate((value_[None], history.values[:-1]), axis=0)
+            times = jnp.concatenate((time_[None], history.times[:-1]), axis=0)
+            return DGTraceHistory(
+                values,
+                times,
+                jnp.minimum(history.effective_depth + 1, history.values.shape[0]),
+            )
+
+        return jax.lax.cond(accepted_, perform, lambda history: history, self)
+
+    def predict(self, time: ArrayLike, /) -> Array:
+        target = jnp.asarray(time)
+        if target.shape != ():
+            raise ValueError("DG trace prediction time must be scalar.")
+        count = self.values.shape[0]
+        valid = jnp.arange(count) < self.effective_depth
+        safe_times = jnp.where(valid, self.times, target + jnp.arange(count) + 1.0)
+        weights = []
+        for index in range(count):
+            numerator = jnp.asarray(1.0, dtype=target.dtype)
+            denominator = jnp.asarray(1.0, dtype=target.dtype)
+            for other in range(count):
+                if other != index:
+                    numerator = numerator * jnp.where(
+                        valid[other], target - safe_times[other], 1.0
+                    )
+                    denominator = denominator * jnp.where(
+                        valid[other],
+                        safe_times[index] - safe_times[other],
+                        1.0,
+                    )
+            weights.append(jnp.where(valid[index], numerator / denominator, 0.0))
+        weights_ = jnp.stack(tuple(weights))
+        predicted = jnp.tensordot(weights_, self.values, axes=((0,), (0,)))
+        return jnp.where(self.effective_depth > 0, predicted, jnp.zeros_like(predicted))
+
+
+class DGInterfaceFluxResult(StrictModule):
+    plus: Array
+    minus: Array
+    conservation_defect: Array
+
+
+def conservative_multirate_flux(
+    plus_trace: ArrayLike,
+    minus_trace: ArrayLike,
+    normal: ArrayLike,
+    flux: Callable,
+    /,
+) -> DGInterfaceFluxResult:
+    if not callable(flux):
+        raise TypeError("flux must be callable.")
+    numerical = jnp.asarray(flux(plus_trace, minus_trace, normal))
+    plus = numerical
+    minus = -numerical
+    defect = jnp.sqrt(jnp.sum(jnp.abs(plus + minus) ** 2))
+    return DGInterfaceFluxResult(plus=plus, minus=minus, conservation_defect=defect)
+
+
+__all__ = [
+    "DGInterfaceFluxResult",
+    "DGMultirateTracePlan",
+    "DGTraceHistory",
+    "conservative_multirate_flux",
+]

--- a/tests/unit/applications/test_incompressible_flow_multirate.py
+++ b/tests/unit/applications/test_incompressible_flow_multirate.py
@@ -1,0 +1,71 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax.numpy as jnp
+
+import phydrax as phx
+
+
+def _operators():
+    return phx.applications.incompressible_flow.IncompressibleFlowOperators(
+        lambda velocity, time, args: jnp.zeros_like(velocity),
+        lambda rhs, gamma, time, args: rhs / gamma,
+        lambda velocity, time, args: velocity,
+        lambda rhs, time, args: -rhs,
+        lambda pressure, time, args: pressure,
+    )
+
+
+def test_pressure_correction_eliminates_identity_divergence():
+    flow = phx.applications.incompressible_flow
+    state = flow.IncompressibleFlowState(jnp.asarray([1.0, 2.0]), jnp.zeros((2,)))
+    updated, diagnostics = flow.pressure_correction_step(
+        state,
+        1.0,
+        _operators(),
+        flow.IncompressibleFlowPolicy(pressure_increment=False),
+        0.0,
+    )
+
+    assert jnp.allclose(updated.velocity, 0.0)
+    assert diagnostics.divergence_before > 0.0
+    assert diagnostics.divergence_after == 0.0
+    assert diagnostics.successful
+
+
+def test_oifs_history_combination_preserves_normalized_partial_sum():
+    flow = phx.applications.incompressible_flow
+    history = (jnp.asarray([1.0]), jnp.asarray([3.0]), jnp.asarray([5.0]))
+    coefficients = jnp.asarray([1.0, 2.0, 1.0])
+
+    combined = flow.oifs_history_combination(history, coefficients)
+
+    assert jnp.allclose(combined, jnp.asarray([3.0]))
+
+
+def test_multirate_trace_history_predicts_linear_trace():
+    history = phx.solver.DGTraceHistory.empty(3, (1,), jnp.float64)
+    history = history.update(jnp.asarray([1.0]), 0.0)
+    history = history.update(jnp.asarray([3.0]), 1.0)
+
+    assert jnp.allclose(history.predict(2.0), jnp.asarray([5.0]), atol=1.0e-12)
+
+
+def test_multirate_interface_flux_is_exactly_conservative():
+    result = phx.solver.conservative_multirate_flux(
+        jnp.asarray([2.0]),
+        jnp.asarray([1.0]),
+        jnp.asarray([[1.0, 0.0]]),
+        lambda plus, minus, normal: plus - minus,
+    )
+
+    assert jnp.allclose(result.plus, -result.minus)
+    assert result.conservation_defect == 0.0
+
+
+def test_power_of_two_multirate_tick_schedule():
+    plan = phx.solver.DGMultirateTracePlan(jnp.asarray([[0, 2], [1, 2]], dtype=jnp.int32))
+
+    assert plan.ticks_per_macro_step == 4
+    assert tuple(plan.active_level(tick) for tick in range(4)) == (2, 0, 1, 0)

--- a/tests/unit/discretization/test_fem_libparanumal_absorption.py
+++ b/tests/unit/discretization/test_fem_libparanumal_absorption.py
@@ -1,0 +1,128 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax.numpy as jnp
+import pytest
+
+import phydrax as phx
+
+
+def _mesh():
+    vertices = jnp.asarray([[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]])
+    cells = jnp.asarray([[0, 1, 3], [1, 2, 3]], dtype=jnp.int32)
+    return phx.discretization.CellMesh.from_triangles(vertices, cells)
+
+
+def test_exact_diagonal_matches_sparse_diffusion():
+    element = phx.discretization.lagrange_element("triangle", 1)
+    discretization = phx.discretization.FiniteElementPlan(
+        _mesh(), phx.discretization.FiniteElementFieldSpec("u", element)
+    ).prepare()
+    form = phx.equations.FiniteElementForm(
+        "poisson", "u", (phx.equations.DiffusionAction("u"),)
+    )
+    compiled = phx.equations.compile_finite_element_problem(form, discretization)
+    diagonal = compiled.exact_diagonal()
+    matrix = compiled.to_scipy_csr().toarray()
+
+    assert diagonal.method == "sparse-coordinate"
+    assert jnp.allclose(diagonal.diagonal, jnp.diag(jnp.asarray(matrix)))
+
+
+def test_generic_p_transfer_preserves_pairing():
+    coarse = phx.discretization.lagrange_element("triangle", 1)
+    fine = phx.discretization.lagrange_element("triangle", 3)
+    transfer = phx.discretization.fem.finite_element_p_transfer(coarse, fine)
+    coarse_value = jnp.asarray([1.0, 2.0, 3.0])
+    fine_dual = jnp.arange(float(fine.local_dof_count))
+
+    prolonged = transfer.apply("primal-prolongation", coarse_value)
+    pulled = transfer.apply("dual-pullback", fine_dual)
+
+    assert jnp.allclose(jnp.vdot(prolonged, fine_dual), jnp.vdot(coarse_value, pulled))
+
+
+def test_p_degree_coarsening_policies_are_deterministic():
+    assert phx.discretization.fem.FiniteElementPMultigridPolicy(
+        "all-degrees"
+    ).degree_sequence("hexahedron", 5) == (5, 4, 3, 2, 1)
+    assert phx.discretization.fem.FiniteElementPMultigridPolicy(
+        "half-degrees"
+    ).degree_sequence("hexahedron", 8) == (8, 4, 2, 1)
+    assert phx.discretization.fem.FiniteElementPMultigridPolicy(
+        "half-dofs"
+    ).degree_sequence("hexahedron", 8) == (8, 6, 4, 2, 1)
+
+
+def test_collocated_tensor_mass_path_is_identity_for_unit_data():
+    derivative = jnp.zeros((2, 2))
+    metric = jnp.ones((1, 2, 2, 3))
+    mass = jnp.ones((1, 2, 2))
+    gathers = jnp.asarray([[0, 1, 2, 3]], dtype=jnp.int32)
+    operator = phx.equations.fem.CollocatedTensorProductOperator(
+        derivative, metric, mass, gathers, 4
+    )
+    value = jnp.arange(1.0, 5.0)
+
+    assert jnp.allclose(operator.mv(value), value)
+    assert jnp.allclose(operator.transpose_mv(value), value)
+
+
+def test_dg_trace_staging_builds_conservative_jet():
+    plus = jnp.asarray([[1.0, 2.0]])
+    minus = jnp.asarray([[3.0, 4.0]])
+    basis = jnp.asarray([[[1.0, 0.0], [0.0, 1.0]]])
+    gradients = jnp.asarray([[[[1.0, 0.0], [0.0, 1.0]], [[1.0, 0.0], [0.0, 1.0]]]])
+    normal = jnp.asarray([[[1.0, 0.0], [1.0, 0.0]]])
+    measure = jnp.ones((1, 2))
+
+    staged = phx.equations.fem.DGTraceBatch(
+        plus, minus, basis, basis, gradients, gradients, normal, measure
+    )
+
+    assert jnp.allclose(staged.jet.jump, jnp.asarray([[-2.0, -2.0]]))
+    assert jnp.allclose(staged.jet.average, jnp.asarray([[2.0, 3.0]]))
+
+
+def test_quadrature_policy_requires_nonpolynomial_evidence():
+    policy = phx.equations.fem.QuadratureAccuracyPolicy("exact-polynomial")
+    assert (
+        policy.resolve_degree(2, 2, coefficient_order=1, kernel_polynomial_degree=2) == 7
+    )
+
+    with pytest.raises(ValueError, match="requires declared"):
+        policy.resolve_degree(2, 2, coefficient_order=None)
+
+
+def test_one_ring_patch_weights_form_partition_of_unity():
+    element = phx.discretization.lagrange_element("triangle", 1)
+    discretization = phx.discretization.FiniteElementPlan(
+        _mesh(), phx.discretization.FiniteElementFieldSpec("u", element)
+    ).prepare()
+    plan = phx.discretization.fem.one_ring_patch_plan(discretization, "u")
+    width = plan.gathers.shape[1]
+    local_inverse = jnp.broadcast_to(
+        jnp.eye(width), (plan.gathers.shape[0], width, width)
+    )
+    preconditioner = phx.discretization.fem.FiniteElementPatchPreconditioner(
+        plan, local_inverse, discretization.field_spaces[0].vector_space
+    )
+    value = jnp.arange(1.0, 5.0)
+
+    assert jnp.allclose(preconditioner.apply(value), value)
+
+
+def test_low_order_auxiliary_identity_path():
+    high = phx.linalg.ArraySpace((3,))
+    low = phx.linalg.ArraySpace((3,))
+    identity = phx.linalg.IdentityLinearOperator(high)
+    plan = phx.discretization.fem.LowOrderAuxiliaryOperatorPlan(
+        identity, identity, jnp.ones((3,))
+    )
+    preconditioner = phx.discretization.fem.LowOrderAuxiliaryPreconditioner(
+        plan, phx.linalg.IdentityPreconditioner(low)
+    )
+    value = jnp.arange(1.0, 4.0)
+
+    assert jnp.allclose(preconditioner.apply(value), value)

--- a/tests/unit/linalg/test_linear_initial_guess_history.py
+++ b/tests/unit/linalg/test_linear_initial_guess_history.py
@@ -1,0 +1,83 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax.numpy as jnp
+
+import phydrax as phx
+
+
+def _operator():
+    space = phx.linalg.ArraySpace((2,))
+    return phx.linalg.DenseLinearOperator(
+        jnp.asarray([[2.0, 0.0], [0.0, 3.0]]), source=space, target=space
+    )
+
+
+def test_projection_history_exactly_recovers_rhs_span():
+    operator = _operator()
+    policy = phx.linalg.LinearSolveHistoryPolicy("projection", capacity=3)
+    history = phx.linalg.LinearSolveHistory.empty(operator, policy, "shifted-family")
+    first = jnp.asarray([1.0, 0.0])
+    second = jnp.asarray([0.0, 2.0])
+    history = history.update(operator, first, time=0.0)
+    history = history.update(operator, second, time=1.0)
+    rhs = operator.mv(2.0 * first + 3.0 * second)
+
+    guess, diagnostics = history.initial_guess(rhs)
+
+    assert jnp.allclose(guess, jnp.asarray([2.0, 6.0]))
+    assert diagnostics.effective_dimension == 2
+    assert diagnostics.rank == 2
+    assert diagnostics.projection_residual_norm < 1.0e-12
+
+
+def test_rolling_qr_history_recovers_span_after_eviction():
+    operator = _operator()
+    history = phx.linalg.LinearSolveHistory.empty(
+        operator,
+        phx.linalg.LinearSolveHistoryPolicy("rolling-qr", capacity=2),
+        "family",
+    )
+    history = history.update(operator, jnp.asarray([1.0, 1.0]), time=0.0)
+    history = history.update(operator, jnp.asarray([1.0, 0.0]), time=1.0)
+    history = history.update(operator, jnp.asarray([0.0, 2.0]), time=2.0)
+
+    guess, diagnostics = history.initial_guess(operator.mv(jnp.asarray([3.0, 4.0])))
+
+    assert jnp.allclose(guess, jnp.asarray([3.0, 4.0]), atol=1.0e-10)
+    assert diagnostics.rank == 2
+    assert history.effective_dimension == 2
+
+
+def test_rejected_history_update_is_bitwise_inert():
+    operator = _operator()
+    history = phx.linalg.LinearSolveHistory.empty(
+        operator,
+        phx.linalg.LinearSolveHistoryPolicy("last-solution", capacity=2),
+        "family",
+    )
+    rejected = history.update(operator, jnp.ones((2,)), accepted=False)
+
+    assert rejected.history_id == history.history_id
+    assert rejected.effective_dimension == 0
+    assert rejected.update_count == 0
+    assert jnp.array_equal(rejected.solution_basis, history.solution_basis)
+
+
+def test_stabilized_extrapolation_reproduces_linear_history():
+    operator = _operator()
+    history = phx.linalg.LinearSolveHistory.empty(
+        operator,
+        phx.linalg.LinearSolveHistoryPolicy(
+            "stabilized-extrapolation", capacity=3, extrapolation_degree=1
+        ),
+        "family",
+    )
+    history = history.update(operator, jnp.asarray([0.0, 1.0]), time=0.0)
+    history = history.update(operator, jnp.asarray([1.0, 3.0]), time=1.0)
+
+    guess, diagnostics = history.initial_guess(operator.mv(jnp.zeros((2,))), time=2.0)
+
+    assert jnp.allclose(guess, jnp.asarray([2.0, 5.0]), atol=1.0e-12)
+    assert diagnostics.rank == 2

--- a/tools/fem_solver_acceleration_benchmarks.py
+++ b/tools/fem_solver_acceleration_benchmarks.py
@@ -1,0 +1,73 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from time import perf_counter
+
+import equinox as eqx
+import jax.numpy as jnp
+
+import phydrax as phx
+
+
+def _average_time(action, value, iterations=50):
+    compiled = eqx.filter_jit(action)
+    compiled(value).block_until_ready()
+    start = perf_counter()
+    for _ in range(iterations):
+        compiled(value).block_until_ready()
+    return (perf_counter() - start) / iterations
+
+
+def run():
+    points = 8
+    derivative = jnp.asarray(
+        [
+            [
+                0.0 if row == column else (-1.0) ** (row + column) / (row - column)
+                for column in range(points)
+            ]
+            for row in range(points)
+        ]
+    )
+    elements = 16
+    local_size = points * points
+    gathers = jnp.arange(elements * local_size, dtype=jnp.int32).reshape(
+        (elements, local_size)
+    )
+    metric = jnp.ones((elements, points, points, 3))
+    mass = jnp.ones((elements, points, points))
+    operator = phx.equations.fem.CollocatedTensorProductOperator(
+        derivative,
+        metric,
+        mass,
+        gathers,
+        elements * local_size,
+    )
+    value = jnp.linspace(0.0, 1.0, elements * local_size)
+    collocated_time = _average_time(operator.mv, value)
+
+    space = phx.linalg.ArraySpace((2,))
+    dense = phx.linalg.DenseLinearOperator(
+        jnp.asarray([[2.0, 0.0], [0.0, 3.0]]), source=space, target=space
+    )
+    history = phx.linalg.LinearSolveHistory.empty(
+        dense,
+        phx.linalg.LinearSolveHistoryPolicy("projection", capacity=3),
+        "benchmark-family",
+    )
+    history = history.update(dense, jnp.asarray([1.0, 0.0]), time=0.0)
+    history = history.update(dense, jnp.asarray([0.0, 1.0]), time=1.0)
+    guess, diagnostics = history.initial_guess(dense.mv(jnp.asarray([2.0, 3.0])))
+
+    return {
+        "collocated_apply_seconds": collocated_time,
+        "collocated_dofs": int(value.size),
+        "history_effective_dimension": int(diagnostics.effective_dimension),
+        "history_projection_residual": float(diagnostics.projection_residual_norm),
+        "history_guess_norm": float(jnp.linalg.norm(guess)),
+    }
+
+
+if __name__ == "__main__":
+    print(run())


### PR DESCRIPTION
## Summary

Adds fixed-mesh finite-element solver acceleration across repeated linear solves, exact diagonal extraction, p-transfer and p-level planning, tensor-product execution, DG trace staging, quadrature evidence, patch and auxiliary preconditioning, incompressible pressure correction, and multirate interface traces.

## Linear solve histories

- Adds immutable accepted solution/RHS-image histories.
- Supports zero, last-solution, projection, rolling-QR, and stabilized-extrapolation initial guesses.
- Binds history reuse to source/target spaces, operator-family identity, constraints, and nullspace policy.
- Updates history only after an explicit accepted successful solve.
- Keeps algorithmic initial-guess construction outside the mathematical derivative of the converged root.

## FEM diagonal and preconditioner data

- Adds `FiniteElementDiagonalData` with exact sparse-coordinate extraction, zero/negative masks, numeric identity, and construction provenance.
- Adds an explicitly enabled, dimension-bounded coordinate-linearization fallback for operators without a structural diagonal lowering.
- Routes prepared FEM preconditioner data through the exact diagonal API.

## p-transfer and p-level planning

- Adds `FiniteElementPTransfer` with separate primal prolongation, raw dual pullback, pairing-aware adjoint, and mass-projection roles.
- Generalizes local transfer construction across matching finite-element cell and conformity families.
- Uses Phydrax factorization for supplied mass-pairing solves.
- Adds all-degree, half-degree, half-DOF, and explicit p-level policies.
- Validates operators, smoothers, transfers, and cycle policy before constructing a generic Phydrax multigrid hierarchy.

## Tensor and DG execution

- Adds a collocated quad/hex mass-diffusion operator with one-dimensional derivative contractions and packed symmetric metric data.
- Adds exact transpose actions and global scatter.
- Adds `CellDerivativeBatch` and `DGTraceBatch` for staged plus/minus values and gradients.
- Adds polynomial-exact, collocated, overintegrated, and explicit quadrature policies with inspectable exactness and aliasing evidence.

## Fixed-mesh preconditioning

- Adds deterministic one-ring patch construction from fixed mesh adjacency.
- Computes reciprocal overlap weights forming a partition of unity.
- Adds weighted additive patch preconditioning over supplied local inverses.
- Adds a low-order auxiliary operator plan with weighted high-to-low interpolation, generic low-order preconditioning, and low-to-high anterpolation.

## Incompressible and multirate workflows

- Adds an incompressible-flow application package that wires supplied advection, velocity Helmholtz, divergence, pressure Poisson, and gradient actions into pressure or pressure-increment correction steps.
- Adds OIFS-style normalized accepted-history combination and accepted-step schedule integration.
- Adds power-of-two DG interface-rate plans, immutable trace histories, intermediate-time trace prediction, and exactly opposite interface flux contributions.

## Documentation and examples

- Adds solver-acceleration and incompressible/multirate guides.
- Adds a public fixed-mesh acceleration example and benchmark tool.
- Documents algorithm provenance, derivative boundaries, current scope, and rejected duplicate backend/solver layers.

## Scope

This PR remains fixed-mesh and single-device. It does not add a communication backend, partitioning, mesh generation, a second kernel language, or duplicate Krylov/AMG implementations.