### PR TITLE
Add finite-horizon LQ feedback Nash games

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,8 @@ benchmarks/*
 !benchmarks/_comparison.py
 !benchmarks/_io.py
 !benchmarks/_runtime.py
+!benchmarks/control_lq_nash.py
+!benchmarks/control_lq_nash.json
 !benchmarks/tensor_network_abelian.py
 !benchmarks/tensor_network_abelian.json
 !benchmarks/tensor_network_chain.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@
   measures now remain exact across weighted, masked, uneven, lazy, and sharded
   microbatches; optimizer, target, reporting, and checkpoint state advance only
   at accepted positive-support update boundaries.
+- Added `phydrax.control.games` finite-horizon affine linear-quadratic
+  full-state feedback Nash policies with explicit player control ownership,
+  per-player quadratic values, case batching, differentiable nonsymmetric
+  dense-LU solves, diagnostic-only rank SVDs, and independent curvature,
+  stationarity, Bellman, conditioning, linear-status, and causal-failure
+  evidence without regularization, pseudoinverses, clipping, or fallback.
 - Added qualified circuit-QED mode reduction and device assembly, one-to-one
   dressed-state tracking, sampled I/Q controls, leakage-aware gate metrics,
   exact-state local product formulas with reversible gradients, and exact

--- a/benchmarks/control_lq_nash.json
+++ b/benchmarks/control_lq_nash.json
@@ -1,0 +1,2271 @@
+{
+  "all_finite": true,
+  "all_valid": true,
+  "cases": [
+    {
+      "case_shape": [],
+      "certificates": {
+        "normalized_bellman": 8.711407920494602e-19,
+        "normalized_stationarity": 6.938893903907228e-18,
+        "rollout_defect": 2.0816681711721685e-17,
+        "terminal_defect": 0.0
+      },
+      "compilation_seconds": 0.351602333,
+      "compiler": {
+        "argument_bytes": 46480,
+        "bytes_accessed": 392457,
+        "flops": 58416,
+        "generated_code_bytes": 0,
+        "output_bytes": 28179,
+        "source": "jax-compiled-executable",
+        "temporary_bytes": 53000,
+        "unavailable_reason": null
+      },
+      "control_sizes": [
+        2,
+        2
+      ],
+      "dtype": "float64",
+      "execution": {
+        "count": 5,
+        "max_ms": 1.155333,
+        "mean_ms": 0.8987998000000001,
+        "median_ms": 0.896958,
+        "min_ms": 0.736125,
+        "samples_ms": [
+          0.936208,
+          0.769375,
+          1.155333,
+          0.736125,
+          0.896958
+        ],
+        "std_ms": 0.1486108460152219
+      },
+      "horizon": 16,
+      "input_fingerprint": {
+        "sha256": "6dda4ee0d9f26bf716c61cd3b1d2489293d260d2988b8ceb4a1a2313401a89c1",
+        "signature": [
+          {
+            "dtype": "<f8",
+            "path": "[0]",
+            "shape": [
+              16,
+              8,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[1]",
+            "shape": [
+              16,
+              8,
+              4
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[2]",
+            "shape": [
+              2,
+              16,
+              8,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[3]",
+            "shape": [
+              2,
+              16,
+              4,
+              4
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[4]",
+            "shape": [
+              2,
+              8,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[5]",
+            "shape": [
+              16,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[6]",
+            "shape": [
+              2,
+              16,
+              8,
+              4
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[7]",
+            "shape": [
+              2,
+              16,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[8]",
+            "shape": [
+              2,
+              16,
+              4
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[9]",
+            "shape": [
+              2,
+              16
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[10]",
+            "shape": [
+              2,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[11]",
+            "shape": [
+              2
+            ]
+          }
+        ]
+      },
+      "joint_control_size": 4,
+      "logical_input_bytes": 46480,
+      "logical_output_bytes": 27843,
+      "lowering_seconds": 0.428398625,
+      "maximum_condition": 1.087716386173645,
+      "minimum_rank": 4,
+      "name": "baseline",
+      "player_count": 2,
+      "state_size": 8,
+      "status": 0,
+      "valid": true
+    },
+    {
+      "case_shape": [],
+      "certificates": {
+        "normalized_bellman": 4.954789172267029e-19,
+        "normalized_stationarity": 6.938893903907228e-18,
+        "rollout_defect": 1.2576745200831851e-17,
+        "terminal_defect": 0.0
+      },
+      "compilation_seconds": 0.343516833,
+      "compiler": {
+        "argument_bytes": 12496,
+        "bytes_accessed": 200877,
+        "flops": 40188,
+        "generated_code_bytes": 0,
+        "output_bytes": 8247,
+        "source": "jax-compiled-executable",
+        "temporary_bytes": 24392,
+        "unavailable_reason": null
+      },
+      "control_sizes": [
+        2,
+        2
+      ],
+      "dtype": "float64",
+      "execution": {
+        "count": 5,
+        "max_ms": 0.522458,
+        "mean_ms": 0.4401418,
+        "median_ms": 0.417042,
+        "min_ms": 0.413459,
+        "samples_ms": [
+          0.41625,
+          0.413459,
+          0.522458,
+          0.43150000000000005,
+          0.417042
+        ],
+        "std_ms": 0.04163418828991384
+      },
+      "horizon": 4,
+      "input_fingerprint": {
+        "sha256": "87c0cbb07fbe4d4ce4e9e10c858e1590a23b64e70369cc2a8978751e253e27c0",
+        "signature": [
+          {
+            "dtype": "<f8",
+            "path": "[0]",
+            "shape": [
+              4,
+              8,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[1]",
+            "shape": [
+              4,
+              8,
+              4
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[2]",
+            "shape": [
+              2,
+              4,
+              8,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[3]",
+            "shape": [
+              2,
+              4,
+              4,
+              4
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[4]",
+            "shape": [
+              2,
+              8,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[5]",
+            "shape": [
+              4,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[6]",
+            "shape": [
+              2,
+              4,
+              8,
+              4
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[7]",
+            "shape": [
+              2,
+              4,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[8]",
+            "shape": [
+              2,
+              4,
+              4
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[9]",
+            "shape": [
+              2,
+              4
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[10]",
+            "shape": [
+              2,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[11]",
+            "shape": [
+              2
+            ]
+          }
+        ]
+      },
+      "joint_control_size": 4,
+      "logical_input_bytes": 12496,
+      "logical_output_bytes": 7911,
+      "lowering_seconds": 0.309636,
+      "maximum_condition": 1.0876203334448087,
+      "minimum_rank": 4,
+      "name": "horizon-4",
+      "player_count": 2,
+      "state_size": 8,
+      "status": 0,
+      "valid": true
+    },
+    {
+      "case_shape": [],
+      "certificates": {
+        "normalized_bellman": 1.0026709181170895e-18,
+        "normalized_stationarity": 1.3877787807814457e-17,
+        "rollout_defect": 1.5178830414797062e-17,
+        "terminal_defect": 0.0
+      },
+      "compilation_seconds": 0.440811167,
+      "compiler": {
+        "argument_bytes": 182416,
+        "bytes_accessed": 1194269,
+        "flops": 136558,
+        "generated_code_bytes": 0,
+        "output_bytes": 107907,
+        "source": "jax-compiled-executable",
+        "temporary_bytes": 206792,
+        "unavailable_reason": null
+      },
+      "control_sizes": [
+        2,
+        2
+      ],
+      "dtype": "float64",
+      "execution": {
+        "count": 5,
+        "max_ms": 2.883709,
+        "mean_ms": 2.7742418,
+        "median_ms": 2.8372089999999996,
+        "min_ms": 2.4637079999999996,
+        "samples_ms": [
+          2.883709,
+          2.86525,
+          2.821333,
+          2.8372089999999996,
+          2.4637079999999996
+        ],
+        "std_ms": 0.15676686555442784
+      },
+      "horizon": 64,
+      "input_fingerprint": {
+        "sha256": "0d869b82870f1a087efb513d75f39b84d8f506abf6ee558f3c582a4deb2853b8",
+        "signature": [
+          {
+            "dtype": "<f8",
+            "path": "[0]",
+            "shape": [
+              64,
+              8,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[1]",
+            "shape": [
+              64,
+              8,
+              4
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[2]",
+            "shape": [
+              2,
+              64,
+              8,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[3]",
+            "shape": [
+              2,
+              64,
+              4,
+              4
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[4]",
+            "shape": [
+              2,
+              8,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[5]",
+            "shape": [
+              64,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[6]",
+            "shape": [
+              2,
+              64,
+              8,
+              4
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[7]",
+            "shape": [
+              2,
+              64,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[8]",
+            "shape": [
+              2,
+              64,
+              4
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[9]",
+            "shape": [
+              2,
+              64
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[10]",
+            "shape": [
+              2,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[11]",
+            "shape": [
+              2
+            ]
+          }
+        ]
+      },
+      "joint_control_size": 4,
+      "logical_input_bytes": 182416,
+      "logical_output_bytes": 107571,
+      "lowering_seconds": 0.493440583,
+      "maximum_condition": 1.088255731757349,
+      "minimum_rank": 4,
+      "name": "horizon-64",
+      "player_count": 2,
+      "state_size": 8,
+      "status": 0,
+      "valid": true
+    },
+    {
+      "case_shape": [],
+      "certificates": {
+        "normalized_bellman": 7.375266307684914e-19,
+        "normalized_stationarity": 6.938893903907228e-18,
+        "rollout_defect": 2.168404344971009e-17,
+        "terminal_defect": 0.0
+      },
+      "compilation_seconds": 0.3213935,
+      "compiler": {
+        "argument_bytes": 19536,
+        "bytes_accessed": 157633,
+        "flops": 19756,
+        "generated_code_bytes": 0,
+        "output_bytes": 11731,
+        "source": "jax-compiled-executable",
+        "temporary_bytes": 24904,
+        "unavailable_reason": null
+      },
+      "control_sizes": [
+        2,
+        2
+      ],
+      "dtype": "float64",
+      "execution": {
+        "count": 5,
+        "max_ms": 0.788833,
+        "mean_ms": 0.7317834,
+        "median_ms": 0.728791,
+        "min_ms": 0.654334,
+        "samples_ms": [
+          0.654334,
+          0.788833,
+          0.728791,
+          0.758875,
+          0.7280840000000001
+        ],
+        "std_ms": 0.04474295749992395
+      },
+      "horizon": 16,
+      "input_fingerprint": {
+        "sha256": "dbf81de3015f7999ed03960759c213860236066135e49c10c7b47ebc043fa89a",
+        "signature": [
+          {
+            "dtype": "<f8",
+            "path": "[0]",
+            "shape": [
+              16,
+              4,
+              4
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[1]",
+            "shape": [
+              16,
+              4,
+              4
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[2]",
+            "shape": [
+              2,
+              16,
+              4,
+              4
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[3]",
+            "shape": [
+              2,
+              16,
+              4,
+              4
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[4]",
+            "shape": [
+              2,
+              4,
+              4
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[5]",
+            "shape": [
+              16,
+              4
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[6]",
+            "shape": [
+              2,
+              16,
+              4,
+              4
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[7]",
+            "shape": [
+              2,
+              16,
+              4
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[8]",
+            "shape": [
+              2,
+              16,
+              4
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[9]",
+            "shape": [
+              2,
+              16
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[10]",
+            "shape": [
+              2,
+              4
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[11]",
+            "shape": [
+              2
+            ]
+          }
+        ]
+      },
+      "joint_control_size": 4,
+      "logical_input_bytes": 19536,
+      "logical_output_bytes": 11395,
+      "lowering_seconds": 0.325856625,
+      "maximum_condition": 1.0872102203840412,
+      "minimum_rank": 4,
+      "name": "state-4",
+      "player_count": 2,
+      "state_size": 4,
+      "status": 0,
+      "valid": true
+    },
+    {
+      "case_shape": [],
+      "certificates": {
+        "normalized_bellman": 1.9891188811927618e-18,
+        "normalized_stationarity": 1.3877787807814457e-17,
+        "rollout_defect": 1.9949319973733282e-17,
+        "terminal_defect": 0.0
+      },
+      "compilation_seconds": 0.455511,
+      "compiler": {
+        "argument_bytes": 476944,
+        "bytes_accessed": 4490049,
+        "flops": 1159334,
+        "generated_code_bytes": 0,
+        "output_bytes": 309651,
+        "source": "jax-compiled-executable",
+        "temporary_bytes": 796232,
+        "unavailable_reason": null
+      },
+      "control_sizes": [
+        2,
+        2
+      ],
+      "dtype": "float64",
+      "execution": {
+        "count": 5,
+        "max_ms": 2.175583,
+        "mean_ms": 2.0877584,
+        "median_ms": 2.102375,
+        "min_ms": 2.007125,
+        "samples_ms": [
+          2.007125,
+          2.02075,
+          2.102375,
+          2.175583,
+          2.1329589999999996
+        ],
+        "std_ms": 0.06474839066293461
+      },
+      "horizon": 16,
+      "input_fingerprint": {
+        "sha256": "39523cf4316bccb06dd5f7c6e7111b1b2f71cf3bf86a35a0718f3bce99a84d8c",
+        "signature": [
+          {
+            "dtype": "<f8",
+            "path": "[0]",
+            "shape": [
+              16,
+              32,
+              32
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[1]",
+            "shape": [
+              16,
+              32,
+              4
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[2]",
+            "shape": [
+              2,
+              16,
+              32,
+              32
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[3]",
+            "shape": [
+              2,
+              16,
+              4,
+              4
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[4]",
+            "shape": [
+              2,
+              32,
+              32
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[5]",
+            "shape": [
+              16,
+              32
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[6]",
+            "shape": [
+              2,
+              16,
+              32,
+              4
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[7]",
+            "shape": [
+              2,
+              16,
+              32
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[8]",
+            "shape": [
+              2,
+              16,
+              4
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[9]",
+            "shape": [
+              2,
+              16
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[10]",
+            "shape": [
+              2,
+              32
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[11]",
+            "shape": [
+              2
+            ]
+          }
+        ]
+      },
+      "joint_control_size": 4,
+      "logical_input_bytes": 476944,
+      "logical_output_bytes": 309315,
+      "lowering_seconds": 0.333929417,
+      "maximum_condition": 1.0876779861535262,
+      "minimum_rank": 4,
+      "name": "state-32",
+      "player_count": 2,
+      "state_size": 32,
+      "status": 0,
+      "valid": true
+    },
+    {
+      "case_shape": [],
+      "certificates": {
+        "normalized_bellman": 2.4847609194012393e-19,
+        "normalized_stationarity": 6.938893903907228e-18,
+        "rollout_defect": 2.42861286636753e-17,
+        "terminal_defect": 0.0
+      },
+      "compilation_seconds": 0.327174833,
+      "compiler": {
+        "argument_bytes": 36752,
+        "bytes_accessed": 337793,
+        "flops": 46962,
+        "generated_code_bytes": 0,
+        "output_bytes": 25875,
+        "source": "jax-compiled-executable",
+        "temporary_bytes": 50384,
+        "unavailable_reason": null
+      },
+      "control_sizes": [
+        1,
+        1
+      ],
+      "dtype": "float64",
+      "execution": {
+        "count": 5,
+        "max_ms": 0.865875,
+        "mean_ms": 0.7098998,
+        "median_ms": 0.695542,
+        "min_ms": 0.620791,
+        "samples_ms": [
+          0.695542,
+          0.620791,
+          0.621708,
+          0.745583,
+          0.865875
+        ],
+        "std_ms": 0.09113272960117016
+      },
+      "horizon": 16,
+      "input_fingerprint": {
+        "sha256": "0b84fbd69d277f3e78e78e64d29dd04cbbd138178517073bfe9c7a104356b8e6",
+        "signature": [
+          {
+            "dtype": "<f8",
+            "path": "[0]",
+            "shape": [
+              16,
+              8,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[1]",
+            "shape": [
+              16,
+              8,
+              2
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[2]",
+            "shape": [
+              2,
+              16,
+              8,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[3]",
+            "shape": [
+              2,
+              16,
+              2,
+              2
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[4]",
+            "shape": [
+              2,
+              8,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[5]",
+            "shape": [
+              16,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[6]",
+            "shape": [
+              2,
+              16,
+              8,
+              2
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[7]",
+            "shape": [
+              2,
+              16,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[8]",
+            "shape": [
+              2,
+              16,
+              2
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[9]",
+            "shape": [
+              2,
+              16
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[10]",
+            "shape": [
+              2,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[11]",
+            "shape": [
+              2
+            ]
+          }
+        ]
+      },
+      "joint_control_size": 2,
+      "logical_input_bytes": 36752,
+      "logical_output_bytes": 25539,
+      "lowering_seconds": 0.546945958,
+      "maximum_condition": 1.0738062539073567,
+      "minimum_rank": 2,
+      "name": "controls-1-1",
+      "player_count": 2,
+      "state_size": 8,
+      "status": 0,
+      "valid": true
+    },
+    {
+      "case_shape": [],
+      "certificates": {
+        "normalized_bellman": 7.848356254476164e-19,
+        "normalized_stationarity": 2.0816681711721685e-17,
+        "rollout_defect": 1.8214596497756474e-17,
+        "terminal_defect": 0.0
+      },
+      "compilation_seconds": 0.388806917,
+      "compiler": {
+        "argument_bytes": 147856,
+        "bytes_accessed": 1051977,
+        "flops": 196380,
+        "generated_code_bytes": 0,
+        "output_bytes": 42003,
+        "source": "jax-compiled-executable",
+        "temporary_bytes": 172936,
+        "unavailable_reason": null
+      },
+      "control_sizes": [
+        8,
+        8
+      ],
+      "dtype": "float64",
+      "execution": {
+        "count": 5,
+        "max_ms": 1.7152910000000001,
+        "mean_ms": 1.6375746,
+        "median_ms": 1.6470829999999999,
+        "min_ms": 1.562041,
+        "samples_ms": [
+          1.562041,
+          1.6076249999999999,
+          1.7152910000000001,
+          1.655833,
+          1.6470829999999999
+        ],
+        "std_ms": 0.05111931325673307
+      },
+      "horizon": 16,
+      "input_fingerprint": {
+        "sha256": "79c8809048c075347462ff243ab0d5213075228ae38e24035f42304cce80009e",
+        "signature": [
+          {
+            "dtype": "<f8",
+            "path": "[0]",
+            "shape": [
+              16,
+              8,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[1]",
+            "shape": [
+              16,
+              8,
+              16
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[2]",
+            "shape": [
+              2,
+              16,
+              8,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[3]",
+            "shape": [
+              2,
+              16,
+              16,
+              16
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[4]",
+            "shape": [
+              2,
+              8,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[5]",
+            "shape": [
+              16,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[6]",
+            "shape": [
+              2,
+              16,
+              8,
+              16
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[7]",
+            "shape": [
+              2,
+              16,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[8]",
+            "shape": [
+              2,
+              16,
+              16
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[9]",
+            "shape": [
+              2,
+              16
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[10]",
+            "shape": [
+              2,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[11]",
+            "shape": [
+              2
+            ]
+          }
+        ]
+      },
+      "joint_control_size": 16,
+      "logical_input_bytes": 147856,
+      "logical_output_bytes": 41667,
+      "lowering_seconds": 0.34031975,
+      "maximum_condition": 1.1682767096923756,
+      "minimum_rank": 16,
+      "name": "controls-8-8",
+      "player_count": 2,
+      "state_size": 8,
+      "status": 0,
+      "valid": true
+    },
+    {
+      "case_shape": [],
+      "certificates": {
+        "normalized_bellman": 3.1237874210987625e-19,
+        "normalized_stationarity": 1.3877787807814457e-17,
+        "rollout_defect": 1.3877787807814457e-17,
+        "terminal_defect": 0.0
+      },
+      "compilation_seconds": 0.323927875,
+      "compiler": {
+        "argument_bytes": 44744,
+        "bytes_accessed": 300141,
+        "flops": 50788,
+        "generated_code_bytes": 0,
+        "output_bytes": 22043,
+        "source": "jax-compiled-executable",
+        "temporary_bytes": 38600,
+        "unavailable_reason": null
+      },
+      "control_sizes": [
+        8
+      ],
+      "dtype": "float64",
+      "execution": {
+        "count": 5,
+        "max_ms": 1.092083,
+        "mean_ms": 0.8680752,
+        "median_ms": 0.814459,
+        "min_ms": 0.738209,
+        "samples_ms": [
+          0.7606660000000001,
+          0.738209,
+          0.934959,
+          1.092083,
+          0.814459
+        ],
+        "std_ms": 0.13109508016153767
+      },
+      "horizon": 16,
+      "input_fingerprint": {
+        "sha256": "1beac46bf956e12677db9e8024b53250c2449e9ae66f8c7b2e8015ee1980e76d",
+        "signature": [
+          {
+            "dtype": "<f8",
+            "path": "[0]",
+            "shape": [
+              16,
+              8,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[1]",
+            "shape": [
+              16,
+              8,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[2]",
+            "shape": [
+              1,
+              16,
+              8,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[3]",
+            "shape": [
+              1,
+              16,
+              8,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[4]",
+            "shape": [
+              1,
+              8,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[5]",
+            "shape": [
+              16,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[6]",
+            "shape": [
+              1,
+              16,
+              8,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[7]",
+            "shape": [
+              1,
+              16,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[8]",
+            "shape": [
+              1,
+              16,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[9]",
+            "shape": [
+              1,
+              16
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[10]",
+            "shape": [
+              1,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[11]",
+            "shape": [
+              1
+            ]
+          }
+        ]
+      },
+      "joint_control_size": 8,
+      "logical_input_bytes": 44744,
+      "logical_output_bytes": 21739,
+      "lowering_seconds": 0.330733416,
+      "maximum_condition": 1.047939094259051,
+      "minimum_rank": 8,
+      "name": "players-1",
+      "player_count": 1,
+      "state_size": 8,
+      "status": 0,
+      "valid": true
+    },
+    {
+      "case_shape": [],
+      "certificates": {
+        "normalized_bellman": 7.37696053245598e-19,
+        "normalized_stationarity": 1.3877787807814457e-17,
+        "rollout_defect": 1.5612511283791264e-17,
+        "terminal_defect": 0.0
+      },
+      "compilation_seconds": 0.351757208,
+      "compiler": {
+        "argument_bytes": 72080,
+        "bytes_accessed": 551241,
+        "flops": 91236,
+        "generated_code_bytes": 0,
+        "output_bytes": 32787,
+        "source": "jax-compiled-executable",
+        "temporary_bytes": 86536,
+        "unavailable_reason": null
+      },
+      "control_sizes": [
+        4,
+        4
+      ],
+      "dtype": "float64",
+      "execution": {
+        "count": 5,
+        "max_ms": 1.253333,
+        "mean_ms": 1.1440998,
+        "median_ms": 1.1098329999999998,
+        "min_ms": 1.078625,
+        "samples_ms": [
+          1.253333,
+          1.078625,
+          1.098625,
+          1.180083,
+          1.1098329999999998
+        ],
+        "std_ms": 0.06442950118819799
+      },
+      "horizon": 16,
+      "input_fingerprint": {
+        "sha256": "182648ced4deee5881d78810ecd062bbc9c6e1cc8de34959d90138293e8b6bd8",
+        "signature": [
+          {
+            "dtype": "<f8",
+            "path": "[0]",
+            "shape": [
+              16,
+              8,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[1]",
+            "shape": [
+              16,
+              8,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[2]",
+            "shape": [
+              2,
+              16,
+              8,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[3]",
+            "shape": [
+              2,
+              16,
+              8,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[4]",
+            "shape": [
+              2,
+              8,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[5]",
+            "shape": [
+              16,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[6]",
+            "shape": [
+              2,
+              16,
+              8,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[7]",
+            "shape": [
+              2,
+              16,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[8]",
+            "shape": [
+              2,
+              16,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[9]",
+            "shape": [
+              2,
+              16
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[10]",
+            "shape": [
+              2,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[11]",
+            "shape": [
+              2
+            ]
+          }
+        ]
+      },
+      "joint_control_size": 8,
+      "logical_input_bytes": 72080,
+      "logical_output_bytes": 32451,
+      "lowering_seconds": 0.290689166,
+      "maximum_condition": 1.114422270934186,
+      "minimum_rank": 8,
+      "name": "players-2",
+      "player_count": 2,
+      "state_size": 8,
+      "status": 0,
+      "valid": true
+    },
+    {
+      "case_shape": [],
+      "certificates": {
+        "normalized_bellman": 4.055079630966981e-19,
+        "normalized_stationarity": 2.0816681711721685e-17,
+        "rollout_defect": 2.0816681711721685e-17,
+        "terminal_defect": 0.0
+      },
+      "compilation_seconds": 0.400852333,
+      "compiler": {
+        "argument_bytes": 126752,
+        "bytes_accessed": 1059423,
+        "flops": 174600,
+        "generated_code_bytes": 0,
+        "output_bytes": 54275,
+        "source": "jax-compiled-executable",
+        "temporary_bytes": 160520,
+        "unavailable_reason": null
+      },
+      "control_sizes": [
+        2,
+        2,
+        2,
+        2
+      ],
+      "dtype": "float64",
+      "execution": {
+        "count": 5,
+        "max_ms": 1.312667,
+        "mean_ms": 1.2739167999999998,
+        "median_ms": 1.303834,
+        "min_ms": 1.1680830000000002,
+        "samples_ms": [
+          1.1680830000000002,
+          1.312667,
+          1.2743749999999998,
+          1.310625,
+          1.303834
+        ],
+        "std_ms": 0.05467195254021928
+      },
+      "horizon": 16,
+      "input_fingerprint": {
+        "sha256": "b1ecb1067c65e9bc6a62d05cc00d5930504328c97a095d538750c229f036007f",
+        "signature": [
+          {
+            "dtype": "<f8",
+            "path": "[0]",
+            "shape": [
+              16,
+              8,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[1]",
+            "shape": [
+              16,
+              8,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[2]",
+            "shape": [
+              4,
+              16,
+              8,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[3]",
+            "shape": [
+              4,
+              16,
+              8,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[4]",
+            "shape": [
+              4,
+              8,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[5]",
+            "shape": [
+              16,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[6]",
+            "shape": [
+              4,
+              16,
+              8,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[7]",
+            "shape": [
+              4,
+              16,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[8]",
+            "shape": [
+              4,
+              16,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[9]",
+            "shape": [
+              4,
+              16
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[10]",
+            "shape": [
+              4,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[11]",
+            "shape": [
+              4
+            ]
+          }
+        ]
+      },
+      "joint_control_size": 8,
+      "logical_input_bytes": 126752,
+      "logical_output_bytes": 53875,
+      "lowering_seconds": 0.302798375,
+      "maximum_condition": 1.2479856594083913,
+      "minimum_rank": 8,
+      "name": "players-4",
+      "player_count": 4,
+      "state_size": 8,
+      "status": 0,
+      "valid": true
+    },
+    {
+      "case_shape": [],
+      "certificates": {
+        "normalized_bellman": 1.0238029157711493e-18,
+        "normalized_stationarity": 2.7755575615628914e-17,
+        "rollout_defect": 2.2551405187698492e-17,
+        "terminal_defect": 0.0
+      },
+      "compilation_seconds": 0.425334916,
+      "compiler": {
+        "argument_bytes": 236096,
+        "bytes_accessed": 2198227,
+        "flops": 348953,
+        "generated_code_bytes": 0,
+        "output_bytes": 97251,
+        "source": "jax-compiled-executable",
+        "temporary_bytes": 304544,
+        "unavailable_reason": null
+      },
+      "control_sizes": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ],
+      "dtype": "float64",
+      "execution": {
+        "count": 5,
+        "max_ms": 1.656917,
+        "mean_ms": 1.5421504,
+        "median_ms": 1.595167,
+        "min_ms": 1.418834,
+        "samples_ms": [
+          1.418834,
+          1.4409169999999998,
+          1.595167,
+          1.656917,
+          1.5989170000000001
+        ],
+        "std_ms": 0.09450895725929905
+      },
+      "horizon": 16,
+      "input_fingerprint": {
+        "sha256": "d4a0488caf53483b69b85b868890a479d0c357fd34644d1a5349bd88ffce1622",
+        "signature": [
+          {
+            "dtype": "<f8",
+            "path": "[0]",
+            "shape": [
+              16,
+              8,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[1]",
+            "shape": [
+              16,
+              8,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[2]",
+            "shape": [
+              8,
+              16,
+              8,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[3]",
+            "shape": [
+              8,
+              16,
+              8,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[4]",
+            "shape": [
+              8,
+              8,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[5]",
+            "shape": [
+              16,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[6]",
+            "shape": [
+              8,
+              16,
+              8,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[7]",
+            "shape": [
+              8,
+              16,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[8]",
+            "shape": [
+              8,
+              16,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[9]",
+            "shape": [
+              8,
+              16
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[10]",
+            "shape": [
+              8,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[11]",
+            "shape": [
+              8
+            ]
+          }
+        ]
+      },
+      "joint_control_size": 8,
+      "logical_input_bytes": 236096,
+      "logical_output_bytes": 96723,
+      "lowering_seconds": 0.548795291,
+      "maximum_condition": 1.5149042587781072,
+      "minimum_rank": 8,
+      "name": "players-8",
+      "player_count": 8,
+      "state_size": 8,
+      "status": 0,
+      "valid": true
+    },
+    {
+      "case_shape": [
+        8
+      ],
+      "certificates": {
+        "normalized_bellman": 4.592363268940062e-19,
+        "normalized_stationarity": 6.938893903907228e-18,
+        "rollout_defect": 2.0816681711721685e-17,
+        "terminal_defect": 0.0
+      },
+      "compilation_seconds": 0.479216125,
+      "compiler": {
+        "argument_bytes": 371840,
+        "bytes_accessed": 3450851,
+        "flops": 465394,
+        "generated_code_bytes": 0,
+        "output_bytes": 220224,
+        "source": "jax-compiled-executable",
+        "temporary_bytes": 486016,
+        "unavailable_reason": null
+      },
+      "control_sizes": [
+        2,
+        2
+      ],
+      "dtype": "float64",
+      "execution": {
+        "count": 5,
+        "max_ms": 6.157042,
+        "mean_ms": 3.081525,
+        "median_ms": 2.245,
+        "min_ms": 2.216417,
+        "samples_ms": [
+          2.233666,
+          2.216417,
+          2.245,
+          6.157042,
+          2.5555
+        ],
+        "std_ms": 1.5428906590607125
+      },
+      "horizon": 16,
+      "input_fingerprint": {
+        "sha256": "621211b35fc7ce1d5e507ad8e97ec40d5628218dd4f3020742ac4cb414e296c4",
+        "signature": [
+          {
+            "dtype": "<f8",
+            "path": "[0]",
+            "shape": [
+              8,
+              16,
+              8,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[1]",
+            "shape": [
+              8,
+              16,
+              8,
+              4
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[2]",
+            "shape": [
+              8,
+              2,
+              16,
+              8,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[3]",
+            "shape": [
+              8,
+              2,
+              16,
+              4,
+              4
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[4]",
+            "shape": [
+              8,
+              2,
+              8,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[5]",
+            "shape": [
+              8,
+              16,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[6]",
+            "shape": [
+              8,
+              2,
+              16,
+              8,
+              4
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[7]",
+            "shape": [
+              8,
+              2,
+              16,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[8]",
+            "shape": [
+              8,
+              2,
+              16,
+              4
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[9]",
+            "shape": [
+              8,
+              2,
+              16
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[10]",
+            "shape": [
+              8,
+              2,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[11]",
+            "shape": [
+              8,
+              2
+            ]
+          }
+        ]
+      },
+      "joint_control_size": 4,
+      "logical_input_bytes": 371840,
+      "logical_output_bytes": 219888,
+      "lowering_seconds": 0.367899458,
+      "maximum_condition": 1.087716386173645,
+      "minimum_rank": 4,
+      "name": "cases-8",
+      "player_count": 2,
+      "state_size": 8,
+      "status": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "valid": true
+    },
+    {
+      "case_shape": [
+        64
+      ],
+      "certificates": {
+        "normalized_bellman": 4.592363268940062e-19,
+        "normalized_stationarity": 6.938893903907228e-18,
+        "rollout_defect": 2.0816681711721685e-17,
+        "terminal_defect": 0.0
+      },
+      "compilation_seconds": 0.508017792,
+      "compiler": {
+        "argument_bytes": 2974720,
+        "bytes_accessed": 27587972,
+        "flops": 3722522,
+        "generated_code_bytes": 0,
+        "output_bytes": 1756584,
+        "source": "jax-compiled-executable",
+        "temporary_bytes": 3873472,
+        "unavailable_reason": null
+      },
+      "control_sizes": [
+        2,
+        2
+      ],
+      "dtype": "float64",
+      "execution": {
+        "count": 5,
+        "max_ms": 11.583166,
+        "mean_ms": 11.2087746,
+        "median_ms": 11.139041,
+        "min_ms": 10.991624999999999,
+        "samples_ms": [
+          11.139041,
+          11.218916,
+          11.111125,
+          11.583166,
+          10.991624999999999
+        ],
+        "std_ms": 0.20090989847053362
+      },
+      "horizon": 16,
+      "input_fingerprint": {
+        "sha256": "a06b96f7f19eac8e1e135249dda5dbddad3b66e150b69ec318dbbb1a460f5bd9",
+        "signature": [
+          {
+            "dtype": "<f8",
+            "path": "[0]",
+            "shape": [
+              64,
+              16,
+              8,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[1]",
+            "shape": [
+              64,
+              16,
+              8,
+              4
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[2]",
+            "shape": [
+              64,
+              2,
+              16,
+              8,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[3]",
+            "shape": [
+              64,
+              2,
+              16,
+              4,
+              4
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[4]",
+            "shape": [
+              64,
+              2,
+              8,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[5]",
+            "shape": [
+              64,
+              16,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[6]",
+            "shape": [
+              64,
+              2,
+              16,
+              8,
+              4
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[7]",
+            "shape": [
+              64,
+              2,
+              16,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[8]",
+            "shape": [
+              64,
+              2,
+              16,
+              4
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[9]",
+            "shape": [
+              64,
+              2,
+              16
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[10]",
+            "shape": [
+              64,
+              2,
+              8
+            ]
+          },
+          {
+            "dtype": "<f8",
+            "path": "[11]",
+            "shape": [
+              64,
+              2
+            ]
+          }
+        ]
+      },
+      "joint_control_size": 4,
+      "logical_input_bytes": 2974720,
+      "logical_output_bytes": 1756248,
+      "lowering_seconds": 0.382454459,
+      "maximum_condition": 1.087716386173645,
+      "minimum_rank": 4,
+      "name": "cases-64",
+      "player_count": 2,
+      "state_size": 8,
+      "status": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "valid": true
+    }
+  ],
+  "environment": {
+    "default_float_dtype": "float64",
+    "fingerprint": "dee1555b843e001a66559ae750b6d1f4ccdbc2174bdae8bb60b178b423512e5e",
+    "jax": {
+      "backend": "cpu",
+      "devices": [
+        {
+          "kind": "cpu",
+          "platform": "cpu"
+        }
+      ],
+      "version": "0.9.2",
+      "x64_enabled": true
+    },
+    "jaxlib_version": "0.9.2",
+    "logical_cpus": 10,
+    "machine": "arm64",
+    "numpy_version": "2.4.6",
+    "package_fingerprint": "04eaf233299b60207aa03bc6f06f20aaebf65a123e625df1bcf04147202cc88d",
+    "performance_environment": {
+      "JAX_COMPILATION_CACHE_DIR": null,
+      "JAX_PLATFORMS": null,
+      "JAX_PLATFORM_NAME": null,
+      "MKL_NUM_THREADS": null,
+      "OMP_NUM_THREADS": null,
+      "OPENBLAS_NUM_THREADS": null,
+      "VECLIB_MAXIMUM_THREADS": null,
+      "XLA_FLAGS": null,
+      "XLA_PYTHON_CLIENT_MEM_FRACTION": null,
+      "XLA_PYTHON_CLIENT_PREALLOCATE": null
+    },
+    "phydrax_version": "0.2.2",
+    "platform": "macOS-15.7.2-arm64-arm-64bit",
+    "processor": "arm",
+    "python_version": "3.12.8"
+  },
+  "maximum_certificate": 2.7755575615628914e-17
+}

--- a/benchmarks/control_lq_nash.py
+++ b/benchmarks/control_lq_nash.py
@@ -1,0 +1,464 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import argparse
+import math
+from pathlib import Path
+from typing import Any
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+
+import phydrax as phx
+import phydrax.ein as ein
+from benchmarks._io import write_json_atomic
+from benchmarks._runtime import (
+    capture_environment,
+    compiler_evidence,
+    logical_array_bytes,
+    measure_lower_and_compile,
+    measure_repeated,
+)
+from phydrax._fingerprint import array_tree_fingerprint
+
+
+BenchmarkArguments = tuple[jax.Array, ...]
+
+
+def _broadcast_case(value: jax.Array, case_shape: tuple[int, ...], /) -> jax.Array:
+    return jnp.broadcast_to(value, case_shape + value.shape)
+
+
+def _problem(
+    horizon: int,
+    state_size: int,
+    control_sizes: tuple[int, ...],
+    case_shape: tuple[int, ...],
+    /,
+) -> tuple[
+    BenchmarkArguments, phx.control.games.PlayerControlPartition, phx.dynamics.TimeGrid
+]:
+    control_size = sum(control_sizes)
+    player_count = len(control_sizes)
+    time = jnp.arange(horizon, dtype=jnp.float64)
+    state_index = jnp.arange(state_size, dtype=jnp.float64)
+    control_index = jnp.arange(control_size, dtype=jnp.float64)
+    identity = jnp.eye(state_size, dtype=jnp.float64)
+    dynamics = jnp.stack(
+        [(0.82 + 0.02 * jnp.cos(0.2 * step)) * identity for step in range(horizon)]
+    )
+    control_base = 0.02 * jnp.cos(
+        (state_index[:, None] + 1.0) * (control_index[None, :] + 1.0)
+    )
+    controls = jnp.stack([control_base * (1.0 + 0.01 * step) for step in range(horizon)])
+    bias = 0.005 * jnp.sin(time[:, None] + state_index[None, :])
+
+    state_costs = jnp.stack(
+        [
+            jnp.broadcast_to(
+                (0.5 + 0.1 * player) * identity,
+                (horizon, state_size, state_size),
+            )
+            for player in range(player_count)
+        ]
+    )
+    control_costs = []
+    cross = []
+    state_linear = []
+    control_linear = []
+    stage_constants = []
+    for player in range(player_count):
+        diagonal = 1.5 + 0.1 * player + 0.01 * control_index
+        control_cost = jnp.diag(diagonal) + 0.002 * (
+            jnp.ones((control_size, control_size), dtype=jnp.float64)
+            - jnp.eye(control_size, dtype=jnp.float64)
+        )
+        control_costs.append(
+            jnp.broadcast_to(control_cost, (horizon, control_size, control_size))
+        )
+        cross_base = (
+            0.001
+            * (player + 1)
+            * jnp.sin((state_index[:, None] + 1.0) + (control_index[None, :] + 1.0))
+        )
+        cross.append(jnp.broadcast_to(cross_base, (horizon,) + cross_base.shape))
+        state_linear.append(
+            0.002 * (player + 1) * jnp.cos(time[:, None] + state_index[None, :])
+        )
+        control_linear.append(
+            0.002 * (player + 1) * jnp.sin(time[:, None] + control_index[None, :])
+        )
+        stage_constants.append(0.001 * (player + 1) * (time + 1.0))
+    control_costs_array = jnp.stack(control_costs)
+    cross_array = jnp.stack(cross)
+    state_linear_array = jnp.stack(state_linear)
+    control_linear_array = jnp.stack(control_linear)
+    stage_constants_array = jnp.stack(stage_constants)
+    terminal_state_costs = jnp.stack(
+        [(0.8 + 0.1 * player) * identity for player in range(player_count)]
+    )
+    terminal_linear = jnp.stack(
+        [
+            0.003 * (player + 1) * jnp.cos(state_index + 1.0)
+            for player in range(player_count)
+        ]
+    )
+    terminal_constants = 0.01 * (jnp.arange(player_count, dtype=jnp.float64) + 1.0)
+    arguments = tuple(
+        _broadcast_case(value, case_shape)
+        for value in (
+            dynamics,
+            controls,
+            state_costs,
+            control_costs_array,
+            terminal_state_costs,
+            bias,
+            cross_array,
+            state_linear_array,
+            control_linear_array,
+            stage_constants_array,
+            terminal_linear,
+            terminal_constants,
+        )
+    )
+    partition = phx.control.games.PlayerControlPartition(
+        tuple(f"player-{player}" for player in range(player_count)),
+        control_sizes,
+    )
+    time_grid = phx.dynamics.TimeGrid(
+        jnp.arange(horizon + 1, dtype=jnp.float64),
+        time_id=(
+            f"benchmark-lq-nash:T{horizon}:n{state_size}:m{control_size}:p{player_count}"
+        ),
+    )
+    return arguments, partition, time_grid
+
+
+def _solve_function(partition, time_grid):
+    def solve_game(arguments):
+        (
+            dynamics,
+            controls,
+            state_costs,
+            control_costs,
+            terminal_state_costs,
+            bias,
+            cross,
+            state_linear,
+            control_linear,
+            stage_constants,
+            terminal_linear,
+            terminal_constants,
+        ) = arguments
+        return phx.control.games.finite_horizon_lq_feedback_nash(
+            dynamics,
+            controls,
+            state_costs,
+            control_costs,
+            terminal_state_costs,
+            partition,
+            dynamics_bias=bias,
+            state_control_cross=cross,
+            state_linear=state_linear,
+            control_linear=control_linear,
+            stage_constants=stage_constants,
+            terminal_linear=terminal_linear,
+            terminal_constants=terminal_constants,
+            time_grid=time_grid,
+            policy_id=f"{time_grid.time_id}:policy",
+        )
+
+    return eqx.filter_jit(solve_game)
+
+
+def _certificates(arguments, partition, result) -> dict[str, float]:
+    (
+        dynamics,
+        controls,
+        state_costs,
+        control_costs,
+        terminal_state_costs,
+        bias,
+        cross,
+        state_linear,
+        control_linear,
+        stage_constants,
+        terminal_linear,
+        terminal_constants,
+    ) = arguments
+    del stage_constants, terminal_constants
+    case_shape = dynamics.shape[:-3]
+    player_axis = len(case_shape)
+    value_matrices = jnp.stack(
+        [value.matrices for value in result.values],
+        axis=player_axis,
+    )
+    value_linear = jnp.stack(
+        [value.linear for value in result.values],
+        axis=player_axis,
+    )
+    maximum_stationarity = jnp.asarray(0.0, dtype=dynamics.dtype)
+    maximum_bellman = jnp.asarray(0.0, dtype=dynamics.dtype)
+    for step in range(dynamics.shape[-3]):
+        a = dynamics[..., step, :, :]
+        b = controls[..., step, :, :]
+        c = bias[..., step, :]
+        k_matrix = result.feedback_gain[..., step, :, :]
+        k_vector = result.feedforward[..., step, :]
+        z_next = value_matrices[..., :, step + 1, :, :]
+        z_linear_next = value_linear[..., :, step + 1, :]
+        h = (
+            control_costs[..., :, step, :, :]
+            + jnp.swapaxes(b, -1, -2)[..., None, :, :] @ z_next @ b[..., None, :, :]
+        )
+        w = jnp.swapaxes(b, -1, -2)[..., None, :, :] @ z_next @ a[
+            ..., None, :, :
+        ] + jnp.swapaxes(cross[..., :, step, :, :], -1, -2)
+        affine_next = ein.contract("...pij,...j->...pi", z_next, c) + z_linear_next
+        g = control_linear[..., :, step, :] + ein.contract(
+            "...ji,...pj->...pi",
+            b,
+            affine_next,
+        )
+        stationarity_matrix_blocks = []
+        stationarity_vector_blocks = []
+        for player, (start, stop) in enumerate(partition.control_slices):
+            stationarity_matrix_blocks.append(
+                h[..., player, start:stop, :] @ k_matrix + w[..., player, start:stop, :]
+            )
+            stationarity_vector_blocks.append(
+                ein.contract(
+                    "...ij,...j->...i",
+                    h[..., player, start:stop, :],
+                    k_vector,
+                )
+                + g[..., player, start:stop]
+            )
+        stationarity_matrix = jnp.concatenate(stationarity_matrix_blocks, axis=-2)
+        stationarity_vector = jnp.concatenate(stationarity_vector_blocks, axis=-1)
+        stationarity_scale = jnp.maximum(
+            jnp.maximum(jnp.max(jnp.abs(w)), jnp.max(jnp.abs(g))),
+            1.0,
+        )
+        maximum_stationarity = jnp.maximum(
+            maximum_stationarity,
+            jnp.maximum(
+                jnp.max(jnp.abs(stationarity_matrix)),
+                jnp.max(jnp.abs(stationarity_vector)),
+            )
+            / stationarity_scale,
+        )
+
+        closed_loop = a + b @ k_matrix
+        closed_bias = c + ein.contract("...ij,...j->...i", b, k_vector)
+        direct_z = (
+            state_costs[..., :, step, :, :]
+            + cross[..., :, step, :, :] @ k_matrix[..., None, :, :]
+            + jnp.swapaxes(k_matrix, -1, -2)[..., None, :, :]
+            @ jnp.swapaxes(cross[..., :, step, :, :], -1, -2)
+            + jnp.swapaxes(k_matrix, -1, -2)[..., None, :, :]
+            @ control_costs[..., :, step, :, :]
+            @ k_matrix[..., None, :, :]
+            + jnp.swapaxes(closed_loop, -1, -2)[..., None, :, :]
+            @ z_next
+            @ closed_loop[..., None, :, :]
+        )
+        direct_linear = (
+            state_linear[..., :, step, :]
+            + ein.contract(
+                "...pij,...j->...pi",
+                cross[..., :, step, :, :],
+                k_vector,
+            )
+            + ein.contract(
+                "...ji,...pj->...pi",
+                k_matrix,
+                ein.contract(
+                    "...pij,...j->...pi",
+                    control_costs[..., :, step, :, :],
+                    k_vector,
+                )
+                + control_linear[..., :, step, :],
+            )
+            + ein.contract(
+                "...ji,...pj->...pi",
+                closed_loop,
+                ein.contract("...pij,...j->...pi", z_next, closed_bias) + z_linear_next,
+            )
+        )
+        z_current = value_matrices[..., :, step, :, :]
+        linear_current = value_linear[..., :, step, :]
+        bellman_numerator = jnp.maximum(
+            jnp.max(jnp.abs(z_current - direct_z)),
+            jnp.max(jnp.abs(linear_current - direct_linear)),
+        )
+        bellman_scale = jnp.maximum(
+            jnp.maximum(jnp.max(jnp.abs(direct_z)), jnp.max(jnp.abs(direct_linear))),
+            1.0,
+        )
+        maximum_bellman = jnp.maximum(
+            maximum_bellman,
+            bellman_numerator / bellman_scale,
+        )
+    terminal_defect = jnp.maximum(
+        jnp.max(jnp.abs(value_matrices[..., :, -1, :, :] - terminal_state_costs)),
+        jnp.max(jnp.abs(value_linear[..., :, -1, :] - terminal_linear)),
+    )
+
+    state_size = dynamics.shape[-1]
+    initial_state = jnp.linspace(-0.25, 0.25, state_size, dtype=dynamics.dtype)
+    states = jnp.broadcast_to(initial_state, case_shape + initial_state.shape)
+    maximum_rollout = jnp.asarray(0.0, dtype=dynamics.dtype)
+    for step in range(dynamics.shape[-3]):
+        action = (result.feedback_gain[..., step, :, :] @ states[..., None])[
+            ..., 0
+        ] + result.feedforward[..., step, :]
+        following = (
+            (dynamics[..., step, :, :] @ states[..., None])[..., 0]
+            + (controls[..., step, :, :] @ action[..., None])[..., 0]
+            + bias[..., step, :]
+        )
+        defect = (
+            following
+            - ein.contract("...ij,...j->...i", dynamics[..., step, :, :], states)
+            - ein.contract("...ij,...j->...i", controls[..., step, :, :], action)
+            - bias[..., step, :]
+        )
+        maximum_rollout = jnp.maximum(maximum_rollout, jnp.max(jnp.abs(defect)))
+        states = following
+    return {
+        "normalized_stationarity": float(maximum_stationarity),
+        "normalized_bellman": float(maximum_bellman),
+        "terminal_defect": float(terminal_defect),
+        "rollout_defect": float(maximum_rollout),
+    }
+
+
+def _case(
+    name: str,
+    horizon: int,
+    state_size: int,
+    control_sizes: tuple[int, ...],
+    case_shape: tuple[int, ...],
+    /,
+    *,
+    warmup: int,
+    repeats: int,
+) -> dict[str, Any]:
+    arguments, partition, time_grid = _problem(
+        horizon,
+        state_size,
+        control_sizes,
+        case_shape,
+    )
+    function = _solve_function(partition, time_grid)
+    compiled, compilation = measure_lower_and_compile(
+        lambda: function.lower(arguments),
+        lambda lowered: lowered.compile(),
+    )
+    result, execution = measure_repeated(
+        lambda: compiled(arguments),
+        warmup=warmup,
+        repeats=repeats,
+    )
+    evidence = compiler_evidence(
+        compiled.compiled.cost_analysis(),
+        compiled.compiled.memory_analysis(),
+        source="jax-compiled-executable",
+    )
+    certificates = _certificates(arguments, partition, result)
+    return {
+        "name": name,
+        "horizon": horizon,
+        "state_size": state_size,
+        "control_sizes": list(control_sizes),
+        "player_count": len(control_sizes),
+        "joint_control_size": sum(control_sizes),
+        "case_shape": list(case_shape),
+        "dtype": str(arguments[0].dtype),
+        "input_fingerprint": array_tree_fingerprint(arguments),
+        "lowering_seconds": compilation.lowering_seconds,
+        "compilation_seconds": compilation.compilation_seconds,
+        "execution": execution.to_milliseconds_dict(),
+        "logical_input_bytes": logical_array_bytes(arguments),
+        "logical_output_bytes": logical_array_bytes(result),
+        "compiler": {
+            "flops": evidence.flops,
+            "bytes_accessed": evidence.bytes_accessed,
+            "argument_bytes": evidence.argument_bytes,
+            "output_bytes": evidence.output_bytes,
+            "temporary_bytes": evidence.temporary_bytes,
+            "generated_code_bytes": evidence.generated_code_bytes,
+            "source": evidence.source,
+            "unavailable_reason": evidence.unavailable_reason,
+        },
+        "valid": bool(jnp.all(result.valid)),
+        "status": jnp.asarray(result.status).tolist(),
+        "minimum_rank": int(jnp.min(result.diagnostics.coupled_ranks)),
+        "maximum_condition": float(jnp.max(result.diagnostics.coupled_condition_numbers)),
+        "certificates": certificates,
+    }
+
+
+def _specifications():
+    return (
+        ("baseline", 16, 8, (2, 2), ()),
+        ("horizon-4", 4, 8, (2, 2), ()),
+        ("horizon-64", 64, 8, (2, 2), ()),
+        ("state-4", 16, 4, (2, 2), ()),
+        ("state-32", 16, 32, (2, 2), ()),
+        ("controls-1-1", 16, 8, (1, 1), ()),
+        ("controls-8-8", 16, 8, (8, 8), ()),
+        ("players-1", 16, 8, (8,), ()),
+        ("players-2", 16, 8, (4, 4), ()),
+        ("players-4", 16, 8, (2, 2, 2, 2), ()),
+        ("players-8", 16, 8, (1, 1, 1, 1, 1, 1, 1, 1), ()),
+        ("cases-8", 16, 8, (2, 2), (8,)),
+        ("cases-64", 16, 8, (2, 2), (64,)),
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--warmup", type=int, default=2)
+    parser.add_argument("--repeats", type=int, default=5)
+    parser.add_argument("--output", type=Path)
+    arguments = parser.parse_args()
+    if arguments.warmup < 0 or arguments.repeats < 1:
+        raise ValueError("warmup must be non-negative and repeats must be positive.")
+    cases = [
+        _case(
+            name,
+            horizon,
+            state_size,
+            control_sizes,
+            case_shape,
+            warmup=arguments.warmup,
+            repeats=arguments.repeats,
+        )
+        for name, horizon, state_size, control_sizes, case_shape in _specifications()
+    ]
+    certificate_values = [
+        value for case in cases for value in case["certificates"].values()
+    ]
+    payload = {
+        "environment": capture_environment().to_dict(),
+        "cases": cases,
+        "all_valid": all(case["valid"] for case in cases),
+        "all_finite": all(math.isfinite(value) for value in certificate_values),
+        "maximum_certificate": max(certificate_values),
+    }
+    if arguments.output is None:
+        import json
+
+        print(json.dumps(payload, indent=2))
+    else:
+        write_json_atomic(arguments.output, payload)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/all-of-phydrax.md
+++ b/docs/all-of-phydrax.md
@@ -783,6 +783,11 @@ linearization and frequency response, Lyapunov/Riccati equations, Gramians,
 finite- and infinite-horizon LQR, iLQR, dense multiple shooting, implicit
 direct collocation, dense or structural-sparse prepared linear-control QPs,
 explicit MPC warm-start shifting, and affine stage/terminal SOCP constraints.
+`phydrax.control.games` adds finite-horizon affine linear-quadratic
+full-state feedback Nash policies with explicit player control ownership,
+per-player values, nonsymmetric dense-LU solves, diagnostic-only rank SVDs,
+and independent curvature, stationarity, Bellman, conditioning, and causal
+failure evidence.
 Direct collocation accepts explicit systems or controlled state-shaped DAEs,
 shared parameter coordinates, fixed or variable duration, exact sparse
 derivatives, and explicitly selected dense-native, sparse-native, or sparse

--- a/docs/api/control.md
+++ b/docs/api/control.md
@@ -13,6 +13,7 @@ failure, or hide a fallback.
 | Roll out a supplied control | `ControlProblem.rollout` | Discrete or differential dynamics; returns a `ControlTrajectory` without evaluating cost or constraints. |
 | Audit a supplied control | `ControlProblem.evaluate` | Adds left-rectangle sampled cost and sampled constraint residuals. Nonlinear feasibility is checked only at declared sample sites and is not certified between them. |
 | Unconstrained affine-quadratic control | `finite_horizon_lqr`, `continuous_lqr`, `discrete_lqr` | Riccati solutions with residual, conditioning, stability, and convergence diagnostics. |
+| Unconstrained affine-quadratic feedback game | `control.games.finite_horizon_lq_feedback_nash` | Simultaneous full-state feedback Nash policy with explicit player ownership, per-player values, curvature, rank, conditioning, stationarity, Bellman, and causal-failure evidence. |
 | Constrained affine discrete control | `compile_linear_quadratic_control`, `solve_linear_quadratic_control` | Canonical, uncondensed QP with exact decision and constraint layouts. |
 | Receding-horizon affine control | `solve_receding_horizon_mpc` | Re-solves canonical QPs and records every subproblem result and exact state handoff. |
 | One unconstrained nonlinear case | `solve_ilqr` | iLQR with a fixed requested regularization and explicit line-search or curvature failure. |
@@ -280,6 +281,56 @@ the policy only where `result.valid` is true.
 ::: phydrax.control.continuous_lqr
 
 ::: phydrax.control.discrete_lqr
+
+## Linear-quadratic feedback games
+
+`phydrax.control.games` solves finite-horizon discrete affine linear-quadratic
+games with simultaneous full-state feedback. Every player minimizes an
+individual quadratic-affine cost that may depend on the full joint control.
+The returned joint `AffineFeedbackPolicy` uses `u = K x + k`; its contiguous
+control rows are owned by the ordered `PlayerControlPartition`.
+
+For `case_shape = C`, `P` players, `T` stages, state size `n`, and joint control
+size `m`, dynamics arrays have shapes `C + (T, n, n)` and `C + (T, n, m)`.
+Player stage costs carry shapes `C + (P, T, ...)`; terminal costs carry
+`C + (P, ...)`. Stage, player, and case axes are explicit and never
+broadcast. The problem has `T` controls and `T + 1` player-value nodes.
+Stage costs are discrete sums; they are not duration-weighted
+`ControlProblem` sampled costs.
+
+At each stage, player-owned first-order rows form one generally nonsymmetric
+coupled Nash system. The authoritative policy comes only from a Phydrax
+`DenseLU` solve with a declared multiple-RHS layout. A separate
+diagnostic-only SVD supplies numerical rank and the full condition number; it
+is never used to solve or repair the system. No inverse, pseudoinverse,
+symmetrization of the coupled system, diagonal jitter, clipping,
+regularization, zero policy, or method fallback is permitted.
+
+A successful result certifies positive continuation-augmented own-action
+curvature, full coupled rank, finite output, and bounded independent
+stationarity and Bellman residuals. Failure to satisfy those conditions means
+this method did not certify a unique feedback Nash policy; it is not a proof
+that no equilibrium exists. `first_failed_stage` is `-1` on success, `T` for
+a terminal-cost failure, or the first direct causal failure encountered by
+the reverse recursion. Earlier stages then report `DEPENDENCY_FAILED`.
+Invalid policy and value arrays are retained only as numerical evidence and
+must not be applied.
+
+The scope is deterministic, unconstrained, discrete-time, finite-horizon,
+simultaneous, full-state feedback with all players minimizing. It does not
+represent open-loop Nash, zero-sum maximizers, constrained or generalized
+Nash equilibria, nonlinear iLQ games, stochastic games, partial observations,
+or mean-field games.
+
+::: phydrax.control.games.PlayerControlPartition
+
+::: phydrax.control.games.LQFeedbackNashStatus
+
+::: phydrax.control.games.FiniteHorizonLQFeedbackNashDiagnostics
+
+::: phydrax.control.games.FiniteHorizonLQFeedbackNashResult
+
+::: phydrax.control.games.finite_horizon_lq_feedback_nash
 
 ## Frequency response
 

--- a/docs/cookbook/control.md
+++ b/docs/cookbook/control.md
@@ -131,6 +131,76 @@ function. Before accepting the result, inspect `lqr.diagnostics.maximum_kkt_resi
 `maximum_riccati_residual`, `maximum_control_condition_number`, and `converged`. LQR does
 not silently regularize an invalid control Hessian.
 
+## Solve a two-player feedback Nash game
+
+`phydrax.control.games` retains one joint physical control vector while naming
+which contiguous rows each player owns. Player costs carry an explicit player
+axis before the stage axis and may couple every joint-control component.
+
+```python
+players = phx.control.games.PlayerControlPartition(
+    ("player-1", "player-2"),
+    (1, 1),
+)
+game_time = phx.dynamics.TimeGrid(
+    jnp.asarray([0.0, 1.0]),
+    time_id="two-player-game",
+)
+A_game = jnp.asarray([[[1.0]]])
+B_game = jnp.asarray([[[1.0, 1.0]]])
+Q_game = jnp.asarray([[[[2.0]]], [[[-1.0]]]])
+R_game = jnp.asarray(
+    [
+        [[[1.0, -0.5], [-0.5, 2.0]]],
+        [[[2.0, -3.0], [-3.0, 1.0]]],
+    ]
+)
+Qf_game = jnp.asarray([[[1.0]], [[2.0]]])
+
+game = phx.control.games.finite_horizon_lq_feedback_nash(
+    A_game,
+    B_game,
+    Q_game,
+    R_game,
+    Qf_game,
+    players,
+    dynamics_bias=jnp.asarray([[1.0]]),
+    state_control_cross=jnp.asarray(
+        [[[[1.0, -1.0]]], [[[0.5, -0.5]]]]
+    ),
+    state_linear=jnp.asarray([[[1.0]], [[-2.0]]]),
+    control_linear=jnp.asarray([[[0.5, -1.0]], [[0.25, 1.0]]]),
+    stage_constants=jnp.asarray([[3.0], [-1.0]]),
+    terminal_linear=jnp.asarray([[0.5], [-1.0]]),
+    terminal_constants=jnp.asarray([0.25, 2.0]),
+    time_grid=game_time,
+)
+if not bool(game.valid):
+    raise RuntimeError(
+        f"feedback Nash solve failed at {game.diagnostics.first_failed_stage}: "
+        f"status={game.status}"
+    )
+
+player_gains = players.split_feedback_gain(game.feedback_gain)
+initial_state = jnp.asarray([0.3])
+initial_values = jnp.stack(
+    [value(game_time.times[0], initial_state) for value in game.values]
+)
+```
+
+Inspect `coupled_ranks`, `coupled_condition_numbers`,
+`own_control_minimum_eigenvalues`, `stationarity_residuals`, and
+`bellman_residuals` before accepting the result. The SVD is diagnostic only;
+the policy comes from the nonsymmetric dense-LU solve. A failed curvature or
+rank certificate means this method did not establish a unique feedback Nash
+policy. It does not establish nonexistence.
+
+The returned policy is an ordinary joint `AffineFeedbackPolicy`. Replay it
+through a `ControlProblem` whose `InputLayout((2,), roles="control")` uses the
+same joint-control order, then use `players.split_controls` to recover the
+player-local trajectories. `examples/lq_nash_game.py` performs that complete
+rollout and compares each direct discrete payoff with its initial value.
+
 ## Compile and solve the canonical QP
 
 `LinearQuadraticControlProblem` is the affine discrete contract used by both direct QP

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -14,6 +14,18 @@ A benchmark notebook for the coupled 3-DOF spring-mass system in matrix form, wi
 
 - Public notebook: [spring-mass-ode](https://static.marimo.app/static/spring-mass-ode-xuq3)
 
+## Linear-quadratic feedback game
+
+```text
+python examples/lq_nash_game.py
+```
+
+The script solves a two-player affine finite-horizon full-state feedback Nash
+game, checks curvature, rank, conditioning, stationarity, and Bellman
+evidence, replays the joint affine policy through the physical control
+contract, and compares both direct discrete payoffs with their initial value
+functions.
+
 ## Shallow-water scripts
 
 The wet/dry and rotating-flow paths have directly runnable qualification examples:

--- a/examples/lq_nash_game.py
+++ b/examples/lq_nash_game.py
@@ -1,0 +1,133 @@
+"""Solve and replay a two-player affine linear-quadratic feedback Nash game."""
+
+import jax.numpy as jnp
+
+import phydrax as phx
+
+
+partition = phx.control.games.PlayerControlPartition(
+    ("player-1", "player-2"),
+    (1, 1),
+)
+time_grid = phx.dynamics.TimeGrid(
+    jnp.asarray([0.0, 1.0]),
+    time_id="example-lq-feedback-nash",
+)
+dynamics_matrices = jnp.asarray([[[1.0]]])
+control_matrices = jnp.asarray([[[1.0, 1.0]]])
+dynamics_bias = jnp.asarray([[1.0]])
+state_costs = jnp.asarray([[[[2.0]]], [[[-1.0]]]])
+control_costs = jnp.asarray(
+    [
+        [[[1.0, -0.5], [-0.5, 2.0]]],
+        [[[2.0, -3.0], [-3.0, 1.0]]],
+    ]
+)
+state_control_cross = jnp.asarray(
+    [
+        [[[1.0, -1.0]]],
+        [[[0.5, -0.5]]],
+    ]
+)
+state_linear = jnp.asarray([[[1.0]], [[-2.0]]])
+control_linear = jnp.asarray([[[0.5, -1.0]], [[0.25, 1.0]]])
+stage_constants = jnp.asarray([[3.0], [-1.0]])
+terminal_state_costs = jnp.asarray([[[1.0]], [[2.0]]])
+terminal_linear = jnp.asarray([[0.5], [-1.0]])
+terminal_constants = jnp.asarray([0.25, 2.0])
+
+solution = phx.control.games.finite_horizon_lq_feedback_nash(
+    dynamics_matrices,
+    control_matrices,
+    state_costs,
+    control_costs,
+    terminal_state_costs,
+    partition,
+    dynamics_bias=dynamics_bias,
+    state_control_cross=state_control_cross,
+    state_linear=state_linear,
+    control_linear=control_linear,
+    stage_constants=stage_constants,
+    terminal_linear=terminal_linear,
+    terminal_constants=terminal_constants,
+    time_grid=time_grid,
+    policy_id="example-lq-feedback-nash",
+)
+if not bool(solution.valid):
+    raise RuntimeError(
+        "feedback Nash solve failed: "
+        f"status={int(solution.status)}, "
+        f"stage={int(solution.diagnostics.first_failed_stage)}"
+    )
+
+
+def transition(context, state, control, args):
+    step = context.step_index
+    return args["A"][step] @ state + args["B"][step] @ control + args["c"][step]
+
+
+dynamics = phx.control.DiscreteControlDynamics(
+    phx.dynamics.DiscreteSystem(
+        transition,
+        state_layout=phx.dynamics.StateLayout((1,)),
+        input_layout=phx.dynamics.InputLayout((2,), roles="control"),
+        system_id="example-lq-feedback-nash",
+    )
+)
+initial_state = jnp.asarray([0.3])
+problem = phx.control.ControlProblem(
+    dynamics,
+    time_grid,
+    initial_state,
+    args={
+        "A": dynamics_matrices,
+        "B": control_matrices,
+        "c": dynamics_bias,
+    },
+    problem_id="example-lq-feedback-nash",
+)
+evaluation = problem.evaluate(solution.policy, jnp.zeros(()))
+if not bool(evaluation.successful):
+    raise RuntimeError(f"feedback policy rollout failed: status={int(evaluation.status)}")
+
+trajectory = evaluation.trajectory
+player_controls = partition.split_controls(trajectory.controls)
+player_costs = []
+for player in range(partition.num_players):
+    state = trajectory.states[0]
+    control = trajectory.controls[0]
+    terminal_state = trajectory.states[1]
+    stage_cost = (
+        0.5 * state @ state_costs[player, 0] @ state
+        + state @ state_control_cross[player, 0] @ control
+        + 0.5 * control @ control_costs[player, 0] @ control
+        + state_linear[player, 0] @ state
+        + control_linear[player, 0] @ control
+        + stage_constants[player, 0]
+    )
+    terminal_cost = (
+        0.5 * terminal_state @ terminal_state_costs[player] @ terminal_state
+        + terminal_linear[player] @ terminal_state
+        + terminal_constants[player]
+    )
+    player_costs.append(stage_cost + terminal_cost)
+
+print(
+    {
+        "feedback_gain": solution.feedback_gain.tolist(),
+        "feedforward": solution.feedforward.tolist(),
+        "player_controls": [control.tolist() for control in player_controls],
+        "player_costs": [float(cost) for cost in player_costs],
+        "initial_values": [
+            float(value(time_grid.times[0], initial_state)) for value in solution.values
+        ],
+        "maximum_stationarity_residual": float(
+            solution.diagnostics.maximum_stationarity_residual
+        ),
+        "maximum_bellman_residual": float(solution.diagnostics.maximum_bellman_residual),
+        "maximum_condition_number": float(
+            solution.diagnostics.maximum_coupled_condition_number
+        ),
+        "status": int(solution.status),
+    }
+)

--- a/phydrax/control/__init__.py
+++ b/phydrax/control/__init__.py
@@ -4,6 +4,7 @@
 
 """Optimal-control problems, dynamics, parameterizations, and diagnostics."""
 
+from . import games
 from ._advanced_collocation import (
     audit_complementarity,
     audit_multiphase_links,
@@ -527,4 +528,5 @@ __all__ = [
     "ConvexTranscriptionRelaxation",
     "LipschitzBoxControlRelaxation",
     "certify_bounded_control_optimum",
+    "games",
 ]

--- a/phydrax/control/games/__init__.py
+++ b/phydrax/control/games/__init__.py
@@ -1,0 +1,22 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+"""Finite-horizon dynamic-game solvers and evidence."""
+
+from ._layout import PlayerControlPartition
+from ._linear_quadratic import (
+    finite_horizon_lq_feedback_nash,
+    FiniteHorizonLQFeedbackNashDiagnostics,
+    FiniteHorizonLQFeedbackNashResult,
+    LQFeedbackNashStatus,
+)
+
+
+__all__ = [
+    "FiniteHorizonLQFeedbackNashDiagnostics",
+    "FiniteHorizonLQFeedbackNashResult",
+    "LQFeedbackNashStatus",
+    "PlayerControlPartition",
+    "finite_horizon_lq_feedback_nash",
+]

--- a/phydrax/control/games/_layout.py
+++ b/phydrax/control/games/_layout.py
@@ -1,0 +1,118 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from itertools import pairwise
+from operator import index
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+
+from ..._fingerprint import canonical_fingerprint
+from ..._strict import StrictModule
+
+
+class PlayerControlPartition(StrictModule):
+    """Ordered contiguous ownership of a flattened joint-control vector."""
+
+    player_ids: tuple[str, ...] = eqx.field(static=True)
+    control_sizes: tuple[int, ...] = eqx.field(static=True)
+    control_slices: tuple[tuple[int, int], ...] = eqx.field(static=True)
+    control_owner: tuple[int, ...] = eqx.field(static=True)
+    num_players: int = eqx.field(static=True)
+    joint_control_size: int = eqx.field(static=True)
+    partition_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        player_ids: Sequence[str],
+        control_sizes: Sequence[int],
+        /,
+    ):
+        if isinstance(player_ids, str):
+            raise TypeError("player_ids must be a sequence of player identifiers.")
+        resolved_ids = tuple(player_ids)
+        if not resolved_ids:
+            raise ValueError("PlayerControlPartition requires at least one player.")
+        if any(
+            not isinstance(player_id, str) or not player_id for player_id in resolved_ids
+        ):
+            raise ValueError("Player identifiers must be non-empty strings.")
+        if len(set(resolved_ids)) != len(resolved_ids):
+            raise ValueError("Player identifiers must be unique.")
+
+        if isinstance(control_sizes, (str, bytes)):
+            raise TypeError("control_sizes must be a sequence of positive integers.")
+        raw_sizes = tuple(control_sizes)
+        if len(raw_sizes) != len(resolved_ids):
+            raise ValueError("control_sizes must provide one size per player.")
+        if any(isinstance(size, bool) for size in raw_sizes):
+            raise TypeError("Control sizes must be positive integers, not booleans.")
+        resolved_sizes = tuple(index(size) for size in raw_sizes)
+        if any(size <= 0 for size in resolved_sizes):
+            raise ValueError("Control sizes must be positive integers.")
+
+        offsets = [0]
+        for size in resolved_sizes:
+            offsets.append(offsets[-1] + size)
+        resolved_slices = tuple(pairwise(offsets))
+        resolved_owner = tuple(
+            player for player, size in enumerate(resolved_sizes) for _ in range(size)
+        )
+        payload = [
+            {"player_id": player_id, "control_size": size}
+            for player_id, size in zip(resolved_ids, resolved_sizes, strict=True)
+        ]
+
+        self.player_ids = resolved_ids
+        self.control_sizes = resolved_sizes
+        self.control_slices = resolved_slices
+        self.control_owner = resolved_owner
+        self.num_players = len(resolved_ids)
+        self.joint_control_size = offsets[-1]
+        self.partition_id = f"player-controls:{canonical_fingerprint(payload)}"
+
+    def split_controls(self, joint_controls, /) -> tuple[jax.Array, ...]:
+        """Split the trailing joint-control axis in declared player order."""
+        array = jnp.asarray(joint_controls)
+        if array.ndim < 1 or array.shape[-1] != self.joint_control_size:
+            raise ValueError(
+                "joint_controls must have trailing shape "
+                f"({self.joint_control_size},); got {array.shape}."
+            )
+        return tuple(array[..., start:stop] for start, stop in self.control_slices)
+
+    def join_controls(self, player_controls: Sequence, /) -> jax.Array:
+        """Join player-local trailing control axes in declared player order."""
+        arrays = tuple(jnp.asarray(value) for value in player_controls)
+        if len(arrays) != self.num_players:
+            raise ValueError("player_controls must provide one array per player.")
+        leading_shape = arrays[0].shape[:-1] if arrays[0].ndim >= 1 else None
+        for player_id, size, array in zip(
+            self.player_ids,
+            self.control_sizes,
+            arrays,
+            strict=True,
+        ):
+            if array.ndim < 1 or array.shape[-1] != size:
+                raise ValueError(
+                    f"Player {player_id!r} controls must have trailing shape ({size},); "
+                    f"got {array.shape}."
+                )
+            if array.shape[:-1] != leading_shape:
+                raise ValueError("All player control arrays must share leading axes.")
+        return jnp.concatenate(arrays, axis=-1)
+
+    def split_feedback_gain(self, gain, /) -> tuple[jax.Array, ...]:
+        """Split the penultimate control-row axis of a joint feedback gain."""
+        array = jnp.asarray(gain)
+        if array.ndim < 2 or array.shape[-2] != self.joint_control_size:
+            raise ValueError(
+                "gain must have penultimate control axis of size "
+                f"{self.joint_control_size}; got {array.shape}."
+            )
+        return tuple(array[..., start:stop, :] for start, stop in self.control_slices)

--- a/phydrax/control/games/_linear_quadratic.py
+++ b/phydrax/control/games/_linear_quadratic.py
@@ -1,0 +1,1021 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+"""Finite-horizon affine linear-quadratic feedback Nash games."""
+
+from __future__ import annotations
+
+import math
+from enum import IntEnum
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array, ArrayLike
+
+import phydrax.ein as ein
+
+from ..._strict import StrictModule
+from ...dynamics import TimeGrid
+from ...linalg import (
+    DenseLinearOperator,
+    DenseLU,
+    DifferentiationPolicy,
+    FactorizationPolicy,
+    factorize,
+    FailurePolicy,
+    LinearSolvePolicy,
+    LinearSolveStatus,
+    LinearSystem,
+    RankPolicy,
+    RHSLayout,
+    solve,
+    TolerancePolicy,
+)
+from .._lqr import AffineFeedbackPolicy, QuadraticValueFunction
+from ._layout import PlayerControlPartition
+
+
+class LQFeedbackNashStatus(IntEnum):
+    """Stable validity codes for finite-horizon LQ feedback Nash solves."""
+
+    SUCCESS = 0
+    NONFINITE_INPUT = 1
+    NONSYMMETRIC_COST = 2
+    OWN_CURVATURE_NOT_POSITIVE_DEFINITE = 3
+    COUPLED_SYSTEM_RANK_DEFICIENT = 4
+    CONDITION_LIMIT_REACHED = 5
+    LINEAR_SOLVE_FAILED = 6
+    NONFINITE_OUTPUT = 7
+    RESIDUAL_TOO_LARGE = 8
+    DEPENDENCY_FAILED = 9
+
+
+class FiniteHorizonLQFeedbackNashDiagnostics(StrictModule):
+    """Per-stage equilibrium, curvature, rank, and failure evidence."""
+
+    stage_status: Array
+    terminal_status: Array
+    linear_status: Array
+    diagnostic_available: Array
+    state_cost_symmetry_residuals: Array
+    control_cost_symmetry_residuals: Array
+    terminal_cost_symmetry_residuals: Array
+    own_control_symmetry_residuals: Array
+    own_control_minimum_eigenvalues: Array
+    coupled_ranks: Array
+    rank_cutoffs: Array
+    minimum_singular_values: Array
+    maximum_singular_values: Array
+    coupled_condition_numbers: Array
+    linear_relative_residuals: Array
+    stationarity_residuals: Array
+    bellman_residuals: Array
+    value_symmetry_residuals: Array
+    maximum_stationarity_residual: Array
+    maximum_bellman_residual: Array
+    maximum_value_symmetry_residual: Array
+    minimum_own_control_eigenvalue: Array
+    maximum_coupled_condition_number: Array
+    first_failed_stage: Array
+    finite: Array
+    valid: Array
+    status: Array
+    method: str = eqx.field(static=True)
+    linear_backend: str = eqx.field(static=True)
+    linear_method: str = eqx.field(static=True)
+
+
+class FiniteHorizonLQFeedbackNashResult(StrictModule):
+    """Joint affine strategy, player values, and feedback-Nash evidence."""
+
+    partition: PlayerControlPartition
+    policy: AffineFeedbackPolicy
+    values: tuple[QuadraticValueFunction, ...]
+    diagnostics: FiniteHorizonLQFeedbackNashDiagnostics
+    valid: Array
+    status: Array
+
+    @property
+    def feedback_gain(self) -> Array:
+        return self.policy.feedback_gain
+
+    @property
+    def feedforward(self) -> Array:
+        return self.policy.feedforward
+
+
+def _real_array(value: ArrayLike, name: str, /) -> Array:
+    array = jnp.asarray(value)
+    if jnp.issubdtype(array.dtype, jnp.complexfloating):
+        raise TypeError(f"{name} must be real-valued.")
+    return array
+
+
+def _require_shape(value: ArrayLike, shape: tuple[int, ...], name: str, /) -> Array:
+    array = jnp.asarray(value)
+    if tuple(array.shape) != shape:
+        raise ValueError(f"{name} must have shape {shape}; got {array.shape}.")
+    return array
+
+
+def _normalized_symmetry_residual(matrix: Array, /) -> Array:
+    difference = matrix - jnp.swapaxes(matrix, -1, -2)
+    numerator = jnp.sqrt(jnp.sum(jnp.square(difference), axis=(-2, -1)))
+    scale = jnp.sqrt(jnp.sum(jnp.square(matrix), axis=(-2, -1)))
+    return numerator / jnp.maximum(jnp.asarray(1.0, dtype=matrix.dtype), scale)
+
+
+def _symmetric(matrix: Array, /) -> Array:
+    return 0.5 * (matrix + jnp.swapaxes(matrix, -1, -2))
+
+
+def _case_where(mask: Array, on_true: Array, on_false: Array, /) -> Array:
+    extra = on_true.ndim - mask.ndim
+    shaped = jnp.reshape(mask, mask.shape + (1,) * extra)
+    return jnp.where(shaped, on_true, on_false)
+
+
+def _all_finite(value: Array, payload_rank: int, /) -> Array:
+    axes = tuple(range(value.ndim - payload_rank, value.ndim))
+    return jnp.all(jnp.isfinite(value), axis=axes) if axes else jnp.isfinite(value)
+
+
+def _normalized_combined_residual(
+    residuals: tuple[Array, ...],
+    references: tuple[Array, ...],
+    payload_ranks: tuple[int, ...],
+    /,
+) -> Array:
+    residual_square = 0.0
+    reference_square = 0.0
+    for residual, reference, rank in zip(
+        residuals,
+        references,
+        payload_ranks,
+        strict=True,
+    ):
+        axes = tuple(range(residual.ndim - rank, residual.ndim))
+        residual_square = residual_square + (
+            jnp.sum(jnp.square(residual), axis=axes) if axes else jnp.square(residual)
+        )
+        reference_square = reference_square + (
+            jnp.sum(jnp.square(reference), axis=axes) if axes else jnp.square(reference)
+        )
+    return jnp.sqrt(residual_square) / (1.0 + jnp.sqrt(reference_square))
+
+
+def _nanmax(value: Array, axis, /) -> Array:
+    available = ~jnp.isnan(value)
+    maximum = jnp.max(jnp.where(available, value, -jnp.inf), axis=axis)
+    any_available = jnp.any(available, axis=axis)
+    return jnp.where(any_available, maximum, jnp.nan)
+
+
+def _nanmin(value: Array, axis, /) -> Array:
+    available = ~jnp.isnan(value)
+    minimum = jnp.min(jnp.where(available, value, jnp.inf), axis=axis)
+    any_available = jnp.any(available, axis=axis)
+    return jnp.where(any_available, minimum, jnp.nan)
+
+
+def _game_inputs(
+    dynamics_matrices: ArrayLike,
+    control_matrices: ArrayLike,
+    state_costs: ArrayLike,
+    control_costs: ArrayLike,
+    terminal_state_costs: ArrayLike,
+    partition: PlayerControlPartition,
+    dynamics_bias: ArrayLike | None,
+    state_control_cross: ArrayLike | None,
+    state_linear: ArrayLike | None,
+    control_linear: ArrayLike | None,
+    stage_constants: ArrayLike | None,
+    terminal_linear: ArrayLike | None,
+    terminal_constants: ArrayLike,
+    /,
+):
+    if not isinstance(partition, PlayerControlPartition):
+        raise TypeError("partition must be a PlayerControlPartition.")
+    a = _real_array(dynamics_matrices, "dynamics_matrices")
+    if a.ndim < 3 or a.shape[-1] != a.shape[-2]:
+        raise ValueError(
+            "dynamics_matrices must have shape case_shape + (horizon, n, n)."
+        )
+    case_shape = tuple(a.shape[:-3])
+    horizon = int(a.shape[-3])
+    n = int(a.shape[-1])
+    if horizon < 1:
+        raise ValueError("Finite-horizon games require at least one stage.")
+
+    b = _real_array(control_matrices, "control_matrices")
+    if b.ndim < 3 or tuple(b.shape[:-3]) != case_shape or b.shape[-3:-1] != (horizon, n):
+        raise ValueError(
+            "control_matrices must have shape case_shape + (horizon, n, m); "
+            f"got {b.shape}."
+        )
+    m = int(b.shape[-1])
+    if partition.joint_control_size != m:
+        raise ValueError(
+            "partition joint control size must match control_matrices; "
+            f"got {partition.joint_control_size} and {m}."
+        )
+    players = partition.num_players
+
+    a = _require_shape(a, case_shape + (horizon, n, n), "dynamics_matrices")
+    b = _require_shape(b, case_shape + (horizon, n, m), "control_matrices")
+    q = _require_shape(
+        _real_array(state_costs, "state_costs"),
+        case_shape + (players, horizon, n, n),
+        "state_costs",
+    )
+    r = _require_shape(
+        _real_array(control_costs, "control_costs"),
+        case_shape + (players, horizon, m, m),
+        "control_costs",
+    )
+    q_terminal = _require_shape(
+        _real_array(terminal_state_costs, "terminal_state_costs"),
+        case_shape + (players, n, n),
+        "terminal_state_costs",
+    )
+
+    c = (
+        jnp.zeros(case_shape + (horizon, n), dtype=a.dtype)
+        if dynamics_bias is None
+        else _require_shape(
+            _real_array(dynamics_bias, "dynamics_bias"),
+            case_shape + (horizon, n),
+            "dynamics_bias",
+        )
+    )
+    cross = (
+        jnp.zeros(case_shape + (players, horizon, n, m), dtype=q.dtype)
+        if state_control_cross is None
+        else _require_shape(
+            _real_array(state_control_cross, "state_control_cross"),
+            case_shape + (players, horizon, n, m),
+            "state_control_cross",
+        )
+    )
+    q_linear = (
+        jnp.zeros(case_shape + (players, horizon, n), dtype=q.dtype)
+        if state_linear is None
+        else _require_shape(
+            _real_array(state_linear, "state_linear"),
+            case_shape + (players, horizon, n),
+            "state_linear",
+        )
+    )
+    r_linear = (
+        jnp.zeros(case_shape + (players, horizon, m), dtype=r.dtype)
+        if control_linear is None
+        else _require_shape(
+            _real_array(control_linear, "control_linear"),
+            case_shape + (players, horizon, m),
+            "control_linear",
+        )
+    )
+    constants = (
+        jnp.zeros(case_shape + (players, horizon), dtype=q.dtype)
+        if stage_constants is None
+        else _require_shape(
+            _real_array(stage_constants, "stage_constants"),
+            case_shape + (players, horizon),
+            "stage_constants",
+        )
+    )
+    q_terminal_linear = (
+        jnp.zeros(case_shape + (players, n), dtype=q_terminal.dtype)
+        if terminal_linear is None
+        else _require_shape(
+            _real_array(terminal_linear, "terminal_linear"),
+            case_shape + (players, n),
+            "terminal_linear",
+        )
+    )
+    terminal_constant_value = _real_array(terminal_constants, "terminal_constants")
+    if terminal_constant_value.shape == ():
+        terminal_constant_value = jnp.broadcast_to(
+            terminal_constant_value,
+            case_shape + (players,),
+        )
+    terminal_constant = _require_shape(
+        terminal_constant_value,
+        case_shape + (players,),
+        "terminal_constants",
+    )
+    values = (
+        a,
+        b,
+        q,
+        r,
+        q_terminal,
+        c,
+        cross,
+        q_linear,
+        r_linear,
+        constants,
+        q_terminal_linear,
+        terminal_constant,
+    )
+    dtype = jnp.result_type(*values, float)
+    if jnp.issubdtype(dtype, jnp.complexfloating):
+        raise TypeError("Finite-horizon games require real-valued arrays.")
+    return (
+        tuple(value.astype(dtype) for value in values),
+        case_shape,
+        horizon,
+        n,
+        m,
+        players,
+    )
+
+
+def finite_horizon_lq_feedback_nash(
+    dynamics_matrices: ArrayLike,
+    control_matrices: ArrayLike,
+    state_costs: ArrayLike,
+    control_costs: ArrayLike,
+    terminal_state_costs: ArrayLike,
+    partition: PlayerControlPartition,
+    /,
+    *,
+    dynamics_bias: ArrayLike | None = None,
+    state_control_cross: ArrayLike | None = None,
+    state_linear: ArrayLike | None = None,
+    control_linear: ArrayLike | None = None,
+    stage_constants: ArrayLike | None = None,
+    terminal_linear: ArrayLike | None = None,
+    terminal_constants: ArrayLike = 0.0,
+    time_grid: TimeGrid | None = None,
+    policy_id: str = "game:lq-feedback-nash",
+    tolerance: float = 1e-9,
+    symmetry_tolerance: float = 1e-10,
+    curvature_tolerance: float = 1e-10,
+    rank_relative_tolerance: float | None = None,
+    rank_absolute_tolerance: float | None = None,
+    maximum_condition: float | None = None,
+) -> FiniteHorizonLQFeedbackNashResult:
+    """Solve a finite-horizon affine LQ full-state feedback Nash game.
+
+    Every player minimizes a quadratic-affine cost over the same affine dynamics.
+    Player costs may depend on the full joint control. All stage arrays carry an
+    explicit time axis and all cost arrays carry a player axis immediately before
+    that time axis. No time or player broadcasting occurs.
+    """
+    scalar_parameters = (
+        ("tolerance", tolerance, False),
+        ("symmetry_tolerance", symmetry_tolerance, True),
+        ("curvature_tolerance", curvature_tolerance, True),
+    )
+    for name, value, allow_zero in scalar_parameters:
+        resolved = float(value)
+        invalid = (
+            not math.isfinite(resolved)
+            or resolved < 0.0
+            or (not allow_zero and resolved == 0.0)
+        )
+        if invalid:
+            relation = "non-negative" if allow_zero else "positive"
+            raise ValueError(f"{name} must be finite and {relation}.")
+    relative_rank = (
+        None if rank_relative_tolerance is None else float(rank_relative_tolerance)
+    )
+    absolute_rank = (
+        None if rank_absolute_tolerance is None else float(rank_absolute_tolerance)
+    )
+    if relative_rank is not None and (
+        not math.isfinite(relative_rank) or relative_rank < 0.0
+    ):
+        raise ValueError("rank_relative_tolerance must be finite and non-negative.")
+    if absolute_rank is not None and (
+        not math.isfinite(absolute_rank) or absolute_rank < 0.0
+    ):
+        raise ValueError("rank_absolute_tolerance must be finite and non-negative.")
+    condition_limit = None if maximum_condition is None else float(maximum_condition)
+    if condition_limit is not None and (
+        not math.isfinite(condition_limit) or condition_limit <= 1.0
+    ):
+        raise ValueError("maximum_condition must be finite and exceed one or be None.")
+
+    values, case_shape, horizon, n, m, players = _game_inputs(
+        dynamics_matrices,
+        control_matrices,
+        state_costs,
+        control_costs,
+        terminal_state_costs,
+        partition,
+        dynamics_bias,
+        state_control_cross,
+        state_linear,
+        control_linear,
+        stage_constants,
+        terminal_linear,
+        terminal_constants,
+    )
+    (
+        a,
+        b,
+        q_raw,
+        r_raw,
+        q_terminal_raw,
+        c,
+        cross,
+        q_linear,
+        r_linear,
+        constants,
+        q_terminal_linear,
+        terminal_constant,
+    ) = values
+    if time_grid is None:
+        time_grid = TimeGrid(
+            jnp.arange(horizon + 1, dtype=a.dtype),
+            time_id=f"{policy_id}:time",
+        )
+    elif not isinstance(time_grid, TimeGrid):
+        raise TypeError("time_grid must be a TimeGrid or None.")
+    if time_grid.num_steps != horizon:
+        raise ValueError(
+            f"time_grid must contain {horizon + 1} times for this game horizon."
+        )
+
+    q_symmetry = _normalized_symmetry_residual(q_raw)
+    r_symmetry = _normalized_symmetry_residual(r_raw)
+    terminal_symmetry = _normalized_symmetry_residual(q_terminal_raw)
+    q = _symmetric(q_raw)
+    r = _symmetric(r_raw)
+    q_terminal = _symmetric(q_terminal_raw)
+
+    terminal_finite = (
+        _all_finite(q_terminal_raw, 3)
+        & _all_finite(q_terminal_linear, 2)
+        & _all_finite(terminal_constant, 1)
+    )
+    terminal_symmetric = jnp.all(
+        terminal_symmetry <= symmetry_tolerance,
+        axis=-1,
+    )
+    terminal_status = jnp.where(
+        ~terminal_finite,
+        int(LQFeedbackNashStatus.NONFINITE_INPUT),
+        jnp.where(
+            ~terminal_symmetric,
+            int(LQFeedbackNashStatus.NONSYMMETRIC_COST),
+            int(LQFeedbackNashStatus.SUCCESS),
+        ),
+    ).astype(jnp.int32)
+    terminal_valid = terminal_status == int(LQFeedbackNashStatus.SUCCESS)
+    failed_stage = jnp.where(
+        terminal_valid,
+        jnp.asarray(-1, dtype=jnp.int32),
+        jnp.asarray(horizon, dtype=jnp.int32),
+    )
+    nan_q_terminal = jnp.full_like(q_terminal, jnp.nan)
+    nan_terminal_linear = jnp.full_like(q_terminal_linear, jnp.nan)
+    nan_terminal_constant = jnp.full_like(terminal_constant, jnp.nan)
+    carry_q_terminal = _case_where(terminal_valid, q_terminal, nan_q_terminal)
+    carry_terminal_linear = _case_where(
+        terminal_valid,
+        q_terminal_linear,
+        nan_terminal_linear,
+    )
+    carry_terminal_constant = _case_where(
+        terminal_valid,
+        terminal_constant,
+        nan_terminal_constant,
+    )
+
+    rank_relative = (
+        float(m * jnp.finfo(a.dtype).eps) if relative_rank is None else relative_rank
+    )
+    rank_absolute = 0.0 if absolute_rank is None else absolute_rank
+    linear_policy = LinearSolvePolicy(
+        DenseLU(),
+        tolerance=TolerancePolicy(relative=tolerance, absolute=tolerance),
+        rank=RankPolicy(require_full_rank=False),
+        differentiation=DifferentiationPolicy("mathematical"),
+        failure=FailurePolicy("status"),
+    )
+    svd_policy = FactorizationPolicy(
+        "svd",
+        rank=RankPolicy(
+            relative_cutoff=rank_relative,
+            absolute_cutoff=rank_absolute,
+            require_full_rank=False,
+        ),
+        differentiation=DifferentiationPolicy("none"),
+        failure=FailurePolicy("status"),
+    )
+    rhs_layout = RHSLayout((n + 1,), names=("feedback-and-affine",))
+    owner = jnp.asarray(partition.control_owner, dtype=jnp.int32)
+    rows = jnp.arange(m, dtype=jnp.int32)
+
+    def to_time_major(value: Array, payload_rank: int) -> Array:
+        return jnp.moveaxis(value, -(payload_rank + 1), 0)
+
+    inputs = (
+        jnp.arange(horizon, dtype=jnp.int32),
+        to_time_major(a, 2),
+        to_time_major(b, 2),
+        to_time_major(q, 2),
+        to_time_major(r, 2),
+        to_time_major(c, 1),
+        to_time_major(cross, 2),
+        to_time_major(q_linear, 1),
+        to_time_major(r_linear, 1),
+        to_time_major(constants, 0),
+        to_time_major(q_symmetry, 0),
+        to_time_major(r_symmetry, 0),
+    )
+
+    def step(carry, stage):
+        (
+            z_next,
+            linear_next,
+            constant_next,
+            continuation_valid,
+            causal_stage,
+            causal_status,
+        ) = carry
+        (
+            stage_index,
+            a_t,
+            b_t,
+            q_t,
+            r_t,
+            c_t,
+            cross_t,
+            q_t_linear,
+            r_t_linear,
+            d_t,
+            q_symmetry_t,
+            r_symmetry_t,
+        ) = stage
+
+        b_player = b_t[..., None, :, :]
+        z_b = z_next @ b_player
+        b_transpose = jnp.swapaxes(b_t, -1, -2)[..., None, :, :]
+        h = r_t + b_transpose @ z_b
+        w = b_transpose @ z_next @ a_t[..., None, :, :] + jnp.swapaxes(
+            cross_t,
+            -1,
+            -2,
+        )
+        affine_next = ein.contract("...pij,...j->...pi", z_next, c_t) + linear_next
+        g = r_t_linear + ein.contract("...ji,...pj->...pi", b_t, affine_next)
+
+        coupled = h[..., owner, rows, :]
+        feedback_rhs = w[..., owner, rows, :]
+        affine_rhs = g[..., owner, rows]
+        rhs = jnp.concatenate((feedback_rhs, affine_rhs[..., None]), axis=-1)
+
+        own_minimum_eigenvalues = []
+        own_symmetry_residuals = []
+        for player, (start, stop) in enumerate(partition.control_slices):
+            own = h[..., player, start:stop, start:stop]
+            own_symmetry_residuals.append(_normalized_symmetry_residual(own))
+            eigenvalues = jnp.linalg.eigvalsh(jax.lax.stop_gradient(_symmetric(own)))
+            own_minimum_eigenvalues.append(jnp.min(eigenvalues, axis=-1))
+        own_minimum = jnp.stack(own_minimum_eigenvalues, axis=-1)
+        own_symmetry = jnp.stack(own_symmetry_residuals, axis=-1)
+
+        solve_result = solve(
+            LinearSystem(
+                DenseLinearOperator(coupled, operator_id="control-games:lq-nash:lu"),
+                problem_id="control-games:lq-nash:stage",
+            ),
+            rhs,
+            policy=linear_policy,
+            rhs_layout=rhs_layout,
+        )
+        solved = solve_result.value
+        p = solved[..., :n]
+        alpha = solved[..., n]
+        feedback = -p
+        feedforward = -alpha
+
+        diagnostic_coupled = jax.lax.stop_gradient(coupled)
+        svd_factorization = factorize(
+            DenseLinearOperator(
+                diagnostic_coupled,
+                operator_id="control-games:lq-nash:svd",
+            ),
+            svd_policy,
+        )
+        singular_values = svd_factorization.singular_values()
+        maximum_singular = jnp.max(singular_values, axis=-1)
+        minimum_singular = jnp.min(singular_values, axis=-1)
+        rank_cutoff = rank_absolute + rank_relative * maximum_singular
+        rank = jnp.sum(singular_values > rank_cutoff[..., None], axis=-1).astype(
+            jnp.int32
+        )
+        condition = jnp.where(
+            minimum_singular > 0.0,
+            maximum_singular / minimum_singular,
+            jnp.asarray(jnp.inf, dtype=a.dtype),
+        )
+
+        closed_loop = a_t - b_t @ p
+        closed_bias = c_t - ein.contract("...ij,...j->...i", b_t, alpha)
+        z_raw = (
+            q_t
+            - cross_t @ p[..., None, :, :]
+            - jnp.swapaxes(p, -1, -2)[..., None, :, :]
+            @ jnp.swapaxes(
+                cross_t,
+                -1,
+                -2,
+            )
+            + jnp.swapaxes(p, -1, -2)[..., None, :, :] @ r_t @ p[..., None, :, :]
+            + jnp.swapaxes(closed_loop, -1, -2)[..., None, :, :]
+            @ z_next
+            @ closed_loop[..., None, :, :]
+        )
+        z_current = _symmetric(z_raw)
+        linear_current = (
+            q_t_linear
+            - ein.contract("...pij,...j->...pi", cross_t, alpha)
+            + ein.contract(
+                "...ji,...pj->...pi",
+                p,
+                ein.contract("...pij,...j->...pi", r_t, alpha) - r_t_linear,
+            )
+            + ein.contract(
+                "...ji,...pj->...pi",
+                closed_loop,
+                ein.contract("...pij,...j->...pi", z_next, closed_bias) + linear_next,
+            )
+        )
+        constant_current = (
+            d_t
+            + constant_next
+            + 0.5
+            * ein.contract("...i,...pij,...j->...p", closed_bias, z_next, closed_bias)
+            + ein.contract("...pi,...i->...p", linear_next, closed_bias)
+            + 0.5 * ein.contract("...i,...pij,...j->...p", alpha, r_t, alpha)
+            - ein.contract("...pi,...i->...p", r_t_linear, alpha)
+        )
+
+        stationarity_matrices = []
+        stationarity_vectors = []
+        stationarity_matrix_references = []
+        stationarity_vector_references = []
+        for player, (start, stop) in enumerate(partition.control_slices):
+            h_owned = h[..., player, start:stop, :]
+            w_owned = w[..., player, start:stop, :]
+            g_owned = g[..., player, start:stop]
+            h_feedback = h_owned @ feedback
+            h_feedforward = ein.contract("...ij,...j->...i", h_owned, feedforward)
+            stationarity_matrices.append(h_feedback + w_owned)
+            stationarity_vectors.append(h_feedforward + g_owned)
+            stationarity_matrix_references.extend((h_feedback, w_owned))
+            stationarity_vector_references.extend((h_feedforward, g_owned))
+        stationarity_matrix = jnp.concatenate(stationarity_matrices, axis=-2)
+        stationarity_vector = jnp.concatenate(stationarity_vectors, axis=-1)
+        stationarity_reference_matrix = jnp.concatenate(
+            stationarity_matrix_references,
+            axis=-2,
+        )
+        stationarity_reference_vector = jnp.concatenate(
+            stationarity_vector_references,
+            axis=-1,
+        )
+        stationarity_residual = _normalized_combined_residual(
+            (stationarity_matrix, stationarity_vector),
+            (stationarity_reference_matrix, stationarity_reference_vector),
+            (2, 1),
+        )
+
+        g_state = (
+            q_t
+            + jnp.swapaxes(a_t, -1, -2)[..., None, :, :] @ z_next @ a_t[..., None, :, :]
+        )
+        a_state = q_t_linear + ein.contract(
+            "...ji,...pj->...pi",
+            a_t,
+            affine_next,
+        )
+        delta = (
+            d_t
+            + constant_next
+            + 0.5 * ein.contract("...i,...pij,...j->...p", c_t, z_next, c_t)
+            + ein.contract("...pi,...i->...p", linear_next, c_t)
+        )
+        feedback_player = feedback[..., None, :, :]
+        bellman_z = (
+            g_state
+            + jnp.swapaxes(w, -1, -2) @ feedback_player
+            + jnp.swapaxes(feedback, -1, -2)[..., None, :, :] @ w
+            + jnp.swapaxes(feedback, -1, -2)[..., None, :, :] @ h @ feedback_player
+        )
+        bellman_linear = (
+            a_state
+            + ein.contract("...pji,...j->...pi", w, feedforward)
+            + ein.contract(
+                "...ji,...pj->...pi",
+                feedback,
+                ein.contract("...pij,...j->...pi", h, feedforward) + g,
+            )
+        )
+        bellman_constant = (
+            delta
+            + 0.5 * ein.contract("...i,...pij,...j->...p", feedforward, h, feedforward)
+            + ein.contract("...pi,...i->...p", g, feedforward)
+        )
+        bellman_residual = _normalized_combined_residual(
+            (
+                z_current - bellman_z,
+                linear_current - bellman_linear,
+                constant_current - bellman_constant,
+            ),
+            (bellman_z, bellman_linear, bellman_constant),
+            (3, 2, 1),
+        )
+        value_symmetry = _normalized_symmetry_residual(z_raw)
+
+        input_finite = (
+            _all_finite(a_t, 2)
+            & _all_finite(b_t, 2)
+            & _all_finite(c_t, 1)
+            & _all_finite(q_t, 3)
+            & _all_finite(r_t, 3)
+            & _all_finite(cross_t, 3)
+            & _all_finite(q_t_linear, 2)
+            & _all_finite(r_t_linear, 2)
+            & _all_finite(d_t, 1)
+        )
+        input_symmetric = jnp.all(
+            (q_symmetry_t <= symmetry_tolerance) & (r_symmetry_t <= symmetry_tolerance),
+            axis=-1,
+        )
+        curvature_finite = jnp.all(jnp.isfinite(own_minimum), axis=-1) & jnp.all(
+            jnp.isfinite(own_symmetry),
+            axis=-1,
+        )
+        curvature_valid = jnp.all(own_minimum > curvature_tolerance, axis=-1)
+        svd_finite = jnp.all(jnp.isfinite(singular_values), axis=-1)
+        diagnostic_available = continuation_valid & input_finite & svd_finite
+        rank_reported = jnp.where(diagnostic_available, rank, -1)
+        cutoff_reported = jnp.where(diagnostic_available, rank_cutoff, jnp.nan)
+        minimum_singular_reported = jnp.where(
+            diagnostic_available,
+            minimum_singular,
+            jnp.nan,
+        )
+        maximum_singular_reported = jnp.where(
+            diagnostic_available,
+            maximum_singular,
+            jnp.nan,
+        )
+        condition_reported = jnp.where(diagnostic_available, condition, jnp.nan)
+        rank_valid = rank == m
+        condition_valid = (
+            jnp.ones_like(condition, dtype=bool)
+            if condition_limit is None
+            else condition <= condition_limit
+        )
+        linear_status = solve_result.status.astype(jnp.int32)
+        linear_valid = jnp.all(
+            linear_status == int(LinearSolveStatus.SUCCESS),
+            axis=-1,
+        )
+        linear_relative = jnp.max(solve_result.diagnostics.relative_residual, axis=-1)
+        output_finite = (
+            _all_finite(feedback, 2)
+            & _all_finite(feedforward, 1)
+            & _all_finite(z_current, 3)
+            & _all_finite(linear_current, 2)
+            & _all_finite(constant_current, 1)
+            & jnp.isfinite(stationarity_residual)
+            & jnp.isfinite(bellman_residual)
+            & jnp.all(jnp.isfinite(value_symmetry), axis=-1)
+        )
+        residual_valid = (
+            (linear_relative <= tolerance)
+            & (stationarity_residual <= tolerance)
+            & (bellman_residual <= tolerance)
+            & jnp.all(value_symmetry <= symmetry_tolerance, axis=-1)
+            & jnp.all(own_symmetry <= symmetry_tolerance, axis=-1)
+        )
+
+        direct_status = jnp.where(
+            ~input_finite,
+            int(LQFeedbackNashStatus.NONFINITE_INPUT),
+            jnp.where(
+                ~input_symmetric,
+                int(LQFeedbackNashStatus.NONSYMMETRIC_COST),
+                jnp.where(
+                    ~curvature_finite | ~svd_finite,
+                    int(LQFeedbackNashStatus.NONFINITE_OUTPUT),
+                    jnp.where(
+                        ~curvature_valid,
+                        int(LQFeedbackNashStatus.OWN_CURVATURE_NOT_POSITIVE_DEFINITE),
+                        jnp.where(
+                            ~rank_valid,
+                            int(LQFeedbackNashStatus.COUPLED_SYSTEM_RANK_DEFICIENT),
+                            jnp.where(
+                                ~condition_valid,
+                                int(LQFeedbackNashStatus.CONDITION_LIMIT_REACHED),
+                                jnp.where(
+                                    ~linear_valid,
+                                    int(LQFeedbackNashStatus.LINEAR_SOLVE_FAILED),
+                                    jnp.where(
+                                        ~output_finite,
+                                        int(LQFeedbackNashStatus.NONFINITE_OUTPUT),
+                                        jnp.where(
+                                            ~residual_valid,
+                                            int(LQFeedbackNashStatus.RESIDUAL_TOO_LARGE),
+                                            int(LQFeedbackNashStatus.SUCCESS),
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        ).astype(jnp.int32)
+        stage_status = jnp.where(
+            continuation_valid,
+            direct_status,
+            int(LQFeedbackNashStatus.DEPENDENCY_FAILED),
+        ).astype(jnp.int32)
+        local_valid = direct_status == int(LQFeedbackNashStatus.SUCCESS)
+        stage_valid = continuation_valid & local_valid
+        direct_failure = continuation_valid & ~local_valid
+        next_failed_stage = jnp.where(direct_failure, stage_index, causal_stage)
+        next_causal_status = jnp.where(direct_failure, direct_status, causal_status)
+
+        nan_z = jnp.full_like(z_current, jnp.nan)
+        nan_linear = jnp.full_like(linear_current, jnp.nan)
+        nan_constant = jnp.full_like(constant_current, jnp.nan)
+        next_z = _case_where(stage_valid, z_current, nan_z)
+        next_linear = _case_where(stage_valid, linear_current, nan_linear)
+        next_constant = _case_where(stage_valid, constant_current, nan_constant)
+        output = (
+            z_current,
+            linear_current,
+            constant_current,
+            feedback,
+            feedforward,
+            stage_status,
+            linear_status,
+            diagnostic_available,
+            own_symmetry,
+            own_minimum,
+            rank_reported,
+            cutoff_reported,
+            minimum_singular_reported,
+            maximum_singular_reported,
+            condition_reported,
+            linear_relative,
+            stationarity_residual,
+            bellman_residual,
+            value_symmetry,
+        )
+        return (
+            next_z,
+            next_linear,
+            next_constant,
+            stage_valid,
+            next_failed_stage,
+            next_causal_status,
+        ), output
+
+    initial_carry = (
+        carry_q_terminal,
+        carry_terminal_linear,
+        carry_terminal_constant,
+        terminal_valid,
+        failed_stage,
+        terminal_status,
+    )
+    final_carry, outputs = jax.lax.scan(step, initial_carry, inputs, reverse=True)
+    _, _, _, _, first_failed_stage, status = final_carry
+    (
+        z_stages,
+        linear_stages,
+        constant_stages,
+        feedback,
+        feedforward,
+        stage_status,
+        linear_status,
+        diagnostic_available,
+        own_symmetry,
+        own_minimum,
+        ranks,
+        rank_cutoffs,
+        minimum_singular,
+        maximum_singular,
+        conditions,
+        linear_relative,
+        stationarity,
+        bellman,
+        value_symmetry,
+    ) = outputs
+
+    z_stages = jnp.moveaxis(z_stages, 0, -3)
+    linear_stages = jnp.moveaxis(linear_stages, 0, -2)
+    constant_stages = jnp.moveaxis(constant_stages, 0, -1)
+    z_all = jnp.concatenate((z_stages, q_terminal[..., None, :, :]), axis=-3)
+    linear_all = jnp.concatenate(
+        (linear_stages, q_terminal_linear[..., None, :]),
+        axis=-2,
+    )
+    constant_all = jnp.concatenate(
+        (constant_stages, terminal_constant[..., None]),
+        axis=-1,
+    )
+    feedback = jnp.moveaxis(feedback, 0, -3)
+    feedforward = jnp.moveaxis(feedforward, 0, -2)
+    stage_status = jnp.moveaxis(stage_status, 0, -1)
+    linear_status = jnp.moveaxis(linear_status, 0, -2)
+    diagnostic_available = jnp.moveaxis(diagnostic_available, 0, -1)
+    own_symmetry = jnp.moveaxis(own_symmetry, 0, -1)
+    own_minimum = jnp.moveaxis(own_minimum, 0, -1)
+    ranks = jnp.moveaxis(ranks, 0, -1)
+    rank_cutoffs = jnp.moveaxis(rank_cutoffs, 0, -1)
+    minimum_singular = jnp.moveaxis(minimum_singular, 0, -1)
+    maximum_singular = jnp.moveaxis(maximum_singular, 0, -1)
+    conditions = jnp.moveaxis(conditions, 0, -1)
+    linear_relative = jnp.moveaxis(linear_relative, 0, -1)
+    stationarity = jnp.moveaxis(stationarity, 0, -1)
+    bellman = jnp.moveaxis(bellman, 0, -1)
+    value_symmetry = jnp.moveaxis(value_symmetry, 0, -1)
+
+    maximum_stationarity = _nanmax(stationarity, -1)
+    maximum_bellman = _nanmax(bellman, -1)
+    maximum_value_symmetry = _nanmax(value_symmetry, (-2, -1))
+    minimum_own = _nanmin(own_minimum, (-2, -1))
+    maximum_condition_number = _nanmax(conditions, -1)
+    result_finite = (
+        _all_finite(feedback, 3)
+        & _all_finite(feedforward, 2)
+        & _all_finite(z_all, 4)
+        & _all_finite(linear_all, 3)
+        & _all_finite(constant_all, 2)
+    )
+    valid = status == int(LQFeedbackNashStatus.SUCCESS)
+
+    policy = AffineFeedbackPolicy(
+        feedback,
+        feedforward,
+        time_grid=time_grid,
+        state_size=n,
+        case_shape=case_shape,
+        policy_id=policy_id,
+        _allow_nonfinite=True,
+    )
+    player_axis = len(case_shape)
+    player_values = tuple(
+        QuadraticValueFunction(
+            jnp.take(z_all, player, axis=player_axis),
+            jnp.take(linear_all, player, axis=player_axis),
+            jnp.take(constant_all, player, axis=player_axis),
+            time_grid=time_grid,
+            case_shape=case_shape,
+        )
+        for player in range(players)
+    )
+    diagnostics = FiniteHorizonLQFeedbackNashDiagnostics(
+        stage_status=stage_status,
+        terminal_status=terminal_status,
+        linear_status=linear_status,
+        diagnostic_available=diagnostic_available,
+        state_cost_symmetry_residuals=q_symmetry,
+        control_cost_symmetry_residuals=r_symmetry,
+        terminal_cost_symmetry_residuals=terminal_symmetry,
+        own_control_symmetry_residuals=own_symmetry,
+        own_control_minimum_eigenvalues=own_minimum,
+        coupled_ranks=ranks,
+        rank_cutoffs=rank_cutoffs,
+        minimum_singular_values=minimum_singular,
+        maximum_singular_values=maximum_singular,
+        coupled_condition_numbers=conditions,
+        linear_relative_residuals=linear_relative,
+        stationarity_residuals=stationarity,
+        bellman_residuals=bellman,
+        value_symmetry_residuals=value_symmetry,
+        maximum_stationarity_residual=maximum_stationarity,
+        maximum_bellman_residual=maximum_bellman,
+        maximum_value_symmetry_residual=maximum_value_symmetry,
+        minimum_own_control_eigenvalue=minimum_own,
+        maximum_coupled_condition_number=maximum_condition_number,
+        first_failed_stage=first_failed_stage,
+        finite=result_finite,
+        valid=valid,
+        status=status,
+        method="backward-feedback-nash",
+        linear_backend="jax-dense",
+        linear_method=DenseLU().name,
+    )
+    return FiniteHorizonLQFeedbackNashResult(
+        partition=partition,
+        policy=policy,
+        values=player_values,
+        diagnostics=diagnostics,
+        valid=valid,
+        status=status,
+    )

--- a/tests/unit/control/test_games_lq_nash.py
+++ b/tests/unit/control/test_games_lq_nash.py
@@ -1,0 +1,705 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import phydrax as phx
+from phydrax.control.games import (
+    finite_horizon_lq_feedback_nash,
+    LQFeedbackNashStatus,
+    PlayerControlPartition,
+)
+
+
+def _rational_game(beta=1.0):
+    partition = PlayerControlPartition(("player-1", "player-2"), (1, 1))
+    time_grid = phx.dynamics.TimeGrid(jnp.asarray([0.0, 1.0]), time_id="rational-game")
+    return {
+        "dynamics_matrices": jnp.asarray([[[1.0]]]),
+        "control_matrices": jnp.asarray([[[beta, 1.0]]]),
+        "state_costs": jnp.asarray([[[[2.0]]], [[[-1.0]]]]),
+        "control_costs": jnp.asarray(
+            [
+                [[[1.0, -0.5], [-0.5, 2.0]]],
+                [[[2.0, -3.0], [-3.0, 1.0]]],
+            ]
+        ),
+        "terminal_state_costs": jnp.asarray([[[1.0]], [[2.0]]]),
+        "partition": partition,
+        "dynamics_bias": jnp.asarray([[1.0]]),
+        "state_control_cross": jnp.asarray([[[[1.0, -1.0]]], [[[0.5, -0.5]]]]),
+        "state_linear": jnp.asarray([[[1.0]], [[-2.0]]]),
+        "control_linear": jnp.asarray([[[0.5, -1.0]], [[0.25, 1.0]]]),
+        "stage_constants": jnp.asarray([[3.0], [-1.0]]),
+        "terminal_linear": jnp.asarray([[0.5], [-1.0]]),
+        "terminal_constants": jnp.asarray([0.25, 2.0]),
+        "time_grid": time_grid,
+    }
+
+
+def _solve_rational(beta=1.0, values=None):
+    values = _rational_game(beta) if values is None else values
+    control_matrices = values["control_matrices"].at[0, 0, 0].set(beta)
+    return finite_horizon_lq_feedback_nash(
+        values["dynamics_matrices"],
+        control_matrices,
+        values["state_costs"],
+        values["control_costs"],
+        values["terminal_state_costs"],
+        values["partition"],
+        dynamics_bias=values["dynamics_bias"],
+        state_control_cross=values["state_control_cross"],
+        state_linear=values["state_linear"],
+        control_linear=values["control_linear"],
+        stage_constants=values["stage_constants"],
+        terminal_linear=values["terminal_linear"],
+        terminal_constants=values["terminal_constants"],
+        time_grid=values["time_grid"],
+    )
+
+
+def _stage_cost(values, player, state, control, step):
+    return (
+        0.5 * state @ values["state_costs"][player, step] @ state
+        + state @ values["state_control_cross"][player, step] @ control
+        + 0.5 * control @ values["control_costs"][player, step] @ control
+        + values["state_linear"][player, step] @ state
+        + values["control_linear"][player, step] @ control
+        + values["stage_constants"][player, step]
+    )
+
+
+def _terminal_cost(values, player, state):
+    return (
+        0.5 * state @ values["terminal_state_costs"][player] @ state
+        + values["terminal_linear"][player] @ state
+        + values["terminal_constants"][player]
+    )
+
+
+def test_player_control_partition_round_trips_leading_axes_and_rejects_invalid_data():
+    partition = PlayerControlPartition(("pursuer", "evader"), (2, 1))
+    controls = jnp.arange(24.0).reshape(2, 4, 3)
+    pursuer, evader = partition.split_controls(controls)
+
+    assert partition.num_players == 2
+    assert partition.joint_control_size == 3
+    assert partition.control_slices == ((0, 2), (2, 3))
+    assert pursuer.shape == (2, 4, 2)
+    assert evader.shape == (2, 4, 1)
+    np.testing.assert_array_equal(partition.join_controls((pursuer, evader)), controls)
+
+    gain = jnp.arange(30.0).reshape(5, 3, 2)
+    split_gain = partition.split_feedback_gain(gain)
+    assert split_gain[0].shape == (5, 2, 2)
+    assert split_gain[1].shape == (5, 1, 2)
+
+    with pytest.raises(ValueError, match="at least one"):
+        PlayerControlPartition((), ())
+    with pytest.raises(ValueError, match="unique"):
+        PlayerControlPartition(("same", "same"), (1, 1))
+    with pytest.raises(ValueError, match="positive"):
+        PlayerControlPartition(("player",), (0,))
+    with pytest.raises(ValueError, match="one size per player"):
+        PlayerControlPartition(("left", "right"), (1,))
+    with pytest.raises(ValueError, match="trailing shape"):
+        partition.split_controls(jnp.zeros((2,)))
+    with pytest.raises(ValueError, match="share leading axes"):
+        partition.join_controls((jnp.zeros((2, 2)), jnp.zeros((3, 1))))
+
+
+def test_rational_affine_two_player_game_matches_closed_form_feedback_and_values():
+    result = _solve_rational()
+
+    assert bool(result.valid)
+    assert int(result.status) == int(LQFeedbackNashStatus.SUCCESS)
+    np.testing.assert_allclose(
+        result.feedback_gain[..., 0],
+        [[-21.0 / 26.0, -10.0 / 13.0]],
+        rtol=2e-13,
+        atol=2e-13,
+    )
+    np.testing.assert_allclose(
+        result.feedforward,
+        [[-10.0 / 13.0, -12.0 / 13.0]],
+        rtol=2e-13,
+        atol=2e-13,
+    )
+    expected_values = (
+        (1173.0 / 338.0, 1015.0 / 338.0, 3025.0 / 676.0),
+        (-745.0 / 338.0, -4837.0 / 1352.0, -19.0 / 338.0),
+    )
+    for value, (matrix, linear, constant) in zip(
+        result.values,
+        expected_values,
+        strict=True,
+    ):
+        np.testing.assert_allclose(value.matrices[0, 0, 0], matrix, rtol=2e-13)
+        np.testing.assert_allclose(value.linear[0, 0], linear, rtol=2e-13)
+        np.testing.assert_allclose(value.constants[0], constant, rtol=2e-13)
+    np.testing.assert_allclose(
+        result.diagnostics.own_control_minimum_eigenvalues,
+        [[2.0], [3.0]],
+        rtol=2e-13,
+    )
+    np.testing.assert_array_equal(result.diagnostics.coupled_ranks, [2])
+    assert result.diagnostics.linear_method == "dense-lu"
+    assert result.diagnostics.linear_backend == "jax-dense"
+    assert result.diagnostics.maximum_stationarity_residual < 1e-13
+    assert result.diagnostics.maximum_bellman_residual < 1e-13
+
+
+def test_feedback_and_feedforward_have_exact_jitted_gradients_through_coupled_solve():
+    values = _rational_game()
+
+    def feedback(beta):
+        return _solve_rational(beta, values).feedback_gain[0, 0, 0]
+
+    def feedforward(beta):
+        return _solve_rational(beta, values).feedforward[0, 0]
+
+    feedback_gradient = jax.jit(jax.grad(feedback))(jnp.asarray(1.0))
+    feedforward_gradient = jax.jit(jax.grad(feedforward))(jnp.asarray(1.0))
+    np.testing.assert_allclose(feedback_gradient, 87.0 / 169.0, rtol=2e-11)
+    np.testing.assert_allclose(feedforward_gradient, 55.0 / 169.0, rtol=2e-11)
+
+
+def test_one_player_game_matches_finite_horizon_lqr_on_shared_affine_domain():
+    horizon = 3
+    time_grid = phx.dynamics.TimeGrid(
+        jnp.arange(horizon + 1, dtype=float),
+        time_id="one-player-reduction",
+    )
+    a = jnp.asarray([[[1.0]], [[0.9]], [[1.1]]])
+    b = jnp.asarray([[[0.8]], [[1.0]], [[0.7]]])
+    q = jnp.asarray([[[1.2]], [[0.8]], [[1.4]]])
+    r = jnp.asarray([[[2.0]], [[1.6]], [[2.4]]])
+    qf = jnp.asarray([[2.5]])
+    c = jnp.asarray([[0.2], [-0.1], [0.3]])
+    cross = jnp.asarray([[[0.1]], [[-0.05]], [[0.08]]])
+    q_linear = jnp.asarray([[0.3], [-0.2], [0.1]])
+    r_linear = jnp.asarray([[0.2], [0.1], [-0.1]])
+    constants = jnp.asarray([0.5, -0.2, 0.4])
+    qf_linear = jnp.asarray([0.25])
+
+    game = finite_horizon_lq_feedback_nash(
+        a,
+        b,
+        q[None, ...],
+        r[None, ...],
+        qf[None, ...],
+        PlayerControlPartition(("controller",), (1,)),
+        dynamics_bias=c,
+        state_control_cross=cross[None, ...],
+        state_linear=q_linear[None, ...],
+        control_linear=r_linear[None, ...],
+        stage_constants=constants[None, ...],
+        terminal_linear=qf_linear[None, ...],
+        terminal_constants=jnp.asarray([0.7]),
+        time_grid=time_grid,
+    )
+    lqr = phx.control.finite_horizon_lqr(
+        a,
+        b,
+        q,
+        r,
+        qf,
+        dynamics_bias=c,
+        state_control_cross=cross,
+        state_linear=q_linear,
+        control_linear=r_linear,
+        stage_constants=constants,
+        terminal_linear=qf_linear,
+        terminal_constant=0.7,
+        time_grid=time_grid,
+    )
+
+    assert bool(game.valid)
+    np.testing.assert_allclose(
+        game.feedback_gain, lqr.feedback_gain, rtol=2e-12, atol=2e-12
+    )
+    np.testing.assert_allclose(game.feedforward, lqr.feedforward, rtol=2e-12, atol=2e-12)
+    np.testing.assert_allclose(
+        game.values[0].matrices, lqr.value.matrices, rtol=2e-12, atol=2e-12
+    )
+    np.testing.assert_allclose(
+        game.values[0].linear, lqr.value.linear, rtol=2e-12, atol=2e-12
+    )
+    np.testing.assert_allclose(
+        game.values[0].constants, lqr.value.constants, rtol=2e-12, atol=2e-12
+    )
+
+
+def test_multistage_policy_satisfies_unilateral_bellman_conditions_and_rolls_out():
+    horizon = 3
+    partition = PlayerControlPartition(("left", "right"), (1, 1))
+    time_grid = phx.dynamics.TimeGrid(
+        jnp.arange(horizon + 1, dtype=float),
+        time_id="multistage-game",
+    )
+    a = jnp.asarray(
+        [
+            [[0.9, 0.1], [0.0, 0.8]],
+            [[0.8, -0.1], [0.1, 0.85]],
+            [[0.95, 0.0], [0.05, 0.9]],
+        ]
+    )
+    b = jnp.asarray(
+        [
+            [[0.5, 0.1], [0.0, 0.4]],
+            [[0.4, 0.0], [0.1, 0.5]],
+            [[0.45, 0.05], [0.05, 0.35]],
+        ]
+    )
+    c = jnp.asarray([[0.1, -0.05], [0.0, 0.08], [-0.04, 0.02]])
+    q = jnp.stack(
+        (
+            jnp.broadcast_to(jnp.diag(jnp.asarray([1.2, 0.6])), (horizon, 2, 2)),
+            jnp.broadcast_to(jnp.diag(jnp.asarray([0.5, 1.4])), (horizon, 2, 2)),
+        )
+    )
+    r = jnp.stack(
+        (
+            jnp.broadcast_to(jnp.asarray([[2.0, 0.2], [0.2, 1.5]]), (horizon, 2, 2)),
+            jnp.broadcast_to(jnp.asarray([[1.5, -0.1], [-0.1, 2.2]]), (horizon, 2, 2)),
+        )
+    )
+    cross = jnp.asarray(
+        [
+            [[[0.08, -0.02], [0.01, 0.04]]] * horizon,
+            [[[-0.03, 0.05], [0.02, -0.04]]] * horizon,
+        ]
+    )
+    qf = jnp.asarray([[[1.5, 0.1], [0.1, 0.8]], [[0.7, -0.05], [-0.05, 1.8]]])
+    q_linear = jnp.asarray([[[0.1, -0.05]] * horizon, [[-0.08, 0.12]] * horizon])
+    r_linear = jnp.asarray([[[0.04, -0.02]] * horizon, [[-0.03, 0.05]] * horizon])
+    constants = jnp.asarray([[0.2, -0.1, 0.3], [-0.2, 0.15, 0.05]])
+    qf_linear = jnp.asarray([[0.1, -0.2], [-0.05, 0.15]])
+    terminal_constants = jnp.asarray([0.4, -0.25])
+    values = {
+        "dynamics_matrices": a,
+        "control_matrices": b,
+        "state_costs": q,
+        "control_costs": r,
+        "terminal_state_costs": qf,
+        "partition": partition,
+        "dynamics_bias": c,
+        "state_control_cross": cross,
+        "state_linear": q_linear,
+        "control_linear": r_linear,
+        "stage_constants": constants,
+        "terminal_linear": qf_linear,
+        "terminal_constants": terminal_constants,
+        "time_grid": time_grid,
+    }
+    result = finite_horizon_lq_feedback_nash(
+        a,
+        b,
+        q,
+        r,
+        qf,
+        partition,
+        dynamics_bias=c,
+        state_control_cross=cross,
+        state_linear=q_linear,
+        control_linear=r_linear,
+        stage_constants=constants,
+        terminal_linear=qf_linear,
+        terminal_constants=terminal_constants,
+        time_grid=time_grid,
+    )
+    assert bool(result.valid)
+
+    probe_states = (
+        jnp.asarray([0.0, 0.0]),
+        jnp.asarray([0.4, -0.3]),
+        jnp.asarray([-0.6, 0.2]),
+    )
+    for step, state in enumerate(probe_states):
+        control = result.feedback_gain[step] @ state + result.feedforward[step]
+        next_state = a[step] @ state + b[step] @ control + c[step]
+        for player, (start, stop) in enumerate(partition.control_slices):
+
+            def unilateral(
+                local_control,
+                *,
+                control=control,
+                player=player,
+                start=start,
+                state=state,
+                step=step,
+                stop=stop,
+            ):
+                joint = control.at[start:stop].set(local_control)
+                following = a[step] @ state + b[step] @ joint + c[step]
+                return _stage_cost(values, player, state, joint, step) + result.values[
+                    player
+                ](time_grid.times[step + 1], following)
+
+            local = control[start:stop]
+            gradient = jax.grad(unilateral)(local)
+            hessian = jax.hessian(unilateral)(local)
+            np.testing.assert_allclose(gradient, 0.0, atol=2e-10)
+            assert np.linalg.eigvalsh(np.asarray(hessian)).min() > 0.0
+            bellman = _stage_cost(values, player, state, control, step) + result.values[
+                player
+            ](time_grid.times[step + 1], next_state)
+            np.testing.assert_allclose(
+                result.values[player](time_grid.times[step], state),
+                bellman,
+                rtol=2e-11,
+                atol=2e-11,
+            )
+    for player in range(partition.num_players):
+        terminal_state = jnp.asarray([0.3, -0.4])
+        np.testing.assert_allclose(
+            result.values[player](time_grid.times[-1], terminal_state),
+            _terminal_cost(values, player, terminal_state),
+            rtol=2e-13,
+            atol=2e-13,
+        )
+
+    def transition(context, state, control, args):
+        step = context.step_index
+        return args["A"][step] @ state + args["B"][step] @ control + args["c"][step]
+
+    dynamics = phx.control.DiscreteControlDynamics(
+        phx.dynamics.DiscreteSystem(
+            transition,
+            state_layout=phx.dynamics.StateLayout((2,)),
+            input_layout=phx.dynamics.InputLayout((2,), roles="control"),
+            system_id="multistage-lq-game",
+        )
+    )
+    initial_state = jnp.asarray([0.35, -0.25])
+    problem = phx.control.ControlProblem(
+        dynamics,
+        time_grid,
+        initial_state,
+        args={"A": a, "B": b, "c": c},
+        problem_id="multistage-lq-game",
+    )
+    evaluation = problem.evaluate(result.policy, jnp.zeros(()))
+    assert bool(evaluation.successful)
+    trajectory = evaluation.trajectory
+    np.testing.assert_allclose(
+        trajectory.states[1:],
+        jax.vmap(lambda A, B, c_, x, u: A @ x + B @ u + c_)(
+            a,
+            b,
+            c,
+            trajectory.states[:-1],
+            trajectory.controls,
+        ),
+        rtol=2e-13,
+        atol=2e-13,
+    )
+    split = partition.split_controls(trajectory.controls)
+    np.testing.assert_allclose(partition.join_controls(split), trajectory.controls)
+    for player in range(partition.num_players):
+        direct = sum(
+            _stage_cost(
+                values,
+                player,
+                trajectory.states[step],
+                trajectory.controls[step],
+                step,
+            )
+            for step in range(horizon)
+        ) + _terminal_cost(values, player, trajectory.states[-1])
+        np.testing.assert_allclose(
+            result.values[player](time_grid.times[0], initial_state),
+            direct,
+            rtol=2e-11,
+            atol=2e-11,
+        )
+
+
+def test_player_permutation_preserves_physical_policy_and_permutes_values():
+    values = _rational_game()
+    baseline = _solve_rational()
+    control_permutation = jnp.asarray([1, 0])
+    player_permutation = jnp.asarray([1, 0])
+    permuted = finite_horizon_lq_feedback_nash(
+        values["dynamics_matrices"],
+        values["control_matrices"][..., control_permutation],
+        values["state_costs"][player_permutation],
+        values["control_costs"][player_permutation][..., control_permutation, :][
+            ..., control_permutation
+        ],
+        values["terminal_state_costs"][player_permutation],
+        PlayerControlPartition(("player-2", "player-1"), (1, 1)),
+        dynamics_bias=values["dynamics_bias"],
+        state_control_cross=values["state_control_cross"][player_permutation][
+            ..., control_permutation
+        ],
+        state_linear=values["state_linear"][player_permutation],
+        control_linear=values["control_linear"][player_permutation][
+            ..., control_permutation
+        ],
+        stage_constants=values["stage_constants"][player_permutation],
+        terminal_linear=values["terminal_linear"][player_permutation],
+        terminal_constants=values["terminal_constants"][player_permutation],
+        time_grid=values["time_grid"],
+    )
+
+    assert bool(permuted.valid)
+    np.testing.assert_allclose(
+        permuted.feedback_gain[..., control_permutation, :],
+        baseline.feedback_gain,
+        rtol=2e-12,
+        atol=2e-12,
+    )
+    np.testing.assert_allclose(
+        permuted.feedforward[..., control_permutation],
+        baseline.feedforward,
+        rtol=2e-12,
+        atol=2e-12,
+    )
+    np.testing.assert_allclose(permuted.values[1].matrices, baseline.values[0].matrices)
+    np.testing.assert_allclose(permuted.values[0].matrices, baseline.values[1].matrices)
+
+
+def test_jitted_mixed_cases_report_independent_numeric_failures():
+    partition = PlayerControlPartition(("left", "right"), (1, 1))
+    time_grid = phx.dynamics.TimeGrid(jnp.asarray([0.0, 1.0]), time_id="mixed-cases")
+    cases = 5
+    a = jnp.ones((cases, 1, 1, 1))
+    a = a.at[4, 0, 0, 0].set(jnp.nan)
+    b = jnp.zeros((cases, 1, 1, 2))
+    q = jnp.zeros((cases, 2, 1, 1, 1))
+    qf = jnp.zeros((cases, 2, 1, 1))
+    identity_costs = jnp.broadcast_to(jnp.eye(2), (2, 1, 2, 2))
+    r = jnp.broadcast_to(identity_costs, (cases, 2, 1, 2, 2))
+    r = r.at[1, 0, 0].set(jnp.asarray([[1.0, 1.0], [0.0, 1.0]]))
+    r = r.at[2, 0, 0].set(jnp.asarray([[1.0, 1.0], [1.0, 2.0]]))
+    r = r.at[2, 1, 0].set(jnp.asarray([[2.0, 1.0], [1.0, 1.0]]))
+    r = r.at[3, 0, 0].set(jnp.asarray([[-1.0, 0.0], [0.0, 1.0]]))
+
+    solve = eqx.filter_jit(finite_horizon_lq_feedback_nash)
+    result = solve(a, b, q, r, qf, partition, time_grid=time_grid)
+    expected = jnp.asarray(
+        [
+            LQFeedbackNashStatus.SUCCESS,
+            LQFeedbackNashStatus.NONSYMMETRIC_COST,
+            LQFeedbackNashStatus.COUPLED_SYSTEM_RANK_DEFICIENT,
+            LQFeedbackNashStatus.OWN_CURVATURE_NOT_POSITIVE_DEFINITE,
+            LQFeedbackNashStatus.NONFINITE_INPUT,
+        ],
+        dtype=jnp.int32,
+    )
+    np.testing.assert_array_equal(result.status, expected)
+    np.testing.assert_array_equal(result.diagnostics.first_failed_stage, [-1, 0, 0, 0, 0])
+    assert bool(result.valid[0])
+    assert not bool(jnp.any(result.valid[1:]))
+    assert bool(result.diagnostics.diagnostic_available[1, 0])
+    assert bool(result.diagnostics.diagnostic_available[2, 0])
+    assert bool(result.diagnostics.diagnostic_available[3, 0])
+    assert not bool(result.diagnostics.diagnostic_available[4, 0])
+    assert np.all(np.isfinite(np.asarray(result.feedback_gain[0])))
+    assert np.all(np.isfinite(np.asarray(result.feedback_gain[3])))
+    assert np.any(~np.isfinite(np.asarray(result.feedback_gain[2])))
+
+    valid = finite_horizon_lq_feedback_nash(
+        a[0],
+        b[0],
+        q[0],
+        r[0],
+        qf[0],
+        partition,
+        time_grid=time_grid,
+    )
+    np.testing.assert_allclose(result.feedback_gain[0], valid.feedback_gain)
+
+
+def test_rank_cutoff_and_condition_limit_are_distinct_from_lu_success():
+    partition = PlayerControlPartition(("left", "right"), (1, 1))
+    time_grid = phx.dynamics.TimeGrid(jnp.asarray([0.0, 1.0]), time_id="rank-policy")
+    delta = 2.0**-20
+    a = jnp.ones((1, 1, 1))
+    b = jnp.zeros((1, 1, 2))
+    q = jnp.zeros((2, 1, 1, 1))
+    qf = jnp.zeros((2, 1, 1))
+    r = jnp.asarray(
+        [
+            [[[1.0, 0.0], [0.0, 1.0]]],
+            [[[1.0, 0.0], [0.0, delta]]],
+        ]
+    )
+
+    rank_rejected = finite_horizon_lq_feedback_nash(
+        a,
+        b,
+        q,
+        r,
+        qf,
+        partition,
+        time_grid=time_grid,
+        rank_relative_tolerance=1e-4,
+    )
+    accepted = finite_horizon_lq_feedback_nash(
+        a,
+        b,
+        q,
+        r,
+        qf,
+        partition,
+        time_grid=time_grid,
+        rank_relative_tolerance=1e-12,
+    )
+    condition_rejected = finite_horizon_lq_feedback_nash(
+        a,
+        b,
+        q,
+        r,
+        qf,
+        partition,
+        time_grid=time_grid,
+        rank_relative_tolerance=1e-12,
+        maximum_condition=1e5,
+    )
+
+    assert int(rank_rejected.status) == int(
+        LQFeedbackNashStatus.COUPLED_SYSTEM_RANK_DEFICIENT
+    )
+    assert bool(rank_rejected.diagnostics.finite)
+    np.testing.assert_array_equal(
+        rank_rejected.diagnostics.linear_status,
+        [[int(phx.linalg.LinearSolveStatus.SUCCESS)] * 2],
+    )
+    assert bool(accepted.valid)
+    assert int(condition_rejected.status) == int(
+        LQFeedbackNashStatus.CONDITION_LIMIT_REACHED
+    )
+    np.testing.assert_allclose(
+        accepted.diagnostics.coupled_condition_numbers, [1.0 / delta]
+    )
+
+
+def test_structural_validation_rejects_shape_dtype_grid_and_tolerance_errors():
+    values = _rational_game()
+    required = (
+        values["dynamics_matrices"],
+        values["control_matrices"],
+        values["state_costs"],
+        values["control_costs"],
+        values["terminal_state_costs"],
+        values["partition"],
+    )
+    with pytest.raises(TypeError, match="real-valued"):
+        finite_horizon_lq_feedback_nash(
+            values["dynamics_matrices"].astype(complex),
+            *required[1:],
+            time_grid=values["time_grid"],
+        )
+    with pytest.raises(ValueError, match="partition joint control size"):
+        finite_horizon_lq_feedback_nash(
+            required[0],
+            required[1][..., :1],
+            *required[2:],
+            time_grid=values["time_grid"],
+        )
+    with pytest.raises(ValueError, match="state_costs must have shape"):
+        finite_horizon_lq_feedback_nash(
+            required[0],
+            required[1],
+            required[2][:1],
+            *required[3:],
+            time_grid=values["time_grid"],
+        )
+    wrong_grid = phx.dynamics.TimeGrid(
+        jnp.asarray([0.0, 0.5, 1.0]),
+        time_id="wrong-game-grid",
+    )
+    with pytest.raises(ValueError, match="must contain 2 times"):
+        finite_horizon_lq_feedback_nash(*required, time_grid=wrong_grid)
+    with pytest.raises(ValueError, match="tolerance must be finite and positive"):
+        finite_horizon_lq_feedback_nash(
+            *required,
+            time_grid=values["time_grid"],
+            tolerance=0.0,
+        )
+    with pytest.raises(ValueError, match="maximum_condition"):
+        finite_horizon_lq_feedback_nash(
+            *required,
+            time_grid=values["time_grid"],
+            maximum_condition=1.0,
+        )
+
+
+def test_reverse_failures_preserve_causal_stage_and_terminal_index():
+    partition = PlayerControlPartition(("left", "right"), (1, 1))
+    time_grid = phx.dynamics.TimeGrid(
+        jnp.asarray([0.0, 1.0, 2.0]),
+        time_id="causal-game-failure",
+    )
+    a = jnp.ones((2, 1, 1))
+    b = jnp.zeros((2, 1, 2))
+    q = jnp.zeros((2, 2, 1, 1))
+    qf = jnp.zeros((2, 1, 1))
+    identity = jnp.eye(2)
+    r = jnp.broadcast_to(identity, (2, 2, 2, 2))
+    r = r.at[0, 1].set(jnp.asarray([[1.0, 1.0], [1.0, 2.0]]))
+    r = r.at[1, 1].set(jnp.asarray([[2.0, 1.0], [1.0, 1.0]]))
+    stage_failure = finite_horizon_lq_feedback_nash(
+        a,
+        b,
+        q,
+        r,
+        qf,
+        partition,
+        time_grid=time_grid,
+    )
+
+    assert int(stage_failure.status) == int(
+        LQFeedbackNashStatus.COUPLED_SYSTEM_RANK_DEFICIENT
+    )
+    assert int(stage_failure.diagnostics.first_failed_stage) == 1
+    np.testing.assert_array_equal(
+        stage_failure.diagnostics.stage_status,
+        [
+            int(LQFeedbackNashStatus.DEPENDENCY_FAILED),
+            int(LQFeedbackNashStatus.COUPLED_SYSTEM_RANK_DEFICIENT),
+        ],
+    )
+    np.testing.assert_array_equal(
+        stage_failure.diagnostics.diagnostic_available,
+        [False, True],
+    )
+
+    terminal_grid = phx.dynamics.TimeGrid(
+        jnp.asarray([0.0, 1.0]),
+        time_id="terminal-game-failure",
+    )
+    terminal_failure = finite_horizon_lq_feedback_nash(
+        jnp.eye(2)[None, ...],
+        jnp.ones((1, 2, 1)),
+        jnp.zeros((1, 1, 2, 2)),
+        jnp.ones((1, 1, 1, 1)),
+        jnp.asarray([[[1.0, 1.0], [0.0, 1.0]]]),
+        PlayerControlPartition(("controller",), (1,)),
+        time_grid=terminal_grid,
+    )
+    assert int(terminal_failure.status) == int(LQFeedbackNashStatus.NONSYMMETRIC_COST)
+    assert int(terminal_failure.diagnostics.first_failed_stage) == 1
+    assert int(terminal_failure.diagnostics.stage_status[0]) == int(
+        LQFeedbackNashStatus.DEPENDENCY_FAILED
+    )
+    assert not bool(terminal_failure.diagnostics.diagnostic_available[0])
+
+
+def test_public_surface_is_namespaced_under_control_games():
+    assert phx.control.games.__all__ == [
+        "FiniteHorizonLQFeedbackNashDiagnostics",
+        "FiniteHorizonLQFeedbackNashResult",
+        "LQFeedbackNashStatus",
+        "PlayerControlPartition",
+        "finite_horizon_lq_feedback_nash",
+    ]
+    assert "games" in phx.control.__all__
+    assert "finite_horizon_lq_feedback_nash" not in phx.control.__all__


### PR DESCRIPTION
## Summary

Adds a narrow `phydrax.control.games` capability for finite-horizon, discrete-time, deterministic affine linear-quadratic games with simultaneous full-state affine feedback Nash policies.

The new surface provides:

- ordered, content-identified ownership of contiguous joint-control blocks;
- one joint `AffineFeedbackPolicy` compatible with the existing physical control runtime;
- one `QuadraticValueFunction` per player;
- case-batched, differentiable backward feedback-Nash recursion;
- explicit equilibrium, rank, curvature, condition, linear-solve, and causal-failure evidence.

## Mathematical contract

For each stage, all players observe the current state and simultaneously minimize individual quadratic-affine costs over the same affine dynamics. A player's cost may depend on every component of the joint control, including cross-player control terms and state-control coupling.

The result is explicitly a finite-horizon full-state feedback Nash policy. It does not claim open-loop, constrained, stochastic, zero-sum maximizer, partial-observation, nonlinear, or mean-field game support.

`PlayerControlPartition` keeps player identity and control ownership as static topology rather than overloading case axes. It validates ordered player IDs and positive control sizes and provides reversible control and feedback-gain splitting.

## Numerical method

The backward recursion constructs each player's continuation-augmented control Hessian and stacks only the rows owned by that player into one generally nonsymmetric coupled Nash system.

- The authoritative feedback and affine terms come from one Phydrax `DenseLU` multiple-RHS solve.
- A separate stop-gradient SVD reports numerical rank, cutoff, extremal singular values, and the full condition number; it is never used to solve or repair the system.
- Each player's continuation-augmented own-action Hessian must be positive definite.
- Value matrices are canonicalized only after recording their raw antisymmetry defect.
- Independent stationarity and Bellman coefficient residuals validate the returned external policy convention.
- Tensor contractions use the package-wide `phydrax.ein` boundary.

The implementation never substitutes an inverse, pseudoinverse, Cholesky assumption, diagonal jitter, regularized system, clipped action, zero policy, or alternate method.

## Failure and evidence semantics

`LQFeedbackNashStatus` distinguishes nonfinite input, nonsymmetric costs, unsupported own curvature, coupled rank loss, explicit condition-limit rejection, linear-solve failure, nonfinite output, excessive residual, and dependency failure.

Terminal and stage status remain separate. The result records the first direct causal failure encountered by the reverse recursion; earlier stages are marked dependency-failed and receive an explicit nonfinite continuation rather than consuming an invalid value function. Independent batch cases remain isolated.

Invalid policy and value arrays are retained only as numerical evidence. Callers must check `result.valid` before applying them.

## Integration

The API is intentionally namespaced under `phydrax.control.games`; individual symbols are not duplicated at `phydrax.control` or the package root. It reuses the existing `TimeGrid`, `AffineFeedbackPolicy`, `QuadraticValueFunction`, control dynamics, physical rollout, strict PyTree, linear algebra, and provenance conventions instead of introducing parallel game, trajectory, or solver frameworks.

The included runnable example solves a coupled affine two-player game, replays its joint policy through `ControlProblem`, separates player controls, and compares direct discrete payoffs with initial player values.

## Documentation and benchmark evidence

The control API, cookbook, examples index, capability overview, and changelog describe the exact array axes, solution concept, diagnostics, failure semantics, replay route, and unsupported problem classes.

A deterministic benchmark records compilation, execution, logical/compiler memory, content fingerprints, rank and condition evidence, and independently recomputed stationarity, Bellman, terminal, and physical-rollout defects across horizon, state dimension, control dimension, player count, and case-batch scaling.