### PR TITLE
Restore native provider build contracts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.html
 *.csv
 *.txt
+!phydrax/meshing/providers/native/**/CMakeLists.txt
 !LICENSES/BEMPP-CL-MIT.txt
 !LICENSES/FMMAX-MIT.txt
 !LICENSES/IREE-APACHE-2.0.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2134,6 +2134,9 @@
 - `phydrax.nn.layers.inference_mode` now switches every inference-aware Equinox or Phydrax leaf in mixed model trees.
 
 ### Fixed
+- Restored packaged standalone CMake build/install contracts for the Omega_h,
+  TIOGA, and VoroCrust bridges, including exact external revision reporting and
+  usable installed runtime linkage; corrected TIOGA's provider license metadata.
 - Reduced ROM evaluations now compute QoIs from the reduced state and declared
   QoI vector instead of copying a supplied truth QoI into the ROM result.
 - Acausal structural matching now prefers assignments that avoid unnecessary

--- a/docs/guides_meshing.md
+++ b/docs/guides_meshing.md
@@ -192,12 +192,76 @@ centroids and is not a continuous Hausdorff certificate. Poisson reconstruction
 does not invent CAD associations. OpenVDB must know how inactive and
 out-of-domain voxels are extended.
 
-Native bridge sources and CMake definitions are packaged under
-`phydrax/meshing/providers/native`. They link separately installed upstream
-libraries; importing `phydrax` does not compile or launch them.
-For VoroCrust, build the upstream checkout, then configure the bridge with
-`VOROCRUST_SOURCE_DIR` and `VOROCRUST_BUILD_DIR` pointing to that checkout/build.
-Pass the `vc_mesh` and `phydrax-vorocrust` executable paths to
+Native bridge sources and standalone CMake projects are packaged under
+`phydrax/meshing/providers/native`. They build small executables against
+separately installed upstream libraries; importing `phydrax` neither compiles
+nor launches them. Build and link each bridge with the same C++ compiler and,
+where applicable, the same MPI implementation as its upstream library. Install
+the executables into one prefix and either put its `bin` directory on `PATH` or
+pass each executable explicitly.
+
+For an installed Omega_h CMake package:
+
+```console
+cmake -S <phydrax>/phydrax/meshing/providers/native/omega_h \
+  -B build/phydrax-omega-h \
+  -DOmega_h_DIR=/path/to/omega-h/lib/cmake/Omega_h
+cmake --build build/phydrax-omega-h
+cmake --install build/phydrax-omega-h --prefix /path/to/phydrax-native
+```
+
+Use the MPI compiler wrapper as `CMAKE_CXX_COMPILER` when the installed Omega_h
+was built with MPI.
+
+TIOGA must first be installed with its CMake package metadata and global node-ID
+support. Its package does not publish a release version, so the bridge requires
+the exact upstream release or Git commit explicitly:
+
+```console
+cmake -S /path/to/tioga -B /path/to/tioga-build \
+  -DCMAKE_CXX_COMPILER=/path/to/mpicxx \
+  -DCMAKE_INSTALL_PREFIX=/path/to/tioga-install \
+  -DTIOGA_HAS_NODEGID=ON -DBUILD_SHARED_LIBS=ON
+cmake --build /path/to/tioga-build
+cmake --install /path/to/tioga-build
+cmake -S <phydrax>/phydrax/meshing/providers/native/tioga \
+  -B build/phydrax-tioga \
+  -DCMAKE_CXX_COMPILER=/path/to/mpicxx \
+  -DTIOGA_DIR=/path/to/tioga-install/lib/cmake/TIOGA \
+  -DPHYDRAX_TIOGA_REVISION=<exact-release-or-git-commit>
+cmake --build build/phydrax-tioga
+cmake --install build/phydrax-tioga --prefix /path/to/phydrax-native
+```
+
+TIOGA is LGPL-2.1-or-later. The bridge links the caller-installed library and
+reports its caller-supplied exact revision; Phydrax does not redistribute TIOGA.
+
+VoroCrust does not install CMake package metadata. Build a serial CPU checkout,
+then point the bridge at that exact source and build tree:
+
+```console
+cmake -S /path/to/vorocrust -B /path/to/vorocrust-build \
+  -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF \
+  -DVOROCRUST_ENABLE_OPENMP=OFF \
+  -DVOROCRUST_ENABLE_MPI=OFF -DVOROCRUST_ENABLE_EXODUS=OFF \
+  -DVOROCRUST_TPL_ENABLE_KOKKOS=OFF \
+  -DVOROCRUST_TPL_ENABLE_KOKKOSKERNELS=OFF \
+  -DVOROCRUST_TPL_USE_LAPACK=OFF \
+  -DVOROCRUST_TPL_BUILD_OPENBLAS=OFF
+cmake --build /path/to/vorocrust-build --target vc_mesh libVCMesh
+cmake -S <phydrax>/phydrax/meshing/providers/native/vorocrust \
+  -B build/phydrax-vorocrust \
+  -DVOROCRUST_SOURCE_DIR=/path/to/vorocrust \
+  -DVOROCRUST_BUILD_DIR=/path/to/vorocrust-build \
+  -DPHYDRAX_VOROCRUST_REVISION=<exact-release-or-git-commit>
+cmake --build build/phydrax-vorocrust
+cmake --install build/phydrax-vorocrust --prefix /path/to/phydrax-native
+```
+
+The bridge refuses VoroCrust builds with optional MPI, Kokkos, LAPACK, or
+Exodus linkage whose transitive build-tree dependencies cannot be reconstructed
+safely. It detects and links OpenMP when the upstream build enabled it. Pass the
+resulting `vc_mesh` and `phydrax-vorocrust` executable paths to
 `VoroCrustProvider`. Its radius control is the backend sphere-sizing bound, not
 a guaranteed edge length. No material identities are inferred from seed colors.
 Backend vertices that differ only within `relative_merge_tolerance` times the
@@ -232,9 +296,10 @@ type ignores or unchecked casts and are exercised against the real libraries.
 
 VoroCrust source is available at
 [sandialabs/vorocrust-meshing](https://github.com/sandialabs/vorocrust-meshing).
-Build with CMake and an OpenMP-capable C++ compiler. On Apple Silicon, Homebrew
-GCC can supply OpenMP. The Sandia website's “Coming Soon” source notice is stale;
-the GitHub source avoids its binary-download CAPTCHA.
+Its upstream build defaults to OpenMP, while the one-thread command above
+disables it. Leave OpenMP enabled only when the upstream library and bridge use
+the same OpenMP-capable compiler. On Apple Silicon, the shown route avoids
+assuming that Apple Clang supplies an OpenMP runtime.
 
 Prime is an extraction feasibility decision, not an implemented provider.
 The documented [Part API](https://prime.docs.pyansys.com/version/stable/api/_autosummary/ansys.meshing.prime.Part.html)

--- a/phydrax/meshing/providers/_tioga.py
+++ b/phydrax/meshing/providers/_tioga.py
@@ -324,7 +324,7 @@ def _info(executable: str, timeout: float) -> MeshingProviderInfo:
     return MeshingProviderInfo(
         "tioga",
         version[len(prefix) :],
-        "BSD-3-Clause",
+        "LGPL-2.1-or-later",
         operations=(MeshingOperation.ASSEMBLE_OVERSET,),
         source_kinds=(MeshingSourceKind.MESH_ASSEMBLY,),
         capabilities=(

--- a/phydrax/meshing/providers/native/omega_h/CMakeLists.txt
+++ b/phydrax/meshing/providers/native/omega_h/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(phydrax_omega_h_bridge LANGUAGES CXX)
+
+include(GNUInstallDirs)
+
+find_package(Omega_h CONFIG REQUIRED)
+if(NOT TARGET Omega_h::omega_h)
+  message(FATAL_ERROR "Omega_h did not provide the required Omega_h::omega_h target.")
+endif()
+
+add_executable(phydrax_omega_h main.cpp)
+target_compile_features(phydrax_omega_h PRIVATE cxx_std_14)
+set_target_properties(
+  phydrax_omega_h
+  PROPERTIES CXX_EXTENSIONS OFF INSTALL_RPATH_USE_LINK_PATH ON
+)
+target_link_libraries(phydrax_omega_h PRIVATE Omega_h::omega_h)
+
+install(TARGETS phydrax_omega_h RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/phydrax/meshing/providers/native/tioga/CMakeLists.txt
+++ b/phydrax/meshing/providers/native/tioga/CMakeLists.txt
@@ -1,0 +1,47 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(phydrax_tioga_bridge LANGUAGES CXX)
+
+include(GNUInstallDirs)
+
+find_package(MPI REQUIRED COMPONENTS CXX)
+find_package(TIOGA CONFIG REQUIRED)
+
+if(TARGET TIOGA::tioga)
+  set(_phydrax_tioga_target TIOGA::tioga)
+elseif(TARGET tioga)
+  set(_phydrax_tioga_target tioga)
+else()
+  message(FATAL_ERROR "TIOGA did not provide a tioga library target.")
+endif()
+
+if(DEFINED TIOGA_HAS_NODEGID AND NOT TIOGA_HAS_NODEGID)
+  message(FATAL_ERROR "The Phydrax bridge requires TIOGA global node-ID support.")
+endif()
+
+set(
+  PHYDRAX_TIOGA_REVISION
+  ""
+  CACHE STRING
+  "Exact TIOGA release or Git revision reported by the bridge"
+)
+if(NOT "${PHYDRAX_TIOGA_REVISION}" MATCHES "^[A-Za-z0-9][-A-Za-z0-9._+:]*$")
+  message(
+    FATAL_ERROR
+    "Set PHYDRAX_TIOGA_REVISION to the exact non-whitespace TIOGA release or Git revision."
+  )
+endif()
+
+add_executable(phydrax-tioga bridge.cpp)
+target_compile_features(phydrax-tioga PRIVATE cxx_std_14)
+set_target_properties(
+  phydrax-tioga
+  PROPERTIES CXX_EXTENSIONS OFF INSTALL_RPATH_USE_LINK_PATH ON
+)
+target_compile_definitions(
+  phydrax-tioga
+  PRIVATE "PHYDRAX_TIOGA_REVISION=\"${PHYDRAX_TIOGA_REVISION}\""
+)
+target_link_libraries(phydrax-tioga PRIVATE "${_phydrax_tioga_target}" MPI::MPI_CXX)
+
+install(TARGETS phydrax-tioga RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/phydrax/meshing/providers/native/vorocrust/CMakeLists.txt
+++ b/phydrax/meshing/providers/native/vorocrust/CMakeLists.txt
@@ -1,0 +1,129 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(phydrax_vorocrust_bridge LANGUAGES CXX)
+
+include(GNUInstallDirs)
+
+set(VOROCRUST_SOURCE_DIR "" CACHE PATH "VoroCrust source checkout")
+set(VOROCRUST_BUILD_DIR "" CACHE PATH "Configured VoroCrust build directory")
+
+set(_phydrax_vorocrust_source "${VOROCRUST_SOURCE_DIR}/src/Meshing")
+set(_phydrax_vorocrust_binary "${VOROCRUST_BUILD_DIR}/src/Meshing")
+set(_phydrax_vorocrust_cache "${VOROCRUST_BUILD_DIR}/CMakeCache.txt")
+foreach(
+  _required
+  IN ITEMS
+    "${_phydrax_vorocrust_source}/MeshingVoronoiMesher.h"
+    "${_phydrax_vorocrust_binary}/Config.h"
+    "${_phydrax_vorocrust_cache}"
+)
+  if(NOT EXISTS "${_required}")
+    message(
+      FATAL_ERROR
+      "VOROCRUST_SOURCE_DIR and VOROCRUST_BUILD_DIR must identify one configured VoroCrust checkout/build; missing ${_required}."
+    )
+  endif()
+endforeach()
+
+set(
+  PHYDRAX_VOROCRUST_REVISION
+  ""
+  CACHE STRING
+  "Exact VoroCrust release or Git revision reported by the bridge"
+)
+if(
+  NOT "${PHYDRAX_VOROCRUST_REVISION}"
+      MATCHES "^[A-Za-z0-9][-A-Za-z0-9._+:]*$"
+)
+  message(
+    FATAL_ERROR
+    "Set PHYDRAX_VOROCRUST_REVISION to the exact non-whitespace VoroCrust release or Git revision."
+  )
+endif()
+
+set(_phydrax_vorocrust_unsupported)
+foreach(
+  _option
+  IN ITEMS
+    VOROCRUST_ENABLE_EXODUS
+    VOROCRUST_ENABLE_MPI
+    VOROCRUST_ENABLE_TUCKERMPI
+    VOROCRUST_TPL_BUILD_HDF5
+    VOROCRUST_TPL_BUILD_NETCDF
+    VOROCRUST_TPL_BUILD_OPENBLAS
+    VOROCRUST_TPL_BUILD_SEACAS
+    VOROCRUST_TPL_BUILD_ZLIB
+    VOROCRUST_TPL_ENABLE_KOKKOS
+    VOROCRUST_TPL_ENABLE_KOKKOSKERNELS
+    VOROCRUST_TPL_USE_LAPACK
+)
+  file(
+    STRINGS "${_phydrax_vorocrust_cache}"
+    _enabled
+    REGEX "^${_option}:BOOL=(ON|TRUE|YES|1)$"
+  )
+  if(_enabled)
+    list(APPEND _phydrax_vorocrust_unsupported "${_option}")
+  endif()
+endforeach()
+if(_phydrax_vorocrust_unsupported)
+  list(JOIN _phydrax_vorocrust_unsupported ", " _unsupported_text)
+  message(
+    FATAL_ERROR
+    "The standalone extraction bridge supports the serial CPU VoroCrust library with optional OpenMP only. Reconfigure VoroCrust without: ${_unsupported_text}."
+  )
+endif()
+
+find_library(
+  VOROCRUST_MESH_LIBRARY
+  NAMES libVCMesh VCMesh
+  HINTS "${VOROCRUST_BUILD_DIR}"
+  PATH_SUFFIXES
+    src/Meshing
+    src/Meshing/Debug
+    src/Meshing/Release
+    lib
+    lib/Debug
+    lib/Release
+  NO_DEFAULT_PATH
+  DOC "VoroCrust libVCMesh library"
+)
+if(NOT VOROCRUST_MESH_LIBRARY)
+  message(
+    FATAL_ERROR
+    "Could not find the built VoroCrust libVCMesh library below VOROCRUST_BUILD_DIR."
+  )
+endif()
+
+file(
+  STRINGS "${_phydrax_vorocrust_cache}"
+  _phydrax_vorocrust_openmp
+  REGEX "^VOROCRUST_ENABLE_OPENMP:BOOL=(ON|TRUE|YES|1)$"
+)
+if(_phydrax_vorocrust_openmp)
+  find_package(OpenMP REQUIRED COMPONENTS CXX)
+endif()
+
+add_executable(phydrax-vorocrust main.cpp)
+target_compile_features(phydrax-vorocrust PRIVATE cxx_std_14)
+set_target_properties(
+  phydrax-vorocrust
+  PROPERTIES CXX_EXTENSIONS OFF INSTALL_RPATH_USE_LINK_PATH ON
+)
+target_compile_definitions(
+  phydrax-vorocrust
+  PRIVATE "PHYDRAX_VOROCRUST_REVISION=\"${PHYDRAX_VOROCRUST_REVISION}\""
+)
+target_include_directories(
+  phydrax-vorocrust
+  PRIVATE "${_phydrax_vorocrust_source}" "${_phydrax_vorocrust_binary}"
+)
+target_link_libraries(
+  phydrax-vorocrust
+  PRIVATE "${VOROCRUST_MESH_LIBRARY}" "${CMAKE_DL_LIBS}"
+)
+if(_phydrax_vorocrust_openmp)
+  target_link_libraries(phydrax-vorocrust PRIVATE OpenMP::OpenMP_CXX)
+endif()
+
+install(TARGETS phydrax-vorocrust RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/phydrax/meshing/providers/native/vorocrust/main.cpp
+++ b/phydrax/meshing/providers/native/vorocrust/main.cpp
@@ -1,7 +1,9 @@
 // Copyright © 2026 PHYDRA, Inc. All rights reserved.
 // Uses the public VoroCrust API; no meshing algorithms are duplicated here.
 #include "MeshingVoronoiMesher.h"
-#include "Version.h"
+#ifndef PHYDRAX_VOROCRUST_REVISION
+#error "Build with the packaged CMake project and an exact VoroCrust revision"
+#endif
 #include <algorithm>
 #include <cmath>
 #include <fstream>
@@ -13,7 +15,7 @@
 
 int main(int argc, char** argv) {
     if (argc == 2 && std::string(argv[1]) == "--version") {
-        std::cout << GIT_COMMIT_SHA1 << '\n';
+        std::cout << PHYDRAX_VOROCRUST_REVISION << '\n';
         return 0;
     }
     if (argc != 3) {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,6 +202,7 @@ markers = [
     "meshing_gmsh: requires the optional real Gmsh provider",
     "meshing_mmg: requires the optional real Mmg provider",
     "meshing_ftetwild: requires the optional real fTetWild provider",
+    "meshing_omega_h: requires the real Omega_h native bridge",
     "meshing_vorocrust: requires the real VoroCrust executable and extraction bridge",
 ]
 filterwarnings = [

--- a/tests/unit/meshing/test_omega_h_provider.py
+++ b/tests/unit/meshing/test_omega_h_provider.py
@@ -1,0 +1,80 @@
+import os
+import shutil
+
+import numpy as np
+import pytest
+
+import phydrax as phx
+
+
+@pytest.mark.meshing_omega_h
+def test_real_omega_h_refines_and_preserves_partition_evidence():
+    requested = os.environ.get("PHYDRAX_OMEGA_H_EXECUTABLE", "phydrax_omega_h")
+    executable = shutil.which(requested)
+    if executable is None:
+        pytest.skip("Real phydrax_omega_h native bridge is not installed")
+
+    points = np.asarray(
+        (
+            (0.0, 0.0),
+            (0.5, 0.0),
+            (1.0, 0.0),
+            (0.0, 0.5),
+            (0.5, 0.5),
+            (1.0, 0.5),
+            (0.0, 1.0),
+            (0.5, 1.0),
+            (1.0, 1.0),
+        )
+    )
+    cells = np.asarray(
+        (
+            (0, 1, 4),
+            (0, 4, 3),
+            (1, 2, 5),
+            (1, 5, 4),
+            (3, 4, 7),
+            (3, 7, 6),
+            (4, 5, 8),
+            (4, 8, 7),
+        )
+    )
+    mesh = phx.discretization.CellMesh.from_triangles(
+        points,
+        cells,
+        vertex_global_ids=11 + 7 * np.arange(len(points), dtype=np.int64),
+        cell_global_ids=17 + 13 * np.arange(len(cells), dtype=np.int64),
+    )
+    scope = phx.meshing.MeshingScope(
+        mesh.mesh_id,
+        mesh.numeric_version,
+        phx.meshing.MeshingEntityKind.MESH,
+        0,
+        mesh.entity_set(0).entity_set_id,
+        mesh.vertex_global_ids,
+    )
+    metric = phx.meshing.MeshMetricField(
+        scope,
+        np.broadcast_to(np.eye(2) * 100.0, (len(points), 2, 2)),
+        minimum_size=0.05,
+        maximum_size=0.5,
+        maximum_anisotropy=1.0,
+    )
+
+    result = phx.meshing.OmegaHProvider(executable).execute(
+        mesh,
+        metric,
+        phx.SpatialCoordinateContract.si(),
+    )
+
+    target = result.target.mesh
+    corners = np.asarray(target.coordinates)[np.asarray(target.blocks[0].vertices)]
+    measures = np.linalg.det(corners[:, 1:] - corners[:, :1]) / 2.0
+    assert np.all(measures > 0.0)
+    assert np.sum(measures) == pytest.approx(1.0, abs=1e-12)
+    assert len(corners) > len(cells)
+    assert result.target.audit.passed
+    assert result.lineage_status == "unknown"
+    assert len(result.partitions) == 1
+    assert all(owner == 0 for owner in result.partitions[0].cell_owner_ranks)
+    assert np.all(np.linalg.eigvalsh(np.asarray(result.metric.values)) > 0.0)


### PR DESCRIPTION
## Summary

- Restore standalone, packaged CMake build projects for the Omega_h, TIOGA, and VoroCrust native bridges.
- Make installed bridge executables retain usable linkage to separately installed upstream libraries.
- Require exact external revision identities where upstream package metadata is insufficient.
- Add real Omega_h provider qualification coverage and correct TIOGA license provenance.

## Problem

The meshing provider layer shipped three C++ bridge sources and documented corresponding CMake projects, but the repository-wide `*.txt` ignore rule excluded every `CMakeLists.txt`. The wheel configuration referenced files that were absent from version control, leaving users without the documented build route.

The native interfaces also had two provenance gaps: TIOGA was reported as BSD-3-Clause despite its LGPL-2.1-or-later source contract, and VoroCrust relied on an upstream generated revision header that can resolve to `UNKNOWN` in a valid out-of-source build.

## Native bridge builds

### Omega_h

- Discover the installed `Omega_h::omega_h` CMake target.
- Build and install `phydrax_omega_h` with the upstream target's MPI and dependency usage requirements.
- Preserve external link directories in the installed executable runtime path.

### TIOGA

- Discover MPI before the installed TIOGA package, whose exported target depends on `MPI::MPI_CXX`.
- Support both current `tioga` and namespaced `TIOGA::tioga` imported targets.
- Require global node-ID support and an explicit exact release or Git revision.
- Build and install `phydrax-tioga` with a revision-bearing protocol response and usable runtime linkage.

### VoroCrust

- Consume a configured upstream source/build pair because VoroCrust does not install CMake package metadata.
- Locate the generated configuration headers and `libVCMesh` build artifact explicitly.
- Require an exact caller-supplied revision instead of trusting the upstream `UNKNOWN` fallback.
- Support the serial CPU library with optional OpenMP and reject MPI, Kokkos, LAPACK, Exodus, and bundled-TPL builds whose transitive build-tree dependencies cannot be reconstructed safely.
- Build and install `phydrax-vorocrust` without duplicating upstream meshing algorithms.

## Distribution and provenance

- Exempt only the three native-provider `CMakeLists.txt` files from the global text-file ignore rule.
- Retain the existing wheel artifact inclusion contract for bridge source and build definitions.
- Correct TIOGA provider metadata to `LGPL-2.1-or-later` while continuing to link only caller-installed libraries.
- Keep every native provider host-side, optional, subprocess-isolated, and nondifferentiable; importing Phydrax still compiles or launches nothing.

## Documentation and qualification surface

- Document complete upstream configure/build/install commands and bridge-specific compiler, MPI, revision, and optional-dependency requirements.
- Add an environment-gated Omega_h qualification that checks real refinement, positive cell measures, domain-measure preservation, authoritative partition ownership, metric positivity, and explicit unknown lineage.
- Register the Omega_h qualification marker and record the repaired contracts in the changelog.
