### PR TITLE
Add composable physics-learning training and deployment paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Unreleased
 
 ### Added
+- Added provenance-safe closure/operator deployment, conflict-free objective
+  gradients, solver-interleaved periodic and MAC learning transitions,
+  validation-driven native-Krylov refinement, terminal-physics flow matching,
+  and conservative learned particle exchange bindings.
 - Added native heterogeneous neural-network execution with linear-storage cable
   solves, numerical event-time sensitivities, physical point neurons, bounded
   delayed routing, lifetime-safe plasticity, artificial recurrent spiking cells,

--- a/NOTICE
+++ b/NOTICE
@@ -460,3 +460,17 @@ basis, S2FFT-normalized product transforms, hybrid radial/angular scaling
 complement, multiresolution plan banks, resource admission, tests, examples,
 and benchmarks. No external ball-transform source, fixtures, generated
 kernels, cache format, or runtime dependency is copied or redistributed.
+
+Physics-learning composition design study
+The multi-objective gradient design considered Liu et al., “ConFIG:
+Towards Conflict-free Training of Physics Informed Neural Networks” (2024).
+The progressively refined solve policy considered “Progressively Refined
+Differentiable Physics” (2025). The terminal transport objective considered
+“Physics-Based Flow Matching” (2025). The conservative learned pair exchange
+considered the pairwise momentum construction in “Deep Lagrangian Fluids”
+and related momentum-conserving learned-fluid work. Phydrax independently
+implements these ideas against its native PyTree, measured-field, closure-data,
+Krylov-control, fixed-step, transport, particle-relation, status, evidence, and
+provenance contracts. No upstream source, tests, fixtures, generated data,
+notebooks, model weights, runtime types, or dependencies are copied, translated,
+bundled, linked, imported, or redistributed.

--- a/docs/all-of-phydrax.md
+++ b/docs/all-of-phydrax.md
@@ -1963,3 +1963,20 @@ Below are the common SciML regimes expressed in Phydrax’s primitives.
   stochastic games, constrained equilibria, and mean-field/finite-state references.
 - `phydrax.solver` for training, differential, delay/memory, rough, stochastic,
   controlled, probabilistic, and geometry-preserving equation solvers.
+
+## Physics-learning composition
+
+Phydrax composes learned and numerical owners without a parallel framework.
+Closure manifests and leakage-safe partitions become operator datasets through
+`prepare_closure_operator_datasets`, then loaded artifacts bind back to learned
+stress only after provenance checks. `fit_discrete_model` accepts explicit
+rollout transitions so model outputs can act inside periodic SSPRK or MAC
+pressure-projected dynamics.
+
+`ConflictFreeGradientPolicy` composes named objective gradients from one
+prepared stochastic realization. `ProgressiveLinearRefinementPolicy` controls a
+training-only native Krylov budget from fixed validation while preserving
+full-fidelity selection. `PhysicsFlowMatchingTerm` adds a differentiably
+unrolled terminal functional to flow matching. Learned particle exchanges use
+the existing pair relation and scatter substrate to guarantee only their
+constructed conservation laws.

--- a/docs/api/discretization/particle.md
+++ b/docs/api/discretization/particle.md
@@ -670,3 +670,25 @@
 ---
 
 ::: phydrax.equations.compile_weakly_compressible_sph_problem
+
+## Learned conservative pair exchanges
+
+`ParticleExchangeLedger` records same-population total exchange, action-reaction
+defect, torque, relative power, pair count, and finiteness. It complements the
+two-population `ParticleInteractionLedger`.
+
+The neural-operator adapters live in `phydrax.nn.operator.adapters`:
+
+- `particle_pair_operator_batch` represents one fixed-capacity pair relation as
+  a masked point-cloud operator batch;
+- `PairwiseExchangeFeatureSchema` binds feature order, units, dtype, and
+  relation schema;
+- `PairwiseExchangeBindingPlan` binds one trained artifact and exchange kind;
+- `PreparedPairwiseExchangeBinding` predicts once per canonical pair and
+  deposits equal and opposite endpoint values with `scatter_pair_exchange`.
+
+An arbitrary vector exchange guarantees linear momentum. A central scalar force
+also guarantees zero internal torque. A scalar flux conserves the exchanged
+scalar. None of these constructions alone guarantees energy conservation,
+dissipation, rotational equivariance, or smooth derivatives through a changed
+neighbor relation.

--- a/docs/api/dynamics.md
+++ b/docs/api/dynamics.md
@@ -717,3 +717,22 @@ times; derivative or transition likelihood errors; rollout or stationary-moment
 errors; covariance error; and energy diagnostics where defined. The benchmark
 reports comparative evidence and never treats one quick random seed as a
 superiority claim.
+
+## Learned transition composition
+
+`AbstractDiscreteModelRolloutTransition` separates a learned model from the
+meaning assigned to its output. `DirectDiscreteModelRolloutTransition` preserves
+the ordinary next-state behavior. Domain transitions may instead interpret a
+model output as a source, flux, stress, control, or correction and return
+`DiscreteModelRolloutTransitionResult`.
+
+The result keeps candidate state, accepted training state, training usability,
+physical convergence, status, residual, and work count separate.
+`fit_discrete_model(..., transition=...)` recurrently uses only its accepted
+training state and includes the transition identity in checkpoint compatibility.
+The bound `DiscreteSystem` commits only physically converged states.
+
+`ProgressiveLinearRefinementPolicy` supplies a validation-driven
+`LinearSolveControl` to transitions that explicitly support it. Its complete
+plateau/refinement state is checkpointed. Training approximations never become
+simulation-success evidence.

--- a/docs/api/optim.md
+++ b/docs/api/optim.md
@@ -1922,3 +1922,21 @@ optimization-gradient claim.
 ---
 
 ::: phydrax.optim.threshold_density
+
+## Multi-objective gradient composition
+
+::: phydrax.optim.ConflictFreeGradientPolicy
+
+---
+
+::: phydrax.optim.ConflictFreeGradientResult
+
+---
+
+::: phydrax.optim.conflict_free_gradient
+
+The implementation uses the real Hilbert pairing of congruent real or complex
+parameter PyTrees and a small rank-aware objective-space pseudoinverse. It
+records norms, cosine matrix, rank, condition estimate, conflicts, and final
+projections. Rank deficiency is not automatically failure: identical gradients
+remain feasible, while opposite gradients fail their projection check.

--- a/docs/api/terms.md
+++ b/docs/api/terms.md
@@ -472,3 +472,34 @@ The band width, phase side, integration target, and plan remain explicit.
 ---
 
 ::: phydrax.terms.free_boundary_term_suite
+
+## Time sampling and terminal-physics flow matching
+
+::: phydrax.terms.AbstractTimeSamplingPolicy
+
+---
+
+::: phydrax.terms.LogitNormalTimeSamplingPolicy
+
+---
+
+::: phydrax.terms.AbstractFlowEndpointFunctional
+
+---
+
+::: phydrax.terms.CallableFlowEndpointFunctional
+
+---
+
+::: phydrax.terms.FlowEndpointRolloutPolicy
+
+---
+
+::: phydrax.terms.PhysicsFlowMatchingTerm
+
+`PhysicsFlowMatchingTerm` samples one `FlowMatchingBatch`, evaluates velocity
+regression, unrolls the same velocity field to the interpolant target with a
+static-capacity Euler scan, and evaluates a nonnegative measure-owned endpoint
+functional. The two scalar components may be summed explicitly or composed by
+`ConflictFreeGradientPolicy`. The endpoint functional is a soft objective, not
+a hard-constraint certificate.

--- a/docs/cookbook/operator_learning.md
+++ b/docs/cookbook/operator_learning.md
@@ -2225,3 +2225,22 @@ python -m tools.operator_benchmarks --uq --quick \
 
 The benchmark keeps calibration-case checksums and resolution, rollout, and
 source/query geometry shifts visible in JSON and Parquet artifacts.
+
+## Closure data to deployed operators
+
+`ClosureOperatorCase` aligns named closure inputs and targets through one
+`ClosureSampleKey`. `prepare_closure_operator_datasets(...)` validates the
+dataset manifest and analysis DAG, preserves the authoritative
+`LeakageSafePartition`, and writes case, trajectory, realization, time-block,
+target, and reference identities into `OperatorCaseProvenance`.
+
+Closure `TrainOnlyNormalizer` values are applied by the bridge. Fit the resulting
+datasets with `normalization=None`; stacking an `OperatorNormalizationPolicy`
+would change the deployment map. Add the returned preparation, manifest,
+partition, DAG, flow-schema, and normalizer IDs to the `TrainedOperator`
+provenance. `bind_trained_stress_operator(...)` checks those identities before a
+loaded operator may enter `LearnedStressBindingPlan`.
+
+The initial deployment adapter has one fixed feature input and fixed query
+geometry. Runtime conditioning must be represented by declared operator inputs,
+not hidden predictor arguments.

--- a/docs/guides_functional_training.md
+++ b/docs/guides_functional_training.md
@@ -241,3 +241,22 @@ to the unscaled physical objective.
 Correction training currently requires a pure `ResidualPenalty` objective;
 nonquadratic scalar terms are rejected rather than assigned an invented scaled
 residual meaning.
+
+## Conflict-free objective gradients
+
+`ConflictFreeGradientPolicy` composes gradients of the scalar objective
+components from one prepared realization. The implementation forms only the
+small objective-space Gram matrix, uses Phydrax rank-aware pseudoinverse
+factors, and returns the final projection of every objective gradient onto the
+composed direction.
+
+Set it with
+`FunctionalTrainingPlan(gradient_composition=...)`. Initial support is a
+standard Optax update with all terms active, one microstep, no attached model
+losses, and no simultaneous term balancing. Infeasible opposite gradients fail
+instead of falling back to an unlabeled weighted sum. Stationary and
+zero-support objectives remain separately identified.
+
+Componentized terms, including `PhysicsFlowMatchingTerm`, share one sampled
+payload and expose multiple gradients without duplicating stochastic
+realizations.

--- a/docs/guides_large_eddy_simulation.md
+++ b/docs/guides_large_eddy_simulation.md
@@ -657,3 +657,28 @@ its base incompressible dependency.
 See [Solver evidence gates](guides_solver_evidence.md) for generic publication and
 resource rules and [Incompressible flow API](api/solver/incompressible.md) for the base
 candidate routes.
+
+## Solver-interleaved learned stress
+
+`PeriodicLearnedStressRolloutTransition` evaluates the current learned stress at
+all three SSPRK(3,3) stages. It uses independent real Hermitian coordinates for
+training while retaining the existing periodic feature, stress-energy,
+divergence, Leray-projection, and evidence kernels. The selected nested model can
+therefore be trained by `fit_discrete_model` with full, truncated, or
+rematerialized rollouts.
+
+`MACLearnedRateRolloutTransition` is the controlled iterative-pressure route.
+Its model emits an additional unconstrained face rate; the MAC pressure
+projection remains authoritative. A transition distinguishes a numerically
+usable coarse training candidate from a physically converged accepted result.
+Normal deployment admits only physical convergence.
+
+`ProgressiveLinearRefinementPolicy` changes the native Krylov iteration budget
+after fixed-validation plateaus. Initial support requires algorithmic
+differentiation through the executed finite Krylov map. Mathematical implicit,
+direct, transform, hybrid, block, recycled, and external-backend solves are not
+part of that claim. Validation and model selection always use the declared
+full-fidelity budget.
+
+Run `python tools/learned_stress_hybrid_benchmarks.py --quick` for a bounded
+stagewise value/gradient/runtime smoke.

--- a/docs/guides_particle_qualification.md
+++ b/docs/guides_particle_qualification.md
@@ -66,3 +66,15 @@ claims remain absent.
 Particle conversion is qualified by exact radial measure identities, thermodynamic inversion residual, interior heat/species cancellation, element balance, phase inventory, accepted-step energy closure, and agreement between reference Rosenbrock and structured tridiagonal backends. `tools/particle_conversion_qualification.py` records these cases as one machine-readable campaign.
 
 Reactive coupling adds particle/fluid momentum, energy, and species closure; subsystem success flags; coupling iteration residual; and atomic rollback. `tools/reactive_cfd_dem_qualification.py` exercises both Strang and iterated schedules. `ParticlePhysicsSupportMatrix` reports claims compositionally: a successful DEM claim does not imply thermochemistry, superquadric, radiation, or distributed support.
+
+## Learned exchange qualification
+
+Qualify a learned pair binding on the exact fixed `ParticlePairRelation`.
+Require artifact/task/feature/relation identity, finite active predictions,
+inactive-route sanitation, and an accepted accumulation policy.
+
+Use `ParticleExchangeLedger` to gate only the construction's actual claim:
+linear exchange cancellation for vector/scalar routes and internal torque for a
+central force. Relative power is diagnostic unless a separate potential or
+dissipation policy supplies an energy claim. Rebuilt neighbor lists, periodic
+image changes, capacity overflow, and topology epochs require new route evidence.

--- a/docs/guides_transport.md
+++ b/docs/guides_transport.md
@@ -504,3 +504,20 @@ size and provenance, dual residuals, integration and transport statuses, replay
 equality, support-gradient cost, and result memory. The Schrödinger bridge harness
 reports exact solve and keyed-sampling timings, endpoint residual, path KL, empirical
 marginal residual, convergence, and reference-process provenance.
+
+## Terminal physical objectives for learned flows
+
+`PhysicsFlowMatchingTerm` keeps generative interpolation time distinct from any
+physical time carried in endpoint context. One endpoint/time realization feeds
+both velocity regression and terminal physics. A fixed Euler rollout with
+optional rematerialization reconstructs the terminal estimate; inference
+transport remains owned by `ContinuousTransport` and `DiffraxEvolution`.
+
+The endpoint functional owns its physical quadrature and reduction. It must
+return one finite nonnegative energy per valid pair. Report the velocity loss,
+endpoint energy, distributional score, terminal step count, model evaluations,
+and runtime separately; no single scalar demonstrates both physical and
+distributional fidelity.
+
+Run `python tools/continuous_transport_benchmarks.py --quick` for the analytic
+terminal-refinement case alongside the existing transport benchmarks.

--- a/phydrax/applications/incompressible_flow/__init__.py
+++ b/phydrax/applications/incompressible_flow/__init__.py
@@ -111,6 +111,11 @@ from ._immersed_support import (
     PRESCRIBED_MARKER_SUPPORT_TUPLE,
     RESOLVED_CFD_DEM_SUPPORT_TUPLE,
 )
+from ._learned_training import (
+    FixedGridStressOperatorModel,
+    MACLearnedRateRolloutTransition,
+    PeriodicLearnedStressRolloutTransition,
+)
 from ._production import (
     MACConstantPressureGradientForcing,
     MACDynamicLESProductionState,
@@ -197,6 +202,7 @@ __all__ = [
     "ConstantPowerFourierForcingResult",
     "DEFORMABLE_CONTACT_SUPPORT_TUPLE",
     "FIXED_TOPOLOGY_SHARP_SUPPORT_TUPLE",
+    "FixedGridStressOperatorModel",
     "FREE_RIGID_MARKER_SUPPORT_TUPLE",
     "IMMERSED_DNS_SUPPORT_TUPLES",
     "IMMERSED_REFERENCE_CASES",
@@ -230,6 +236,7 @@ __all__ = [
     "MACConstantPressureGradientForcing",
     "MACFlowControlConditioningEvidence",
     "MACFlowControlDiagnostics",
+    "MACLearnedRateRolloutTransition",
     "MACFlowControlKind",
     "MACFlowControlPlan",
     "MACFlowControlResourceEvidence",
@@ -247,6 +254,7 @@ __all__ = [
     "PeriodicSpectralProductionPlan",
     "PeriodicSpectralProductionCase",
     "PeriodicDynamicLESProductionState",
+    "PeriodicLearnedStressRolloutTransition",
     "PreparedImmersedRuntimeAdmission",
     "PreparedMACFlowControl",
     "PreparedOUForcedETDRKMethod",

--- a/phydrax/applications/incompressible_flow/_learned_training.py
+++ b/phydrax/applications/incompressible_flow/_learned_training.py
@@ -1,0 +1,487 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from math import prod
+from typing import Any
+
+import equinox as eqx
+import jax.numpy as jnp
+import numpy as np
+from jaxtyping import Array
+
+from ..._fingerprint import canonical_fingerprint
+from ..._model import AbstractArrayModel
+from ..._numerics._ssp_runge_kutta import (
+    ssprk33_step_with_evidence,
+    StageTransformResult,
+)
+from ..._strict import StrictModule
+from ...discretization.spectral._coordinates import HermitianSpectralCoordinates
+from ...dynamics import DiscreteStepContext, InputLayout, StateLayout
+from ...dynamics.identification._neural_transition import (
+    AbstractDiscreteModelRolloutTransition,
+    DiscreteModelRolloutTransitionResult,
+)
+from ...equations._learned_stress import PreparedPeriodicLearnedStress
+from ...equations._mac_incompressible import CompiledMACIncompressibleDynamics
+from ...linalg import LinearSolveControl, LinearSolveStatus
+from ...nn.operator.data import FunctionSamples, OperatorBatch
+from ...nn.operator.engine import AbstractOperatorModel
+
+
+class FixedGridStressOperatorModel(AbstractArrayModel):
+    """Expose one fixed-grid neural operator through a flat array-model ABI."""
+
+    operator: AbstractOperatorModel
+    template: OperatorBatch
+    source_name: str = eqx.field(static=True)
+    target_name: str = eqx.field(static=True)
+    source_shape: tuple[int, ...] = eqx.field(static=True)
+    target_shape: tuple[int, ...] = eqx.field(static=True)
+    in_size: int = eqx.field(static=True)
+    out_size: int = eqx.field(static=True)
+
+    def __init__(
+        self,
+        operator: AbstractOperatorModel,
+        template: OperatorBatch,
+        /,
+        *,
+        source_name: str,
+        target_name: str,
+    ):
+        if not isinstance(operator, AbstractOperatorModel):
+            raise TypeError("operator must be an AbstractOperatorModel.")
+        if not isinstance(template, OperatorBatch) or template.case_shape:
+            raise ValueError("Fixed-grid operator templates must have no case axes.")
+        source = str(source_name)
+        target = str(target_name)
+        if source not in template.inputs:
+            raise KeyError("Fixed-grid operator source is absent from its template.")
+        samples = template.input(source)
+        if samples.values is None:
+            raise ValueError("Fixed-grid operator templates require source values.")
+        if (
+            len(operator.operator_output_specs) != 1
+            or target not in operator.operator_output_specs
+        ):
+            raise ValueError(
+                "Fixed-grid stress adapters require one named operator output."
+            )
+        output = operator.operator_output_specs[target]
+        query = template.require_single_query()
+        source_shape = tuple(samples.values.shape)
+        target_shape = query.sample_shape + (
+            () if output.channels == "scalar" else (int(output.channels),)
+        )
+        self.operator = operator
+        self.template = template
+        self.source_name = source
+        self.target_name = target
+        self.source_shape = source_shape
+        self.target_shape = target_shape
+        self.in_size = prod(source_shape)
+        self.out_size = prod(target_shape)
+
+    def __call__(self, values: Array, /, *, key: Array | None = None) -> Array:
+        source = self.template.input(self.source_name)
+        reshaped = jnp.asarray(values).reshape(self.source_shape)
+        inputs = dict(self.template.inputs)
+        inputs[self.source_name] = FunctionSamples(
+            values=reshaped,
+            axes=source.axes,
+            coordinates=source.coordinates,
+            quadrature_weights=source.quadrature_weights,
+            mask=source.mask,
+            topology=source.topology,
+            support_id=source.support_id,
+            measure_id=source.measure_id,
+        )
+        batch = OperatorBatch(
+            inputs=inputs,
+            queries=self.template.queries,
+            case_axes=(),
+            case_shape=(),
+        )
+        prediction = self.operator.predict_prevalidated(batch, key=key)
+        return prediction.field(self.target_name).values.reshape((self.out_size,))
+
+
+class _CurrentStressPredictor(StrictModule):
+    model: AbstractArrayModel
+    key: Array | None
+    iteration: Array | None
+    output_shape: tuple[int, ...] = eqx.field(static=True)
+
+    def __init__(
+        self,
+        model: AbstractArrayModel,
+        key: Array | None,
+        iteration: Array | None,
+        output_shape: tuple[int, ...],
+        /,
+    ):
+        self.model = model
+        self.key = key
+        self.iteration = iteration
+        self.output_shape = output_shape
+
+    def __call__(self, normalized: Array, args: Any = None, /) -> Array:
+        del args
+        binding = self.model.input_binding()
+        point = binding.pack_point((jnp.asarray(normalized).reshape((-1,)),))
+        values = binding.call(
+            self.model,
+            point,
+            key=self.key,
+            iter_=self.iteration,
+            kwargs={},
+        )
+        return jnp.asarray(values).reshape(self.output_shape)
+
+
+class PeriodicLearnedStressRolloutTransition(AbstractDiscreteModelRolloutTransition):
+    """SSPRK(3,3) periodic dynamics with learned stress at every stage."""
+
+    prepared_stress: PreparedPeriodicLearnedStress
+    coordinates: HermitianSpectralCoordinates
+    base_rate: Callable = eqx.field(static=True)
+    base_rate_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        prepared_stress: PreparedPeriodicLearnedStress,
+        coordinates: HermitianSpectralCoordinates,
+        base_rate: Callable[[Array, Array, Array | None], Array],
+        /,
+        *,
+        base_rate_id: str,
+        state_layout: StateLayout,
+        input_layout: InputLayout | None = None,
+        step_size: float,
+        step_rtol: float = 1e-7,
+        step_atol: float = 1e-12,
+    ):
+        if not isinstance(prepared_stress, PreparedPeriodicLearnedStress):
+            raise TypeError("prepared_stress must be PreparedPeriodicLearnedStress.")
+        if not isinstance(coordinates, HermitianSpectralCoordinates):
+            raise TypeError("coordinates must be HermitianSpectralCoordinates.")
+        if (
+            prepared_stress.projector.discretization.prepared_id
+            != coordinates.discretization.prepared_id
+        ):
+            raise ValueError("Learned stress and Hermitian coordinates disagree.")
+        if state_layout.shape != (coordinates.coordinate_size,):
+            raise ValueError("State layout must contain the real Hermitian coordinates.")
+        if not callable(base_rate):
+            raise TypeError("base_rate must be callable.")
+        rate_id = str(base_rate_id).strip()
+        step = float(step_size)
+        rtol = float(step_rtol)
+        atol = float(step_atol)
+        if not rate_id:
+            raise ValueError("base_rate_id must be non-empty.")
+        if not np.isfinite(step) or step <= 0.0:
+            raise ValueError("step_size must be finite and positive.")
+        if not np.isfinite(rtol) or rtol < 0.0 or not np.isfinite(atol) or atol < 0.0:
+            raise ValueError("Step tolerances must be finite and nonnegative.")
+        self.prepared_stress = prepared_stress
+        self.coordinates = coordinates
+        self.base_rate = base_rate
+        self.base_rate_id = rate_id
+        self.state_layout = state_layout
+        self.input_layout = input_layout
+        self.step_size = step
+        self.step_rtol = rtol
+        self.step_atol = atol
+        self.transition_id = canonical_fingerprint(
+            {
+                "kind": "periodic-learned-stress-rollout-transition",
+                "learned_stress": prepared_stress.prepared_id,
+                "coordinates": coordinates.coordinate_id,
+                "base_rate": rate_id,
+                "state_layout": state_layout.layout_id,
+                "input_layout": None if input_layout is None else input_layout.layout_id,
+                "step_size": step,
+                "step_rtol": rtol,
+                "step_atol": atol,
+                "integrator": "ssprk33-stagewise",
+            }
+        )
+
+    def validate_model(self, model: AbstractArrayModel, /) -> None:
+        if not isinstance(model, AbstractArrayModel):
+            raise TypeError("Learned stress transitions require AbstractArrayModel.")
+        feature_size = prod(self.prepared_stress.binding.plan.feature_schema.shape)
+        output_size = prod(self.prepared_stress.binding.plan.output_contract.shape)
+        if model.in_size != feature_size or model.out_size != output_size:
+            raise ValueError(
+                "Learned stress model sizes do not match the prepared feature/output ABI."
+            )
+
+    def evaluate(
+        self,
+        model: AbstractArrayModel,
+        context: DiscreteStepContext,
+        state: Array,
+        inputs: Array | None,
+        /,
+        *,
+        key: Array | None,
+        iteration: Array | None,
+        control: Any = None,
+    ) -> DiscreteModelRolloutTransitionResult:
+        if control is not None:
+            raise ValueError("Periodic learned stress does not use linear solve control.")
+        predictor = _CurrentStressPredictor(
+            model,
+            key,
+            iteration,
+            self.prepared_stress.binding.plan.output_contract.shape,
+        )
+        prepared = eqx.tree_at(
+            lambda value: value.binding.predictor,
+            self.prepared_stress,
+            predictor,
+        )
+
+        def vector_field(time, real_state, _args):
+            modal = self.coordinates.from_real_coordinates(real_state)
+            stage = prepared.evaluate(modal)
+            base = jnp.asarray(self.base_rate(time, modal, inputs))
+            if base.shape != modal.shape:
+                raise ValueError(
+                    "Periodic base rate must preserve the modal state shape."
+                )
+            rate = base + stage.projected_rate
+            rate = jnp.where(stage.successful, rate, jnp.full_like(rate, jnp.nan))
+            rate = self.coordinates.project(rate)
+            return self.coordinates.to_real_coordinates(rate)
+
+        def project_stage(index, time, candidate, _args):
+            del index, time
+            modal = self.coordinates.from_real_coordinates(candidate)
+            projected = self.coordinates.project(
+                self.prepared_stress.projector.project(modal)
+            )
+            selected = self.coordinates.to_real_coordinates(projected)
+            correction = jnp.linalg.norm(selected - candidate)
+            finite = jnp.all(jnp.isfinite(selected))
+            return StageTransformResult(
+                selected,
+                correction > 0.0,
+                finite,
+                correction,
+            )
+
+        result = ssprk33_step_with_evidence(
+            vector_field,
+            context.source,
+            self.coordinates.validate_coordinates(state),
+            context.duration,
+            None,
+            stage_transform=project_stage,
+        )
+        finite = jnp.all(jnp.isfinite(result.state))
+        successful = result.successful & finite
+        accepted = jnp.where(successful, result.state, jnp.zeros_like(result.state))
+        return DiscreteModelRolloutTransitionResult(
+            result.state,
+            accepted,
+            training_usable=successful,
+            physically_converged=successful,
+            status=jnp.where(successful, 0, 1),
+            residual=result.correction_norm,
+            iterations=jnp.asarray(3, dtype=jnp.int32),
+            transition_id=self.transition_id,
+        )
+
+
+class MACLearnedRateRolloutTransition(AbstractDiscreteModelRolloutTransition):
+    """Explicit MAC transition with a learned rate and controlled projection."""
+
+    dynamics: CompiledMACIncompressibleDynamics
+    coarse_relative_residual: float = eqx.field(static=True)
+
+    def __init__(
+        self,
+        dynamics: CompiledMACIncompressibleDynamics,
+        /,
+        *,
+        state_layout: StateLayout,
+        step_size: float,
+        coarse_relative_residual: float = 1.0,
+        step_rtol: float = 1e-7,
+        step_atol: float = 1e-12,
+    ):
+        if not isinstance(dynamics, CompiledMACIncompressibleDynamics):
+            raise TypeError("dynamics must be CompiledMACIncompressibleDynamics.")
+        if dynamics.algebraic_les is not None or dynamics.dynamic_les is not None:
+            raise ValueError(
+                "MAC learned-rate training requires base dynamics without another LES closure."
+            )
+        if dynamics.projection.constant_route != "iterative":
+            raise ValueError(
+                "MAC learned-rate refinement requires an iterative pressure route."
+            )
+        if dynamics.projection.linear_policy.differentiation.mode != "algorithmic":
+            raise ValueError(
+                "MAC linear refinement initially requires algorithmic differentiation."
+            )
+        if state_layout.shape != dynamics.state_shape:
+            raise ValueError("MAC learned-rate state layout does not match dynamics.")
+        residual = float(coarse_relative_residual)
+        step = float(step_size)
+        rtol = float(step_rtol)
+        atol = float(step_atol)
+        if not np.isfinite(residual) or residual <= 0.0:
+            raise ValueError(
+                "coarse_relative_residual must be finite and strictly positive."
+            )
+        if not np.isfinite(step) or step <= 0.0:
+            raise ValueError("step_size must be finite and positive.")
+        if not np.isfinite(rtol) or rtol < 0.0 or not np.isfinite(atol) or atol < 0.0:
+            raise ValueError("Step tolerances must be finite and nonnegative.")
+        self.dynamics = dynamics
+        self.coarse_relative_residual = residual
+        self.state_layout = state_layout
+        self.input_layout = None
+        self.step_size = step
+        self.step_rtol = rtol
+        self.step_atol = atol
+        self.transition_id = canonical_fingerprint(
+            {
+                "kind": "mac-learned-rate-rollout-transition",
+                "dynamics": dynamics.compilation_id,
+                "projection": dynamics.projection.plan_id,
+                "state_layout": state_layout.layout_id,
+                "step_size": step,
+                "step_rtol": rtol,
+                "step_atol": atol,
+                "coarse_relative_residual": residual,
+                "integrator": "explicit-euler-projected",
+                "differentiation": "algorithmic",
+            }
+        )
+
+    @property
+    def supports_linear_refinement(self) -> bool:
+        return True
+
+    def validate_model(self, model: AbstractArrayModel, /) -> None:
+        if not isinstance(model, AbstractArrayModel):
+            raise TypeError("MAC learned rates require AbstractArrayModel.")
+        if (
+            model.in_size != self.state_layout.size
+            or model.out_size != self.state_layout.size
+        ):
+            raise ValueError(
+                "MAC learned-rate model input and output must match the state layout."
+            )
+
+    def evaluate(
+        self,
+        model: AbstractArrayModel,
+        context: DiscreteStepContext,
+        state: Array,
+        inputs: Array | None,
+        /,
+        *,
+        key: Array | None,
+        iteration: Array | None,
+        control: Any = None,
+    ) -> DiscreteModelRolloutTransitionResult:
+        if inputs is not None:
+            raise ValueError("MAC learned-rate transitions are initially autonomous.")
+        if control is not None and not isinstance(control, LinearSolveControl):
+            raise TypeError("control must be a LinearSolveControl or None.")
+        current = self.dynamics.validate_state(state)
+        binding = model.input_binding()
+        learned_coordinates = jnp.asarray(
+            binding.call(
+                model,
+                binding.pack_point((current,)),
+                key=key,
+                iter_=iteration,
+                kwargs={},
+            ),
+            dtype=current.dtype,
+        )
+        if learned_coordinates.shape != self.dynamics.state_shape:
+            raise ValueError("Learned MAC rate does not match the state shape.")
+        operators = self.dynamics.momentum.operators
+        learned_rate = tuple(operators.velocity_space.unflatten(learned_coordinates))
+        boundary = self.dynamics.boundary_stage(context.source, None)
+        base_rate = self.dynamics.unconstrained_rate(context.source, current, None)
+        combined = self.dynamics.momentum.boundaries.enforce_rate(
+            tuple(
+                base + learned
+                for base, learned in zip(base_rate, learned_rate, strict=True)
+            ),
+            boundary,
+        )
+        projected = self.dynamics.projection.project_rate(
+            combined,
+            boundary_stage=boundary,
+            control=control,
+        )
+        linear = projected.linear
+        if linear is None:
+            raise RuntimeError("Iterative MAC projection did not return linear evidence.")
+        relative_residual = jnp.asarray(linear.diagnostics.relative_residual)
+        incomplete = linear.status == int(LinearSolveStatus.MAXIMUM_STEPS_REACHED)
+        approximate = (
+            incomplete
+            & linear.diagnostics.finite
+            & jnp.isfinite(relative_residual)
+            & (relative_residual <= self.coarse_relative_residual)
+        )
+        usable_projection = projected.converged | approximate
+        rate = tuple(
+            jnp.where(projected.converged, accepted, candidate)
+            for accepted, candidate in zip(
+                projected.rate,
+                projected.candidate_rate,
+                strict=True,
+            )
+        )
+        velocity = self.dynamics.unpack_velocity(current)
+        candidate_velocity = tuple(
+            value + context.duration * derivative
+            for value, derivative in zip(velocity, rate, strict=True)
+        )
+        target_boundary = self.dynamics.boundary_stage(context.target, None)
+        candidate_velocity = self.dynamics.momentum.boundaries.enforce(
+            candidate_velocity,
+            target_boundary,
+        )
+        candidate = operators.velocity_space.flatten(candidate_velocity)
+        finite = (
+            boundary.successful
+            & target_boundary.successful
+            & jnp.all(jnp.isfinite(candidate))
+        )
+        training_usable = usable_projection & finite
+        physically_converged = projected.converged & finite
+        accepted = jnp.where(training_usable, candidate, jnp.zeros_like(candidate))
+        return DiscreteModelRolloutTransitionResult(
+            candidate,
+            accepted,
+            training_usable=training_usable,
+            physically_converged=physically_converged,
+            status=linear.status,
+            residual=relative_residual,
+            iterations=linear.diagnostics.iterations,
+            transition_id=self.transition_id,
+        )
+
+
+__all__ = [
+    "FixedGridStressOperatorModel",
+    "MACLearnedRateRolloutTransition",
+    "PeriodicLearnedStressRolloutTransition",
+]

--- a/phydrax/closure_data/__init__.py
+++ b/phydrax/closure_data/__init__.py
@@ -80,6 +80,13 @@ from ._les import (
     PeriodicLESAnalysisContext,
     prepare_periodic_les_analysis,
 )
+from ._operator import (
+    bind_trained_stress_operator,
+    ClosureOperatorCase,
+    ClosureOperatorDatasets,
+    prepare_closure_operator_datasets,
+    TrainedClosureOperatorPredictor,
+)
 from ._state import (
     ClosureSeries,
     ClosureSnapshot,
@@ -99,6 +106,10 @@ __all__ = [
     "ClosureDeploymentKind",
     "ClosureField",
     "ClosureQualityReport",
+    "bind_trained_stress_operator",
+    "ClosureOperatorCase",
+    "ClosureOperatorDatasets",
+    "TrainedClosureOperatorPredictor",
     "ClosureSample",
     "ClosureSampleKey",
     "ClosureSeries",
@@ -154,6 +165,7 @@ __all__ = [
     "les_reynolds_stress_target",
     "les_scalar_flux_target",
     "les_stress_divergence_target",
+    "prepare_closure_operator_datasets",
     "prepare_periodic_les_analysis",
     "sgs_energy_target",
     "sgs_stress_target",

--- a/phydrax/closure_data/_binding.py
+++ b/phydrax/closure_data/_binding.py
@@ -580,7 +580,7 @@ class LearnedStressResult(StrictModule, NonTrainableState):
 class PreparedLearnedStressBinding(StrictModule, NonTrainableState):
     """JIT-compatible stress evaluation without a backend divergence operator."""
 
-    predictor: Callable = eqx.field(static=True)
+    predictor: Callable
     normalizer: TrainOnlyNormalizer
     plan: LearnedStressBindingPlan
     prepared_id: str = eqx.field(static=True)

--- a/phydrax/closure_data/_operator.py
+++ b/phydrax/closure_data/_operator.py
@@ -1,0 +1,633 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+import jax.numpy as jnp
+
+from .._fingerprint import canonical_fingerprint
+from .._frozendict import frozendict
+from .._strict import StrictModule
+from .._trainable import NonTrainableState
+from ..nn.operator.data import (
+    FunctionSamples,
+    OperatorBatch,
+    OperatorCaseProvenance,
+    OperatorTargetBatch,
+)
+from ..nn.operator.task import OperatorTask
+from ..nn.operator.training._dataset import (
+    operator_dataset_from_cases,
+    OperatorDataset,
+)
+from ..nn.operator.training._execution import PreparedOperatorInput
+from ..nn.operator.training._trained_operator import TrainedOperator
+from ._analysis import ClosureAnalysisDAG, ClosureTarget
+from ._binding import LearnedStressBindingPlan, PreparedLearnedStressBinding
+from ._dataset import (
+    ChunkedClosureDatasetManifest,
+    ClosureSample,
+    DatasetSplit,
+    LeakageSafePartition,
+    TrainOnlyNormalizer,
+)
+from ._les import LESAnalysisReference
+
+
+@dataclass(frozen=True)
+class ClosureOperatorCase:
+    """One explicitly aligned closure-learning case."""
+
+    inputs: Mapping[str, ClosureSample]
+    targets: Mapping[str, ClosureTarget]
+    references: Mapping[str, LESAnalysisReference] = field(default_factory=dict)
+
+    def __post_init__(self):
+        inputs = frozendict({str(name): value for name, value in self.inputs.items()})
+        targets = frozendict({str(name): value for name, value in self.targets.items()})
+        references = frozendict(
+            {str(name): value for name, value in self.references.items()}
+        )
+        if not inputs or not targets:
+            raise ValueError("Closure operator cases require inputs and targets.")
+        if any(not name for name in (*inputs, *targets, *references)):
+            raise ValueError("Closure operator field names must be non-empty.")
+        if any(not isinstance(value, ClosureSample) for value in inputs.values()):
+            raise TypeError("Closure operator inputs must be ClosureSample values.")
+        if any(not isinstance(value, ClosureTarget) for value in targets.values()):
+            raise TypeError("Closure operator targets must be ClosureTarget values.")
+        if any(
+            not isinstance(value, LESAnalysisReference) for value in references.values()
+        ):
+            raise TypeError(
+                "Closure operator references must be LESAnalysisReference values."
+            )
+        keys = {value.key.sample_id for value in inputs.values()}
+        if len(keys) != 1:
+            raise ValueError("All closure operator inputs must share one sample key.")
+        schemas = {
+            *(value.schema_id for value in inputs.values()),
+            *(value.schema_id for value in targets.values()),
+        }
+        if len(schemas) != 1:
+            raise ValueError("Closure operator inputs and targets must share one schema.")
+        if set(references) - set(targets):
+            raise ValueError(
+                "Closure references must name closure targets in the same case."
+            )
+        for name, reference in references.items():
+            if reference.target_id != targets[name].target_id:
+                raise ValueError(
+                    "Closure target and LES reference identities do not match."
+                )
+        object.__setattr__(self, "inputs", inputs)
+        object.__setattr__(self, "targets", targets)
+        object.__setattr__(self, "references", references)
+
+    @property
+    def key(self):
+        return next(iter(self.inputs.values())).key
+
+    @property
+    def schema_id(self) -> str:
+        return next(iter(self.inputs.values())).schema_id
+
+    @property
+    def case_id(self) -> str:
+        return self.key.sample_id
+
+    @property
+    def fingerprint(self) -> str:
+        return canonical_fingerprint(
+            {
+                "kind": "closure-operator-case",
+                "key": self.key.sample_id,
+                "inputs": {name: value.sample_id for name, value in self.inputs.items()},
+                "targets": {
+                    name: value.target_id for name, value in self.targets.items()
+                },
+                "references": {
+                    name: value.reference_id for name, value in self.references.items()
+                },
+            }
+        )
+
+
+@dataclass(frozen=True)
+class ClosureOperatorDatasets:
+    """Authoritative closure partitions represented as operator datasets."""
+
+    train: OperatorDataset
+    validation: OperatorDataset | None
+    test: OperatorDataset | None
+    dataset_manifest_id: str
+    partition_id: str
+    analysis_dag_id: str
+    flow_schema_id: str
+    task_fingerprint: str
+    preparation_id: str
+
+
+def _samples_with_values(samples: FunctionSamples, values: Any, /) -> FunctionSamples:
+    return FunctionSamples(
+        values=values,
+        axes=samples.axes,
+        coordinates=samples.coordinates,
+        quadrature_weights=samples.quadrature_weights,
+        mask=samples.mask,
+        topology=samples.topology,
+        support_id=samples.support_id,
+        measure_id=samples.measure_id,
+    )
+
+
+def _extent_for_case(
+    case: ClosureOperatorCase,
+    manifest: ChunkedClosureDatasetManifest,
+    /,
+):
+    key = case.key
+    matches = tuple(
+        extent
+        for extent in manifest.extents
+        if (
+            extent.case_id,
+            extent.trajectory_id,
+            extent.realization_id,
+            extent.time_block_id,
+        )
+        == (
+            key.case_id,
+            key.trajectory_id,
+            key.realization_id,
+            key.time_block_id,
+        )
+    )
+    if len(matches) != 1:
+        raise ValueError("Closure operator case has no unique dataset extent.")
+    extent = matches[0]
+    if key.time_index >= extent.sample_count:
+        raise ValueError("Closure operator case time_index exceeds its dataset extent.")
+    return extent
+
+
+def _case_provenance(
+    case: ClosureOperatorCase,
+    /,
+    *,
+    manifest: ChunkedClosureDatasetManifest,
+    partition: LeakageSafePartition,
+    analysis: ClosureAnalysisDAG,
+) -> OperatorCaseProvenance:
+    key = case.key
+    identities = {
+        "closure_case": key.case_id,
+        "closure_trajectory": key.trajectory_id,
+        "closure_realization": key.realization_id,
+        "closure_time_block": key.time_block_id,
+        "closure_dataset_manifest": manifest.dataset_id,
+        "closure_partition": partition.partition_id,
+        "closure_analysis_dag": analysis.dag_id,
+        "flow_schema": case.schema_id,
+    }
+    identities.update(
+        {
+            f"closure_target:{name}": target.target_id
+            for name, target in case.targets.items()
+        }
+    )
+    identities.update(
+        {
+            f"closure_reference:{name}": reference.reference_id
+            for name, reference in case.references.items()
+        }
+    )
+    return OperatorCaseProvenance(
+        case.case_id,
+        identities=identities,
+        order={"time_index": float(key.time_index)},
+    )
+
+
+def _materialize_operator_case(
+    case: ClosureOperatorCase,
+    template: OperatorBatch,
+    task: OperatorTask,
+    /,
+    *,
+    normalizers: Mapping[str, TrainOnlyNormalizer],
+) -> tuple[OperatorBatch, OperatorTargetBatch]:
+    if set(case.inputs) != {field.name for field in task.source_fields}:
+        raise ValueError("Closure inputs must match the task source fields exactly.")
+    if set(case.targets) != {field.name for field in task.target_fields}:
+        raise ValueError("Closure targets must match the task target fields exactly.")
+    inputs = dict(template.inputs)
+    for field_spec in task.source_fields:
+        assert field_spec.source_name is not None
+        if field_spec.source_name not in inputs:
+            raise KeyError(
+                f"Operator template is missing task source {field_spec.source_name!r}."
+            )
+        sample = case.inputs[field_spec.name]
+        values = sample.values
+        if field_spec.name in normalizers:
+            values = normalizers[field_spec.name].normalize(values)
+        inputs[field_spec.source_name] = _samples_with_values(
+            inputs[field_spec.source_name], values
+        )
+    batch = OperatorBatch(
+        inputs=inputs,
+        queries=template.queries,
+        case_axes=template.case_axes,
+        case_shape=template.case_shape,
+    )
+    task.validate_batch(batch)
+    target_values = {name: target.values for name, target in case.targets.items()}
+    query_names = {}
+    specs = {}
+    for field_spec in task.target_fields:
+        assert field_spec.query_name is not None
+        assert field_spec.output_spec is not None
+        query_names[field_spec.name] = field_spec.query_name
+        specs[field_spec.name] = field_spec.output_spec
+    targets = OperatorTargetBatch.from_arrays(
+        target_values,
+        batch,
+        query_names=query_names,
+        specs=specs,
+    )
+    return batch, targets
+
+
+def prepare_closure_operator_datasets(
+    cases: Sequence[ClosureOperatorCase],
+    template: OperatorBatch,
+    task: OperatorTask,
+    manifest: ChunkedClosureDatasetManifest,
+    analysis: ClosureAnalysisDAG,
+    partition: LeakageSafePartition,
+    /,
+    *,
+    normalizers: Mapping[str, TrainOnlyNormalizer] | None = None,
+) -> ClosureOperatorDatasets:
+    """Bind closure cases to their authoritative split and operator geometry."""
+
+    values = tuple(cases)
+    if not values or any(not isinstance(case, ClosureOperatorCase) for case in values):
+        raise ValueError("At least one ClosureOperatorCase is required.")
+    if not isinstance(template, OperatorBatch) or template.case_shape:
+        raise ValueError("Closure operator templates must have no case axes.")
+    if not isinstance(task, OperatorTask):
+        raise TypeError("task must be an OperatorTask.")
+    if not isinstance(manifest, ChunkedClosureDatasetManifest):
+        raise TypeError("manifest must be a ChunkedClosureDatasetManifest.")
+    if not isinstance(analysis, ClosureAnalysisDAG):
+        raise TypeError("analysis must be a ClosureAnalysisDAG.")
+    if not isinstance(partition, LeakageSafePartition):
+        raise TypeError("partition must be a LeakageSafePartition.")
+    if len({case.case_id for case in values}) != len(values):
+        raise ValueError("Closure operator cases must have unique sample keys.")
+    if any(case.schema_id != manifest.schema_id for case in values):
+        raise ValueError("Closure operator case schema does not match the manifest.")
+    if manifest.analysis_dag_id != analysis.dag_id:
+        raise ValueError("Closure manifest and analysis DAG identities do not match.")
+    source_names = {field.name for field in task.source_fields}
+    target_names = {field.name for field in task.target_fields}
+    if any(set(case.inputs) != source_names for case in values):
+        raise ValueError("Closure inputs must match the task source fields exactly.")
+    if any(set(case.targets) != target_names for case in values):
+        raise ValueError("Closure targets must match the task target fields exactly.")
+    assignment_by_sample = {
+        assignment.sample_id: assignment for assignment in partition.assignments
+    }
+    task.validate_batch(template)
+    analysis_nodes = {node.node_id for node in analysis.nodes}
+    normalizer_map = frozendict(
+        {}
+        if normalizers is None
+        else {str(name): value for name, value in normalizers.items()}
+    )
+    if set(normalizer_map) - set(task.field_by_name):
+        raise KeyError("Closure normalizers contain fields absent from the task.")
+    for name, normalizer in normalizer_map.items():
+        if not isinstance(normalizer, TrainOnlyNormalizer):
+            raise TypeError(
+                "Closure input normalizers must be TrainOnlyNormalizer values."
+            )
+        if not task.field_by_name[name].is_source:
+            raise ValueError("Closure normalizers may only bind source fields.")
+        field_spec = task.field_by_name[name]
+        if any(value != 1.0 for value in field_spec.scale) or any(
+            value != 0.0 for value in field_spec.offset
+        ):
+            raise ValueError(
+                "Closure-normalized inputs require identity task affine scaling."
+            )
+        if (
+            normalizer.provenance.partition_id != partition.partition_id
+            or normalizer.provenance.schema_id != manifest.schema_id
+            or normalizer.provenance.feature_name != name
+        ):
+            raise ValueError("Closure normalizer provenance does not match preparation.")
+        field_assignments = tuple(
+            assignment_by_sample[case.inputs[name].sample_id] for case in values
+        )
+        expected_assignments = tuple(
+            assignment for assignment in field_assignments if assignment.split == "train"
+        )
+        if set(normalizer.provenance.training_sample_ids) != {
+            assignment.sample_id for assignment in expected_assignments
+        } or set(normalizer.provenance.training_assignment_ids) != {
+            assignment.assignment_id for assignment in expected_assignments
+        }:
+            raise ValueError(
+                "Closure normalizer was not fitted on the complete authoritative "
+                "training split."
+            )
+
+    split_batches: dict[DatasetSplit, list[OperatorBatch]] = {
+        "train": [],
+        "validation": [],
+        "test": [],
+    }
+    split_targets: dict[DatasetSplit, list[OperatorTargetBatch]] = {
+        "train": [],
+        "validation": [],
+        "test": [],
+    }
+    split_provenance: dict[DatasetSplit, list[OperatorCaseProvenance]] = {
+        "train": [],
+        "validation": [],
+        "test": [],
+    }
+    case_fingerprints = []
+    for case in values:
+        _extent_for_case(case, manifest)
+        if any(
+            target.node.node_id not in analysis_nodes for target in case.targets.values()
+        ):
+            raise ValueError("Closure target is absent from the supplied analysis DAG.")
+        if any(
+            reference.analysis_dag_id != analysis.dag_id
+            for reference in case.references.values()
+        ):
+            raise ValueError("LES reference analysis DAG does not match preparation.")
+        assignments = tuple(
+            assignment_by_sample[sample.sample_id] for sample in case.inputs.values()
+        )
+        split_names = {assignment.split for assignment in assignments}
+        if len(split_names) != 1:
+            raise ValueError("Aligned closure inputs cannot cross dataset partitions.")
+        split = next(iter(split_names))
+        batch, targets = _materialize_operator_case(
+            case,
+            template,
+            task,
+            normalizers=normalizer_map,
+        )
+        split_batches[split].append(batch)
+        split_targets[split].append(targets)
+        split_provenance[split].append(
+            _case_provenance(
+                case,
+                manifest=manifest,
+                partition=partition,
+                analysis=analysis,
+            )
+        )
+        case_fingerprints.append(case.fingerprint)
+
+    def materialize(split: DatasetSplit) -> OperatorDataset | None:
+        if not split_batches[split]:
+            return None
+        return operator_dataset_from_cases(
+            split_batches[split],
+            split_targets[split],
+            provenance=split_provenance[split],
+        )
+
+    train = materialize("train")
+    if train is None:
+        raise ValueError("Closure operator preparation produced an empty train split.")
+    preparation_id = canonical_fingerprint(
+        {
+            "kind": "closure-operator-datasets",
+            "cases": case_fingerprints,
+            "template": {
+                "inputs": {
+                    name: value.support_id for name, value in template.inputs.items()
+                },
+                "queries": {
+                    name: value.support_id for name, value in template.queries.items()
+                },
+            },
+            "task": task.fingerprint,
+            "manifest": manifest.dataset_id,
+            "partition": partition.partition_id,
+            "analysis": analysis.dag_id,
+            "normalizers": {
+                name: value.normalizer_id for name, value in normalizer_map.items()
+            },
+        }
+    )
+    return ClosureOperatorDatasets(
+        train=train,
+        validation=materialize("validation"),
+        test=materialize("test"),
+        dataset_manifest_id=manifest.dataset_id,
+        partition_id=partition.partition_id,
+        analysis_dag_id=analysis.dag_id,
+        flow_schema_id=manifest.schema_id,
+        task_fingerprint=task.fingerprint,
+        preparation_id=preparation_id,
+    )
+
+
+class TrainedClosureOperatorPredictor(StrictModule, NonTrainableState):
+    """Prepared fixed-geometry operator exposed through the stress-predictor ABI."""
+
+    trained: TrainedOperator
+    prepared: PreparedOperatorInput
+    source_name: str
+    target_name: str
+    output_shape: tuple[int, ...] | None
+    predictor_id: str
+
+    def __init__(
+        self,
+        trained: TrainedOperator,
+        template: OperatorBatch,
+        /,
+        *,
+        source_name: str,
+        target_name: str,
+        output_shape: Sequence[int] | None = None,
+    ):
+        if not isinstance(trained, TrainedOperator):
+            raise TypeError("trained must be a TrainedOperator.")
+        if not trained.artifact_id:
+            raise ValueError("Trained closure operators require an artifact identity.")
+        if trained.normalization is not None:
+            raise ValueError(
+                "Closure-trained operators must not apply a second normalization."
+            )
+        if trained.output_pipeline is not None:
+            raise ValueError(
+                "Closure-trained operators must leave stress policy enforcement "
+                "to the learned-stress binding."
+            )
+        if template.case_shape:
+            raise ValueError("Closure predictor templates must have no case axes.")
+        source = str(source_name)
+        target = str(target_name)
+        if len(trained.task.source_fields) != 1:
+            raise ValueError(
+                "Closure predictors initially support exactly one source field."
+            )
+        source_field = trained.task.source_fields[0]
+        if source_field.name != source or source_field.source_name not in template.inputs:
+            raise ValueError(
+                "Closure predictor source does not match its task or template."
+            )
+        if target not in {field.name for field in trained.task.target_fields}:
+            raise ValueError("Closure predictor target is absent from the operator task.")
+        shape = (
+            None if output_shape is None else tuple(int(size) for size in output_shape)
+        )
+        if shape is not None and (not shape or any(size <= 0 for size in shape)):
+            raise ValueError(
+                "Closure predictor output_shape must contain positive sizes."
+            )
+        self.trained = trained
+        self.prepared = trained.prepare(template)
+        self.source_name = source
+        self.target_name = target
+        self.output_shape = shape
+        self.predictor_id = canonical_fingerprint(
+            {
+                "kind": "trained-closure-operator-predictor",
+                "artifact": trained.artifact_id,
+                "task": trained.task_fingerprint,
+                "contract": trained.contract_fingerprint,
+                "source": source,
+                "target": target,
+                "output_shape": shape,
+                "physical_support": self.prepared.physical_batch.input(
+                    source_field.source_name
+                ).support_id,
+            }
+        )
+
+    def __call__(self, normalized: Any, args: Any = None, /):
+        if args is not None:
+            raise ValueError(
+                "Trained closure operator predictors do not accept hidden runtime args."
+            )
+        source_field = self.trained.task.field_by_name[self.source_name]
+        assert source_field.source_name is not None
+        value = jnp.asarray(normalized)
+        physical_source = self.prepared.physical_batch.input(source_field.source_name)
+        execution_source = self.prepared.execution_batch.input(source_field.source_name)
+        if physical_source.values is None or execution_source.values is None:
+            raise ValueError("Closure predictor templates require source values.")
+        if value.shape != physical_source.values.shape:
+            raise ValueError(
+                "Closure predictor input does not match the bound feature shape."
+            )
+        physical_inputs = dict(self.prepared.physical_batch.inputs)
+        physical_inputs[source_field.source_name] = _samples_with_values(
+            physical_source, value
+        )
+        execution_value = source_field.nondimensionalize(value).astype(
+            execution_source.values.dtype
+        )
+        execution_inputs = dict(self.prepared.execution_batch.inputs)
+        execution_inputs[source_field.source_name] = _samples_with_values(
+            execution_source, execution_value
+        )
+        physical_batch = OperatorBatch(
+            inputs=physical_inputs,
+            queries=self.prepared.physical_batch.queries,
+            case_axes=(),
+            case_shape=(),
+        )
+        execution_batch = OperatorBatch(
+            inputs=execution_inputs,
+            queries=self.prepared.execution_batch.queries,
+            case_axes=(),
+            case_shape=(),
+        )
+        prediction = self.trained.predict_prepared(
+            PreparedOperatorInput(
+                physical_batch,
+                execution_batch,
+                plan_fingerprint=self.prepared.plan_fingerprint,
+            )
+        )
+        values = prediction.field(self.target_name).values
+        return values if self.output_shape is None else values.reshape(self.output_shape)
+
+
+def bind_trained_stress_operator(
+    trained: TrainedOperator,
+    plan: LearnedStressBindingPlan,
+    normalizer: TrainOnlyNormalizer,
+    template: OperatorBatch,
+    datasets: ClosureOperatorDatasets,
+    /,
+    *,
+    source_name: str,
+    target_name: str,
+) -> PreparedLearnedStressBinding:
+    """Bind a trained operator to learned stress after exact provenance checks."""
+
+    if not isinstance(plan, LearnedStressBindingPlan):
+        raise TypeError("plan must be a LearnedStressBindingPlan.")
+    if not isinstance(normalizer, TrainOnlyNormalizer):
+        raise TypeError("normalizer must be a TrainOnlyNormalizer.")
+    if not isinstance(datasets, ClosureOperatorDatasets):
+        raise TypeError("datasets must be ClosureOperatorDatasets.")
+    if trained.artifact_id != plan.model_artifact_id:
+        raise ValueError("Trained operator artifact does not match the stress plan.")
+    if trained.task_fingerprint != datasets.task_fingerprint:
+        raise ValueError("Trained operator task does not match the closure datasets.")
+    expected = {
+        "closure_dataset_manifest": datasets.dataset_manifest_id,
+        "closure_partition": datasets.partition_id,
+        "closure_analysis_dag": datasets.analysis_dag_id,
+        "closure_flow_schema": datasets.flow_schema_id,
+        "closure_normalizer": normalizer.normalizer_id,
+        "closure_preparation": datasets.preparation_id,
+    }
+    if any(trained.provenance.get(name) != value for name, value in expected.items()):
+        raise ValueError(
+            "Trained operator provenance does not match the closure preparation."
+        )
+    predictor = TrainedClosureOperatorPredictor(
+        trained,
+        template,
+        source_name=source_name,
+        target_name=target_name,
+        output_shape=plan.output_contract.shape,
+    )
+    return plan.prepare(
+        predictor,
+        normalizer,
+        model_artifact_id=trained.artifact_id,
+        target_id=plan.output_contract.target_id,
+        output_units=plan.output_contract.units,
+    )
+
+
+__all__ = [
+    "ClosureOperatorCase",
+    "ClosureOperatorDatasets",
+    "TrainedClosureOperatorPredictor",
+    "bind_trained_stress_operator",
+    "prepare_closure_operator_datasets",
+]

--- a/phydrax/discretization/particle/__init__.py
+++ b/phydrax/discretization/particle/__init__.py
@@ -19,6 +19,7 @@ from ._adaptive_smoothing import (
 from ._assembly import (
     ParticleAssemblyPlan,
     ParticleAssemblyStateLayout,
+    ParticleExchangeLedger,
     ParticleInteractionKey,
     ParticleInteractionLedger,
     ParticlePopulation,
@@ -897,6 +898,7 @@ __all__ = [
     "ParticleAssemblyPlan",
     "ParticleAssemblyStateLayout",
     "ParticleInteractionKey",
+    "ParticleExchangeLedger",
     "ParticleInteractionLedger",
     "ParticlePopulation",
     "PhaseDefinition",

--- a/phydrax/discretization/particle/_assembly.py
+++ b/phydrax/discretization/particle/_assembly.py
@@ -16,6 +16,7 @@ from ..._numerics._compensated import compensated_sum
 from ..._strict import StrictModule
 from ..._trainable import NonTrainableState
 from ._core import ParticleDiscretization
+from ._pairwise import ParticlePairGeometry, ParticlePairRelation
 
 
 ParticlePopulationRole: TypeAlias = Literal[
@@ -250,7 +251,95 @@ class ParticleInteractionLedger(StrictModule):
         )
 
 
+class ParticleExchangeLedger(StrictModule):
+    """Same-population exchange, torque, and relative-power evidence."""
+
+    total_exchange: Array
+    action_reaction_defect: Array
+    torque: Array
+    relative_power: Array
+    pair_count: Array
+    finite: Array
+    relation_schema_id: str = eqx.field(static=True)
+
+    @classmethod
+    def from_exchange(
+        cls,
+        pairs: ParticlePairRelation,
+        geometry: ParticlePairGeometry,
+        pair_values: ArrayLike,
+        particle_values: ArrayLike,
+        /,
+        *,
+        velocities: ArrayLike | None = None,
+    ) -> "ParticleExchangeLedger":
+        if not isinstance(pairs, ParticlePairRelation):
+            raise TypeError("pairs must be ParticlePairRelation.")
+        if not isinstance(geometry, ParticlePairGeometry):
+            raise TypeError("geometry must be ParticlePairGeometry.")
+        if geometry.relation_schema_id != pairs.relation_schema_id:
+            raise ValueError("Pair relation and geometry schemas differ.")
+        exchange = jnp.asarray(pair_values)
+        scattered = jnp.asarray(particle_values)
+        if exchange.ndim < 1 or exchange.shape[0] != pairs.capacity:
+            raise ValueError("Pair exchange must begin with relation capacity.")
+        if scattered.ndim < 1 or scattered.shape[0] != pairs.relation.source_size:
+            raise ValueError("Particle exchange does not match the particle support.")
+        mask = pairs.valid.reshape((pairs.capacity,) + (1,) * (exchange.ndim - 1))
+        exchange = jnp.where(mask, exchange, 0.0)
+        total = compensated_sum(scattered, axis=0)
+        defect = jnp.linalg.norm(jnp.asarray(total).reshape((-1,)))
+        dimension = int(geometry.displacement.shape[-1])
+        if exchange.ndim == 2 and exchange.shape[-1] == dimension:
+            if dimension == 3:
+                torque = compensated_sum(
+                    jnp.cross(geometry.displacement, exchange),
+                    axis=0,
+                )
+            elif dimension == 2:
+                torque = compensated_sum(
+                    geometry.displacement[:, 0] * exchange[:, 1]
+                    - geometry.displacement[:, 1] * exchange[:, 0]
+                )
+            else:
+                torque = jnp.asarray(0.0, dtype=exchange.dtype)
+        else:
+            torque = jnp.asarray(0.0, dtype=exchange.dtype)
+        if velocities is None:
+            power = jnp.asarray(0.0, dtype=exchange.dtype)
+        else:
+            velocity = jnp.asarray(velocities)
+            if velocity.shape[0] != pairs.relation.source_size:
+                raise ValueError("Particle velocities do not match the pair relation.")
+            relative = velocity[pairs.left_indices] - velocity[pairs.right_indices]
+            if exchange.ndim == relative.ndim:
+                pair_power = jnp.sum(exchange * relative, axis=-1)
+            elif exchange.ndim == 1 and relative.ndim == 2 and relative.shape[-1] == 1:
+                pair_power = exchange * relative[:, 0]
+            else:
+                raise ValueError(
+                    "Particle velocities do not match the pair exchange quantity."
+                )
+            power = compensated_sum(jnp.where(pairs.valid, pair_power, 0.0))
+        finite = (
+            jnp.all(jnp.isfinite(exchange))
+            & jnp.all(jnp.isfinite(scattered))
+            & jnp.all(jnp.isfinite(jnp.asarray(torque)))
+            & jnp.isfinite(power)
+        )
+        return cls(
+            total_exchange=total,
+            action_reaction_defect=defect,
+            torque=torque,
+            relative_power=power,
+            pair_count=jnp.sum(pairs.valid, dtype=jnp.int32),
+            finite=finite,
+            relation_schema_id=pairs.relation_schema_id,
+        )
+
+
 __all__ = [
+    "ParticleExchangeLedger",
     "ParticleAssemblyPlan",
     "ParticleAssemblyStateLayout",
     "ParticleInteractionKey",

--- a/phydrax/dynamics/__init__.py
+++ b/phydrax/dynamics/__init__.py
@@ -116,13 +116,20 @@ from ._trajectory import (
     TrajectoryTransitions,
 )
 from .identification import (
+    AbstractDiscreteModelRolloutTransition,
+    DirectDiscreteModelRolloutTransition,
+    DiscreteModelRolloutTransitionResult,
     LearnedMarginalTransition,
     LearnedPathwiseTransition,
+    ProgressiveLinearRefinementPolicy,
+    ProgressiveLinearRefinementRecord,
+    ProgressiveLinearRefinementState,
     TargetDiscreteModelObjective,
 )
 
 
 __all__ = [
+    "AbstractDiscreteModelRolloutTransition",
     "AbstractDiscretePlant",
     "ArrayDiscreteSystemPlant",
     "ArrayLeafSchema",
@@ -176,6 +183,8 @@ __all__ = [
     "DiscreteModelTransition",
     "DiscreteSystem",
     "DiscreteTransitionEvidence",
+    "DirectDiscreteModelRolloutTransition",
+    "DiscreteModelRolloutTransitionResult",
     "DiscreteTransitionResult",
     "EVOLUTION_BACKEND_FAILED",
     "EVOLUTION_NONFINITE",
@@ -222,5 +231,8 @@ __all__ = [
     "DiscreteStepContext",
     "LearnedMarginalTransition",
     "LearnedPathwiseTransition",
+    "ProgressiveLinearRefinementPolicy",
+    "ProgressiveLinearRefinementRecord",
+    "ProgressiveLinearRefinementState",
     "TargetDiscreteModelObjective",
 ]

--- a/phydrax/dynamics/identification/__init__.py
+++ b/phydrax/dynamics/identification/__init__.py
@@ -46,6 +46,11 @@ from ._implicit import (
     ImplicitSINDyResult,
     PolynomialImplicitFeatureLibrary,
 )
+from ._linear_refinement import (
+    ProgressiveLinearRefinementPolicy,
+    ProgressiveLinearRefinementRecord,
+    ProgressiveLinearRefinementState,
+)
 from ._markov_state import (
     fit_markov_state_model,
     MarkovStateDiagnostics,
@@ -61,6 +66,11 @@ from ._neural import (
     ResidualDiscreteModelObjective,
     SupervisedDiscreteModelObjective,
     TargetDiscreteModelObjective,
+)
+from ._neural_transition import (
+    AbstractDiscreteModelRolloutTransition,
+    DirectDiscreteModelRolloutTransition,
+    DiscreteModelRolloutTransitionResult,
 )
 from ._pde import (
     AbstractPDEDerivative,
@@ -156,6 +166,7 @@ from ._variational_training import (
 
 
 __all__ = [
+    "AbstractDiscreteModelRolloutTransition",
     "AbstractImplicitFeatureLibrary",
     "AbstractPDEDerivative",
     "AbstractPDEFeatureLibrary",
@@ -173,6 +184,8 @@ __all__ = [
     "DiscreteSINDyFormulation",
     "DiscreteModelFitHistory",
     "DiscreteModelFitResult",
+    "DirectDiscreteModelRolloutTransition",
+    "DiscreteModelRolloutTransitionResult",
     "DiscreteModelRolloutPolicy",
     "DiscreteModelValidationPolicy",
     "DerivativeEstimate",
@@ -216,6 +229,9 @@ __all__ = [
     "PolynomialFeatureLibrary",
     "TensorProductFeatureLibrary",
     "SequentialThresholdedLeastSquares",
+    "ProgressiveLinearRefinementPolicy",
+    "ProgressiveLinearRefinementRecord",
+    "ProgressiveLinearRefinementState",
     "SINDyDesign",
     "SINDyDesignDiagnostics",
     "SINDyFormulationKind",

--- a/phydrax/dynamics/identification/_linear_refinement.py
+++ b/phydrax/dynamics/identification/_linear_refinement.py
@@ -1,0 +1,211 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+
+import equinox as eqx
+import numpy as np
+
+from ..._fingerprint import canonical_fingerprint
+from ..._strict import StrictModule
+from ..._trainable import NonTrainableState
+from ...linalg import LinearSolveControl
+
+
+@dataclass(frozen=True, slots=True)
+class ProgressiveLinearRefinementRecord:
+    validation_step: int
+    metric: float
+    smoothed_metric: float
+    previous_steps: int
+    current_steps: int
+    plateau: bool
+    refined: bool
+    stopped: bool
+
+
+@dataclass(frozen=True, slots=True)
+class ProgressiveLinearRefinementState:
+    current_steps: int
+    validation_count: int = 0
+    smoothed_metric: float | None = None
+    history: tuple[float, ...] = ()
+    plateau_checkpoint: float | None = None
+    refinement_count: int = 0
+    last_refinement_step: int | None = None
+    stopped: bool = False
+
+
+class ProgressiveLinearRefinementPolicy(StrictModule, NonTrainableState):
+    """Validation-plateau controller for a training-only Krylov budget."""
+
+    initial_steps: int = eqx.field(static=True)
+    step_increment: int = eqx.field(static=True)
+    maximum_steps: int = eqx.field(static=True)
+    evaluation_steps: int = eqx.field(static=True)
+    smoothing: float = eqx.field(static=True)
+    grace_validations: int = eqx.field(static=True)
+    plateau_relative_improvement: float = eqx.field(static=True)
+    stop_relative_improvement: float = eqx.field(static=True)
+    minimum_validations: int = eqx.field(static=True)
+    coarse_relative_residual: float = eqx.field(static=True)
+    policy_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        initial_steps: int,
+        step_increment: int,
+        maximum_steps: int,
+        evaluation_steps: int | None = None,
+        smoothing: float = 0.9,
+        grace_validations: int = 5,
+        plateau_relative_improvement: float = 1e-3,
+        stop_relative_improvement: float = 1e-4,
+        minimum_validations: int = 6,
+        coarse_relative_residual: float = 1.0,
+    ):
+        initial = int(initial_steps)
+        increment = int(step_increment)
+        maximum = int(maximum_steps)
+        evaluation = maximum if evaluation_steps is None else int(evaluation_steps)
+        grace = int(grace_validations)
+        minimum = int(minimum_validations)
+        scalars = tuple(
+            float(value)
+            for value in (
+                smoothing,
+                plateau_relative_improvement,
+                stop_relative_improvement,
+                coarse_relative_residual,
+            )
+        )
+        if initial < 1 or increment < 1 or maximum < initial or evaluation < maximum:
+            raise ValueError("Linear refinement iteration capacities are invalid.")
+        if grace < 1 or minimum <= grace:
+            raise ValueError("minimum_validations must exceed the positive grace window.")
+        if any(not np.isfinite(value) for value in scalars):
+            raise ValueError("Linear refinement scalars must be finite.")
+        if not 0.0 <= scalars[0] < 1.0:
+            raise ValueError("smoothing must lie in [0, 1).")
+        if scalars[1] < 0.0 or scalars[2] < 0.0 or scalars[3] <= 0.0:
+            raise ValueError("Refinement thresholds or residual guard are invalid.")
+        self.initial_steps = initial
+        self.step_increment = increment
+        self.maximum_steps = maximum
+        self.evaluation_steps = evaluation
+        self.smoothing = scalars[0]
+        self.grace_validations = grace
+        self.plateau_relative_improvement = scalars[1]
+        self.stop_relative_improvement = scalars[2]
+        self.minimum_validations = minimum
+        self.coarse_relative_residual = scalars[3]
+        self.policy_id = canonical_fingerprint(
+            {
+                "kind": "progressive-linear-refinement",
+                "initial_steps": initial,
+                "step_increment": increment,
+                "maximum_steps": maximum,
+                "evaluation_steps": evaluation,
+                "smoothing": scalars[0],
+                "grace_validations": grace,
+                "plateau_relative_improvement": scalars[1],
+                "stop_relative_improvement": scalars[2],
+                "minimum_validations": minimum,
+                "coarse_relative_residual": scalars[3],
+            }
+        )
+
+    def initialize(self) -> ProgressiveLinearRefinementState:
+        return ProgressiveLinearRefinementState(self.initial_steps)
+
+    def training_control(
+        self,
+        state: ProgressiveLinearRefinementState,
+        /,
+    ) -> LinearSolveControl:
+        if not isinstance(state, ProgressiveLinearRefinementState):
+            raise TypeError("state must be ProgressiveLinearRefinementState.")
+        return LinearSolveControl(maximum_steps=state.current_steps)
+
+    def evaluation_control(self) -> LinearSolveControl:
+        return LinearSolveControl(maximum_steps=self.evaluation_steps)
+
+    def observe(
+        self,
+        state: ProgressiveLinearRefinementState,
+        metric: float,
+        /,
+        *,
+        validation_step: int,
+    ) -> tuple[ProgressiveLinearRefinementState, ProgressiveLinearRefinementRecord]:
+        if not isinstance(state, ProgressiveLinearRefinementState):
+            raise TypeError("state must be ProgressiveLinearRefinementState.")
+        value = float(metric)
+        step = int(validation_step)
+        if not np.isfinite(value) or value < 0.0 or step < 0:
+            raise ValueError("Validation metric and step must be finite and nonnegative.")
+        smoothed = (
+            value
+            if state.smoothed_metric is None
+            else self.smoothing * state.smoothed_metric + (1.0 - self.smoothing) * value
+        )
+        history = (*state.history, smoothed)
+        count = state.validation_count + 1
+        plateau = False
+        refined = False
+        stopped = state.stopped
+        current = state.current_steps
+        checkpoint = state.plateau_checkpoint
+        refinement_count = state.refinement_count
+        last_refinement = state.last_refinement_step
+        if count >= self.minimum_validations and len(history) > self.grace_validations:
+            prior = history[-self.grace_validations - 1]
+            scale = max(abs(prior), np.finfo(float).tiny)
+            relative_improvement = (prior - smoothed) / scale
+            plateau = relative_improvement <= self.plateau_relative_improvement
+        if plateau and not stopped and current < self.maximum_steps:
+            if checkpoint is not None:
+                scale = max(abs(checkpoint), np.finfo(float).tiny)
+                level_improvement = (checkpoint - smoothed) / scale
+                if level_improvement <= self.stop_relative_improvement:
+                    stopped = True
+            if not stopped:
+                previous = current
+                current = min(self.maximum_steps, current + self.step_increment)
+                refined = current != previous
+                refinement_count += int(refined)
+                last_refinement = step if refined else last_refinement
+                checkpoint = smoothed
+                history = (smoothed,)
+        next_state = replace(
+            state,
+            current_steps=current,
+            validation_count=count,
+            smoothed_metric=smoothed,
+            history=history,
+            plateau_checkpoint=checkpoint,
+            refinement_count=refinement_count,
+            last_refinement_step=last_refinement,
+            stopped=stopped,
+        )
+        return next_state, ProgressiveLinearRefinementRecord(
+            validation_step=step,
+            metric=value,
+            smoothed_metric=smoothed,
+            previous_steps=state.current_steps,
+            current_steps=current,
+            plateau=plateau,
+            refined=refined,
+            stopped=stopped,
+        )
+
+
+__all__ = [
+    "ProgressiveLinearRefinementPolicy",
+    "ProgressiveLinearRefinementRecord",
+    "ProgressiveLinearRefinementState",
+]

--- a/phydrax/dynamics/identification/_neural.py
+++ b/phydrax/dynamics/identification/_neural.py
@@ -47,13 +47,21 @@ from ..._training_objective import (
 )
 from ...metrix import EuclideanStateGeometry
 from .._layout import InputLayout, StateLayout
-from .._model_system import DiscreteModelTransition
 from .._system import DiscreteStepContext, DiscreteSystem
 from .._trajectory import TrajectoryData
+from ._linear_refinement import (
+    ProgressiveLinearRefinementPolicy,
+    ProgressiveLinearRefinementRecord,
+    ProgressiveLinearRefinementState,
+)
 from ._neural_checkpoint import (
     _load_neural_training_checkpoint,
     _read_neural_training_manifest,
     _save_neural_training_checkpoint,
+)
+from ._neural_transition import (
+    AbstractDiscreteModelRolloutTransition,
+    DirectDiscreteModelRolloutTransition,
 )
 from ._neural_windows import (
     _active_window_evidence,
@@ -324,9 +332,12 @@ class DiscreteModelFitResult:
     model: AbstractArrayModel
     last_model: AbstractArrayModel
     system: DiscreteSystem
+    fit_fingerprint: str
     history: DiscreteModelFitHistory
     progress: TrainingProgress
     resumed_from_step: int
+    linear_refinement_state: ProgressiveLinearRefinementState | None
+    linear_refinement_records: tuple[ProgressiveLinearRefinementRecord, ...]
     training_seconds: float
     checkpoint_path: Path | None
     stopped_by_signal: bool = False
@@ -406,26 +417,6 @@ def _mean_square(values: Array, event_rank: int, /) -> Array:
     return squared
 
 
-def _model_point(
-    model: AbstractArrayModel,
-    state: Array,
-    inputs: Array | None,
-    key: Array,
-    iteration: Array,
-    /,
-) -> Array:
-    binding = model.input_binding()
-    point = (
-        binding.pack_point((state,))
-        if inputs is None
-        else binding.pack_point((state, inputs))
-    )
-    return jnp.asarray(
-        binding.call(model, point, key=key, iter_=iteration, kwargs={}),
-        dtype=state.dtype,
-    )
-
-
 def _rollout_scan_step(
     carry: _RolloutCarry,
     depth: Array,
@@ -436,9 +427,11 @@ def _rollout_scan_step(
     eligible: Array,
     active_horizon: Array,
     state_layout: StateLayout,
+    transition: AbstractDiscreteModelRolloutTransition,
     truncate_every: int | None,
     root_key: Array,
     iteration: Array,
+    execution_control: Any,
 ) -> tuple[_RolloutCarry, tuple[Array, Array]]:
     active = depth < active_horizon
     run = eligible & active
@@ -451,34 +444,78 @@ def _rollout_scan_step(
     )
     controls = None if batch.inputs is None else batch.inputs[:, depth]
 
+    sources = batch.coordinates[:, depth]
     if controls is None:
 
-        def one(state, key, enabled):
+        def one(state, source, key, enabled):
+            def advance(_):
+                result = transition.evaluate(
+                    model,
+                    DiscreteStepContext(
+                        source,
+                        source + transition.step_size,
+                        depth,
+                    ),
+                    state,
+                    None,
+                    key=key,
+                    iteration=iteration,
+                    control=execution_control,
+                )
+                return result.accepted_state, result.training_usable
+
             return jax.lax.cond(
                 enabled,
-                lambda _: _model_point(model, state, None, key, iteration),
-                lambda _: state,
+                advance,
+                lambda _: (state, jnp.asarray(True)),
                 operand=None,
             )
 
-        candidate = jax.vmap(one)(carry.state, keys, run)
+        candidate, transition_valid = jax.vmap(one)(
+            carry.state,
+            sources,
+            keys,
+            run,
+        )
     else:
 
-        def one(state, inputs, key, enabled):
+        def one(state, inputs, source, key, enabled):
+            def advance(_):
+                result = transition.evaluate(
+                    model,
+                    DiscreteStepContext(
+                        source,
+                        source + transition.step_size,
+                        depth,
+                    ),
+                    state,
+                    inputs,
+                    key=key,
+                    iteration=iteration,
+                    control=execution_control,
+                )
+                return result.accepted_state, result.training_usable
+
             return jax.lax.cond(
                 enabled,
-                lambda _: _model_point(model, state, inputs, key, iteration),
-                lambda _: state,
+                advance,
+                lambda _: (state, jnp.asarray(True)),
                 operand=None,
             )
 
-        candidate = jax.vmap(one)(carry.state, controls, keys, run)
+        candidate, transition_valid = jax.vmap(one)(
+            carry.state,
+            controls,
+            sources,
+            keys,
+            run,
+        )
     finite = jnp.all(
         jnp.isfinite(candidate),
         axis=tuple(range(1, candidate.ndim)),
     )
     member = jax.vmap(state_layout.geometry.contains)(candidate)
-    step_valid = ~run | (finite & member)
+    step_valid = ~run | (transition_valid & finite & member)
     safe_candidate = jnp.where(
         _event_mask(step_valid, len(state_layout.shape)),
         candidate,
@@ -505,6 +542,8 @@ def _rollout_states(
     active_horizon: Array,
     policy: DiscreteModelRolloutPolicy,
     state_layout: StateLayout,
+    transition: AbstractDiscreteModelRolloutTransition,
+    execution_control: Any,
     root_key: Array,
     iteration: Array,
     /,
@@ -519,6 +558,8 @@ def _rollout_states(
             batch=batch,
             eligible=eligible,
             active_horizon=active_horizon,
+            execution_control=execution_control,
+            transition=transition,
             state_layout=state_layout,
             truncate_every=policy.truncate_every,
             root_key=root_key,
@@ -797,11 +838,13 @@ def _objective_contributions(
     policy: DiscreteModelRolloutPolicy,
     objectives: tuple[DiscreteModelObjective, ...],
     state_layout: StateLayout,
+    transition: AbstractDiscreteModelRolloutTransition,
     root_key: Array,
     iteration: Array | None = None,
     /,
     *,
     target_model: AbstractArrayModel | None = None,
+    execution_control: Any = None,
 ) -> tuple[_ObjectiveContribution, tuple[_ObjectiveContribution, ...], Array]:
     resolved_iteration = (
         jnp.asarray(0, dtype=jnp.int32) if iteration is None else jnp.asarray(iteration)
@@ -812,6 +855,8 @@ def _objective_contributions(
         active_horizon,
         policy,
         state_layout,
+        transition,
+        execution_control,
         root_key,
         resolved_iteration,
     )
@@ -826,6 +871,8 @@ def _objective_contributions(
             active_horizon,
             policy,
             state_layout,
+            transition,
+            execution_control,
             jr.fold_in(root_key, 707),
             resolved_iteration,
         )
@@ -993,7 +1040,9 @@ def fit_discrete_model(
     step_size: float,
     step_rtol: float = 1e-7,
     step_atol: float = 1e-12,
+    transition: AbstractDiscreteModelRolloutTransition | None = None,
     rollout_policy: DiscreteModelRolloutPolicy,
+    linear_refinement: ProgressiveLinearRefinementPolicy | None = None,
     objectives: Sequence[DiscreteModelObjective] | None = None,
     optimizer: optax.GradientTransformation
     | optax.GradientTransformationExtraArgs
@@ -1043,14 +1092,54 @@ def fit_discrete_model(
         raise TypeError("input_layout must be an InputLayout or None.")
     if not isinstance(system_id, str) or not system_id:
         raise ValueError("system_id must be a nonempty string.")
-    DiscreteModelTransition(
-        model,
-        state_layout=state_layout,
-        input_layout=input_layout,
-        step_size=step_size,
-        step_rtol=step_rtol,
-        step_atol=step_atol,
+    resolved_transition = (
+        DirectDiscreteModelRolloutTransition(
+            state_layout,
+            input_layout=input_layout,
+            step_size=step_size,
+            step_rtol=step_rtol,
+            step_atol=step_atol,
+        )
+        if transition is None
+        else transition
     )
+    if not isinstance(
+        resolved_transition,
+        AbstractDiscreteModelRolloutTransition,
+    ):
+        raise TypeError(
+            "transition must be an AbstractDiscreteModelRolloutTransition or None."
+        )
+    if (
+        resolved_transition.state_layout.layout_id != state_layout.layout_id
+        or (
+            None
+            if resolved_transition.input_layout is None
+            else resolved_transition.input_layout.layout_id
+        )
+        != (None if input_layout is None else input_layout.layout_id)
+        or resolved_transition.step_size != float(step_size)
+        or resolved_transition.step_rtol != float(step_rtol)
+        or resolved_transition.step_atol != float(step_atol)
+    ):
+        raise ValueError(
+            "Discrete rollout transition and fit contracts must match exactly."
+        )
+    resolved_transition.validate_model(model)
+    if linear_refinement is not None:
+        if not isinstance(linear_refinement, ProgressiveLinearRefinementPolicy):
+            raise TypeError(
+                "linear_refinement must be ProgressiveLinearRefinementPolicy or None."
+            )
+        if not resolved_transition.supports_linear_refinement:
+            raise ValueError(
+                "The selected discrete rollout transition does not support linear "
+                "refinement."
+            )
+        if validation is None:
+            raise ValueError("Linear refinement requires fixed validation data.")
+        if int(gradient_accumulation) != 1:
+            raise ValueError("Linear refinement does not support gradient accumulation.")
     _validate_data_contract(train, state_layout, input_layout)
     if validation is not None:
         _validate_data_contract(validation, state_layout, input_layout)
@@ -1222,6 +1311,10 @@ def fit_discrete_model(
         )
     if validation_config is not None and validation_source is None:
         raise ValueError("validation_policy requires validation data.")
+    if linear_refinement is not None:
+        assert validation_config is not None
+        if validation_config.mode != "min":
+            raise ValueError("Linear refinement requires a minimized validation metric.")
 
     parameters, fixed = partition_trainable(model)
     accumulation_dtype = _tree_real_result_dtype(parameters)
@@ -1265,6 +1358,7 @@ def fit_discrete_model(
         "step_rtol": float(step_rtol),
         "step_atol": float(step_atol),
         "rollout": rollout_policy.fingerprint,
+        "transition": resolved_transition.transition_id,
         "objectives": [term.fingerprint for term in terms],
         "optimizer_id": resolved_optimizer_id,
         "evaluation_parameters_id": resolved_evaluation_id,
@@ -1276,6 +1370,9 @@ def fit_discrete_model(
         "gradient_accumulation": int(gradient_accumulation),
         "validation_policy": (
             None if validation_config is None else asdict(validation_config)
+        ),
+        "linear_refinement": (
+            None if linear_refinement is None else linear_refinement.policy_id
         ),
         "jit": bool(jit),
         "key_policy_id": _KEY_POLICY_ID,
@@ -1295,8 +1392,29 @@ def fit_discrete_model(
     validation_history: list[dict[str, float]] = []
     resumed_from_step = 0
     prior_training_seconds = 0.0
+    refinement_state = (
+        None if linear_refinement is None else linear_refinement.initialize()
+    )
+    refinement_records: list[ProgressiveLinearRefinementRecord] = []
 
-    def loss_components(current_model, target_model, batch, root_key, step):
+    def training_execution_control():
+        if linear_refinement is None:
+            return None
+        assert refinement_state is not None
+        return linear_refinement.training_control(refinement_state)
+
+    evaluation_execution_control = (
+        None if linear_refinement is None else linear_refinement.evaluation_control()
+    )
+
+    def loss_components(
+        current_model,
+        target_model,
+        batch,
+        root_key,
+        step,
+        execution_control,
+    ):
         active_horizon = rollout_policy.active_horizon(step)
         return _objective_contributions(
             current_model,
@@ -1305,12 +1423,21 @@ def fit_discrete_model(
             rollout_policy,
             terms,
             state_layout,
+            resolved_transition,
             root_key,
             step,
             target_model=target_model,
+            execution_control=execution_control,
         )
 
-    def gradient_fn(current_parameters, target_parameters, batch, root_key, step):
+    def gradient_fn(
+        current_parameters,
+        target_parameters,
+        batch,
+        root_key,
+        step,
+        execution_control,
+    ):
         def objective(candidate):
             current_model = combine_trainable(candidate, fixed)
             target_model = (
@@ -1324,6 +1451,7 @@ def fit_discrete_model(
                 batch,
                 root_key,
                 step,
+                execution_control,
             )
             return contribution.numerator, (
                 contribution.numerator,
@@ -1368,7 +1496,7 @@ def fit_discrete_model(
         for batch_index, start in enumerate(range(0, source.size, size)):
             yield batch_index, source.prepare(indices[start : start + size])
 
-    def evaluate(current_model, source, size, step):
+    def evaluate(current_model, source, size, step, execution_control):
         metric_accumulators = [_ObjectiveAccumulator() for _ in metric_names]
         evaluation_key = control.key_for(int(step), site=1000)
         target_model = (
@@ -1383,6 +1511,7 @@ def fit_discrete_model(
                 batch,
                 evaluation_key,
                 jnp.asarray(step, dtype=jnp.int32),
+                execution_control,
             )
             if not bool(jax.device_get(valid_array)):
                 raise FloatingPointError(
@@ -1439,6 +1568,14 @@ def fit_discrete_model(
         train_history = [dict(value) for value in metadata["train_metrics"]]
         validation_steps = [int(value) for value in metadata["validation_steps"]]
         validation_history = [dict(value) for value in metadata["validation_metrics"]]
+        if linear_refinement is not None:
+            saved_refinement = dict(metadata["linear_refinement_state"])
+            saved_refinement["history"] = tuple(saved_refinement["history"])
+            refinement_state = ProgressiveLinearRefinementState(**saved_refinement)
+            refinement_records = [
+                ProgressiveLinearRefinementRecord(**dict(value))
+                for value in metadata["linear_refinement_records"]
+            ]
         parameters, fixed = partition_trainable(model)
     else:
         initial_metrics = evaluate(
@@ -1446,6 +1583,7 @@ def fit_discrete_model(
             train_source,
             resolved_batch_size,
             0,
+            evaluation_execution_control,
         )
         if validation_source is not None:
             assert resolved_validation_batch is not None
@@ -1455,6 +1593,7 @@ def fit_discrete_model(
                 validation_source,
                 int(resolved_validation_batch),
                 0,
+                evaluation_execution_control,
             )
             if validation_config.monitor not in validation_metrics:
                 raise KeyError(
@@ -1469,6 +1608,14 @@ def fit_discrete_model(
                 best_value=validation_metrics[validation_config.monitor],
                 best_step=0,
             )
+            if linear_refinement is not None:
+                assert refinement_state is not None
+                refinement_state, record = linear_refinement.observe(
+                    refinement_state,
+                    validation_metrics[validation_config.monitor],
+                    validation_step=0,
+                )
+                refinement_records.append(record)
 
     def save_progress(training_seconds):
         if checkpoint is None or not gradient_accumulator.is_empty:
@@ -1488,6 +1635,12 @@ def fit_discrete_model(
                 "train_metrics": train_history,
                 "validation_steps": validation_steps,
                 "validation_metrics": validation_history,
+                "linear_refinement_state": (
+                    None if refinement_state is None else asdict(refinement_state)
+                ),
+                "linear_refinement_records": [
+                    asdict(value) for value in refinement_records
+                ],
                 "training_seconds": float(training_seconds),
             },
         )
@@ -1577,6 +1730,7 @@ def fit_discrete_model(
                             control.progress.update_step,
                             dtype=jnp.int32,
                         ),
+                        training_execution_control(),
                     )
                     if not bool(jax.device_get(finite_array)):
                         raise FloatingPointError(
@@ -1690,6 +1844,7 @@ def fit_discrete_model(
                             validation_source,
                             int(resolved_validation_batch),
                             update_step,
+                            evaluation_execution_control,
                         )
                         if validation_config.monitor not in validation_metrics:
                             raise KeyError(
@@ -1698,6 +1853,14 @@ def fit_discrete_model(
                         validation_steps.append(update_step)
                         validation_history.append(validation_metrics)
                         consider_validation(validation_metrics, evaluation_model)
+                        if linear_refinement is not None:
+                            assert refinement_state is not None
+                            refinement_state, record = linear_refinement.observe(
+                                refinement_state,
+                                validation_metrics[validation_config.monitor],
+                                validation_step=update_step,
+                            )
+                            refinement_records.append(record)
                         control.emit("validation_end", metrics=validation_metrics)
                         if tensorboard is not None:
                             for name, value in validation_metrics.items():
@@ -1744,10 +1907,19 @@ def fit_discrete_model(
             validation_source,
             int(resolved_validation_batch),
             control.progress.update_step,
+            evaluation_execution_control,
         )
         validation_steps.append(control.progress.update_step)
         validation_history.append(validation_metrics)
         consider_validation(validation_metrics, evaluation_model)
+        if linear_refinement is not None:
+            assert refinement_state is not None
+            refinement_state, record = linear_refinement.observe(
+                refinement_state,
+                validation_metrics[validation_config.monitor],
+                validation_step=control.progress.update_step,
+            )
+            refinement_records.append(record)
     selected_model = (
         best_model
         if validation_config is not None and validation_config.select_best
@@ -1758,6 +1930,7 @@ def fit_discrete_model(
         train_source,
         resolved_batch_size,
         control.progress.update_step,
+        evaluation_execution_control,
     )
     if checkpoint is not None and (
         control.progress.update_step == 0
@@ -1774,14 +1947,7 @@ def fit_discrete_model(
         validation_metrics=tuple(frozendict(value) for value in validation_history),
         final_metrics=frozendict(final_metrics),
     )
-    transition = DiscreteModelTransition(
-        selected_model,
-        state_layout=state_layout,
-        input_layout=input_layout,
-        step_size=step_size,
-        step_rtol=step_rtol,
-        step_atol=step_atol,
-    )
+    system = resolved_transition.bind(selected_model, system_id=system_id)
     sample_state = train.states.reshape((-1,) + state_layout.shape)[0]
     sample_coordinate = jnp.asarray(0.0, dtype=train.coordinates.dtype)
     sample_context = DiscreteStepContext(
@@ -1791,38 +1957,32 @@ def fit_discrete_model(
     )
     if input_layout is None:
         jax.eval_shape(
-            lambda state: transition(sample_context, state, None),
+            lambda state: system.evaluate(sample_context, state, None),
             sample_state,
         )
     else:
         assert train.inputs is not None
         sample_input = train.inputs.reshape((-1,) + input_layout.shape)[0]
         jax.eval_shape(
-            lambda state, inputs: transition(
+            lambda state, inputs: system.evaluate(
                 sample_context,
                 state,
-                inputs,
                 None,
+                inputs=inputs,
             ),
             sample_state,
             sample_input,
         )
-    system = DiscreteSystem(
-        transition,
-        state_layout=state_layout,
-        input_layout=input_layout,
-        system_id=system_id,
-        step_size=step_size,
-        step_rtol=step_rtol,
-        step_atol=step_atol,
-    )
     return DiscreteModelFitResult(
         model=selected_model,
         last_model=evaluation_model,
         system=system,
+        fit_fingerprint=fit_fingerprint,
         history=history,
         progress=control.progress,
         resumed_from_step=resumed_from_step,
+        linear_refinement_state=refinement_state,
+        linear_refinement_records=tuple(refinement_records),
         training_seconds=training_seconds,
         checkpoint_path=checkpoint,
         stopped_by_signal=stopped_by_signal,

--- a/phydrax/dynamics/identification/_neural_transition.py
+++ b/phydrax/dynamics/identification/_neural_transition.py
@@ -1,0 +1,250 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import Any
+
+import equinox as eqx
+import jax.numpy as jnp
+import numpy as np
+from jaxtyping import Array
+
+from ..._fingerprint import canonical_fingerprint
+from ..._model import AbstractArrayModel
+from ..._strict import StrictModule
+from ..._trainable import NonTrainableState
+from .._layout import InputLayout, StateLayout
+from .._model_system import DiscreteModelTransition
+from .._system import DiscreteStepContext, DiscreteSystem, DiscreteTransitionResult
+
+
+class DiscreteModelRolloutTransitionResult(StrictModule):
+    """Candidate/accepted state and separate training/physical validity."""
+
+    candidate_state: Array
+    accepted_state: Array
+    training_usable: Array
+    physically_converged: Array
+    status: Array
+    residual: Array
+    iterations: Array
+    transition_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        candidate_state: Array,
+        accepted_state: Array,
+        /,
+        *,
+        training_usable: Any,
+        physically_converged: Any,
+        status: Any,
+        residual: Any,
+        iterations: Any,
+        transition_id: str,
+    ):
+        self.candidate_state = jnp.asarray(candidate_state)
+        self.accepted_state = jnp.asarray(accepted_state)
+        self.training_usable = jnp.asarray(training_usable, dtype=bool)
+        self.physically_converged = jnp.asarray(physically_converged, dtype=bool)
+        self.status = jnp.asarray(status, dtype=jnp.int32)
+        self.residual = jnp.asarray(residual)
+        self.iterations = jnp.asarray(iterations, dtype=jnp.int32)
+        self.transition_id = str(transition_id)
+
+
+class AbstractDiscreteModelRolloutTransition(StrictModule, NonTrainableState):
+    """Interpret a learned model output inside one accepted discrete transition."""
+
+    transition_id: str = eqx.field(static=True)
+    state_layout: StateLayout
+    input_layout: InputLayout | None
+    step_size: float = eqx.field(static=True)
+    step_rtol: float = eqx.field(static=True)
+    step_atol: float = eqx.field(static=True)
+
+    @abstractmethod
+    def validate_model(self, model: AbstractArrayModel, /) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def evaluate(
+        self,
+        model: AbstractArrayModel,
+        context: DiscreteStepContext,
+        state: Array,
+        inputs: Array | None,
+        /,
+        *,
+        key: Array | None,
+        iteration: Array | None,
+        control: Any = None,
+    ) -> DiscreteModelRolloutTransitionResult:
+        raise NotImplementedError
+
+    @property
+    def supports_linear_refinement(self) -> bool:
+        return False
+
+    def bind(self, model: AbstractArrayModel, /, *, system_id: str) -> DiscreteSystem:
+        self.validate_model(model)
+        return DiscreteSystem(
+            _BoundDiscreteModelRolloutTransition(model, self),
+            state_layout=self.state_layout,
+            input_layout=self.input_layout,
+            system_id=system_id,
+            step_size=self.step_size,
+            step_rtol=self.step_rtol,
+            step_atol=self.step_atol,
+        )
+
+
+class DirectDiscreteModelRolloutTransition(AbstractDiscreteModelRolloutTransition):
+    """Current direct next-state model semantics as an explicit rollout route."""
+
+    def __init__(
+        self,
+        state_layout: StateLayout,
+        /,
+        *,
+        input_layout: InputLayout | None = None,
+        step_size: float,
+        step_rtol: float = 1e-7,
+        step_atol: float = 1e-12,
+    ):
+        if not isinstance(state_layout, StateLayout):
+            raise TypeError("state_layout must be a StateLayout.")
+        if input_layout is not None and not isinstance(input_layout, InputLayout):
+            raise TypeError("input_layout must be an InputLayout or None.")
+        step = float(step_size)
+        rtol = float(step_rtol)
+        atol = float(step_atol)
+        if not np.isfinite(step) or step <= 0.0:
+            raise ValueError("step_size must be finite and positive.")
+        if not np.isfinite(rtol) or rtol < 0.0 or not np.isfinite(atol) or atol < 0.0:
+            raise ValueError("Step tolerances must be finite and nonnegative.")
+        self.state_layout = state_layout
+        self.input_layout = input_layout
+        self.step_size = step
+        self.step_rtol = rtol
+        self.step_atol = atol
+        self.transition_id = canonical_fingerprint(
+            {
+                "kind": "direct-discrete-model-rollout-transition",
+                "state_layout": state_layout.layout_id,
+                "input_layout": None if input_layout is None else input_layout.layout_id,
+                "step_size": step,
+                "step_rtol": rtol,
+                "step_atol": atol,
+            }
+        )
+
+    def validate_model(self, model: AbstractArrayModel, /) -> None:
+        DiscreteModelTransition(
+            model,
+            state_layout=self.state_layout,
+            input_layout=self.input_layout,
+            step_size=self.step_size,
+            step_rtol=self.step_rtol,
+            step_atol=self.step_atol,
+        )
+
+    def evaluate(
+        self,
+        model: AbstractArrayModel,
+        context: DiscreteStepContext,
+        state: Array,
+        inputs: Array | None,
+        /,
+        *,
+        key: Array | None,
+        iteration: Array | None,
+        control: Any = None,
+    ) -> DiscreteModelRolloutTransitionResult:
+        del context
+        if control is not None:
+            raise ValueError("Direct model transitions do not accept numerical control.")
+        binding = model.input_binding()
+        point = (
+            binding.pack_point((state,))
+            if inputs is None
+            else binding.pack_point((state, inputs))
+        )
+        candidate = jnp.asarray(
+            binding.call(model, point, key=key, iter_=iteration, kwargs={}),
+            dtype=state.dtype,
+        )
+        if candidate.shape != self.state_layout.shape:
+            raise ValueError("Direct model output does not match the state layout shape.")
+        finite = jnp.all(jnp.isfinite(candidate))
+        member = self.state_layout.geometry.contains(candidate)
+        valid = finite & member
+        accepted = jnp.where(valid, candidate, jnp.zeros_like(candidate))
+        return DiscreteModelRolloutTransitionResult(
+            candidate,
+            accepted,
+            training_usable=valid,
+            physically_converged=valid,
+            status=jnp.where(valid, 0, 1),
+            residual=jnp.asarray(0.0, dtype=jnp.real(candidate).dtype),
+            iterations=jnp.asarray(1, dtype=jnp.int32),
+            transition_id=self.transition_id,
+        )
+
+
+class _BoundDiscreteModelRolloutTransition(StrictModule):
+    model: AbstractArrayModel
+    transition: AbstractDiscreteModelRolloutTransition
+
+    def __init__(
+        self,
+        model: AbstractArrayModel,
+        transition: AbstractDiscreteModelRolloutTransition,
+        /,
+    ):
+        self.model = model
+        self.transition = transition
+
+    def __call__(
+        self,
+        context: DiscreteStepContext,
+        state: Array,
+        *arguments: Any,
+    ) -> DiscreteTransitionResult:
+        if self.transition.input_layout is None:
+            if len(arguments) != 1:
+                raise TypeError("Autonomous learned transitions require args.")
+            inputs = None
+        else:
+            if len(arguments) != 2:
+                raise TypeError("Controlled learned transitions require inputs and args.")
+            inputs = jnp.asarray(arguments[0])
+        result = self.transition.evaluate(
+            self.model,
+            context,
+            jnp.asarray(state),
+            inputs,
+            key=None,
+            iteration=context.step_index,
+        )
+        physically_accepted = jnp.where(
+            result.physically_converged,
+            result.candidate_state,
+            jnp.asarray(state),
+        )
+        return DiscreteTransitionResult(
+            result.candidate_state,
+            physically_accepted,
+            result.physically_converged,
+            result.status,
+        )
+
+
+__all__ = [
+    "AbstractDiscreteModelRolloutTransition",
+    "DirectDiscreteModelRolloutTransition",
+    "DiscreteModelRolloutTransitionResult",
+]

--- a/phydrax/nn/operator/adapters/__init__.py
+++ b/phydrax/nn/operator/adapters/__init__.py
@@ -16,6 +16,14 @@ from ._external import (
     verify_operator_checkpoint,
 )
 from ._group_average import GroupAveragedOperator
+from ._particle_exchange import (
+    LearnedPairwiseExchangeResult,
+    PairwiseExchangeBindingPlan,
+    PairwiseExchangeFeatureSchema,
+    PairwiseExchangeKind,
+    particle_pair_operator_batch,
+    PreparedPairwiseExchangeBinding,
+)
 
 
 register_operator_architecture_codec(
@@ -31,6 +39,12 @@ __all__ = [
     "ExternalOperatorAdapter",
     "OperatorCheckpointManifest",
     "OperatorContextModel",
+    "LearnedPairwiseExchangeResult",
+    "particle_pair_operator_batch",
+    "PairwiseExchangeBindingPlan",
+    "PairwiseExchangeFeatureSchema",
+    "PairwiseExchangeKind",
+    "PreparedPairwiseExchangeBinding",
     "bind_operator_context",
     "checkpoint_sha256",
     "load_external_operator_adapter",

--- a/phydrax/nn/operator/adapters/_particle_exchange.py
+++ b/phydrax/nn/operator/adapters/_particle_exchange.py
@@ -1,0 +1,365 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from typing import Any, Literal, TypeAlias
+
+import equinox as eqx
+import jax.numpy as jnp
+import numpy as np
+from jaxtyping import Array, ArrayLike
+
+from ...._fingerprint import canonical_fingerprint
+from ...._strict import StrictModule
+from ...._trainable import NonTrainableState
+from ....discretization.particle._assembly import ParticleExchangeLedger
+from ....discretization.particle._pairwise import (
+    ParticlePairGeometry,
+    ParticlePairRelation,
+    scatter_pair_exchange,
+)
+from ....discretization.particle._precision import ParticleAccumulation
+from ..data import FunctionSamples, OperatorBatch
+from ..training._trained_operator import TrainedOperator
+
+
+PairwiseExchangeKind: TypeAlias = Literal["vector", "central_force", "scalar_flux"]
+
+
+class PairwiseExchangeFeatureSchema(StrictModule, NonTrainableState):
+    """Exact learned edge-feature layout for one fixed particle relation."""
+
+    names: tuple[str, ...] = eqx.field(static=True)
+    units: tuple[str, ...] = eqx.field(static=True)
+    dtype: str = eqx.field(static=True)
+    relation_schema_id: str = eqx.field(static=True)
+    schema_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        names: tuple[str, ...],
+        units: tuple[str, ...],
+        /,
+        *,
+        dtype: Any,
+        relation_schema_id: str,
+    ):
+        names_ = tuple(str(value).strip() for value in names)
+        units_ = tuple(str(value).strip() for value in units)
+        dtype_ = np.dtype(dtype)
+        relation = str(relation_schema_id).strip()
+        if (
+            not names_
+            or len(names_) != len(units_)
+            or len(set(names_)) != len(names_)
+            or any(not value for value in (*names_, *units_))
+            or not jnp.issubdtype(dtype_, jnp.floating)
+            or not relation
+        ):
+            raise ValueError("Pairwise exchange feature schema is invalid.")
+        self.names = names_
+        self.units = units_
+        self.dtype = dtype_.name
+        self.relation_schema_id = relation
+        self.schema_id = canonical_fingerprint(
+            {
+                "kind": "pairwise-exchange-feature-schema",
+                "names": list(names_),
+                "units": list(units_),
+                "dtype": dtype_.name,
+                "relation_schema": relation,
+            }
+        )
+
+    @property
+    def width(self) -> int:
+        return len(self.names)
+
+
+def particle_pair_operator_batch(
+    features: ArrayLike,
+    pairs: ParticlePairRelation,
+    geometry: ParticlePairGeometry,
+    /,
+    *,
+    source_name: str = "pair_features",
+    query_name: str = "pairs",
+) -> OperatorBatch:
+    """Represent one fixed-capacity pair realization as a point-cloud operator batch."""
+
+    if not isinstance(pairs, ParticlePairRelation):
+        raise TypeError("pairs must be ParticlePairRelation.")
+    if not isinstance(geometry, ParticlePairGeometry):
+        raise TypeError("geometry must be ParticlePairGeometry.")
+    if geometry.relation_schema_id != pairs.relation_schema_id:
+        raise ValueError("Pair relation and geometry schemas differ.")
+    values = jnp.asarray(features)
+    if values.ndim != 2 or values.shape[0] != pairs.capacity:
+        raise ValueError("Pair features must have shape (capacity, features).")
+    source = str(source_name).strip()
+    query = str(query_name).strip()
+    if not source or not query:
+        raise ValueError("Pair operator source and query names must be non-empty.")
+    valid = pairs.valid & geometry.valid
+    safe = jnp.where(valid[:, None], values, jnp.zeros_like(values))
+    coordinates = geometry.displacement
+    return OperatorBatch(
+        inputs={
+            source: FunctionSamples(
+                values=safe,
+                coordinates=coordinates,
+                mask=valid,
+                support_id=pairs.relation_schema_id,
+            )
+        },
+        queries={
+            query: FunctionSamples(
+                values=None,
+                coordinates=coordinates,
+                mask=valid,
+                support_id=pairs.relation_schema_id,
+            )
+        },
+    )
+
+
+class PairwiseExchangeBindingPlan(StrictModule, NonTrainableState):
+    """Artifact-bound construction for a conservative same-set learned exchange."""
+
+    feature_schema: PairwiseExchangeFeatureSchema
+    exchange_kind: PairwiseExchangeKind = eqx.field(static=True)
+    model_artifact_id: str = eqx.field(static=True)
+    source_name: str = eqx.field(static=True)
+    target_name: str = eqx.field(static=True)
+    query_name: str = eqx.field(static=True)
+    accumulation: ParticleAccumulation = eqx.field(static=True)
+    conservation_tolerance: float = eqx.field(static=True)
+    plan_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        feature_schema: PairwiseExchangeFeatureSchema,
+        /,
+        *,
+        exchange_kind: PairwiseExchangeKind,
+        model_artifact_id: str,
+        source_name: str = "pair_features",
+        target_name: str = "pair_exchange",
+        query_name: str = "pairs",
+        accumulation: ParticleAccumulation = "deterministic",
+        conservation_tolerance: float = 1e-10,
+    ):
+        if not isinstance(feature_schema, PairwiseExchangeFeatureSchema):
+            raise TypeError("feature_schema must be PairwiseExchangeFeatureSchema.")
+        kind = str(exchange_kind)
+        artifact = str(model_artifact_id).strip()
+        source = str(source_name).strip()
+        target = str(target_name).strip()
+        query = str(query_name).strip()
+        tolerance = float(conservation_tolerance)
+        if kind not in ("vector", "central_force", "scalar_flux"):
+            raise ValueError("Unknown pairwise exchange kind.")
+        if not artifact or not source or not target or not query:
+            raise ValueError("Pairwise exchange binding identities must be non-empty.")
+        if accumulation not in ("fast", "deterministic", "compensated"):
+            raise ValueError("Unknown particle accumulation policy.")
+        if not np.isfinite(tolerance) or tolerance < 0.0:
+            raise ValueError("conservation_tolerance must be finite and nonnegative.")
+        self.feature_schema = feature_schema
+        self.exchange_kind = kind
+        self.model_artifact_id = artifact
+        self.source_name = source
+        self.target_name = target
+        self.query_name = query
+        self.accumulation = accumulation
+        self.conservation_tolerance = tolerance
+        self.plan_id = canonical_fingerprint(
+            {
+                "kind": "pairwise-exchange-binding-plan",
+                "feature_schema": feature_schema.schema_id,
+                "exchange_kind": kind,
+                "model_artifact": artifact,
+                "source": source,
+                "target": target,
+                "query": query,
+                "accumulation": accumulation,
+                "conservation_tolerance": tolerance,
+            }
+        )
+
+    def prepare(
+        self,
+        trained: TrainedOperator,
+        pairs: ParticlePairRelation,
+        geometry: ParticlePairGeometry,
+        /,
+    ) -> PreparedPairwiseExchangeBinding:
+        if not isinstance(trained, TrainedOperator):
+            raise TypeError("trained must be TrainedOperator.")
+        if trained.artifact_id != self.model_artifact_id:
+            raise ValueError("Trained pair model artifact does not match the plan.")
+        if not pairs.same_set or not pairs.unordered:
+            raise ValueError(
+                "Conservative pair exchange requires unordered same-set relations."
+            )
+        if pairs.relation_schema_id != self.feature_schema.relation_schema_id:
+            raise ValueError("Pair relation does not match the feature schema.")
+        template = particle_pair_operator_batch(
+            jnp.zeros(
+                (pairs.capacity, self.feature_schema.width),
+                dtype=np.dtype(self.feature_schema.dtype),
+            ),
+            pairs,
+            geometry,
+            source_name=self.source_name,
+            query_name=self.query_name,
+        )
+        prepared = trained.prepare(template)
+        return PreparedPairwiseExchangeBinding(
+            trained,
+            prepared.physical_batch,
+            pairs,
+            geometry,
+            self,
+        )
+
+
+class LearnedPairwiseExchangeResult(StrictModule):
+    pair_values: Array
+    particle_values: Array
+    ledger: ParticleExchangeLedger
+    successful: Array
+    binding_id: str = eqx.field(static=True)
+
+
+class PreparedPairwiseExchangeBinding(StrictModule, NonTrainableState):
+    trained: TrainedOperator
+    template: OperatorBatch
+    pairs: ParticlePairRelation
+    geometry: ParticlePairGeometry
+    plan: PairwiseExchangeBindingPlan
+    prepared_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        trained: TrainedOperator,
+        template: OperatorBatch,
+        pairs: ParticlePairRelation,
+        geometry: ParticlePairGeometry,
+        plan: PairwiseExchangeBindingPlan,
+        /,
+    ):
+        self.trained = trained
+        self.template = template
+        self.pairs = pairs
+        self.geometry = geometry
+        self.plan = plan
+        self.prepared_id = canonical_fingerprint(
+            {
+                "kind": "prepared-pairwise-exchange-binding",
+                "plan": plan.plan_id,
+                "task": trained.task_fingerprint,
+                "contract": trained.contract_fingerprint,
+                "normalization": trained.normalization_fingerprint,
+                "relation": pairs.relation_schema_id,
+                "geometry": geometry.schema_id,
+            }
+        )
+
+    def evaluate(
+        self,
+        features: ArrayLike,
+        /,
+        *,
+        velocities: ArrayLike | None = None,
+    ) -> LearnedPairwiseExchangeResult:
+        values = jnp.asarray(features)
+        expected = (self.pairs.capacity, self.plan.feature_schema.width)
+        if values.shape != expected:
+            raise ValueError(f"Pair features must have shape {expected}.")
+        if np.dtype(values.dtype).name != self.plan.feature_schema.dtype:
+            raise TypeError("Pair features do not match the bound dtype.")
+        valid = self.pairs.valid & self.geometry.valid
+        values = eqx.error_if(
+            values,
+            jnp.any(valid[:, None] & ~jnp.isfinite(values)),
+            "Active learned pair features must be finite.",
+        )
+        batch = particle_pair_operator_batch(
+            values,
+            self.pairs,
+            self.geometry,
+            source_name=self.plan.source_name,
+            query_name=self.plan.query_name,
+        )
+        prediction = self.trained.predict_prepared(
+            self.trained.execution_plan.prepare_prevalidated(batch)
+        )
+        raw = jnp.asarray(prediction.field(self.plan.target_name).values)
+        dimension = int(self.geometry.displacement.shape[-1])
+        if self.plan.exchange_kind == "vector":
+            if raw.shape != (self.pairs.capacity, dimension):
+                raise ValueError("Vector pair exchange has the wrong shape.")
+            pair_values = raw
+        else:
+            if raw.shape == (self.pairs.capacity, 1):
+                raw = raw[:, 0]
+            if raw.shape != (self.pairs.capacity,):
+                raise ValueError("Scalar pair exchange has the wrong shape.")
+            pair_values = (
+                raw[:, None] * self.geometry.direction
+                if self.plan.exchange_kind == "central_force"
+                else raw
+            )
+        mask = valid.reshape(valid.shape + (1,) * (pair_values.ndim - 1))
+        pair_values = jnp.where(mask, pair_values, jnp.zeros_like(pair_values))
+        pair_values = eqx.error_if(
+            pair_values,
+            jnp.any(~jnp.isfinite(pair_values)),
+            "Active learned pair exchange contains nonfinite values.",
+        )
+        particle_values = scatter_pair_exchange(
+            self.pairs,
+            pair_values,
+            size=self.pairs.relation.source_size,
+            accumulation=self.plan.accumulation,
+            valid=valid,
+        )
+        ledger = ParticleExchangeLedger.from_exchange(
+            self.pairs,
+            self.geometry,
+            pair_values,
+            particle_values,
+            velocities=velocities,
+        )
+        successful = ledger.finite & (
+            ledger.action_reaction_defect <= self.plan.conservation_tolerance
+        )
+        return LearnedPairwiseExchangeResult(
+            pair_values,
+            particle_values,
+            ledger,
+            successful,
+            self.prepared_id,
+        )
+
+    def __call__(
+        self,
+        features: ArrayLike,
+        /,
+        *,
+        velocities: ArrayLike | None = None,
+    ) -> LearnedPairwiseExchangeResult:
+        return self.evaluate(features, velocities=velocities)
+
+
+__all__ = [
+    "LearnedPairwiseExchangeResult",
+    "PairwiseExchangeBindingPlan",
+    "PairwiseExchangeFeatureSchema",
+    "PairwiseExchangeKind",
+    "PreparedPairwiseExchangeBinding",
+    "particle_pair_operator_batch",
+]

--- a/phydrax/nn/operator/training/_fit.py
+++ b/phydrax/nn/operator/training/_fit.py
@@ -44,6 +44,10 @@ from ....optim import (
     OptimizerStateCompressionPolicy,
     prepare_compressed_optimizer,
 )
+from ....optim._gradient_composition import (
+    conflict_free_gradient,
+    ConflictFreeGradientPolicy,
+)
 from ..._loss import model_loss_labels, model_loss_values
 from ...layers._dropout import inference_mode
 from ...parameters import ParameterSubspace
@@ -556,6 +560,7 @@ def fit_operator(
     rollout_route: OperatorRolloutRoute | None = None,
     rollout_policy: OperatorRolloutPolicy | None = None,
     include_model_losses: bool = True,
+    gradient_composition: ConflictFreeGradientPolicy | None = None,
     optimizer: optax.GradientTransformation
     | optax.GradientTransformationExtraArgs
     | None = None,
@@ -669,6 +674,23 @@ def fit_operator(
             raise ValueError(
                 "gradient_accumulation > 1 requires case-additive mean loss terms; "
                 f"unsupported terms: {unsupported}."
+            )
+    if gradient_composition is not None:
+        if not isinstance(gradient_composition, ConflictFreeGradientPolicy):
+            raise TypeError(
+                "gradient_composition must be a ConflictFreeGradientPolicy or None."
+            )
+        if int(gradient_accumulation) != 1:
+            raise ValueError(
+                "Operator gradient composition does not support gradient accumulation."
+            )
+        if include_model_losses:
+            raise ValueError(
+                "Operator gradient composition does not yet support attached model losses."
+            )
+        if loss_scale_policy is not None:
+            raise ValueError(
+                "Operator gradient composition does not yet support dynamic loss scaling."
             )
     if (
         any(isinstance(term, TargetOperatorConsistencyLoss) for term in specified_terms)
@@ -942,6 +964,8 @@ def fit_operator(
     )
     if len(set(metric_names)) != len(metric_names):
         raise ValueError("Training metric names must be unique.")
+    if gradient_composition is not None and len(terms) < 1:
+        raise ValueError("Gradient composition requires at least one operator objective.")
 
     def predict_for_loss(
         evaluated_model,
@@ -1307,16 +1331,78 @@ def fit_operator(
             )
             return scaled, (total_arrays, component_arrays)
 
-        (_, (total_arrays, component_arrays)), gradient = eqx.filter_value_and_grad(
-            objective,
-            has_aux=True,
-        )(current_parameters)
-        if loss_scale_policy is not None:
-            gradient = loss_scale_policy.unscale_gradients(
-                gradient,
-                loss_scale_state_,
+        if gradient_composition is None:
+            (_, (total_arrays, component_arrays)), gradient = eqx.filter_value_and_grad(
+                objective,
+                has_aux=True,
+            )(current_parameters)
+            if loss_scale_policy is not None:
+                gradient = loss_scale_policy.unscale_gradients(
+                    gradient,
+                    loss_scale_state_,
+                )
+            composition_finite = jnp.asarray(True)
+        else:
+
+            def component_objective(candidate):
+                current_model = reconstruct_fit_model(candidate, fixed)
+                target_model = (
+                    reconstruct_fit_model(target_parameters, fixed)
+                    if target_state is not None
+                    else None
+                )
+                total, components = loss_components(
+                    current_model,
+                    target_model,
+                    batch,
+                    targets,
+                    physical_batch,
+                    physical_targets,
+                    case_log_weights,
+                    case_mask,
+                    sampling_probabilities,
+                    key,
+                    step,
+                    active_rollout_horizon,
+                    training=True,
+                )
+                values = jnp.stack(tuple(component.value for component in components))
+                total_arrays_ = (total.numerator, total.support, total.log_scale)
+                component_arrays_ = tuple(
+                    (component.numerator, component.support, component.log_scale)
+                    for component in components
+                )
+                active_ = jnp.stack(
+                    tuple(component.support > 0.0 for component in components)
+                )
+                return values, (total_arrays_, component_arrays_, active_)
+
+            component_values, pullback, auxiliary = eqx.filter_vjp(
+                component_objective,
+                current_parameters,
+                has_aux=True,
             )
+            total_arrays, component_arrays, active = auxiliary
+            gradients = tuple(
+                pullback(jnp.zeros_like(component_values).at[index].set(1.0))[0]
+                for index in range(int(component_values.shape[0]))
+            )
+            composition = conflict_free_gradient(
+                gradients,
+                active=active,
+                policy=gradient_composition,
+            )
+            gradient = jax.tree.map(
+                lambda leaf: eqx.error_if(
+                    leaf,
+                    ~composition.successful,
+                    "Operator objectives do not admit a conflict-free direction.",
+                ),
+                composition.direction,
+            )
+            composition_finite = composition.successful
         finite = tree_all_finite((gradient, total_arrays, component_arrays))
+        finite = finite & composition_finite
         if sharding_policy is not None:
             finite = eqx.filter_shard(finite, sharding_policy.replicated)
         return total_arrays, component_arrays, gradient, finite
@@ -1508,6 +1594,9 @@ def fit_operator(
         "dtype_policy": resolved_dtype.to_dict(),
         "loss_scale_policy": (
             None if loss_scale_policy is None else asdict(loss_scale_policy)
+        ),
+        "gradient_composition": (
+            None if gradient_composition is None else gradient_composition.policy_id
         ),
         "output_pipeline": (
             None if output_pipeline is None else output_pipeline.fingerprint

--- a/phydrax/optim/__init__.py
+++ b/phydrax/optim/__init__.py
@@ -84,6 +84,13 @@ from ._finite import (
     FiniteTopK,
     search_finite,
 )
+from ._gradient_composition import (
+    conflict_free_gradient,
+    ConflictFreeFailureMode,
+    ConflictFreeGradientPolicy,
+    ConflictFreeGradientResult,
+    ConflictFreeGradientStatus,
+)
 from ._graph_least_squares import (
     linearize_residual_graph,
     ResidualGraphLinearization,
@@ -557,6 +564,11 @@ __all__ = [
     "DifferentialEvolutionContinuous",
     "DifferentialEvolutionInteger",
     "DifferentialEvolutionResult",
+    "conflict_free_gradient",
+    "ConflictFreeFailureMode",
+    "ConflictFreeGradientPolicy",
+    "ConflictFreeGradientResult",
+    "ConflictFreeGradientStatus",
     "DifferentialEvolutionSelection",
     "DifferentialEvolutionSpace",
     "DifferentialEvolutionStatus",

--- a/phydrax/optim/_gradient_composition.py
+++ b/phydrax/optim/_gradient_composition.py
@@ -1,0 +1,278 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from enum import IntEnum
+from typing import Any, Literal
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jaxtyping import Array, PyTree
+
+from .._fingerprint import canonical_fingerprint
+from .._strict import StrictModule
+from .._trainable import NonTrainableState
+from .._tree_math import (
+    tree_allfinite,
+    tree_inner,
+    tree_norm,
+    tree_scale,
+    validate_inexact_tree,
+)
+from ..linalg._dense_pseudoinverse import (
+    apply_pseudoinverse,
+    factor_pseudoinverse,
+)
+from ..linalg._policies import RankPolicy
+
+
+ConflictFreeFailureMode = Literal["status", "error"]
+
+
+class ConflictFreeGradientStatus(IntEnum):
+    SUCCESS = 0
+    STATIONARY = 1
+    INFEASIBLE = 2
+    NONFINITE = 3
+
+
+class ConflictFreeGradientPolicy(StrictModule, NonTrainableState):
+    """Numerical policy for inverse-gradient multi-objective composition."""
+
+    rank_policy: RankPolicy
+    minimum_norm: float = eqx.field(static=True)
+    projection_tolerance: float = eqx.field(static=True)
+    failure: ConflictFreeFailureMode = eqx.field(static=True)
+    policy_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        rank_policy: RankPolicy | None = None,
+        minimum_norm: float = 1e-12,
+        projection_tolerance: float = 1e-10,
+        failure: ConflictFreeFailureMode = "status",
+    ):
+        rank = RankPolicy() if rank_policy is None else rank_policy
+        if not isinstance(rank, RankPolicy):
+            raise TypeError("rank_policy must be a RankPolicy.")
+        norm = float(minimum_norm)
+        tolerance = float(projection_tolerance)
+        if not np.isfinite(norm) or norm <= 0.0:
+            raise ValueError("minimum_norm must be finite and strictly positive.")
+        if not np.isfinite(tolerance) or tolerance < 0.0:
+            raise ValueError("projection_tolerance must be finite and nonnegative.")
+        if failure not in ("status", "error"):
+            raise ValueError("failure must be 'status' or 'error'.")
+        self.rank_policy = rank
+        self.minimum_norm = norm
+        self.projection_tolerance = tolerance
+        self.failure = failure
+        self.policy_id = canonical_fingerprint(
+            {
+                "kind": "conflict-free-gradient-policy",
+                "rank": {
+                    "relative_cutoff": rank.relative_cutoff,
+                    "absolute_cutoff": rank.absolute_cutoff,
+                    "require_full_rank": rank.require_full_rank,
+                },
+                "minimum_norm": norm,
+                "projection_tolerance": tolerance,
+                "failure": failure,
+            }
+        )
+
+
+class ConflictFreeGradientResult(StrictModule):
+    """Composed direction and complete local multi-objective evidence."""
+
+    direction: PyTree[Array]
+    norms: Array
+    cosine_matrix: Array
+    projections: Array
+    active: Array
+    stationary: Array
+    conflicts: Array
+    rank: Array
+    rank_cutoff: Array
+    condition_estimate: Array
+    direction_norm: Array
+    successful: Array
+    status: Array
+    policy_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        direction: PyTree[Array],
+        /,
+        *,
+        norms: Array,
+        cosine_matrix: Array,
+        projections: Array,
+        active: Array,
+        stationary: Array,
+        conflicts: Array,
+        rank: Array,
+        rank_cutoff: Array,
+        condition_estimate: Array,
+        direction_norm: Array,
+        successful: Array,
+        status: Array,
+        policy_id: str,
+    ):
+        self.direction = direction
+        self.norms = jnp.asarray(norms)
+        self.cosine_matrix = jnp.asarray(cosine_matrix)
+        self.projections = jnp.asarray(projections)
+        self.active = jnp.asarray(active, dtype=bool)
+        self.stationary = jnp.asarray(stationary, dtype=bool)
+        self.conflicts = jnp.asarray(conflicts, dtype=bool)
+        self.rank = jnp.asarray(rank)
+        self.rank_cutoff = jnp.asarray(rank_cutoff)
+        self.condition_estimate = jnp.asarray(condition_estimate)
+        self.direction_norm = jnp.asarray(direction_norm)
+        self.successful = jnp.asarray(successful, dtype=bool)
+        self.status = jnp.asarray(status, dtype=jnp.int32)
+        self.policy_id = str(policy_id)
+
+
+def _tree_add(left: PyTree[Array], right: PyTree[Array], /) -> PyTree[Array]:
+    return jax.tree.map(lambda x, y: x + y, left, right)
+
+
+def conflict_free_gradient(
+    gradients: Sequence[PyTree[Any]],
+    /,
+    *,
+    active: Any | None = None,
+    policy: ConflictFreeGradientPolicy | None = None,
+) -> ConflictFreeGradientResult:
+    """Compose objective gradients without materializing parameter coordinates."""
+
+    values = tuple(
+        validate_inexact_tree(value, name=f"objective gradient {index}")
+        for index, value in enumerate(gradients)
+    )
+    if not values:
+        raise ValueError("At least one objective gradient is required.")
+    structure = jax.tree.structure(values[0])
+    if any(jax.tree.structure(value) != structure for value in values[1:]):
+        raise ValueError("Objective gradients must have congruent PyTree structures.")
+    shapes = tuple(
+        tuple(leaf.shape for leaf in jax.tree.leaves(value)) for value in values
+    )
+    if any(shape != shapes[0] for shape in shapes[1:]):
+        raise ValueError("Objective gradient leaves must have congruent shapes.")
+    resolved = ConflictFreeGradientPolicy() if policy is None else policy
+    if not isinstance(resolved, ConflictFreeGradientPolicy):
+        raise TypeError("policy must be a ConflictFreeGradientPolicy.")
+    count = len(values)
+    active_mask = (
+        jnp.ones((count,), dtype=bool)
+        if active is None
+        else jnp.asarray(active, dtype=bool)
+    )
+    if active_mask.shape != (count,):
+        raise ValueError("active must contain one Boolean per objective gradient.")
+
+    norms = jnp.stack(tuple(tree_norm(value) for value in values))
+    finite = jnp.stack(tuple(tree_allfinite(value) for value in values))
+    stationary = active_mask & finite & (norms <= resolved.minimum_norm)
+    effective = active_mask & finite & ~stationary
+    safe_norms = jnp.where(effective, norms, jnp.ones_like(norms))
+    normalized = tuple(
+        tree_scale(effective[index] / safe_norms[index], value)
+        for index, value in enumerate(values)
+    )
+    gram = jnp.stack(
+        tuple(
+            jnp.stack(tuple(tree_inner(left, right) for right in normalized))
+            for left in normalized
+        )
+    )
+    factors = factor_pseudoinverse(
+        gram,
+        resolved.rank_policy,
+        hermitian=True,
+    )
+    coefficients = apply_pseudoinverse(
+        factors,
+        effective.astype(gram.dtype),
+    )
+    candidate = tree_scale(0.0, values[0])
+    for coefficient, direction in zip(coefficients, normalized, strict=True):
+        candidate = _tree_add(candidate, tree_scale(coefficient, direction))
+    candidate_norm = tree_norm(candidate)
+    candidate_finite = tree_allfinite(candidate)
+    usable_candidate = (
+        candidate_finite & factors.finite & (candidate_norm > resolved.minimum_norm)
+    )
+    unit_candidate = tree_scale(
+        jnp.where(usable_candidate, 1.0 / candidate_norm, 0.0),
+        candidate,
+    )
+    unit_projections = jnp.stack(
+        tuple(tree_inner(value, unit_candidate) for value in values)
+    )
+    scale = jnp.sum(jnp.where(effective, unit_projections, 0.0))
+    positive_scale = jnp.maximum(scale, 0.0)
+    direction = tree_scale(positive_scale, unit_candidate)
+    projections = jnp.stack(tuple(tree_inner(value, direction) for value in values))
+    conflicts = effective & (projections < -resolved.projection_tolerance)
+    all_input_finite = jnp.all(~active_mask | finite)
+    active_count = jnp.sum(effective.astype(jnp.int32))
+    stationary_only = active_count == 0
+    feasible = usable_candidate & ~jnp.any(conflicts) & (positive_scale > 0.0)
+    successful = all_input_finite & (stationary_only | feasible)
+    status = jnp.where(
+        ~all_input_finite,
+        int(ConflictFreeGradientStatus.NONFINITE),
+        jnp.where(
+            stationary_only,
+            int(ConflictFreeGradientStatus.STATIONARY),
+            jnp.where(
+                feasible,
+                int(ConflictFreeGradientStatus.SUCCESS),
+                int(ConflictFreeGradientStatus.INFEASIBLE),
+            ),
+        ),
+    )
+    if resolved.failure == "error":
+        direction = jax.tree.map(
+            lambda leaf: eqx.error_if(
+                leaf,
+                ~successful,
+                "Objective gradients do not admit a finite conflict-free direction.",
+            ),
+            direction,
+        )
+    return ConflictFreeGradientResult(
+        direction,
+        norms=norms,
+        cosine_matrix=gram,
+        projections=projections,
+        active=active_mask,
+        stationary=stationary,
+        conflicts=conflicts,
+        rank=factors.rank,
+        rank_cutoff=factors.rank_cutoff,
+        condition_estimate=factors.condition_estimate,
+        direction_norm=tree_norm(direction),
+        successful=successful,
+        status=status,
+        policy_id=resolved.policy_id,
+    )
+
+
+__all__ = [
+    "ConflictFreeFailureMode",
+    "ConflictFreeGradientPolicy",
+    "ConflictFreeGradientResult",
+    "ConflictFreeGradientStatus",
+    "conflict_free_gradient",
+]

--- a/phydrax/solver/_functional_gradient.py
+++ b/phydrax/solver/_functional_gradient.py
@@ -39,6 +39,7 @@ from .._training_objective import (
 from ..nn.parameters import ParameterSubspace
 from ..nn.parameters._low_rank import validate_low_rank_subspace
 from ..optim._composite import CompositeLeastSquaresProblem
+from ..optim._gradient_composition import conflict_free_gradient
 from ..optim._iterative import (
     AbstractCompositeLeastSquaresMethod,
     AbstractLeastSquaresMethod,
@@ -345,6 +346,27 @@ def solve_gradient(
                 "Least-squares FunctionalSolver methods require a pure "
                 "ResidualPenalty objective without model-level scalar losses."
             )
+        gradient_composition = None if training is None else training.gradient_composition
+        if gradient_composition is not None:
+            if _opt_standard is None:
+                raise ValueError(
+                    "Functional gradient composition requires a standard Optax "
+                    "transformation."
+                )
+            if accumulation_steps != 1:
+                raise ValueError(
+                    "Functional gradient composition does not support gradient "
+                    "accumulation."
+                )
+            if train_term_sample_size not in (None, len(self.terms)):
+                raise ValueError(
+                    "Functional gradient composition requires every training term."
+                )
+            if model_loss_names:
+                raise ValueError(
+                    "Functional gradient composition does not yet support attached "
+                    "model losses."
+                )
         evaluation_term_names = tuple(_term_label(c) for c in self.evaluation_terms)
         term_sample_size = _train_term_sample_size(
             train_term_sample_size,
@@ -381,6 +403,22 @@ def solve_gradient(
                 values = evaluate_prepared_objective(prepared_, functions)
             return values.total, values.flat_values
 
+        def _composition_loss_wrt_params(params_, non_trainable_, prepared_):
+            if isinstance(prepared_, PreparedFunctionalUpdate):
+                surrogate_params, surrogate_non_trainable = surrogate_coordinates(
+                    params_,
+                    non_trainable_,
+                )
+                values = prepared_.surrogate_values(
+                    surrogate_params,
+                    surrogate_non_trainable,
+                )
+                return values.total, values.gradient_values
+            functions = reconstruct_functions(params_, non_trainable_)
+            with _precision_context():
+                values = evaluate_prepared_objective(prepared_, functions)
+            return values.total, values.gradient_values
+
         def _term_values_wrt_params(params_, non_trainable_, prepared_):
             functions = reconstruct_functions(params_, non_trainable_)
             with _precision_context():
@@ -396,6 +434,37 @@ def solve_gradient(
                 return prepared_data_metrics(_physical_prepared(prepared_), functions)
 
         loss_fn = eqx.filter_value_and_grad(_loss_wrt_params, has_aux=True)
+
+        def _composed_loss_and_grad(params_, non_trainable_, prepared_):
+            outputs, pullback = eqx.filter_vjp(
+                _composition_loss_wrt_params,
+                params_,
+                non_trainable_,
+                prepared_,
+            )
+            loss_value, component_values = outputs
+            gradients = []
+            for index in range(int(component_values.shape[0])):
+                component_cotangent = jnp.zeros_like(component_values).at[index].set(1)
+                gradient, _, _ = pullback(
+                    (jnp.zeros_like(loss_value), component_cotangent)
+                )
+                gradients.append(gradient)
+            if gradient_composition is None:
+                raise RuntimeError("Gradient composition is not configured.")
+            composition = conflict_free_gradient(
+                tuple(gradients),
+                policy=gradient_composition,
+            )
+            gradient = jax.tree.map(
+                lambda leaf: eqx.error_if(
+                    leaf,
+                    ~composition.successful,
+                    "Functional objectives do not admit a conflict-free direction.",
+                ),
+                composition.direction,
+            )
+            return (loss_value, component_values), gradient
 
         is_composite = _opt_composite is not None
         is_least_squares = _opt_least_squares is not None
@@ -648,11 +717,18 @@ def solve_gradient(
                 )
                 return params_, opt_state, loss_val, term_values
 
-            (loss_val, term_values), grads = loss_fn(
-                params_,
-                non_trainable_,
-                prepared_,
-            )
+            if gradient_composition is None:
+                (loss_val, term_values), grads = loss_fn(
+                    params_,
+                    non_trainable_,
+                    prepared_,
+                )
+            else:
+                (loss_val, term_values), grads = _composed_loss_and_grad(
+                    params_,
+                    non_trainable_,
+                    prepared_,
+                )
             assert _opt_standard is not None
             updates, opt_state = _opt_standard.update(grads, opt_state, params_)
             params_ = eqx.apply_updates(params_, updates)

--- a/phydrax/solver/_functional_objective.py
+++ b/phydrax/solver/_functional_objective.py
@@ -40,6 +40,19 @@ class _SupportsDataMetrics(Protocol):
     ) -> dict[str, Any]: ...
 
 
+@runtime_checkable
+class _SupportsObjectiveComponents(Protocol):
+    def objective_components(
+        self,
+        functions: Any,
+        /,
+        *,
+        key: Any,
+        iter_: Any,
+        **kwargs: Any,
+    ) -> tuple[Any, ...]: ...
+
+
 _ObjectiveTermMode = Literal["plain", "sampled", "adaptive_population"]
 
 
@@ -202,21 +215,28 @@ class _ObjectiveValues(StrictModule):
     total: Any
     term_values: Any
     model_loss_values: Any
+    component_values: Any
 
     def __init__(
         self,
         total: Any,
         term_values: Any,
         model_loss_values: Any,
+        component_values: Any,
         /,
     ):
         self.total = total
         self.term_values = term_values
         self.model_loss_values = model_loss_values
+        self.component_values = component_values
 
     @property
     def flat_values(self) -> Any:
         return jnp.concatenate((self.term_values, self.model_loss_values), axis=0)
+
+    @property
+    def gradient_values(self) -> Any:
+        return jnp.concatenate((self.component_values, self.model_loss_values), axis=0)
 
 
 def _prepare_slots(
@@ -309,17 +329,38 @@ def evaluate_prepared_objective(
     """Evaluate one prepared objective without rematerializing stochastic payloads."""
     enforced = _apply_prepared_enforcement(prepared, functions)
     term_values: list[Any] = []
+    component_values: list[Any] = []
     total = jnp.asarray(0.0, dtype=float)
     scale = jnp.asarray(prepared.selection.scale, dtype=float).reshape(())
     with derivative_runtime_context():
         for prepared_term in prepared.terms:
-            value = evaluate(
-                prepared_term.term,
-                enforced,
-                key=prepared_term.key,
-                step=prepared.iteration,
-                **prepared_term.kwargs,
-            ).value
+            if isinstance(prepared_term.term, _SupportsObjectiveComponents):
+                components = tuple(
+                    jnp.asarray(value, dtype=float).reshape(())
+                    for value in prepared_term.term.objective_components(
+                        enforced,
+                        key=prepared_term.key,
+                        iter_=prepared.iteration,
+                        **prepared_term.kwargs,
+                    )
+                )
+                if not components:
+                    raise ValueError(
+                        "Componentized scalar terms must expose at least one objective."
+                    )
+                value = sum(components, start=jnp.asarray(0.0, dtype=float))
+                component_values.extend(scale * component for component in components)
+            else:
+                value = evaluate(
+                    prepared_term.term,
+                    enforced,
+                    key=prepared_term.key,
+                    step=prepared.iteration,
+                    **prepared_term.kwargs,
+                ).value
+                component_values.append(
+                    scale * jnp.asarray(value, dtype=float).reshape(())
+                )
             value = scale * jnp.asarray(value, dtype=float).reshape(())
             term_values.append(value)
             total = total + value
@@ -336,12 +377,17 @@ def evaluate_prepared_objective(
     terms_array = (
         jnp.stack(term_values, axis=0) if term_values else jnp.zeros((0,), dtype=float)
     )
+    component_array = (
+        jnp.stack(component_values, axis=0)
+        if component_values
+        else jnp.zeros((0,), dtype=float)
+    )
     model_array = (
         jnp.stack(model_loss_values, axis=0)
         if model_loss_values
         else jnp.zeros((0,), dtype=float)
     )
-    return _ObjectiveValues(total, terms_array, model_array)
+    return _ObjectiveValues(total, terms_array, model_array, component_array)
 
 
 def evaluate_prepared_scalar_remainder(

--- a/phydrax/solver/_functional_surrogate.py
+++ b/phydrax/solver/_functional_surrogate.py
@@ -183,6 +183,7 @@ class PseudoTransientResidualTransform(StrictModule):
             residual_override=self.residual_override(params, residual, term),
         )
 
+
 class _CausalScaledEvaluator(StrictModule, BatchEvaluator):
     source: DomainFunction
     gates: tuple[cx.Field, ...]
@@ -221,8 +222,7 @@ class _CausalScaledEvaluator(StrictModule, BatchEvaluator):
         axis = event_positions[self.blocks.event_axis]
         pieces = self.blocks.split(value)
         scaled = tuple(
-            block
-            * cx.Field(jnp.sqrt(jnp.asarray(gate.data)), dims=gate.dims)
+            block * cx.Field(jnp.sqrt(jnp.asarray(gate.data)), dims=gate.dims)
             for block, gate in zip(
                 pieces,
                 self.gates if len(self.gates) > 1 else self.gates * len(pieces),
@@ -347,10 +347,7 @@ def _causal_gate_fields(score, coefficient, time, schedule, /):
         losses.append(numerator / support)
     gates = schedule.causal_weights(jnp.stack(tuple(losses)))
     multiplier = sum(
-        (
-            mask * jnp.asarray(gates[index])
-            for index, mask in enumerate(masks)
-        ),
+        (mask * jnp.asarray(gates[index]) for index, mask in enumerate(masks)),
         start=cx.Field(jnp.zeros_like(masks[0].data), dims=masks[0].dims),
     )
     return multiplier
@@ -373,7 +370,9 @@ def _prepare_causal_gates(residual, params, policies, inner, /):
         term = matching[0]
         batch = term.realization.batch
         if not isinstance(batch, PointIntegrationBatch):
-            raise TypeError("Causal residual training initially requires point integration.")
+            raise TypeError(
+                "Causal residual training initially requires point integration."
+            )
         time = batch.points[policy.time_label]
         if not isinstance(time, cx.Field) or any(
             dimension is None for dimension in time.dims
@@ -420,6 +419,7 @@ def _prepare_causal_gates(residual, params, policies, inner, /):
         prepared_gates.append((term.index, gates))
     return tuple(prepared_gates)
 
+
 class BalancedResidualTransform(StrictModule):
     inner: Any
     references: tuple[Any, ...]
@@ -448,9 +448,7 @@ class BalancedResidualTransform(StrictModule):
         scaled = []
         for block in blocks:
             multiplier = jnp.asarray(1.0, dtype=block.values.dtype)
-            for reference, value in zip(
-                self.references, self.multipliers, strict=True
-            ):
+            for reference, value in zip(self.references, self.multipliers, strict=True):
                 matches = reference.term_index == block.term_index and (
                     reference.block_name is None
                     or reference.block_name == block.block_name
@@ -471,9 +469,7 @@ class BalancedResidualTransform(StrictModule):
 
 
 def _tree_norm(tree, /) -> Array:
-    leaves = tuple(
-        leaf for leaf in jax.tree.leaves(tree) if eqx.is_inexact_array(leaf)
-    )
+    leaves = tuple(leaf for leaf in jax.tree.leaves(tree) if eqx.is_inexact_array(leaf))
     if not leaves:
         return jnp.asarray(0.0)
     return jnp.sqrt(
@@ -482,6 +478,7 @@ def _tree_norm(tree, /) -> Array:
             start=jnp.asarray(0.0),
         )
     )
+
 
 def _tree_inner(left, right, /) -> Array:
     left_leaves = tuple(
@@ -495,9 +492,7 @@ def _tree_inner(left, right, /) -> Array:
     return sum(
         (
             jnp.real(jnp.vdot(left_leaf, right_leaf))
-            for left_leaf, right_leaf in zip(
-                left_leaves, right_leaves, strict=True
-            )
+            for left_leaf, right_leaf in zip(left_leaves, right_leaves, strict=True)
         ),
         start=jnp.asarray(0.0),
     )
@@ -534,9 +529,7 @@ def _interstep_alignment(previous, current, /) -> Array:
         & (left_norm > 0.0)
         & (right_norm > 0.0)
     )
-    value = _tree_inner(previous, current) / jnp.where(
-        valid, left_norm * right_norm, 1.0
-    )
+    value = _tree_inner(previous, current) / jnp.where(valid, left_norm * right_norm, 1.0)
     return jnp.where(valid, value, jnp.nan)
 
 
@@ -572,10 +565,7 @@ def _gradient_balance_statistics(residual, params, references, /):
 def _residual_reference_available(layout, reference, /) -> bool:
     return any(
         entry.term_index == reference.term_index
-        and (
-            reference.block_name is None
-            or entry.block_name == reference.block_name
-        )
+        and (reference.block_name is None or entry.block_name == reference.block_name)
         for entry in layout.entries
     )
 
@@ -641,6 +631,7 @@ def _updated_balance_multipliers(
     updated = updated / jnp.mean(updated)
     return jax.lax.stop_gradient(updated), gradients, statistics
 
+
 def _functional_ntk_diagnostics(residual, params, policy, key, /):
     roots = residual.roots(params)
     ntk = prepare_empirical_ntk(
@@ -675,6 +666,7 @@ def _functional_ntk_diagnostic_values(diagnostics, /) -> dict[str, Array]:
         "ntk/finite": diagnostics.finite,
         "ntk/converged": diagnostics.converged,
     }
+
 
 class PreparedFunctionalUpdate(StrictModule):
     """Physical objective and immutable same-update optimizer surrogate."""
@@ -712,13 +704,11 @@ class PreparedFunctionalUpdate(StrictModule):
         self.pseudo_inverse_steps = tuple(
             jnp.asarray(value) for value in pseudo_inverse_steps
         )
-        self.term_multipliers = jnp.asarray(
-            term_multipliers, dtype=float
-        ).reshape((-1,))
+        self.term_multipliers = jnp.asarray(term_multipliers, dtype=float).reshape((-1,))
         self.block_gradients = tuple(block_gradients)
-        self.balance_statistics = jnp.asarray(
-            balance_statistics, dtype=float
-        ).reshape((-1,))
+        self.balance_statistics = jnp.asarray(balance_statistics, dtype=float).reshape(
+            (-1,)
+        )
         self.intra_gradient_alignment = jnp.asarray(intra_gradient_alignment)
         self.inter_gradient_alignment = jnp.asarray(inter_gradient_alignment)
         self.diagnostic_gradient = diagnostic_gradient
@@ -763,8 +753,8 @@ class PreparedFunctionalUpdate(StrictModule):
             surrogate,
             physical.term_values,
             physical.model_loss_values,
+            physical.component_values,
         )
-
 
 
 def _validate_pseudo_source(policy, term, /) -> None:
@@ -785,7 +775,9 @@ def _validate_pseudo_source(policy, term, /) -> None:
                 "Pseudo-time freshness='every_update' requires refresh_every=1."
             )
         return
-    raise TypeError("Pseudo-transient residual terms require a resampled integration source.")
+    raise TypeError(
+        "Pseudo-transient residual terms require a resampled integration source."
+    )
 
 
 def _block_squared_norms(blocks, names, /) -> Array:
@@ -859,12 +851,10 @@ def _adapt_pseudo_inverse_steps(
                 "Pseudo-time relaxation and residual block layouts must match."
             )
         if old_.ndim == 1 and (
-            relaxation_blocks is None
-            or int(old_.size) != relaxation_blocks.block_count
+            relaxation_blocks is None or int(old_.size) != relaxation_blocks.block_count
         ):
             raise ValueError(
-                "Vector pseudo-time inverse steps require one value per "
-                "relaxation block."
+                "Vector pseudo-time inverse steps require one value per relaxation block."
             )
         adaptation = policy.adaptation
         if adaptation is None or not adaptation.due(step):
@@ -913,6 +903,7 @@ def _adapt_pseudo_inverse_steps(
         smoothed = adaptation.momentum * old_ + (1.0 - adaptation.momentum) * candidate
         updated.append(jax.lax.stop_gradient(jnp.where(valid, smoothed, old_)))
     return tuple(updated)
+
 
 def prepare_functional_update(
     physical: _PreparedObjective,
@@ -999,9 +990,7 @@ def prepare_functional_update(
         if residual is None:
             raise ValueError("Functional term balancing requires residual terms.")
         if multipliers.size == 0:
-            multipliers = jnp.ones(
-                (len(training.term_balance.blocks),), dtype=float
-            )
+            multipliers = jnp.ones((len(training.term_balance.blocks),), dtype=float)
         step = int(jax.device_get(jnp.asarray(physical.iteration)).reshape(()))
         if training.term_balance.due(step):
             all_available = all(
@@ -1044,9 +1033,7 @@ def prepare_functional_update(
         and training.diagnostics is not None
         and training.diagnostics.gradient_alignment
     ):
-        diagnostic_step = int(
-            jax.device_get(jnp.asarray(physical.iteration)).reshape(())
-        )
+        diagnostic_step = int(jax.device_get(jnp.asarray(physical.iteration)).reshape(()))
         if training.diagnostics.due(diagnostic_step):
             if residual is None:
                 raise ValueError("Gradient alignment requires residual terms.")
@@ -1064,14 +1051,10 @@ def prepare_functional_update(
             )
             gradients = block_gradients
             if not gradients:
-                gradients, _ = _gradient_balance_statistics(
-                    residual, params, references
-                )
+                gradients, _ = _gradient_balance_statistics(residual, params, references)
             intra_alignment = _gradient_alignment(gradients)
             diagnostic_gradient = eqx.filter_grad(residual.loss)(params)
-            inter_alignment = _interstep_alignment(
-                previous_gradient, diagnostic_gradient
-            )
+            inter_alignment = _interstep_alignment(previous_gradient, diagnostic_gradient)
     return PreparedFunctionalUpdate(
         physical,
         residual,

--- a/phydrax/solver/_functional_training.py
+++ b/phydrax/solver/_functional_training.py
@@ -20,6 +20,7 @@ from .._trainable import NonTrainableState
 from .._training import TargetParameterState, TrainingProgress
 from ..domain import DomainFunction
 from ..enforcement import EnforcementState
+from ..optim._gradient_composition import ConflictFreeGradientPolicy
 from ..sampling.collocation import CausalTimeSlabSchedule
 from ..terms import ResidualBlockLayout, ResidualBlockRef
 
@@ -463,6 +464,7 @@ class FunctionalTrainingPlan(StrictModule, NonTrainableState):
     pseudo_transient: tuple[PseudoTransientPolicy, ...]
     causal: tuple[CausalResidualPolicy, ...]
     term_balance: FunctionalTermBalancePolicy | None
+    gradient_composition: ConflictFreeGradientPolicy | None
     diagnostics: FunctionalDiagnosticsPolicy | None
     selection: FunctionalSelectionPolicy | None
     checkpoint: FunctionalCheckpointPolicy | None
@@ -475,6 +477,7 @@ class FunctionalTrainingPlan(StrictModule, NonTrainableState):
         pseudo_transient: Sequence[PseudoTransientPolicy] = (),
         causal: Sequence[CausalResidualPolicy] = (),
         term_balance: FunctionalTermBalancePolicy | None = None,
+        gradient_composition: ConflictFreeGradientPolicy | None = None,
         diagnostics: FunctionalDiagnosticsPolicy | None = None,
         selection: FunctionalSelectionPolicy | None = None,
         checkpoint: FunctionalCheckpointPolicy | None = None,
@@ -490,8 +493,18 @@ class FunctionalTrainingPlan(StrictModule, NonTrainableState):
             raise ValueError("At most one pseudo-transient policy may target each term.")
         if len({value.term_index for value in causal_}) != len(causal_):
             raise ValueError("At most one causal policy may target each term.")
+        if term_balance is not None and gradient_composition is not None:
+            raise ValueError(
+                "Functional term balancing and gradient composition are mutually "
+                "exclusive."
+            )
         expected = (
             (term_balance, FunctionalTermBalancePolicy, "term_balance"),
+            (
+                gradient_composition,
+                ConflictFreeGradientPolicy,
+                "gradient_composition",
+            ),
             (diagnostics, FunctionalDiagnosticsPolicy, "diagnostics"),
             (selection, FunctionalSelectionPolicy, "selection"),
             (checkpoint, FunctionalCheckpointPolicy, "checkpoint"),
@@ -507,6 +520,7 @@ class FunctionalTrainingPlan(StrictModule, NonTrainableState):
         self.pseudo_transient = pseudo
         self.causal = causal_
         self.term_balance = term_balance
+        self.gradient_composition = gradient_composition
         self.diagnostics = diagnostics
         self.selection = selection
         self.checkpoint = checkpoint
@@ -517,6 +531,11 @@ class FunctionalTrainingPlan(StrictModule, NonTrainableState):
                 "pseudo_transient": [value.policy_id for value in pseudo],
                 "causal": [value.policy_id for value in causal_],
                 "term_balance": None if term_balance is None else term_balance.policy_id,
+                "gradient_composition": (
+                    None
+                    if gradient_composition is None
+                    else gradient_composition.policy_id
+                ),
                 "diagnostics": (
                     None
                     if diagnostics is None

--- a/phydrax/solver/_structured_incompressible.py
+++ b/phydrax/solver/_structured_incompressible.py
@@ -30,6 +30,7 @@ from ..linalg import (
     DifferentiationPolicy,
     FGMRES,
     FunctionLinearOperator,
+    LinearSolveControl,
     LinearSolvePolicy,
     LinearSolveResult,
     LinearSystem,
@@ -119,6 +120,9 @@ class MACPressureProjectionResult(StrictModule):
     velocity: FaceVelocity
     pressure: Array
     pressure_increment: Array
+    candidate_velocity: FaceVelocity
+    candidate_pressure: Array
+    candidate_pressure_increment: Array
     divergence_before: Array
     divergence_after: Array
     pressure_residual: Array
@@ -144,6 +148,8 @@ class MACRateProjectionResult(StrictModule):
 
     rate: FaceVelocity
     pressure: Array
+    candidate_rate: FaceVelocity
+    candidate_pressure: Array
     divergence_before: Array
     divergence_after: Array
     pressure_residual: Array
@@ -683,7 +689,10 @@ class MACPressureProjectionPlan(StrictModule, NonTrainableState):
         pressure: ArrayLike | None = None,
         inverse_momentum_diagonal: ArrayLike | None = None,
         boundary_stage: MACBoundaryStageData | None = None,
+        control: LinearSolveControl | None = None,
     ) -> MACPressureProjectionResult:
+        if control is not None and not isinstance(control, LinearSolveControl):
+            raise TypeError("control must be a LinearSolveControl or None.")
         stage = self._stage(boundary_stage)
         values = self.operators.validate_velocity(velocity)
         dtype = self.operators.pressure_space.dtype
@@ -739,7 +748,14 @@ class MACPressureProjectionPlan(StrictModule, NonTrainableState):
         active_hybrid_plan = self.hybrid_plan
         active_hybrid_defect = self.hybrid_action_defect
         direct_scale = step / self.density
-        if inverse_momentum_diagonal is not None:
+        if inverse_momentum_diagonal is not None and self.solve_method == "iterative":
+            route = "iterative"
+            route_reason = (
+                "FGMRES selected for stabilized nonsymmetric traction"
+                if self.nonsymmetric_traction
+                else "PCG selected for general positive beta"
+            )
+        elif inverse_momentum_diagonal is not None:
             coefficient_host = np.asarray(inverse)
             coefficient_scale = max(1.0, float(np.max(np.abs(coefficient_host))))
             coefficient_constant = bool(
@@ -799,6 +815,10 @@ class MACPressureProjectionPlan(StrictModule, NonTrainableState):
                     if self.nonsymmetric_traction
                     else "PCG selected for general positive beta"
                 )
+        if control is not None and route != "iterative":
+            raise ValueError(
+                "LinearSolveControl is only valid for iterative MAC pressure routes."
+            )
         if route == "transform":
             transform = self.transform_plan.solve(rhs / direct_scale)
             solution_candidate = (
@@ -836,7 +856,12 @@ class MACPressureProjectionPlan(StrictModule, NonTrainableState):
             )
             problem = LinearSystem(pressure_operator, problem_id=self.pressure_problem_id)
             prepared = refresh(self.prepared_linear, problem)
-            linear = solve(prepared, rhs, initial_guess=incoming_pressure)
+            linear = solve(
+                prepared,
+                rhs,
+                initial_guess=incoming_pressure,
+                control=control,
+            )
             solution_candidate = linear.value
             if self.closure_kind == "neumann":
                 solution_candidate = self.operators.gauge_project(solution_candidate)
@@ -920,6 +945,9 @@ class MACPressureProjectionPlan(StrictModule, NonTrainableState):
             velocity=corrected,
             pressure=pressure_value,
             pressure_increment=increment,
+            candidate_velocity=corrected_candidate,
+            candidate_pressure=pressure_candidate,
+            candidate_pressure_increment=increment_candidate,
             divergence_before=divergence_before,
             divergence_after=divergence_after,
             pressure_residual=residual,
@@ -946,12 +974,20 @@ class MACPressureProjectionPlan(StrictModule, NonTrainableState):
         /,
         *,
         boundary_stage: MACBoundaryStageData | None = None,
+        control: LinearSolveControl | None = None,
     ) -> MACRateProjectionResult:
         """Project one face-velocity rate without changing essential normal faces."""
-        projected = self.project(rate, 1.0, boundary_stage=boundary_stage)
+        projected = self.project(
+            rate,
+            1.0,
+            boundary_stage=boundary_stage,
+            control=control,
+        )
         return MACRateProjectionResult(
             rate=projected.velocity,
             pressure=projected.pressure_increment,
+            candidate_rate=projected.candidate_velocity,
+            candidate_pressure=projected.candidate_pressure_increment,
             divergence_before=projected.divergence_before,
             divergence_after=projected.divergence_after,
             pressure_residual=projected.pressure_residual,

--- a/phydrax/terms/__init__.py
+++ b/phydrax/terms/__init__.py
@@ -119,6 +119,13 @@ from ._operator_dataset import (
     OperatorDatasetTerm,
     PhysicsInformedOperatorTerm,
 )
+from ._physics_flow_matching import (
+    AbstractFlowEndpointFunctional,
+    CallableFlowEndpointFunctional,
+    FlowEndpointRolloutPolicy,
+    PhysicsFlowMatchingDiagnostics,
+    PhysicsFlowMatchingTerm,
+)
 from ._ragged_series import RaggedSeriesSupervisedBatch, RaggedSeriesSupervisedTerm
 from ._ragged_time_series import (
     RaggedTimeSeriesBatch,
@@ -154,7 +161,11 @@ from ._score_matching import (
 )
 from ._supervised_dataset import SupervisedDatasetBatch, SupervisedDatasetTerm
 from ._target_consistency import TargetConsistencyTerm
-from ._time_sampling import UniformTimeSamplingPolicy
+from ._time_sampling import (
+    AbstractTimeSamplingPolicy,
+    LogitNormalTimeSamplingPolicy,
+    UniformTimeSamplingPolicy,
+)
 from ._topology import FrozenTopologyTerm
 from ._trajectory_classification import (
     RaggedTimeSeriesClassificationBatch,
@@ -211,11 +222,14 @@ __all__ = [
     "wasserstein_adversarial_evaluation",
     "FrozenTopologyTerm",
     "BSDETerm",
+    "AbstractFlowEndpointFunctional",
     "BarycenterObjectiveTerm",
     "BatchSampler",
     "CochainResidualTerm",
     "CompiledModalResidualTerm",
+    "AbstractTimeSamplingPolicy",
     "DeepBSDEPredictor",
+    "CallableFlowEndpointFunctional",
     "DeepBSDERollout",
     "DeepBSDESamplingMode",
     "DeepBSDEShootingDiagnostics",
@@ -245,6 +259,7 @@ __all__ = [
     "FlowEndpointProvider",
     "DenseOverlapClassificationTerm",
     "DenseSiteClassificationBatch",
+    "FlowEndpointRolloutPolicy",
     "DenseSiteClassificationTerm",
     "FlowMatchingBatch",
     "FlowMatchingDiagnostics",
@@ -271,6 +286,7 @@ __all__ = [
     "InvariantSubspaceResidualEvaluation",
     "InvariantSubspaceResidualResult",
     "LabelProvider",
+    "LogitNormalTimeSamplingPolicy",
     "ModalObservationTerm",
     "ModalTimeProvider",
     "MomentPenalty",
@@ -280,6 +296,8 @@ __all__ = [
     "RaggedSeriesSupervisedBatch",
     "RaggedSeriesSupervisedTerm",
     "RaggedTimeSeriesBatch",
+    "PhysicsFlowMatchingDiagnostics",
+    "PhysicsFlowMatchingTerm",
     "RaggedTimeSeriesDataTerm",
     "RaggedTimeSeriesInterpolation",
     "RandomizedMomentBatch",

--- a/phydrax/terms/_flow_matching.py
+++ b/phydrax/terms/_flow_matching.py
@@ -31,13 +31,11 @@ from .._term import AbstractSamplingTerm
 from ..transport.continuous._coupling import EndpointCouplingSample
 from ..transport.continuous._interpolant import AbstractEndpointInterpolant
 from ._sample_statistics import effective_sample_size, normalized_log_weights
-from ._time_sampling import UniformTimeSamplingPolicy
+from ._time_sampling import AbstractTimeSamplingPolicy, UniformTimeSamplingPolicy
 
 
 FlowMatchingSamplingMode: TypeAlias = Literal["fixed", "resample"]
 FlowEndpointProvider: TypeAlias = Callable[[Key[Array, ""]], EndpointCouplingSample]
-
-
 
 
 class FlowMatchingBatch(StrictModule):
@@ -176,7 +174,7 @@ class FlowMatchingTerm(AbstractSamplingTerm):
     fixed_endpoints: EndpointCouplingSample | None
     endpoint_provider: FlowEndpointProvider | None
     interpolant: AbstractEndpointInterpolant
-    policy: UniformTimeSamplingPolicy
+    policy: AbstractTimeSamplingPolicy
     metric: AbstractFlowMatchingMetric
     scalar_weight: Array
     velocity_name: str = eqx.field(static=True)
@@ -192,7 +190,7 @@ class FlowMatchingTerm(AbstractSamplingTerm):
         interpolant: AbstractEndpointInterpolant,
         /,
         *,
-        policy: UniformTimeSamplingPolicy | None = None,
+        policy: AbstractTimeSamplingPolicy | None = None,
         metric: AbstractFlowMatchingMetric | None = None,
         sampling_mode: FlowMatchingSamplingMode = "fixed",
         scalar_weight: ArrayLike = 1.0,
@@ -210,8 +208,8 @@ class FlowMatchingTerm(AbstractSamplingTerm):
             raise ValueError("state_label and time_label must be distinct and non-empty.")
         resolved_policy = UniformTimeSamplingPolicy() if policy is None else policy
         resolved_metric = EuclideanFlowMatchingMetric() if metric is None else metric
-        if not isinstance(resolved_policy, UniformTimeSamplingPolicy):
-            raise TypeError("policy must be UniformTimeSamplingPolicy or None.")
+        if not isinstance(resolved_policy, AbstractTimeSamplingPolicy):
+            raise TypeError("policy must implement AbstractTimeSamplingPolicy.")
         if not isinstance(resolved_metric, AbstractFlowMatchingMetric):
             raise TypeError("metric must implement AbstractFlowMatchingMetric.")
         if bool(resolved_policy.minimum_time < interpolant.source_coordinate) or bool(

--- a/phydrax/terms/_physics_flow_matching.py
+++ b/phydrax/terms/_physics_flow_matching.py
@@ -1,0 +1,417 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from collections.abc import Callable, Mapping
+from typing import Any, Literal
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import numpy as np
+from jaxtyping import Array, ArrayLike, Key
+
+from .._doc import DOC_KEY0
+from .._fingerprint import canonical_fingerprint
+from .._strict import StrictModule
+from .._term import AbstractSamplingTerm
+from .._trainable import NonTrainableState
+from ..domain import DomainFunction
+from ..transport.continuous._coupling import EndpointCouplingSample
+from ..transport.continuous._interpolant import AbstractEndpointInterpolant
+from ._flow_matching import (
+    AbstractFlowMatchingMetric,
+    FlowEndpointProvider,
+    FlowMatchingBatch,
+    FlowMatchingDiagnostics,
+    FlowMatchingSamplingMode,
+    FlowMatchingTerm,
+)
+from ._sample_statistics import normalized_log_weights
+from ._time_sampling import AbstractTimeSamplingPolicy
+
+
+class AbstractFlowEndpointFunctional(StrictModule, NonTrainableState):
+    """Measure-aware scalar physical energy evaluated on one endpoint state."""
+
+    event_shape: tuple[int, ...] = eqx.field(static=True)
+    functional_id: str = eqx.field(static=True)
+
+    @abstractmethod
+    def __call__(self, state: Array, context: Mapping[str, Array], /) -> Array:
+        raise NotImplementedError
+
+
+class CallableFlowEndpointFunctional(AbstractFlowEndpointFunctional):
+    """Explicitly identified endpoint functional backed by a static callable."""
+
+    function: Callable = eqx.field(static=True)
+
+    def __init__(
+        self,
+        function: Callable[[Array, Mapping[str, Array]], ArrayLike],
+        /,
+        *,
+        event_shape: tuple[int, ...],
+        functional_id: str,
+    ):
+        if not callable(function):
+            raise TypeError("function must be callable.")
+        shape = tuple(int(size) for size in event_shape)
+        identifier = str(functional_id).strip()
+        if not shape or any(size <= 0 for size in shape) or not identifier:
+            raise ValueError("Endpoint functional shape and identity are invalid.")
+        self.function = function
+        self.event_shape = shape
+        self.functional_id = identifier
+
+    def __call__(self, state: Array, context: Mapping[str, Array], /) -> Array:
+        return jnp.asarray(self.function(state, context))
+
+
+class FlowEndpointRolloutPolicy(StrictModule, NonTrainableState):
+    """Static-capacity Euler terminal reconstruction with a traced curriculum."""
+
+    maximum_steps: int = eqx.field(static=True)
+    initial_steps: int = eqx.field(static=True)
+    transition_steps: int = eqx.field(static=True)
+    schedule: Literal["constant", "linear"] = eqx.field(static=True)
+    rematerialize: bool = eqx.field(static=True)
+    time_power: float = eqx.field(static=True)
+    policy_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        maximum_steps: int,
+        /,
+        *,
+        initial_steps: int | None = None,
+        transition_steps: int = 0,
+        schedule: Literal["constant", "linear"] = "constant",
+        rematerialize: bool = False,
+        time_power: float = 0.0,
+    ):
+        maximum = int(maximum_steps)
+        initial = maximum if initial_steps is None else int(initial_steps)
+        transition = int(transition_steps)
+        power = float(time_power)
+        if maximum < 1 or initial < 1 or initial > maximum or transition < 0:
+            raise ValueError("Endpoint rollout capacities are invalid.")
+        if schedule not in ("constant", "linear"):
+            raise ValueError("schedule must be 'constant' or 'linear'.")
+        if schedule == "constant" and initial != maximum:
+            raise ValueError("A constant endpoint schedule requires equal step counts.")
+        if schedule == "linear" and initial < maximum and transition < 1:
+            raise ValueError("A nonconstant endpoint schedule requires transition_steps.")
+        if not np.isfinite(power) or power < 0.0:
+            raise ValueError("time_power must be finite and nonnegative.")
+        self.maximum_steps = maximum
+        self.initial_steps = initial
+        self.transition_steps = transition
+        self.schedule = schedule
+        self.rematerialize = bool(rematerialize)
+        self.time_power = power
+        self.policy_id = canonical_fingerprint(
+            {
+                "kind": "flow-endpoint-rollout-policy",
+                "maximum_steps": maximum,
+                "initial_steps": initial,
+                "transition_steps": transition,
+                "schedule": schedule,
+                "rematerialize": bool(rematerialize),
+                "time_power": power,
+                "integrator": "explicit-euler",
+            }
+        )
+
+    def active_steps(self, iteration: Any, /) -> Array:
+        if self.schedule == "constant" or self.initial_steps == self.maximum_steps:
+            return jnp.asarray(self.maximum_steps, dtype=jnp.int32)
+        step = jnp.asarray(0 if iteration is None else iteration, dtype=jnp.float32)
+        progress = jnp.clip(step / float(self.transition_steps), 0.0, 1.0)
+        span = self.maximum_steps - self.initial_steps
+        return self.initial_steps + jnp.floor(progress * span).astype(jnp.int32)
+
+
+class PhysicsFlowMatchingDiagnostics(StrictModule):
+    flow: FlowMatchingDiagnostics
+    flow_objective: Array
+    physics_objective: Array
+    mean_endpoint_energy: Array
+    maximum_endpoint_energy: Array
+    terminal_valid_fraction: Array
+    active_steps: Array
+    finite: Array
+    endpoint_functional_id: str = eqx.field(static=True)
+    rollout_policy_id: str = eqx.field(static=True)
+
+
+class PhysicsFlowMatchingTerm(AbstractSamplingTerm):
+    """Flow matching plus a physical energy on one unrolled terminal estimate."""
+
+    flow: FlowMatchingTerm
+    label: str | None = eqx.field(static=True)
+    endpoint_functional: AbstractFlowEndpointFunctional
+    endpoint_rollout: FlowEndpointRolloutPolicy
+    physics_weight: Array
+
+    def __init__(
+        self,
+        velocity_name: str,
+        endpoints: EndpointCouplingSample | FlowEndpointProvider,
+        interpolant: AbstractEndpointInterpolant,
+        endpoint_functional: AbstractFlowEndpointFunctional,
+        endpoint_rollout: FlowEndpointRolloutPolicy,
+        /,
+        *,
+        policy: AbstractTimeSamplingPolicy | None = None,
+        metric: AbstractFlowMatchingMetric | None = None,
+        sampling_mode: FlowMatchingSamplingMode = "fixed",
+        scalar_weight: ArrayLike = 1.0,
+        physics_weight: ArrayLike = 1.0,
+        state_label: str = "x",
+        time_label: str = "t",
+        label: str | None = None,
+    ):
+        if not isinstance(endpoint_functional, AbstractFlowEndpointFunctional):
+            raise TypeError(
+                "endpoint_functional must implement AbstractFlowEndpointFunctional."
+            )
+        if not isinstance(endpoint_rollout, FlowEndpointRolloutPolicy):
+            raise TypeError("endpoint_rollout must be FlowEndpointRolloutPolicy.")
+        if endpoint_functional.event_shape != interpolant.event_shape:
+            raise ValueError(
+                "Endpoint functional and interpolant event shapes must match."
+            )
+        physics = jnp.asarray(physics_weight, dtype=float).reshape(())
+        if not bool(jnp.isfinite(physics)) or float(physics) < 0.0:
+            raise ValueError("physics_weight must be finite and nonnegative.")
+        self.flow = FlowMatchingTerm(
+            velocity_name,
+            endpoints,
+            interpolant,
+            policy=policy,
+            metric=metric,
+            sampling_mode=sampling_mode,
+            scalar_weight=scalar_weight,
+            state_label=state_label,
+            time_label=time_label,
+            label=label,
+        )
+        self.endpoint_functional = endpoint_functional
+        self.endpoint_rollout = endpoint_rollout
+        self.physics_weight = physics
+        self.label = self.flow.label
+
+    def sample(self, *, key: Key[Array, ""] = DOC_KEY0) -> FlowMatchingBatch:
+        return self.flow.sample(key=key)
+
+    def _terminal_endpoint(
+        self,
+        functions: Mapping[str, DomainFunction],
+        batch: FlowMatchingBatch,
+        iteration: Any,
+        /,
+    ) -> tuple[Array, Array, Array]:
+        velocity = self.flow._velocity_function(functions, batch)
+        count = batch.num_pairs
+        state_rank = len(batch.event_shape)
+        valid = batch.valid
+        expanded = valid.reshape((count,) + (1,) * state_rank)
+        initial_state = jnp.where(expanded, batch.state, jnp.zeros_like(batch.state))
+        initial_time = jnp.where(valid, batch.time, 0.0)
+        active_steps = self.endpoint_rollout.active_steps(iteration)
+        target_time = jnp.asarray(
+            self.flow.interpolant.target_coordinate,
+            dtype=batch.time.dtype,
+        )
+        step_size = (target_time - initial_time) / active_steps.astype(batch.time.dtype)
+        context_names = tuple(batch.context)
+        context_values = tuple(batch.context[name] for name in context_names)
+        node_keys = jr.split(batch.evaluation_key, count)
+
+        def step(carry, depth):
+            state, time = carry
+            enabled = depth < active_steps
+            keys = jax.vmap(lambda value: jr.fold_in(value, depth))(node_keys)
+
+            def velocity_at(key, point, coordinate, *contexts):
+                values = {
+                    name: context
+                    for name, context in zip(context_names, contexts, strict=True)
+                }
+                arguments = []
+                for dependency in velocity.deps:
+                    if dependency == self.flow.state_label:
+                        arguments.append(point)
+                    elif dependency == self.flow.time_label:
+                        arguments.append(coordinate)
+                    else:
+                        arguments.append(values[dependency])
+                return jnp.asarray(velocity.func(*arguments, key=key))
+
+            predicted = jax.vmap(velocity_at)(
+                keys,
+                state,
+                time,
+                *context_values,
+            )
+            if predicted.shape != state.shape:
+                raise ValueError(
+                    "Flow velocity must preserve the endpoint event shape during unrolling."
+                )
+            next_state = (
+                state + step_size.reshape((count,) + (1,) * state_rank) * predicted
+            )
+            next_time = time + step_size
+            state = jnp.where(expanded & enabled, next_state, state)
+            time = jnp.where(valid & enabled, next_time, time)
+            return (state, time), None
+
+        scan_step = jax.checkpoint(step) if self.endpoint_rollout.rematerialize else step
+        (endpoint, final_time), _ = jax.lax.scan(
+            scan_step,
+            (initial_state, initial_time),
+            jnp.arange(self.endpoint_rollout.maximum_steps, dtype=jnp.int32),
+        )
+        event_axes = tuple(range(1, endpoint.ndim))
+        finite = jnp.isfinite(final_time)
+        if event_axes:
+            finite = finite & jnp.all(jnp.isfinite(endpoint), axis=event_axes)
+        terminal_valid = valid & finite & jnp.isclose(final_time, target_time)
+        endpoint = jnp.where(
+            terminal_valid.reshape((count,) + (1,) * state_rank),
+            endpoint,
+            jnp.zeros_like(endpoint),
+        )
+        return endpoint, terminal_valid, active_steps
+
+    def _physics_component(
+        self,
+        functions: Mapping[str, DomainFunction],
+        batch: FlowMatchingBatch,
+        iteration: Any,
+        /,
+    ) -> tuple[Array, Array, Array, Array]:
+        endpoint, valid, active_steps = self._terminal_endpoint(
+            functions,
+            batch,
+            iteration,
+        )
+        context_names = tuple(batch.context)
+        context_values = tuple(batch.context[name] for name in context_names)
+
+        def evaluate_endpoint(state, *contexts):
+            values = {
+                name: context
+                for name, context in zip(context_names, contexts, strict=True)
+            }
+            return jnp.asarray(self.endpoint_functional(state, values)).reshape(())
+
+        energies = jax.vmap(evaluate_endpoint)(endpoint, *context_values)
+        if energies.shape != (batch.num_pairs,):
+            raise ValueError("Endpoint functional must return one scalar per flow pair.")
+        energies = eqx.error_if(
+            energies,
+            jnp.any(valid & (~jnp.isfinite(energies) | (energies < 0.0))),
+            "Active endpoint physical energies must be finite and nonnegative.",
+        )
+        weights = normalized_log_weights(batch.log_weights, valid)
+        source = jnp.asarray(
+            self.flow.interpolant.source_coordinate, dtype=batch.time.dtype
+        )
+        target = jnp.asarray(
+            self.flow.interpolant.target_coordinate, dtype=batch.time.dtype
+        )
+        progress = jnp.clip((batch.time - source) / (target - source), 0.0, 1.0)
+        time_weight = progress**self.endpoint_rollout.time_power
+        value = self.physics_weight * jnp.sum(weights * time_weight * energies)
+        return value, energies, valid, active_steps
+
+    def objective_components(
+        self,
+        functions: Mapping[str, DomainFunction],
+        /,
+        *,
+        key: Key[Array, ""] = DOC_KEY0,
+        iter_: Any = None,
+        batch: FlowMatchingBatch | None = None,
+        **kwargs: Any,
+    ) -> tuple[Array, Array]:
+        del kwargs
+        materialized = self.sample(key=key) if batch is None else batch
+        evaluation = self.flow._evaluate_nodes(functions, materialized)
+        precision = self.flow.metric.precision
+        flow = precision.decision(
+            precision.decision(self.flow.scalar_weight)
+            * precision.sum(evaluation.weights * precision.accumulation(evaluation.loss))
+        )
+        physics, _, _, _ = self._physics_component(
+            functions,
+            materialized,
+            iter_,
+        )
+        return flow, physics
+
+    def loss(
+        self,
+        functions: Mapping[str, DomainFunction],
+        /,
+        *,
+        key: Key[Array, ""] = DOC_KEY0,
+        iter_: Any = None,
+        batch: FlowMatchingBatch | None = None,
+        **kwargs: Any,
+    ) -> Array:
+        flow, physics = self.objective_components(
+            functions,
+            key=key,
+            iter_=iter_,
+            batch=batch,
+            **kwargs,
+        )
+        return flow + physics
+
+    def diagnostics(
+        self,
+        functions: Mapping[str, DomainFunction],
+        /,
+        *,
+        key: Key[Array, ""] = DOC_KEY0,
+        batch: FlowMatchingBatch | None = None,
+        iter_: Any = None,
+    ) -> PhysicsFlowMatchingDiagnostics:
+        materialized = self.sample(key=key) if batch is None else batch
+        flow = self.flow.diagnostics(functions, key=key, batch=materialized)
+        physics, energies, valid, active_steps = self._physics_component(
+            functions,
+            materialized,
+            iter_,
+        )
+        weights = normalized_log_weights(materialized.log_weights, valid)
+        safe = jnp.where(valid, energies, 0.0)
+        return PhysicsFlowMatchingDiagnostics(
+            flow=flow,
+            flow_objective=flow.objective,
+            physics_objective=physics,
+            mean_endpoint_energy=jnp.sum(weights * safe),
+            maximum_endpoint_energy=jnp.max(safe, initial=0.0),
+            terminal_valid_fraction=jnp.mean(valid.astype(float)),
+            active_steps=active_steps,
+            finite=flow.finite & jnp.all(~valid | jnp.isfinite(energies)),
+            endpoint_functional_id=self.endpoint_functional.functional_id,
+            rollout_policy_id=self.endpoint_rollout.policy_id,
+        )
+
+
+__all__ = [
+    "AbstractFlowEndpointFunctional",
+    "CallableFlowEndpointFunctional",
+    "FlowEndpointRolloutPolicy",
+    "PhysicsFlowMatchingDiagnostics",
+    "PhysicsFlowMatchingTerm",
+]

--- a/phydrax/terms/_time_sampling.py
+++ b/phydrax/terms/_time_sampling.py
@@ -4,9 +4,11 @@
 
 from __future__ import annotations
 
+from abc import abstractmethod
 from collections.abc import Sequence
 
 import equinox as eqx
+import jax
 import jax.numpy as jnp
 import jax.random as jr
 from jaxtyping import Array, ArrayLike, Key
@@ -15,7 +17,26 @@ from .._fingerprint import canonical_fingerprint
 from .._strict import StrictModule
 
 
-class UniformTimeSamplingPolicy(StrictModule):
+class AbstractTimeSamplingPolicy(StrictModule):
+    """A finite-interval continuous-time sampling law."""
+
+    minimum_time: Array
+    maximum_time: Array
+    policy_id: str = eqx.field(static=True)
+
+    @abstractmethod
+    def sample(
+        self,
+        key: Key[Array, ""],
+        shape: Sequence[int],
+        /,
+        *,
+        dtype,
+    ) -> Array:
+        raise NotImplementedError
+
+
+class UniformTimeSamplingPolicy(AbstractTimeSamplingPolicy):
     """Uniform sampling on one finite continuous-time interval."""
 
     minimum_time: Array
@@ -69,4 +90,69 @@ class UniformTimeSamplingPolicy(StrictModule):
         )
 
 
-__all__ = ["UniformTimeSamplingPolicy"]
+class LogitNormalTimeSamplingPolicy(AbstractTimeSamplingPolicy):
+    """Sigmoid-normal sampling rescaled onto one finite time interval."""
+
+    location: float = eqx.field(static=True)
+    scale: float = eqx.field(static=True)
+
+    def __init__(
+        self,
+        minimum_time: ArrayLike = 0.0,
+        maximum_time: ArrayLike = 1.0,
+        /,
+        *,
+        location: float = 0.0,
+        scale: float = 1.0,
+        policy_id: str | None = None,
+    ):
+        lower = jnp.asarray(minimum_time, dtype=float).reshape(())
+        upper = jnp.asarray(maximum_time, dtype=float).reshape(())
+        location_ = float(location)
+        scale_ = float(scale)
+        if not bool(jnp.isfinite(lower) & jnp.isfinite(upper)) or not bool(upper > lower):
+            raise ValueError("Time-sampling bounds must be finite and increasing.")
+        if not jnp.isfinite(location_) or not jnp.isfinite(scale_) or scale_ <= 0.0:
+            raise ValueError("Logit-normal location/scale are invalid.")
+        resolved_id = policy_id or canonical_fingerprint(
+            {
+                "kind": "logit-normal-continuous-time-sampling",
+                "minimum_time": float(lower),
+                "maximum_time": float(upper),
+                "location": location_,
+                "scale": scale_,
+            }
+        )
+        if not isinstance(resolved_id, str) or not resolved_id:
+            raise ValueError("policy_id must be a non-empty string or None.")
+        self.minimum_time = lower
+        self.maximum_time = upper
+        self.location = location_
+        self.scale = scale_
+        self.policy_id = resolved_id
+
+    def sample(
+        self,
+        key: Key[Array, ""],
+        shape: Sequence[int],
+        /,
+        *,
+        dtype,
+    ) -> Array:
+        sample_shape = tuple(int(size) for size in shape)
+        if any(size <= 0 for size in sample_shape):
+            raise ValueError("Time sample dimensions must be positive.")
+        normal = self.location + self.scale * jr.normal(
+            key,
+            sample_shape,
+            dtype=dtype,
+        )
+        unit = jax.nn.sigmoid(normal)
+        return self.minimum_time + (self.maximum_time - self.minimum_time) * unit
+
+
+__all__ = [
+    "AbstractTimeSamplingPolicy",
+    "LogitNormalTimeSamplingPolicy",
+    "UniformTimeSamplingPolicy",
+]

--- a/tests/unit/applications/test_learned_stress_training.py
+++ b/tests/unit/applications/test_learned_stress_training.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+from math import prod
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+import phydrax as phx
+from phydrax._model import AbstractArrayModel
+from phydrax.equations._learned_stress import (
+    LEARNED_STRESS_FEATURE_NAME,
+    LEARNED_STRESS_VELOCITY_GRADIENT_COMPONENTS,
+    LEARNED_STRESS_VELOCITY_GRADIENT_UNITS,
+)
+
+
+class _ViscosityStressModel(AbstractArrayModel):
+    coefficient: jax.Array
+    physical_shape: tuple[int, ...] = eqx.field(static=True)
+    in_size: int = eqx.field(static=True)
+    out_size: int = eqx.field(static=True)
+
+    def __init__(self, coefficient, physical_shape, dtype):
+        self.coefficient = jnp.asarray(coefficient, dtype=dtype)
+        self.physical_shape = tuple(physical_shape)
+        self.in_size = prod(self.physical_shape + (9,))
+        self.out_size = prod(self.physical_shape + (3, 3))
+
+    def __call__(self, values, /, *, key=None):
+        del key
+        gradient = jnp.asarray(values).reshape(self.physical_shape + (3, 3))
+        strain = 0.5 * (gradient + jnp.swapaxes(gradient, -1, -2))
+        trace = jnp.trace(strain, axis1=-2, axis2=-1)
+        deviatoric = strain - (trace / 3.0)[..., None, None] * jnp.eye(
+            3, dtype=strain.dtype
+        )
+        return (-2.0 * self.coefficient * deviatoric).reshape((self.out_size,))
+
+
+def _periodic_prepared():
+    space = phx.discretization.TensorSpectralPlan(
+        tuple(phx.discretization.FourierBasisPlan(3) for _ in range(3)),
+        axis_names=("x", "y", "z"),
+        field_name="velocity",
+    ).prepare(
+        tuple(phx.discretization.AxisDomain.periodic(0.0, 2.0 * jnp.pi) for _ in range(3))
+    )
+    dtype = jnp.dtype(space.plan.precision.physical_dtype)
+    resolved_filter = phx.equations.ResolvedLESFilter(
+        "retained Fourier grid",
+        family="sharp-fourier-projection",
+        axis_names=("x", "y", "z"),
+        topology="tensor-product",
+        boundary_class="periodic",
+        scale_rule="cutoff-equivalent",
+        commutation_status="commuting",
+        repeated_filter_semantics="idempotent",
+    )
+    schema = phx.closure_data.LearnedStressFeatureSchema(
+        name=LEARNED_STRESS_FEATURE_NAME,
+        component_names=LEARNED_STRESS_VELOCITY_GRADIENT_COMPONENTS,
+        component_units=LEARNED_STRESS_VELOCITY_GRADIENT_UNITS,
+        shape=space.physical_shape + (9,),
+        dtype=dtype,
+        flow_schema_id="periodic-flow",
+    )
+    output = phx.closure_data.LearnedStressOutputContract(
+        shape=space.physical_shape + (3, 3),
+        dtype=dtype,
+        units="(m/s)^2",
+        target_id="periodic-stress",
+        filter_id=resolved_filter.filter_id,
+        discretization_id=space.prepared_id,
+        regime="three-dimensional-periodic-unit-density",
+        symmetry_tolerance=2e-6,
+        trace_tolerance=2e-6,
+    )
+    normalizer = phx.closure_data.TrainOnlyNormalizer(
+        jnp.zeros((9,), dtype=dtype),
+        jnp.ones((9,), dtype=dtype),
+        phx.closure_data.NormalizerProvenance(
+            partition_id="train",
+            training_assignment_ids=("assignment",),
+            training_sample_ids=("sample",),
+            feature_name=LEARNED_STRESS_FEATURE_NAME,
+            schema_id="periodic-flow",
+        ),
+        epsilon=1e-12,
+    )
+    plan = phx.closure_data.LearnedStressBindingPlan(
+        schema,
+        output,
+        resolved_filter,
+        phx.equations.LESParameterProvenance(
+            resolved_filter,
+            space.prepared_id,
+            "three-dimensional-periodic-unit-density",
+            source_kind="user",
+            evidence_ids=(),
+        ),
+        model_artifact_id="stress-model",
+        normalizer_id=normalizer.normalizer_id,
+    )
+
+    def dummy_predictor(features, args):
+        del args
+        return jnp.zeros(features.shape[:-1] + (3, 3), dtype=features.dtype)
+
+    binding = plan.prepare(
+        dummy_predictor,
+        normalizer,
+        model_artifact_id="stress-model",
+        target_id=output.target_id,
+        output_units=output.units,
+    )
+    projector = phx.discretization.PeriodicLerayProjector(space)
+    prepared = phx.equations.PeriodicLearnedStressPlan(binding).prepare(
+        space,
+        projector,
+    )
+    coordinates = phx.discretization.HermitianSpectralCoordinates(
+        space,
+        component_shape=(3,),
+    )
+    return space, prepared, coordinates
+
+
+def _initial_state(space, prepared, coordinates):
+    x, y, z = jnp.meshgrid(
+        space.axes[0].nodes,
+        space.axes[1].nodes,
+        space.axes[2].nodes,
+        indexing="ij",
+    )
+    velocity = jnp.stack(
+        (
+            jnp.sin(y) * jnp.cos(z),
+            jnp.sin(z) * jnp.cos(x),
+            jnp.sin(x) * jnp.cos(y),
+        ),
+        axis=-1,
+    )
+    modal = prepared.projector.project(space.project(velocity))
+    return coordinates.to_real_coordinates(modal)
+
+
+def test_periodic_learned_stress_is_evaluated_inside_every_ssprk_stage():
+    space, prepared, coordinates = _periodic_prepared()
+    state = _initial_state(space, prepared, coordinates)
+    layout = phx.dynamics.StateLayout((coordinates.coordinate_size,))
+
+    def zero_base_rate(time, modal, inputs):
+        del time, inputs
+        return jnp.zeros_like(modal)
+
+    transition = (
+        phx.applications.incompressible_flow.PeriodicLearnedStressRolloutTransition(
+            prepared,
+            coordinates,
+            zero_base_rate,
+            base_rate_id="zero-periodic-base-rate",
+            state_layout=layout,
+            step_size=0.01,
+            step_rtol=0.0,
+            step_atol=0.0,
+        )
+    )
+    context = phx.dynamics.DiscreteStepContext(
+        jnp.asarray(0.0),
+        jnp.asarray(0.01),
+        jnp.asarray(0, dtype=jnp.int32),
+    )
+    zero = _ViscosityStressModel(
+        0.0,
+        space.physical_shape,
+        jnp.dtype(space.plan.precision.physical_dtype),
+    )
+    unchanged = transition.evaluate(
+        zero,
+        context,
+        state,
+        None,
+        key=jax.random.key(0),
+        iteration=jnp.asarray(0),
+    )
+    np.testing.assert_allclose(unchanged.accepted_state, state, atol=1e-6)
+    assert bool(unchanged.training_usable)
+    assert int(unchanged.iterations) == 3
+
+    model = _ViscosityStressModel(
+        0.1,
+        space.physical_shape,
+        jnp.dtype(space.plan.precision.physical_dtype),
+    )
+
+    def displacement(candidate):
+        result = transition.evaluate(
+            candidate,
+            context,
+            state,
+            None,
+            key=jax.random.key(1),
+            iteration=jnp.asarray(0),
+        )
+        return jnp.sum(jnp.square(result.accepted_state - state))
+
+    value, gradient = eqx.filter_value_and_grad(displacement)(model)
+    assert float(value) > 0.0
+    assert bool(jnp.isfinite(gradient.coefficient))
+    assert float(jnp.abs(gradient.coefficient)) > 0.0
+
+    system = transition.bind(model, system_id="periodic-learned-stress")
+    deployed = system.evaluate(context, state)
+    np.testing.assert_allclose(
+        deployed,
+        transition.evaluate(
+            model,
+            context,
+            state,
+            None,
+            key=None,
+            iteration=context.step_index,
+        ).accepted_state,
+    )

--- a/tests/unit/closure_data/test_closure_operator_bridge.py
+++ b/tests/unit/closure_data/test_closure_operator_bridge.py
@@ -1,0 +1,362 @@
+from __future__ import annotations
+
+import equinox as eqx
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import phydrax as phx
+
+
+class _StressOperator(phx.nn.operator.AbstractOperatorModel):
+    in_size: int = eqx.field(static=True)
+    out_size: int = eqx.field(static=True)
+
+    def __init__(self):
+        self.in_size = 2
+        self.out_size = 9
+
+    @property
+    def operator_contract(self):
+        return phx.nn.operator.operator_architecture_contract("DeepONet")
+
+    def __call_operator_batch__(self, batch, *, key=None):
+        del key
+        values = batch.input("features").values
+        assert values is not None
+        diagonal = values[..., 0]
+        zero = jnp.zeros_like(diagonal)
+        stress = jnp.stack(
+            (
+                jnp.stack((diagonal, zero, zero), axis=-1),
+                jnp.stack((zero, -diagonal, zero), axis=-1),
+                jnp.stack((zero, zero, zero), axis=-1),
+            ),
+            axis=-2,
+        )
+        return stress.reshape(stress.shape[:-2] + (9,))
+
+    def __call__(self, batch, *, key=None):
+        return self.__call_operator_batch__(batch, key=key)
+
+
+def _task_and_template():
+    axis = phx.nn.operator.OperatorAxis("x", jnp.asarray((0.0, 1.0)))
+    template = phx.nn.operator.OperatorBatch(
+        inputs={
+            "features": phx.nn.operator.FunctionSamples(
+                values=jnp.zeros((2, 2), dtype=jnp.float32),
+                axes=(axis,),
+            )
+        },
+        queries={"grid": phx.nn.operator.FunctionSamples(values=None, axes=(axis,))},
+    )
+    task = phx.nn.operator.OperatorTask(
+        "closure-stress",
+        fields=(
+            phx.nn.operator.OperatorFieldSpec(
+                "features",
+                channels=2,
+                role="source",
+                component_names=("s_xx", "s_xy"),
+            ),
+            phx.nn.operator.OperatorFieldSpec(
+                "stress",
+                channels=9,
+                role="target",
+                query_name="grid",
+            ),
+        ),
+        queries=(
+            phx.nn.operator.OperatorQuerySpec(
+                "grid",
+                geometry_kind="tensor_grid",
+                coordinate_components=("x",),
+            ),
+        ),
+    )
+    return task, template
+
+
+def _closure_inputs():
+    node = phx.closure_data.ClosureAnalysisNode(
+        "reynolds_sgs_stress",
+        ("resolved",),
+        output_name="stress",
+        output_units="(m/s)^2",
+    )
+    dag = phx.closure_data.ClosureAnalysisDAG(("resolved",), (node,))
+    cases = []
+    extents = []
+    chunks = []
+    assignments = []
+    plan = phx.closure_data.LeakageSafePartitionPlan(
+        "case",
+        train_fraction=0.34,
+        validation_fraction=0.33,
+        test_fraction=0.33,
+        salt="closure-operator-test",
+    )
+    split_names = ("train", "validation", "test")
+    for index, split in enumerate(split_names):
+        key = phx.closure_data.ClosureSampleKey(
+            case_id=f"case-{index}",
+            trajectory_id=f"trajectory-{index}",
+            realization_id="realization",
+            time_block_id="block",
+            time_index=0,
+        )
+        sample = phx.closure_data.ClosureSample(
+            jnp.asarray(
+                ((float(index + 1), 0.0), (float(index + 2), 0.0)),
+                dtype=jnp.float32,
+            ),
+            key,
+            schema_id="flow-schema",
+        )
+        diagonal = sample.values[..., 0]
+        zero = jnp.zeros_like(diagonal)
+        stress = jnp.stack(
+            (
+                jnp.stack((diagonal, zero, zero), axis=-1),
+                jnp.stack((zero, -diagonal, zero), axis=-1),
+                jnp.stack((zero, zero, zero), axis=-1),
+            ),
+            axis=-2,
+        )
+        target = phx.closure_data.ClosureTarget(
+            stress.reshape((2, 9)),
+            node,
+            target_kind="sgs_stress",
+            schema_id="flow-schema",
+        )
+        cases.append(
+            phx.closure_data.ClosureOperatorCase(
+                {"features": sample},
+                {"stress": target},
+            )
+        )
+        extent = phx.closure_data.DatasetExtent(
+            case_id=key.case_id,
+            trajectory_id=key.trajectory_id,
+            realization_id=key.realization_id,
+            time_block_id=key.time_block_id,
+            sample_count=1,
+        )
+        extents.append(extent)
+        chunks.append(
+            phx.closure_data.ClosureDatasetChunk.from_payload(
+                bytes((index,)),
+                extent_id=extent.extent_id,
+                logical_name=f"case-{index}",
+                chunk_index=0,
+                sample_start=0,
+                sample_stop=1,
+                byte_offset=0,
+            )
+        )
+        assignments.append(
+            phx.closure_data.PartitionAssignment(
+                sample_id=sample.sample_id,
+                group_key=key.group_key("case"),
+                split=split,
+            )
+        )
+    partition = phx.closure_data.LeakageSafePartition(plan, tuple(assignments))
+    manifest = phx.closure_data.ChunkedClosureDatasetManifest(
+        dataset_id="closure-dataset",
+        schema_id="flow-schema",
+        analysis_dag_id=dag.dag_id,
+        extents=tuple(extents),
+        chunks=tuple(chunks),
+    )
+    normalizer = phx.closure_data.TrainOnlyNormalizer(
+        jnp.zeros((2,), dtype=jnp.float32),
+        jnp.ones((2,), dtype=jnp.float32),
+        phx.closure_data.NormalizerProvenance(
+            partition_id=partition.partition_id,
+            training_assignment_ids=(assignments[0].assignment_id,),
+            training_sample_ids=(cases[0].inputs["features"].sample_id,),
+            feature_name="features",
+            schema_id="flow-schema",
+        ),
+        epsilon=1e-6,
+    )
+    return tuple(cases), dag, manifest, partition, normalizer
+
+
+def _datasets():
+    task, template = _task_and_template()
+    cases, dag, manifest, partition, normalizer = _closure_inputs()
+    datasets = phx.closure_data.prepare_closure_operator_datasets(
+        cases,
+        template,
+        task,
+        manifest,
+        dag,
+        partition,
+        normalizers={"features": normalizer},
+    )
+    return task, template, cases, normalizer, datasets
+
+
+def test_closure_partitions_and_provenance_remain_authoritative():
+    task, template, cases, _, datasets = _datasets()
+
+    assert datasets.train.size == 1
+    assert datasets.validation is not None and datasets.validation.size == 1
+    assert datasets.test is not None and datasets.test.size == 1
+    assert datasets.task_fingerprint == task.fingerprint
+    assert datasets.train.provenance[0].case_id == cases[0].case_id
+    assert (
+        datasets.validation.provenance[0].identities["closure_partition"]
+        == datasets.partition_id
+    )
+    assert datasets.test.provenance[0].order["time_index"] == 0.0
+    np.testing.assert_allclose(
+        datasets.train.batch.input("features").axes[0].nodes,
+        template.input("features").axes[0].nodes,
+    )
+
+
+def test_closure_preparation_rejects_schema_and_partition_mismatches():
+    task, template = _task_and_template()
+    cases, dag, manifest, partition, normalizer = _closure_inputs()
+    wrong = phx.closure_data.ClosureSample(
+        cases[0].inputs["features"].values,
+        cases[0].key,
+        schema_id="other-schema",
+    )
+    with pytest.raises(ValueError, match="share one schema"):
+        phx.closure_data.ClosureOperatorCase(
+            {"features": wrong},
+            cases[0].targets,
+        )
+    with pytest.raises(ValueError, match="normalizer provenance"):
+        bad_normalizer = phx.closure_data.TrainOnlyNormalizer(
+            normalizer.mean,
+            normalizer.scale,
+            phx.closure_data.NormalizerProvenance(
+                partition_id="other-partition",
+                training_assignment_ids=("assignment",),
+                training_sample_ids=(wrong.sample_id,),
+                feature_name="features",
+                schema_id="other-schema",
+            ),
+            epsilon=1e-6,
+        )
+        phx.closure_data.prepare_closure_operator_datasets(
+            cases,
+            template,
+            task,
+            manifest,
+            dag,
+            partition,
+            normalizers={"features": bad_normalizer},
+        )
+
+
+def test_trained_operator_binds_through_the_existing_stress_policy():
+    task, template, _, normalizer, datasets = _datasets()
+    resolved_filter = phx.equations.ResolvedLESFilter(
+        "cell filter",
+        family="implicit-grid-volume",
+        axis_names=("x", "y", "z"),
+        topology="tensor-product",
+        boundary_class="periodic",
+        scale_rule="volume-equivalent",
+        commutation_status="commuting",
+        repeated_filter_semantics="unmodeled",
+    )
+    parameter_provenance = phx.equations.LESParameterProvenance(
+        resolved_filter,
+        "mesh",
+        "constant-density-incompressible",
+        source_kind="user",
+        evidence_ids=(),
+    )
+    artifact_id = "trained-stress-artifact"
+    plan = phx.closure_data.LearnedStressBindingPlan(
+        phx.closure_data.LearnedStressFeatureSchema(
+            name="features",
+            component_names=("s_xx", "s_xy"),
+            component_units=("1/s", "1/s"),
+            shape=(2, 2),
+            dtype=jnp.float32,
+            flow_schema_id="flow-schema",
+        ),
+        phx.closure_data.LearnedStressOutputContract(
+            shape=(2, 3, 3),
+            dtype=jnp.float32,
+            units="(m/s)^2",
+            target_id="stress-target",
+            filter_id=resolved_filter.filter_id,
+            discretization_id="mesh",
+            regime="constant-density-incompressible",
+            stress_convention="deviatoric",
+            symmetry_tolerance=1e-6,
+            trace_tolerance=1e-6,
+        ),
+        resolved_filter,
+        parameter_provenance,
+        model_artifact_id=artifact_id,
+        normalizer_id=normalizer.normalizer_id,
+    )
+    provenance = {
+        "closure_dataset_manifest": datasets.dataset_manifest_id,
+        "closure_partition": datasets.partition_id,
+        "closure_analysis_dag": datasets.analysis_dag_id,
+        "closure_flow_schema": datasets.flow_schema_id,
+        "closure_normalizer": normalizer.normalizer_id,
+        "closure_preparation": datasets.preparation_id,
+    }
+    trained = phx.nn.operator.training.TrainedOperator(
+        _StressOperator(),
+        task,
+        training_evidence=phx.nn.operator.OperatorTrainingEvidence("task_specific"),
+        output_field_map={"output": "stress"},
+        artifact_id=artifact_id,
+        provenance=provenance,
+    )
+    prepared = phx.closure_data.bind_trained_stress_operator(
+        trained,
+        plan,
+        normalizer,
+        template,
+        datasets,
+        source_name="features",
+        target_name="stress",
+    )
+    features = jnp.asarray(((1.0, 0.0), (2.0, 0.0)), dtype=jnp.float32)
+    strain = jnp.asarray(
+        (
+            ((1.0, 0.0, 0.0), (0.0, -1.0, 0.0), (0.0, 0.0, 0.0)),
+            ((1.0, 0.0, 0.0), (0.0, -1.0, 0.0), (0.0, 0.0, 0.0)),
+        ),
+        dtype=jnp.float32,
+    )
+    result = eqx.filter_jit(prepared)(features, strain)
+
+    np.testing.assert_allclose(result.stress[..., 0, 0], (1.0, 2.0))
+    np.testing.assert_allclose(result.stress[..., 1, 1], (-1.0, -2.0))
+    assert bool(result.evidence.valid)
+
+    with pytest.raises(ValueError, match="provenance"):
+        phx.closure_data.bind_trained_stress_operator(
+            phx.nn.operator.training.TrainedOperator(
+                _StressOperator(),
+                task,
+                training_evidence=phx.nn.operator.OperatorTrainingEvidence(
+                    "task_specific"
+                ),
+                output_field_map={"output": "stress"},
+                artifact_id=artifact_id,
+                provenance=provenance | {"closure_partition": "other"},
+            ),
+            plan,
+            normalizer,
+            template,
+            datasets,
+            source_name="features",
+            target_name="stress",
+        )

--- a/tests/unit/discretization/test_learned_particle_exchange.py
+++ b/tests/unit/discretization/test_learned_particle_exchange.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import equinox as eqx
+import jax.numpy as jnp
+import numpy as np
+
+import phydrax as phx
+
+
+class _ScalarPairOperator(phx.nn.operator.AbstractOperatorModel):
+    in_size: int = eqx.field(static=True)
+    out_size: str = eqx.field(static=True)
+
+    def __init__(self):
+        self.in_size = 2
+        self.out_size = "scalar"
+
+    @property
+    def operator_contract(self):
+        return phx.nn.operator.operator_architecture_contract("DeepONet")
+
+    def __call_operator_batch__(self, batch, *, key=None):
+        del key
+        values = batch.input("pair_features").values
+        assert values is not None
+        return values[..., 0]
+
+    def __call__(self, batch, *, key=None):
+        return self.__call_operator_batch__(batch, key=key)
+
+
+class _VectorPairOperator(phx.nn.operator.AbstractOperatorModel):
+    in_size: int = eqx.field(static=True)
+    out_size: int = eqx.field(static=True)
+
+    def __init__(self):
+        self.in_size = 2
+        self.out_size = 2
+
+    @property
+    def operator_contract(self):
+        return phx.nn.operator.operator_architecture_contract("DeepONet")
+
+    def __call_operator_batch__(self, batch, *, key=None):
+        del key
+        values = batch.input("pair_features").values
+        assert values is not None
+        return values
+
+    def __call__(self, batch, *, key=None):
+        return self.__call_operator_batch__(batch, key=key)
+
+
+def _pairs_and_geometry():
+    relation = phx.sparse.EdgeRelation(
+        jnp.asarray((0, 0, 1), dtype=jnp.int32),
+        jnp.asarray((1, 2, 2), dtype=jnp.int32),
+        source_size=3,
+        target_size=3,
+        valid=jnp.asarray((True, True, False)),
+    )
+    pairs = phx.discretization.particle.ParticlePairRelation(
+        relation,
+        jnp.asarray((10, 10, 20), dtype=jnp.int64),
+        jnp.asarray((20, 30, 20), dtype=jnp.int64),
+        source_support_id="particles",
+        target_support_id="particles",
+        same_set=True,
+        unordered=True,
+        relation_schema_id="fixed-pairs",
+    )
+    positions = jnp.asarray(((0.0, 0.0), (1.0, 0.0), (0.0, 1.0)))
+    return pairs, phx.discretization.particle.particle_pair_geometry(positions, pairs)
+
+
+def _task(channels):
+    return phx.nn.operator.OperatorTask(
+        "pair-exchange",
+        fields=(
+            phx.nn.operator.OperatorFieldSpec(
+                "pair_features",
+                channels=2,
+                role="source",
+                component_names=("a", "b"),
+            ),
+            phx.nn.operator.OperatorFieldSpec(
+                "pair_exchange",
+                channels=channels,
+                role="target",
+                query_name="pairs",
+            ),
+        ),
+        queries=(
+            phx.nn.operator.OperatorQuerySpec(
+                "pairs",
+                geometry_kind="point_cloud",
+                coordinate_components=("dx", "dy"),
+                fixed_geometry=False,
+            ),
+        ),
+        problem=phx.nn.operator.OperatorProblemSpec(
+            source_query_relation="coincident",
+            query_is_fixed=False,
+        ),
+    )
+
+
+def _trained(model, channels, artifact):
+    return phx.nn.operator.training.TrainedOperator(
+        model,
+        _task(channels),
+        training_evidence=phx.nn.operator.OperatorTrainingEvidence("task_specific"),
+        output_field_map={"output": "pair_exchange"},
+        artifact_id=artifact,
+    )
+
+
+def _schema():
+    return phx.nn.operator.adapters.PairwiseExchangeFeatureSchema(
+        ("a", "b"),
+        ("1", "1"),
+        dtype=jnp.float32,
+        relation_schema_id="fixed-pairs",
+    )
+
+
+def test_central_learned_exchange_conserves_linear_and_angular_momentum():
+    pairs, geometry = _pairs_and_geometry()
+    plan = phx.nn.operator.adapters.PairwiseExchangeBindingPlan(
+        _schema(),
+        exchange_kind="central_force",
+        model_artifact_id="central",
+        accumulation="compensated",
+        conservation_tolerance=1e-6,
+    )
+    prepared = plan.prepare(
+        _trained(_ScalarPairOperator(), "scalar", "central"), pairs, geometry
+    )
+    features = jnp.asarray(
+        ((2.0, 0.0), (3.0, 0.0), (jnp.nan, jnp.nan)), dtype=jnp.float32
+    )
+    result = prepared(features, velocities=jnp.zeros((3, 2), dtype=jnp.float32))
+
+    assert bool(result.successful)
+    np.testing.assert_allclose(result.ledger.total_exchange, 0.0, atol=1e-6)
+    np.testing.assert_allclose(result.ledger.torque, 0.0, atol=1e-6)
+    assert result.ledger.pair_count == 2
+    np.testing.assert_allclose(result.pair_values[2], 0.0)
+
+
+def test_noncentral_vector_exchange_only_claims_linear_conservation():
+    pairs, geometry = _pairs_and_geometry()
+    plan = phx.nn.operator.adapters.PairwiseExchangeBindingPlan(
+        _schema(),
+        exchange_kind="vector",
+        model_artifact_id="vector",
+        accumulation="deterministic",
+        conservation_tolerance=1e-6,
+    )
+    prepared = plan.prepare(_trained(_VectorPairOperator(), 2, "vector"), pairs, geometry)
+    features = jnp.asarray(((0.0, 1.0), (0.0, 0.0), (0.0, 0.0)), dtype=jnp.float32)
+    result = prepared(features)
+
+    assert bool(result.successful)
+    np.testing.assert_allclose(result.ledger.total_exchange, 0.0, atol=1e-6)
+    assert float(jnp.abs(result.ledger.torque)) > 0.0
+
+
+def test_relation_and_artifact_mismatches_are_rejected():
+    pairs, geometry = _pairs_and_geometry()
+    plan = phx.nn.operator.adapters.PairwiseExchangeBindingPlan(
+        _schema(),
+        exchange_kind="central_force",
+        model_artifact_id="expected",
+    )
+    with np.testing.assert_raises(ValueError):
+        plan.prepare(_trained(_ScalarPairOperator(), "scalar", "other"), pairs, geometry)

--- a/tests/unit/discretization/test_structured_mac_operators.py
+++ b/tests/unit/discretization/test_structured_mac_operators.py
@@ -125,7 +125,7 @@ def test_mac_projection_validates_coefficients_and_transform_eligibility():
         0.1,
         inverse_momentum_diagonal=jnp.ones((12,)),
     )
-    assert switched.solve_method == "iterative"
+    assert switched.solve_method == "transform"
     assert switched.converged
     with pytest.raises(Exception, match="positive"):
         phx.solver.MACPressureProjectionPlan(operators, solve_method="iterative").project(

--- a/tests/unit/dynamics/test_neural_identification.py
+++ b/tests/unit/dynamics/test_neural_identification.py
@@ -116,6 +116,16 @@ def _source(data, horizon):
     )
 
 
+def _direct_transition(batch):
+    return phx.dynamics.identification.DirectDiscreteModelRolloutTransition(
+        phx.dynamics.StateLayout((1,)),
+        input_layout=(None if batch.inputs is None else phx.dynamics.InputLayout((1,))),
+        step_size=1.0,
+        step_rtol=0.0,
+        step_atol=0.0,
+    )
+
+
 def _loss(model, batch, policy, objectives=None):
     terms = (
         (phx.dynamics.identification.SupervisedDiscreteModelObjective(),)
@@ -129,6 +139,7 @@ def _loss(model, batch, policy, objectives=None):
         policy,
         terms,
         phx.dynamics.StateLayout((1,)),
+        _direct_transition(batch),
         jr.key(17),
     )
     assert bool(valid)
@@ -186,6 +197,7 @@ def test_rematerialization_and_semantic_chunk_keys_preserve_value_and_gradient()
         plain,
         (phx.dynamics.identification.SupervisedDiscreteModelObjective(),),
         data.state_layout,
+        _direct_transition(left),
         jr.key(17),
     )[0]
     right_contribution = _objective_contributions(
@@ -195,6 +207,7 @@ def test_rematerialization_and_semantic_chunk_keys_preserve_value_and_gradient()
         plain,
         (phx.dynamics.identification.SupervisedDiscreteModelObjective(),),
         data.state_layout,
+        _direct_transition(right),
         jr.key(17),
     )[0]
     np.testing.assert_allclose(
@@ -510,4 +523,12 @@ def test_fit_rejects_key_required_deployment_and_freezes_dropout_inference():
         **common,
     )
     state = jnp.asarray([3.0], dtype=jnp.float32)
-    np.testing.assert_allclose(fitted.system.evaluate(0.0, state, None), 2.0 * state)
+    context = phx.dynamics.DiscreteStepContext(
+        jnp.asarray(0.0),
+        jnp.asarray(1.0),
+        jnp.asarray(0, dtype=jnp.int32),
+    )
+    np.testing.assert_allclose(
+        fitted.system.evaluate(context, state, None),
+        2.0 * state,
+    )

--- a/tests/unit/dynamics/test_progressive_linear_refinement.py
+++ b/tests/unit/dynamics/test_progressive_linear_refinement.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import equinox as eqx
+import jax.numpy as jnp
+import pytest
+
+import phydrax as phx
+from phydrax._model import AbstractArrayModel
+
+
+class _IdentityModel(AbstractArrayModel):
+    in_size: int = eqx.field(static=True)
+    out_size: int = eqx.field(static=True)
+
+    def __init__(self):
+        self.in_size = 1
+        self.out_size = 1
+
+    def __call__(self, state, /, *, key=None):
+        del key
+        return state
+
+
+def _trajectory():
+    return phx.dynamics.TrajectoryData(
+        jnp.asarray((0.0, 1.0, 2.0, 3.0), dtype=jnp.float32),
+        jnp.ones((4, 1), dtype=jnp.float32),
+        state_layout=phx.dynamics.StateLayout((1,)),
+        source_id="refinement-test",
+    )
+
+
+def test_progressive_policy_refines_on_plateau_then_stops_without_improvement():
+    policy = phx.dynamics.identification.ProgressiveLinearRefinementPolicy(
+        initial_steps=1,
+        step_increment=2,
+        maximum_steps=7,
+        evaluation_steps=9,
+        smoothing=0.0,
+        grace_validations=2,
+        minimum_validations=3,
+        plateau_relative_improvement=0.01,
+        stop_relative_improvement=0.01,
+    )
+    state = policy.initialize()
+    records = []
+    for step, metric in enumerate((1.0, 1.0, 1.0), start=1):
+        state, record = policy.observe(state, metric, validation_step=step)
+        records.append(record)
+
+    assert state.current_steps == 3
+    assert state.refinement_count == 1
+    assert records[-1].refined
+    assert policy.training_control(state).maximum_steps == 3
+    assert policy.evaluation_control().maximum_steps == 9
+
+    for step, metric in enumerate((1.0, 1.0, 1.0), start=4):
+        state, record = policy.observe(state, metric, validation_step=step)
+
+    assert state.stopped
+    assert state.current_steps == 3
+    assert not record.refined
+    assert record.stopped
+
+
+def test_progressive_policy_rejects_invalid_metrics_and_unsupported_transitions():
+    policy = phx.dynamics.identification.ProgressiveLinearRefinementPolicy(
+        initial_steps=1,
+        step_increment=1,
+        maximum_steps=3,
+        grace_validations=1,
+        minimum_validations=2,
+    )
+    with pytest.raises(ValueError, match="metric"):
+        policy.observe(policy.initialize(), -1.0, validation_step=0)
+
+    data = _trajectory()
+    with pytest.raises(ValueError, match="does not support linear refinement"):
+        phx.dynamics.identification.fit_discrete_model(
+            _IdentityModel(),
+            data,
+            validation=data,
+            state_layout=data.state_layout,
+            system_id="direct-no-refinement",
+            step_size=1.0,
+            transition=phx.dynamics.identification.DirectDiscreteModelRolloutTransition(
+                data.state_layout,
+                step_size=1.0,
+            ),
+            rollout_policy=phx.dynamics.identification.DiscreteModelRolloutPolicy(
+                max_horizon=1
+            ),
+            linear_refinement=policy,
+            steps=0,
+        )
+
+
+class _ZeroMACRateModel(AbstractArrayModel):
+    scale: jnp.ndarray
+    in_size: int = eqx.field(static=True)
+    out_size: int = eqx.field(static=True)
+
+    def __init__(self, size):
+        self.scale = jnp.asarray(0.0)
+        self.in_size = int(size)
+        self.out_size = int(size)
+
+    def __call__(self, state, /, *, key=None):
+        del key
+        return self.scale * state
+
+
+def _mac_refinement_case():
+    grid = phx.discretization.TensorGridPlan(
+        tuple(phx.discretization.UniformCellAxisSpec(4, periodic=True) for _ in range(2)),
+        axis_names=("x", "y"),
+    ).prepare(jnp.asarray(((0.0, 0.0), (1.0, 1.0))))
+    finite_volume = phx.discretization.FiniteVolumePlan(grid).prepare()
+    operators = phx.discretization.MACOperatorPlan(finite_volume).prepare()
+    momentum = phx.discretization.MACMomentumPlan(operators).prepare()
+    linear_policy = phx.linalg.LinearSolvePolicy(
+        phx.linalg.PCG(),
+        tolerance=phx.linalg.TolerancePolicy(
+            relative=1e-8,
+            absolute=1e-10,
+            max_steps=8,
+        ),
+        differentiation=phx.linalg.DifferentiationPolicy("algorithmic"),
+    )
+    projection = phx.solver.MACPressureProjectionPlan(
+        operators,
+        solve_method="iterative",
+        tolerance=1e-8,
+        maximum_iterations=8,
+        linear_policy=linear_policy,
+    )
+    dynamics = phx.equations.compile_mac_incompressible_flow(
+        phx.equations.IncompressibleFlowProblem(2, 0.01),
+        momentum,
+        projection,
+    )
+    layout = phx.dynamics.StateLayout(dynamics.state_shape)
+    transition = phx.applications.incompressible_flow.MACLearnedRateRolloutTransition(
+        dynamics,
+        state_layout=layout,
+        step_size=0.1,
+    )
+    return dynamics, layout, transition
+
+
+def test_mac_transition_consumes_dynamic_krylov_control_and_full_fidelity_evaluation(
+    tmp_path,
+):
+    dynamics, layout, transition = _mac_refinement_case()
+    model = _ZeroMACRateModel(layout.size)
+    state = jnp.zeros(
+        layout.shape, dtype=dynamics.momentum.operators.pressure_space.dtype
+    )
+    context = phx.dynamics.DiscreteStepContext(
+        jnp.asarray(0.0),
+        jnp.asarray(0.1),
+        jnp.asarray(0, dtype=jnp.int32),
+    )
+    result = transition.evaluate(
+        model,
+        context,
+        state,
+        None,
+        key=None,
+        iteration=jnp.asarray(0),
+        control=phx.linalg.LinearSolveControl(maximum_steps=1),
+    )
+
+    assert bool(result.training_usable)
+    assert int(result.iterations) <= 1
+    assert bool(result.physically_converged)
+
+    coordinates = jnp.asarray((0.0, 0.1, 0.2), dtype=state.dtype)
+    trajectory = phx.dynamics.TrajectoryData(
+        coordinates,
+        jnp.zeros((3,) + layout.shape, dtype=state.dtype),
+        state_layout=layout,
+        source_id="mac-linear-refinement",
+    )
+    policy = phx.dynamics.identification.ProgressiveLinearRefinementPolicy(
+        initial_steps=1,
+        step_increment=1,
+        maximum_steps=4,
+        grace_validations=1,
+        minimum_validations=2,
+    )
+    fitted = phx.dynamics.identification.fit_discrete_model(
+        model,
+        trajectory,
+        validation=trajectory,
+        state_layout=layout,
+        system_id="mac-refined-rate",
+        model_id="zero-mac-rate",
+        step_size=0.1,
+        transition=transition,
+        rollout_policy=phx.dynamics.identification.DiscreteModelRolloutPolicy(
+            max_horizon=1
+        ),
+        linear_refinement=policy,
+        steps=0,
+        checkpoint_path=tmp_path / "mac-refinement",
+        shuffle=False,
+    )
+
+    assert fitted.linear_refinement_state is not None
+    assert fitted.linear_refinement_state.validation_count == 1
+    assert len(fitted.linear_refinement_records) == 1
+    resumed = phx.dynamics.identification.fit_discrete_model(
+        model,
+        trajectory,
+        validation=trajectory,
+        state_layout=layout,
+        system_id="mac-refined-rate",
+        model_id="zero-mac-rate",
+        step_size=0.1,
+        transition=transition,
+        rollout_policy=phx.dynamics.identification.DiscreteModelRolloutPolicy(
+            max_horizon=1
+        ),
+        linear_refinement=policy,
+        steps=0,
+        shuffle=False,
+        checkpoint_path=tmp_path / "mac-refinement",
+        resume=True,
+    )
+    assert resumed.linear_refinement_state == fitted.linear_refinement_state
+    assert resumed.linear_refinement_records == fitted.linear_refinement_records

--- a/tests/unit/optim/test_gradient_composition.py
+++ b/tests/unit/optim/test_gradient_composition.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import numpy as np
+import optax
+import pytest
+
+import phydrax as phx
+from phydrax.optim import (
+    conflict_free_gradient,
+    ConflictFreeGradientPolicy,
+    ConflictFreeGradientStatus,
+)
+
+
+def test_orthogonal_gradients_receive_positive_equal_projections():
+    result = conflict_free_gradient((jnp.asarray((1.0, 0.0)), jnp.asarray((0.0, 1.0))))
+
+    np.testing.assert_allclose(result.direction, (1.0, 1.0), atol=1e-6)
+    np.testing.assert_allclose(result.projections, (1.0, 1.0), atol=1e-6)
+    np.testing.assert_allclose(result.cosine_matrix, jnp.eye(2), atol=1e-6)
+    assert bool(result.successful)
+    assert int(result.status) == int(ConflictFreeGradientStatus.SUCCESS)
+
+
+def test_conflicting_feasible_gradients_still_share_a_descent_direction():
+    gradients = (
+        {"weight": jnp.asarray((1.0, 0.0))},
+        {"weight": jnp.asarray((-0.5, 1.0))},
+    )
+    result = conflict_free_gradient(gradients)
+
+    assert bool(result.successful)
+    assert bool(jnp.all(result.projections > 0.0))
+    assert not bool(jnp.any(result.conflicts))
+
+
+def test_opposite_gradients_fail_without_a_false_conflict_free_claim():
+    result = conflict_free_gradient((jnp.asarray((1.0, 0.0)), jnp.asarray((-1.0, 0.0))))
+
+    assert not bool(result.successful)
+    assert int(result.status) == int(ConflictFreeGradientStatus.INFEASIBLE)
+    np.testing.assert_allclose(result.direction, 0.0, atol=1e-7)
+    with pytest.raises(eqx.EquinoxRuntimeError, match="conflict-free"):
+        checked = conflict_free_gradient(
+            (jnp.asarray((1.0, 0.0)), jnp.asarray((-1.0, 0.0))),
+            policy=ConflictFreeGradientPolicy(failure="error"),
+        )
+        np.asarray(checked.direction)
+
+
+def test_rank_deficient_identical_gradients_remain_usable():
+    result = conflict_free_gradient((jnp.asarray((2.0, -1.0)), jnp.asarray((2.0, -1.0))))
+
+    assert int(result.rank) == 1
+    assert bool(result.successful)
+    assert bool(jnp.all(result.projections > 0.0))
+
+
+def test_stationary_inactive_and_complex_objectives_are_distinct():
+    result = conflict_free_gradient(
+        (
+            {"z": jnp.asarray((1.0 + 1.0j,))},
+            {"z": jnp.asarray((1.0 - 1.0j,))},
+            {"z": jnp.asarray((0.0 + 0.0j,))},
+        ),
+        active=jnp.asarray((True, True, False)),
+    )
+
+    assert bool(result.successful)
+    assert not bool(result.active[2])
+    assert not bool(result.stationary[2])
+    np.testing.assert_allclose(result.projections[:2], (2.0, 2.0), atol=1e-6)
+
+    stationary = conflict_free_gradient((jnp.zeros((2,)),))
+    assert bool(stationary.successful)
+    assert bool(stationary.stationary[0])
+    assert int(stationary.status) == int(ConflictFreeGradientStatus.STATIONARY)
+
+
+def test_structure_shape_nonfinite_and_active_contracts_are_checked():
+    with pytest.raises(ValueError, match="structures"):
+        conflict_free_gradient(({"a": jnp.ones(1)}, {"b": jnp.ones(1)}))
+    with pytest.raises(ValueError, match="shapes"):
+        conflict_free_gradient((jnp.ones(1), jnp.ones(2)))
+    with pytest.raises(ValueError, match="one Boolean"):
+        conflict_free_gradient((jnp.ones(1),), active=jnp.ones((2,), dtype=bool))
+
+    nonfinite = conflict_free_gradient((jnp.asarray((jnp.nan,)),))
+    assert not bool(nonfinite.successful)
+    assert int(nonfinite.status) == int(ConflictFreeGradientStatus.NONFINITE)
+
+
+class _ScaledOperator(phx.nn.operator.AbstractOperatorModel):
+    gain: jax.Array
+    in_size: str = eqx.field(static=True)
+    out_size: str = eqx.field(static=True)
+
+    def __init__(self, gain: float):
+        self.gain = jnp.asarray(gain)
+        self.in_size = "scalar"
+        self.out_size = "scalar"
+
+    @property
+    def operator_contract(self):
+        return phx.nn.operator.operator_architecture_contract("DeepONet")
+
+    def __call_operator_batch__(self, batch, *, key=None):
+        del key
+        values = batch.input("state").values
+        assert values is not None
+        return self.gain * values
+
+    def __call__(self, batch, *, key=None):
+        return self.__call_operator_batch__(batch, key=key)
+
+
+def _two_term_functional_solver():
+    domain = phx.domain.Interval1d(0.0, 1.0)
+    field = domain.Parameter(jnp.asarray([1.0]))
+    component = domain.component()
+    batch = component.points({"x": jnp.asarray([[0.25], [0.75]])})
+    realization = phx.integration.from_samples(
+        phx.integration.mean_over(component),
+        batch,
+    )
+    condition = phx.conditions.Residual("u", component, lambda value: value)
+    return phx.solver.FunctionalSolver(
+        functions={"u": field},
+        terms=(
+            phx.terms.ResidualPenalty(
+                condition,
+                phx.integration.fixed(realization),
+                label="first",
+            ),
+            phx.terms.ResidualPenalty(
+                condition,
+                phx.integration.fixed(realization),
+                label="second",
+            ),
+        ),
+    )
+
+
+def test_functional_solver_composes_one_prepared_objective_vector():
+    optimizer = optax.sgd(0.1)
+    baseline = _two_term_functional_solver().solve(
+        num_iter=1,
+        optim=optimizer,
+        keep_best=False,
+        log_every=0,
+        jit=False,
+        training=phx.solver.FunctionalTrainingPlan(),
+    )
+    composed = _two_term_functional_solver().solve(
+        num_iter=1,
+        optim=optimizer,
+        keep_best=False,
+        log_every=0,
+        jit=False,
+        training=phx.solver.FunctionalTrainingPlan(
+            gradient_composition=ConflictFreeGradientPolicy()
+        ),
+    )
+
+    np.testing.assert_allclose(
+        composed.functions["u"].func(),
+        baseline.functions["u"].func(),
+        atol=1e-6,
+    )
+    with pytest.raises(ValueError, match="gradient accumulation"):
+        _two_term_functional_solver().solve(
+            num_iter=1,
+            optim=optimizer,
+            keep_best=False,
+            log_every=0,
+            gradient_accumulation=2,
+            training=phx.solver.FunctionalTrainingPlan(
+                gradient_composition=ConflictFreeGradientPolicy()
+            ),
+        )
+
+
+def test_operator_fit_composes_explicit_loss_terms():
+    axis = phx.nn.operator.OperatorAxis("x", jnp.linspace(0.0, 1.0, 4))
+    values = jnp.stack((axis.nodes, axis.nodes + 1.0), axis=0)
+    dataset = phx.nn.operator.training.operator_dataset_from_arrays(
+        {"state": values},
+        {"solution": 2.0 * values},
+        source_axes={"state": (axis,)},
+        query_axes=(axis,),
+    )
+    terms = (
+        phx.nn.operator.training.SupervisedOperatorLoss(name="first"),
+        phx.nn.operator.training.SupervisedOperatorLoss(name="second"),
+    )
+    result = phx.nn.operator.training.fit_operator(
+        _ScaledOperator(0.0),
+        dataset,
+        loss_terms=terms,
+        include_model_losses=False,
+        gradient_composition=ConflictFreeGradientPolicy(),
+        optimizer=optax.sgd(0.05),
+        optimizer_id="sgd",
+        epochs=1,
+        batch_size=2,
+        shuffle=False,
+        output_field_map={"output": "solution"},
+        jit=False,
+    )
+
+    assert float(result.execution_model.gain) > 0.0
+    assert result.final_loss < result.initial_loss
+    with pytest.raises(ValueError, match="attached model losses"):
+        phx.nn.operator.training.fit_operator(
+            _ScaledOperator(0.0),
+            dataset,
+            loss_terms=terms,
+            gradient_composition=ConflictFreeGradientPolicy(),
+            optimizer=optax.sgd(0.05),
+            optimizer_id="sgd",
+            epochs=1,
+            batch_size=2,
+            shuffle=False,
+            output_field_map={"output": "solution"},
+            jit=False,
+        )

--- a/tests/unit/solver/test_physics_flow_matching.py
+++ b/tests/unit/solver/test_physics_flow_matching.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import equinox as eqx
+import jax.numpy as jnp
+import jax.random as jr
+import optax
+
+import phydrax as phx
+
+
+class _ConstantVelocity(eqx.Module):
+    value: jnp.ndarray
+
+    def __call__(self, state, time):
+        del time
+        return jnp.broadcast_to(self.value, state.shape)
+
+
+class _LinearVelocity(eqx.Module):
+    def __call__(self, state, time):
+        del time
+        return state
+
+
+def _velocity_function(model):
+    state = phx.domain.HyperRectangle(
+        jnp.asarray((-10.0,)),
+        jnp.asarray((10.0,)),
+        label="x",
+    )
+    domain = state @ phx.domain.TimeInterval(0.0, 1.0)
+    return domain.Function("x", "t")(model)
+
+
+def _endpoints(count=8):
+    source = jnp.zeros((count, 1))
+    target = jnp.ones((count, 1))
+    return phx.transport.EndpointCouplingSample(
+        source=source,
+        target=target,
+        source_indices=jnp.arange(count),
+        target_indices=jnp.arange(count),
+        valid=jnp.ones((count,), dtype=bool),
+        log_weights=jnp.zeros((count,)),
+        context={"desired": target},
+        coupling_id="unit-translation",
+        provenance="unit-test",
+    )
+
+
+def _functional():
+    return phx.terms.CallableFlowEndpointFunctional(
+        lambda state, context: jnp.sum(jnp.square(state - context["desired"])),
+        event_shape=(1,),
+        functional_id="squared-target-distance",
+    )
+
+
+def _term(steps, *, velocity=0.0, sampling_mode="fixed", endpoints=None):
+    endpoint_source = _endpoints() if endpoints is None else endpoints
+    term = phx.terms.PhysicsFlowMatchingTerm(
+        "velocity",
+        endpoint_source,
+        phx.transport.LinearEndpointInterpolant((1,)),
+        _functional(),
+        phx.terms.FlowEndpointRolloutPolicy(steps),
+        sampling_mode=sampling_mode,
+    )
+    return term, _velocity_function(_ConstantVelocity(jnp.asarray((velocity,))))
+
+
+def test_logit_normal_time_sampling_is_bounded_and_reproducible():
+    policy = phx.terms.LogitNormalTimeSamplingPolicy(
+        0.1,
+        0.9,
+        location=0.0,
+        scale=1.5,
+    )
+    first = policy.sample(jr.key(4), (128,), dtype=jnp.float32)
+    second = policy.sample(jr.key(4), (128,), dtype=jnp.float32)
+
+    assert jnp.array_equal(first, second)
+    assert jnp.all(first > 0.1)
+    assert jnp.all(first < 0.9)
+
+
+def test_exact_constant_velocity_satisfies_both_shared_batch_objectives():
+    term, velocity = _term(4, velocity=1.0)
+    batch = term.sample(key=jr.key(7))
+    flow, physics = term.objective_components(
+        {"velocity": velocity},
+        batch=batch,
+        iter_=jnp.asarray(0),
+    )
+    diagnostics = term.diagnostics(
+        {"velocity": velocity},
+        batch=batch,
+        iter_=jnp.asarray(0),
+    )
+
+    assert jnp.allclose(flow, 0.0, atol=1e-7)
+    assert jnp.allclose(physics, 0.0, atol=1e-7)
+    assert diagnostics.active_steps == 4
+    assert diagnostics.terminal_valid_fraction == 1.0
+    assert diagnostics.finite
+
+
+def test_endpoint_refinement_reduces_nonlinear_euler_error():
+    endpoints = _endpoints(count=1)
+    interpolant = phx.transport.LinearEndpointInterpolant((1,))
+    batch = phx.terms.FlowMatchingBatch(
+        state=jnp.ones((1, 1)),
+        time=jnp.zeros((1,)),
+        target_velocity=jnp.zeros((1, 1)),
+        valid=jnp.ones((1,), dtype=bool),
+        log_weights=jnp.zeros((1,)),
+        context={"desired": jnp.full((1, 1), jnp.e)},
+        evaluation_key=jr.key(1),
+        source_indices=jnp.zeros((1,), dtype=jnp.int32),
+        target_indices=jnp.zeros((1,), dtype=jnp.int32),
+        interpolant_id=interpolant.interpolant_id,
+        coupling_id=endpoints.coupling_id,
+        policy_id="manual",
+        batch_id="manual-nonlinear",
+    )
+    velocity = _velocity_function(_LinearVelocity())
+    one = phx.terms.PhysicsFlowMatchingTerm(
+        "velocity",
+        endpoints,
+        interpolant,
+        _functional(),
+        phx.terms.FlowEndpointRolloutPolicy(1),
+    )
+    four = phx.terms.PhysicsFlowMatchingTerm(
+        "velocity",
+        endpoints,
+        interpolant,
+        _functional(),
+        phx.terms.FlowEndpointRolloutPolicy(4, rematerialize=True),
+    )
+
+    one_physics = one.objective_components({"velocity": velocity}, batch=batch)[1]
+    four_physics = four.objective_components({"velocity": velocity}, batch=batch)[1]
+    assert four_physics < one_physics
+
+
+def test_physics_flow_term_trains_with_conflict_free_component_gradients():
+    calls = []
+
+    def provider(key):
+        calls.append(key)
+        return _endpoints()
+
+    term, velocity = _term(
+        2,
+        velocity=0.5,
+        sampling_mode="resample",
+        endpoints=provider,
+    )
+    solver = phx.solver.FunctionalSolver(
+        functions={"velocity": velocity},
+        terms=(term,),
+    )
+    trained = solver.solve(
+        num_iter=1,
+        optim=optax.sgd(0.1),
+        jit=False,
+        keep_best=False,
+        log_every=0,
+        training=phx.solver.FunctionalTrainingPlan(
+            gradient_composition=phx.optim.ConflictFreeGradientPolicy()
+        ),
+    )
+
+    assert len(calls) == 1
+    assert trained.functions["velocity"].func.function.value[0] > 0.5

--- a/tools/continuous_transport_benchmarks.py
+++ b/tools/continuous_transport_benchmarks.py
@@ -43,6 +43,12 @@ class _LinearField(eqx.Module):
         return self.matrix @ state + self.shift
 
 
+class _EndpointVelocity(eqx.Module):
+    def __call__(self, state, time):
+        del time
+        return state
+
+
 def _timings(function, arguments, *, repetitions: int):
     jitted = eqx.filter_jit(function)
     compiled, compilation = measure_lower_and_compile(
@@ -185,6 +191,82 @@ def benchmark_translation_case(
     }
 
 
+def benchmark_endpoint_physics_case(*, repetitions: int) -> dict[str, Any]:
+    state_domain = phx.domain.HyperRectangle(
+        jnp.asarray((-10.0,)),
+        jnp.asarray((10.0,)),
+        label="x",
+    )
+    domain = state_domain @ phx.domain.TimeInterval(0.0, 1.0)
+    velocity = domain.Function("x", "t")(_EndpointVelocity())
+    endpoints = phx.transport.EndpointCouplingSample(
+        source=jnp.ones((1, 1)),
+        target=jnp.full((1, 1), jnp.e),
+        source_indices=jnp.zeros((1,), dtype=jnp.int32),
+        target_indices=jnp.zeros((1,), dtype=jnp.int32),
+        valid=jnp.ones((1,), dtype=bool),
+        log_weights=jnp.zeros((1,)),
+        context={"desired": jnp.full((1, 1), jnp.e)},
+        coupling_id="benchmark-exponential-endpoint",
+        provenance="analytic",
+    )
+    interpolant = phx.transport.LinearEndpointInterpolant((1,))
+    functional = phx.terms.CallableFlowEndpointFunctional(
+        lambda value, context: jnp.sum(jnp.square(value - context["desired"])),
+        event_shape=(1,),
+        functional_id="analytic-exponential-endpoint-error",
+    )
+    batch = phx.terms.FlowMatchingBatch(
+        state=jnp.ones((1, 1)),
+        time=jnp.zeros((1,)),
+        target_velocity=jnp.zeros((1, 1)),
+        valid=jnp.ones((1,), dtype=bool),
+        log_weights=jnp.zeros((1,)),
+        context={"desired": jnp.full((1, 1), jnp.e)},
+        evaluation_key=jr.key(91),
+        source_indices=jnp.zeros((1,), dtype=jnp.int32),
+        target_indices=jnp.zeros((1,), dtype=jnp.int32),
+        interpolant_id=interpolant.interpolant_id,
+        coupling_id=endpoints.coupling_id,
+        policy_id="analytic-time-zero",
+        batch_id="analytic-exponential-endpoint",
+    )
+
+    def term(steps):
+        return phx.terms.PhysicsFlowMatchingTerm(
+            "velocity",
+            endpoints,
+            interpolant,
+            functional,
+            phx.terms.FlowEndpointRolloutPolicy(steps, rematerialize=steps > 1),
+        )
+
+    def physics_objective(current, function, materialized):
+        return current.objective_components(
+            {"velocity": function},
+            batch=materialized,
+        )[1]
+
+    one_value, one_timing = _timings(
+        physics_objective,
+        (term(1), velocity, batch),
+        repetitions=repetitions,
+    )
+    four_value, four_timing = _timings(
+        physics_objective,
+        (term(4), velocity, batch),
+        repetitions=repetitions,
+    )
+    return {
+        "case": "terminal-physics-euler-refinement",
+        "one_step_endpoint_energy": float(one_value),
+        "four_step_endpoint_energy": float(four_value),
+        "one_step_timing": one_timing,
+        "four_step_timing": four_timing,
+        "refinement_reduced_error": bool(four_value < one_value),
+    }
+
+
 def run_continuous_transport_benchmarks(*, quick: bool = False) -> dict[str, Any]:
     dimensions = (2,) if quick else (2, 8, 16)
     sample_count = 8 if quick else 128
@@ -207,6 +289,7 @@ def run_continuous_transport_benchmarks(*, quick: bool = False) -> dict[str, Any
                 seed=20260852 + index,
             )
         )
+    cases.append(benchmark_endpoint_physics_case(repetitions=repetitions))
     return {
         "schema": "phydrax-continuous-transport-benchmark-v1",
         "backend": jax.default_backend(),

--- a/tools/learned_stress_hybrid_benchmarks.py
+++ b/tools/learned_stress_hybrid_benchmarks.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+"""Runtime and derivative evidence for periodic solver-interleaved learned stress."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from math import prod
+from pathlib import Path
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+
+import phydrax as phx
+from benchmarks._runtime import (
+    measure_lower_and_compile,
+    measure_repeated,
+    measure_synchronized,
+)
+from phydrax._model import AbstractArrayModel
+from phydrax.equations._learned_stress import (
+    LEARNED_STRESS_FEATURE_NAME,
+    LEARNED_STRESS_VELOCITY_GRADIENT_COMPONENTS,
+    LEARNED_STRESS_VELOCITY_GRADIENT_UNITS,
+)
+
+
+class _ViscosityStressModel(AbstractArrayModel):
+    coefficient: jax.Array
+    physical_shape: tuple[int, ...] = eqx.field(static=True)
+    in_size: int = eqx.field(static=True)
+    out_size: int = eqx.field(static=True)
+
+    def __init__(self, coefficient, physical_shape, dtype):
+        self.coefficient = jnp.asarray(coefficient, dtype=dtype)
+        self.physical_shape = tuple(physical_shape)
+        self.in_size = prod(self.physical_shape + (9,))
+        self.out_size = prod(self.physical_shape + (3, 3))
+
+    def __call__(self, values, /, *, key=None):
+        del key
+        gradient = jnp.asarray(values).reshape(self.physical_shape + (3, 3))
+        strain = 0.5 * (gradient + jnp.swapaxes(gradient, -1, -2))
+        trace = jnp.trace(strain, axis1=-2, axis2=-1)
+        deviatoric = strain - (trace / 3.0)[..., None, None] * jnp.eye(
+            3, dtype=strain.dtype
+        )
+        return (-2.0 * self.coefficient * deviatoric).reshape((self.out_size,))
+
+
+def _case(count):
+    space = phx.discretization.TensorSpectralPlan(
+        tuple(phx.discretization.FourierBasisPlan(count) for _ in range(3)),
+        axis_names=("x", "y", "z"),
+        field_name="velocity",
+    ).prepare(
+        tuple(phx.discretization.AxisDomain.periodic(0.0, 2.0 * jnp.pi) for _ in range(3))
+    )
+    dtype = jnp.dtype(space.plan.precision.physical_dtype)
+    resolved_filter = phx.equations.ResolvedLESFilter(
+        "retained Fourier grid",
+        family="sharp-fourier-projection",
+        axis_names=("x", "y", "z"),
+        topology="tensor-product",
+        boundary_class="periodic",
+        scale_rule="cutoff-equivalent",
+        commutation_status="commuting",
+        repeated_filter_semantics="idempotent",
+    )
+    feature_schema = phx.closure_data.LearnedStressFeatureSchema(
+        name=LEARNED_STRESS_FEATURE_NAME,
+        component_names=LEARNED_STRESS_VELOCITY_GRADIENT_COMPONENTS,
+        component_units=LEARNED_STRESS_VELOCITY_GRADIENT_UNITS,
+        shape=space.physical_shape + (9,),
+        dtype=dtype,
+        flow_schema_id="benchmark-periodic-flow",
+    )
+    output = phx.closure_data.LearnedStressOutputContract(
+        shape=space.physical_shape + (3, 3),
+        dtype=dtype,
+        units="(m/s)^2",
+        target_id="benchmark-periodic-stress",
+        filter_id=resolved_filter.filter_id,
+        discretization_id=space.prepared_id,
+        regime="three-dimensional-periodic-unit-density",
+        symmetry_tolerance=2e-6,
+        trace_tolerance=2e-6,
+    )
+    normalizer = phx.closure_data.TrainOnlyNormalizer(
+        jnp.zeros((9,), dtype=dtype),
+        jnp.ones((9,), dtype=dtype),
+        phx.closure_data.NormalizerProvenance(
+            partition_id="benchmark-train",
+            training_assignment_ids=("assignment",),
+            training_sample_ids=("sample",),
+            feature_name=LEARNED_STRESS_FEATURE_NAME,
+            schema_id="benchmark-periodic-flow",
+        ),
+        epsilon=1e-12,
+    )
+    plan = phx.closure_data.LearnedStressBindingPlan(
+        feature_schema,
+        output,
+        resolved_filter,
+        phx.equations.LESParameterProvenance(
+            resolved_filter,
+            space.prepared_id,
+            "three-dimensional-periodic-unit-density",
+            source_kind="user",
+            evidence_ids=(),
+        ),
+        model_artifact_id="benchmark-stress-model",
+        normalizer_id=normalizer.normalizer_id,
+    )
+
+    def zero_predictor(features, args):
+        del args
+        return jnp.zeros(features.shape[:-1] + (3, 3), dtype=features.dtype)
+
+    binding = plan.prepare(
+        zero_predictor,
+        normalizer,
+        model_artifact_id="benchmark-stress-model",
+        target_id=output.target_id,
+        output_units=output.units,
+    )
+    projector = phx.discretization.PeriodicLerayProjector(space)
+    prepared = phx.equations.PeriodicLearnedStressPlan(binding).prepare(space, projector)
+    coordinates = phx.discretization.HermitianSpectralCoordinates(
+        space,
+        component_shape=(3,),
+    )
+    x, y, z = jnp.meshgrid(
+        space.axes[0].nodes,
+        space.axes[1].nodes,
+        space.axes[2].nodes,
+        indexing="ij",
+    )
+    velocity = jnp.stack(
+        (
+            jnp.sin(y) * jnp.cos(z),
+            jnp.sin(z) * jnp.cos(x),
+            jnp.sin(x) * jnp.cos(y),
+        ),
+        axis=-1,
+    )
+    state = coordinates.to_real_coordinates(projector.project(space.project(velocity)))
+
+    def zero_base_rate(time, modal, inputs):
+        del time, inputs
+        return jnp.zeros_like(modal)
+
+    transition = (
+        phx.applications.incompressible_flow.PeriodicLearnedStressRolloutTransition(
+            prepared,
+            coordinates,
+            zero_base_rate,
+            base_rate_id="benchmark-zero-base-rate",
+            state_layout=phx.dynamics.StateLayout((coordinates.coordinate_size,)),
+            step_size=0.01,
+            step_rtol=0.0,
+            step_atol=0.0,
+        )
+    )
+    context = phx.dynamics.DiscreteStepContext(
+        jnp.asarray(0.0),
+        jnp.asarray(0.01),
+        jnp.asarray(0, dtype=jnp.int32),
+    )
+    model = _ViscosityStressModel(0.1, space.physical_shape, dtype)
+    return transition, context, state, model
+
+
+def run(*, quick: bool) -> dict:
+    count = 3 if quick else 5
+    repetitions = 2 if quick else 5
+    transition, context, state, model = _case(count)
+
+    def advance(candidate, current):
+        return transition.evaluate(
+            candidate,
+            context,
+            current,
+            None,
+            key=jax.random.key(0),
+            iteration=jnp.asarray(0),
+        )
+
+    jitted = eqx.filter_jit(advance)
+    compiled, compilation = measure_lower_and_compile(
+        lambda: jitted.lower(model, state),
+        lambda lowered: lowered.compile(),
+    )
+    result, first = measure_synchronized(lambda: compiled(model, state))
+    _, steady = measure_repeated(
+        lambda: compiled(model, state),
+        warmup=0,
+        repeats=repetitions,
+    )
+
+    def objective(candidate):
+        value = advance(candidate, state).accepted_state
+        return jnp.sum(jnp.square(value - state))
+
+    objective_value, gradient = eqx.filter_value_and_grad(objective)(model)
+    return {
+        "benchmark": "phydrax-learned-stress-hybrid",
+        "backend": jax.default_backend(),
+        "quick": quick,
+        "grid_count": count,
+        "coordinate_size": int(state.size),
+        "lowering_seconds": compilation.lowering_seconds,
+        "compilation_seconds": compilation.compilation_seconds,
+        "first_execution_seconds": first,
+        "steady": steady.to_seconds_dict(),
+        "successful": bool(result.training_usable),
+        "ssprk_stages": int(result.iterations),
+        "state_displacement_squared": float(objective_value),
+        "coefficient_gradient": float(gradient.coefficient),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--quick", action="store_true")
+    parser.add_argument("--output", type=Path, default=None)
+    arguments = parser.parse_args()
+    report = run(quick=arguments.quick)
+    payload = json.dumps(report, indent=2, sort_keys=True)
+    if arguments.output is None:
+        print(payload)
+    else:
+        arguments.output.parent.mkdir(parents=True, exist_ok=True)
+        arguments.output.write_text(payload + "\n")
+        print(arguments.output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/pinn_training_strategy_campaign.py
+++ b/tools/pinn_training_strategy_campaign.py
@@ -18,7 +18,14 @@ import phydrax as phx
 from phydrax.solver._functional_objective import evaluate_prepared_objective
 
 
-_STRATEGIES = ("baseline", "grad_norm", "ntk_trace", "pseudo", "combined")
+_STRATEGIES = (
+    "baseline",
+    "conflict_free",
+    "grad_norm",
+    "ntk_trace",
+    "pseudo",
+    "combined",
+)
 _OPTIMIZERS = ("adam", "kfac", "soap")
 
 
@@ -41,8 +48,7 @@ def _problem(*, seed: int, samples: int, width: int, depth: int):
     equation = phx.conditions.Residual(
         "u",
         interior,
-        lambda value: phx.operators.laplacian(value, var="x")
-        + jnp.pi**2 * exact,
+        lambda value: phx.operators.laplacian(value, var="x") + jnp.pi**2 * exact,
         label="equation",
     )
     equation_term = phx.terms.ResidualPenalty(
@@ -107,6 +113,9 @@ def _problem(*, seed: int, samples: int, width: int, depth: int):
 
 def _training_plan(strategy: str):
     balance = None
+    gradient_composition = (
+        phx.optim.ConflictFreeGradientPolicy() if strategy == "conflict_free" else None
+    )
     pseudo = ()
     diagnostics = phx.solver.FunctionalDiagnosticsPolicy(
         every=10,
@@ -147,6 +156,7 @@ def _training_plan(strategy: str):
     return phx.solver.FunctionalTrainingPlan(
         pseudo_transient=pseudo,
         term_balance=balance,
+        gradient_composition=gradient_composition,
         diagnostics=diagnostics,
     )
 
@@ -228,9 +238,7 @@ def run(args):
         "ntk_trace": float(ntk_diagnostics.trace),
         "ntk_stable_rank": float(ntk_diagnostics.stable_rank),
         "ntk_effective_rank": float(ntk_diagnostics.effective_rank),
-        "gradient_alignment_intra": (
-            alignment if math.isfinite(alignment) else None
-        ),
+        "gradient_alignment_intra": (alignment if math.isfinite(alignment) else None),
     }
 
 


### PR DESCRIPTION
## Summary

Adds a native composition layer between Phydrax physics, operator learning, functional objectives, dynamical-system identification, and deployment. The change completes six previously disconnected paths without introducing a second trainer, solver hierarchy, tensor substrate, or third-party runtime dependency:

- provenance-safe closure data to operator training and learned-stress deployment;
- conflict-free multi-objective gradient composition over parameter PyTrees;
- explicit solver-interleaved learned transition semantics;
- validation-driven native Krylov refinement for training physics;
- terminal-physics objectives for flow matching;
- conservative learned pair exchanges on canonical particle relations.

## Closure data lifecycle

Introduces `ClosureOperatorCase`, `ClosureOperatorDatasets`, and `prepare_closure_operator_datasets` in `phydrax.closure_data`.

The adapter preserves the authoritative closure manifest, analysis DAG, leakage-safe partition, case, trajectory, realization, time block, target lineage, support, geometry, and physical measure. It validates full train-only normalizer provenance and rejects a second affine normalization convention.

`TrainedClosureOperatorPredictor` and `bind_trained_stress_operator` connect loaded `TrainedOperator` artifacts to the existing learned-stress binding. Artifact, task, contract, normalization, flow schema, target, and preparation identities must agree before the model can enter a physical backend.

## Multi-objective optimization

Adds `ConflictFreeGradientPolicy`, `ConflictFreeGradientResult`, and `conflict_free_gradient` under `phydrax.optim`.

The implementation operates directly on congruent real or complex parameter PyTrees. It forms only the objective-space Gram matrix, uses the native rank-aware pseudoinverse substrate, and records norms, cosines, numerical rank, conditioning, active/stationary objectives, conflicts, and final objective projections. Feasibility is determined from the resulting projections rather than rank alone, so identical gradients remain admissible while irreconcilable opposite gradients fail closed.

Functional and operator trainers now support opt-in component-gradient composition. Each update evaluates one component vector from one prepared stochastic realization and reuses one VJP linearization. Existing ordinary-gradient paths remain unchanged when the policy is absent. Initial composition deliberately excludes ambiguous combinations with term balancing, term subsampling, attached model losses, dynamic loss scaling, non-Euclidean optimizers, and gradient accumulation.

## Solver-interleaved learned transitions

Adds `AbstractDiscreteModelRolloutTransition`, `DirectDiscreteModelRolloutTransition`, and `DiscreteModelRolloutTransitionResult` to dynamical-system identification.

`fit_discrete_model` now delegates model-output interpretation to an explicit transition. The result retains candidate state, training usability, physical convergence, status, residual, and work count as independent values. Training recurrence uses its accepted training state, while the bound `DiscreteSystem` commits only physical convergence. Transition identity participates in fit and checkpoint compatibility.

The incompressible-flow application adds:

- `FixedGridStressOperatorModel` for exposing a fixed-grid neural operator through the array-model interface;
- `PeriodicLearnedStressRolloutTransition`, evaluating learned stress at every SSPRK(3,3) stage in independent real Hermitian coordinates;
- `MACLearnedRateRolloutTransition`, placing a learned unconstrained face rate before the authoritative MAC pressure projection.

Periodic execution reuses the existing feature construction, train-only normalization, stress tensor validation, energy policy, conservative divergence, and Leray projection. The MAC path keeps coarse training candidates distinct from fully converged projected states.

## Progressive differentiable-physics refinement

Adds `ProgressiveLinearRefinementPolicy`, state, and immutable refinement records.

The policy observes one fixed validation metric, smooths its history, detects plateaus after a grace window, refines the training Krylov budget, and stops refinement when another fidelity level no longer yields the declared improvement. Its complete state and history participate in checkpoint resume.

`MACPressureProjectionPlan.project` and `project_rate` now accept `LinearSolveControl` on iterative routes and retain candidate velocity, pressure, pressure increment, and projected rate independently of committed values. Explicit iterative routing no longer performs host conversion of dynamic coefficients, preserving JIT execution.

Initial refinement support is intentionally restricted to algorithmic differentiation through the executed native scalar Krylov map. Mathematical implicit, direct, transform, hybrid, block, recycled, and external-backend derivative claims remain excluded.

## Terminal-physics flow matching

Adds an abstract time-sampling contract, a logit-normal policy, endpoint physical functionals, fixed-capacity endpoint rollout policy, and `PhysicsFlowMatchingTerm`.

The term materializes one `FlowMatchingBatch`, evaluates velocity regression, reconstructs a terminal estimate with a differentiable Euler scan, and evaluates a nonnegative measure-owned physical functional on that estimate. The velocity and terminal-physics scalars are exposed as separate objective components for gradient composition. Generative interpolation time remains distinct from physical time carried in endpoint context, and the endpoint functional remains a soft objective rather than a hard-constraint claim.

## Conservative learned particle exchange

Adds `ParticleExchangeLedger` for same-population exchange, torque, relative power, and finiteness evidence. Neural-operator integration lives in `phydrax.nn.operator.adapters` rather than the particle core, avoiding a dependency cycle.

`particle_pair_operator_batch`, `PairwiseExchangeFeatureSchema`, and `PairwiseExchangeBindingPlan` bind a loaded operator to one fixed-capacity unordered same-set relation. Invalid routes are sanitized before model evaluation, and pair values are deposited through the existing equal-and-opposite scatter.

The construction makes only the invariant claim supplied by its output parameterization:

- arbitrary vector exchange conserves the total exchanged vector;
- central scalar force additionally has zero internal torque;
- scalar flux conserves the exchanged scalar;
- energy, dissipation, rotational equivariance, and topology-changing differentiability require separate contracts.

## Compatibility and scope

- No dependency additions.
- No artifact-format or benchmark-schema version is introduced.
- Existing direct discrete-model behavior remains the default transition.
- Existing functional and operator optimization behavior remains the default without gradient composition.
- Existing arbitrary callable learned-stress deployment remains available.
- Dynamic topology, adaptive timestep, implicit-refinement adjoints, and energy-conserving learned particle potentials remain outside the declared support envelope.

## Documentation and provenance

Updates the operator-learning cookbook, LES guide, dynamics API, functional-training guide, optimization API, scalar-term API, transport guide, particle API and qualification guide, all-in-one architecture map, changelog, and notice. The notice records an independent native implementation against Phydrax state, measure, status, solver-control, and provenance contracts; no external source, fixtures, model weights, notebooks, or runtime dependencies are incorporated.