### PR TITLE
Add native sparse execution substrates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 ## Unreleased
 
 ### Added
+- Added fixed-capacity active-key worklists, prepared target-grouped relation
+  execution, virtual tensor index spaces, and sparse block topologies. Particle
+  cell lists now store occupied cells only; sparse voxels and AMR metadata
+  reuse canonical key grouping; Gaussian rasterization has a tile-major
+  realization; and compact LBM, explicit/implicit/multifield MPM, phase-field,
+  and transactional FLIP paths preserve logical IDs, capacity evidence, and
+  branchwise differentiation.
 - Added a default-silent Loguru event substrate with privacy-bounded text and
   canonical JSONL sinks, context-local correlation, structured training and
   provider/runtime events, explicit host/JAX telemetry snapshots, and

--- a/NOTICE
+++ b/NOTICE
@@ -25,6 +25,17 @@ Licensed under the Apache License, Version 2.0.
 The Faddeeva and Dawson implementations are adapted from JAX special-function kernels.
 See LICENSES/JAX-APACHE-2.0.txt.
 
+Taichi
+Copyright The Taichi Authors
+Licensed under the Apache License, Version 2.0.
+The fixed-capacity active-key worklist, explicit sparse block placement, and
+logical-index/access-lowering design are informed by the SNode and
+active-container architecture documented in Taichi v1.7.4. Phydrax implements
+these ideas independently through immutable JAX arrays, explicit capacities,
+branchwise differentiation, transactional topology state, and domain-owned
+physics. No Taichi runtime or source code is redistributed.
+The Apache License text is included at LICENSES/JAX-APACHE-2.0.txt.
+
 Fast Soft Sort
 Copyright 2020 Google LLC
 Licensed under the Apache License, Version 2.0.

--- a/benchmarks/sparse_execution.json
+++ b/benchmarks/sparse_execution.json
@@ -1,0 +1,68 @@
+{
+  "device": "TFRT_CPU_0",
+  "cases": {
+    "key_groups": {
+      "items": 4096,
+      "logical_keys": 512,
+      "active_groups": 512,
+      "state_bytes": 113187,
+      "compile_and_first_ms": 217.68900007009506,
+      "steady_ms": 1.066375058144331,
+      "successful": true
+    },
+    "relation_execution": {
+      "routes": 4096,
+      "targets": 512,
+      "maximum_contention": 8,
+      "fast_compile_and_first_ms": 46.36504198424518,
+      "fast_steady_ms": 0.07545901462435722,
+      "deterministic_compile_and_first_ms": 51.649415981955826,
+      "deterministic_steady_ms": 0.030916999094188213,
+      "fast_deterministic_defect": 0.0
+    },
+    "gaussian_raster": {
+      "particles": 256,
+      "image_pixels": 16384,
+      "routes": 9604,
+      "reference_compile_and_first_ms": 139.97908297460526,
+      "reference_steady_ms": 0.236417050473392,
+      "tiled_compile_and_first_ms": 374.68420795630664,
+      "tiled_steady_ms": 6.743000005371869,
+      "image_defect": 0.0,
+      "successful": true
+    },
+    "sparse_lbm": {
+      "logical_cells": 1024,
+      "fluid_cells": 256,
+      "storage_cells": 256,
+      "state_bytes": 36410,
+      "compile_and_first_ms": 167.6008750218898,
+      "steady_ms": 1.1554589727893472,
+      "mass_defect": 0.0,
+      "successful": true
+    },
+    "sparse_mpm": {
+      "logical_nodes": 1024,
+      "storage_nodes": 256,
+      "active_blocks": 4,
+      "state_bytes": 20366,
+      "compile_and_first_ms": 1923.057375010103,
+      "steady_ms": 1.6589999431744218,
+      "successful": true
+    },
+    "sparse_flip": {
+      "logical_cells": 1024,
+      "cell_storage": 256,
+      "face_storage": [
+        256,
+        256
+      ],
+      "compile_and_first_ms": 3835.51958296448,
+      "steady_ms": 3.3527910709381104,
+      "mass_defect": 0.0,
+      "projection_residual": 3.875575412650768e-17,
+      "successful": true
+    }
+  },
+  "passed": true
+}

--- a/docs/all-of-phydrax.md
+++ b/docs/all-of-phydrax.md
@@ -91,6 +91,17 @@ native JAX and produces ordinary sparse coordinate operators. See
 [API → Linear algebra runtime](api/linalg.md) and
 [API → Sparse derivatives](api/sparse_derivatives.md).
 
+Fixed-capacity irregular execution is shared through `phydrax.sparse`.
+`KeyGroupPlan` creates canonical active-key worklists without dense key-space
+tables. `RelationExecutionPlan` prepares target segments for compact, fast,
+deterministic, or compensated route reductions. Structured sparse consumers
+use `TensorGridPlan.prepare_index_space` for factorized logical addressing and
+`SparseBlockTopologyPlan` for canonical block-major placement. Particle cell
+lists, sparse voxels, block AMR metadata, tile-major Gaussian rasterization,
+static sparse LBM, compact explicit/implicit/multifield MPM, and transactional
+compact FLIP reuse these substrates while retaining their domain-specific
+physical semantics.
+
 Einstein-style array operations are shared through `phydrax.ein`: an exact
 optimized contraction boundary plus named static JAX rearrangement, reduction,
 and repetition. Patterns compile to reshape, transpose, reduction, and

--- a/docs/guides_flip.md
+++ b/docs/guides_flip.md
@@ -21,6 +21,27 @@ face_velocity = face_momentum / face_mass
 The extensive numerator balances are reported before normalization. Unsupported face velocity is
 zero with a false support mask. P2G and G2P use the same prepared B-spline relation.
 
+`SparseFLIPParticleTransferPlan` is the virtual-grid realization of the same
+transfer. It binds one `PreparedTensorIndexSpace`, one cell
+`SparseBlockTopologyPlan`, and one topology for each staggered face layout.
+Route construction remains the existing B-spline authority; only logical
+targets are lowered to compact cell/face storage. P2G returns compact cell
+volume and face mass/momentum arrays. G2P consumes those compact face arrays
+through the same mapped stencils. Topology refresh is fixed-capacity and
+transactional.
+
+`SparseMACFreeSurfaceProjectionPlan` lowers compact cell-to-face and
+face-to-cell relations for atmospheric pressure projection. Liquid pressure is
+solved only on compact storage cells through `phydrax.linalg`; air pressure is
+zero and an all-liquid periodic component receives the zero-mean gauge.
+Every liquid cell must resolve both adjacent face slots on every axis.
+
+`compile_sparse_flip_problem` composes compact P2G, pressure projection, G2P,
+midpoint advection, topology refresh, pressure remapping by logical cell ID,
+CFL evidence, and atomic state commit. The current compact problem supports
+periodic/atmospheric geometry without a sharp solid bundle. It never falls
+back to a dense MAC grid.
+
 ## Atmospheric pressure projection
 
 `MACFreeSurfaceProjectionPlan` adds the one pressure closure absent from the full-grid MAC stack: a

--- a/docs/guides_lattice_boltzmann.md
+++ b/docs/guides_lattice_boltzmann.md
@@ -48,6 +48,7 @@ profile evaluation remains a candidate for one exact operating/deployment tuple.
 | Prepared production sharding | Implemented execution path | Actual prepared hydrodynamics runs under fixed spatial NamedSharding with global reference equivalence |
 | AA/even-odd memory layout and fused step | Implemented execution path | Logical-state equivalence evidence and checkpoint parity metadata |
 | Block reverse replay | Implemented execution path | Fixed-size replay blocks; no adaptive recomputation policy |
+| Static block-sparse fluid cells | Implemented research path | Explicit fluid logical IDs, compact block populations, periodic pull streaming, and halfway bounce-back on missing fluid neighbors |
 | IREE export | Forward inference only | Stable tuple ABI; gradients remain in JAX |
 | Portable kinetic checkpoint | Implemented execution path | Full array PyTree, runtime controls, program identity, topology, parity, and checksums |
 
@@ -71,6 +72,32 @@ boundary-closed, and pre-collision. One accepted step:
 Macroscopic velocity follows `rho * u = sum_i(c_i * f_i) + 0.5 * dt * F`.
 Pressure is derived from density for the athermal weakly compressible path. No API
 labels this path as an exact incompressible projection.
+
+## Static sparse fluid domains
+
+`SparseLatticeBoltzmannPlan` binds a `PreparedTensorIndexSpace`, one certified
+velocity set, collision plan, block shape, and block capacity. Preparation
+accepts explicit fluid-cell logical IDs. It constructs a
+`SparseBlockTopologyState`, stores populations on the compact storage-cell
+axis, and lowers every pull-streaming source to a compact slot. A missing
+nonperiodic or nonfluid source is owned by halfway bounce-back.
+
+The path supports all unforced collision families accepted by
+`collide_detailed`, periodic axes, fixed walls, JIT execution, and explicit
+geometry refresh. `refresh_geometry` aligns retained populations by logical
+cell ID, initializes activated cells from declared density/velocity, reports
+activated and retired mass, and advances the topology generation.
+
+This is an explicit realization. It does not silently scan a virtual grid to
+discover fluid cells and does not fall back to dense execution. Moving
+arbitrary SDF discovery, staged open boundaries, multiphase stencil closures,
+AA addressing, multiblock, and distributed sparse execution remain outside
+this realization and must use an existing qualified dense path.
+
+Logical cell count and storage-cell capacity are separate resource facts.
+Sparse storage is appropriate when a fluid region occupies a minority of its
+bounding box; the dense realization remains appropriate above the measured
+crossover.
 
 ## Collision, moments, and forcing
 

--- a/docs/guides_mpm_fracture_sparse.md
+++ b/docs/guides_mpm_fracture_sparse.md
@@ -33,23 +33,34 @@ moments remain well posed.
 Field duplication and CPIC must not be applied to the same crack: that would suppress
 transfer twice and define a different method.
 
-## Active blocks
+## Sparse nodal storage
 
-`MPMActiveBlockPlan` derives block activation from all valid routes, dilates a fixed
-block halo, carries current/previous union, produces a dense active-node mask, and
-fails before grid update on capacity overflow.
+`BlockSparseMPMNodalStoragePlan` binds a shared
+`SparseBlockTopologyPlan`. The topology is constructed from valid logical
+particle-grid routes, stores only canonical block keys and dense local node
+IDs, and maps the existing `GatherStencil` into compact storage. There is no
+full logical block mask, active-node mask, or MPM-specific page table.
 
-## Compact storage
+Pass the storage plan as `nodal_storage` when compiling the material-point
+problem. A splat prepared against `TensorGridPlan.prepare_index_space` avoids
+materializing the logical tensor grid entirely. Mass, momentum, internal and
+external force, grid contact, prescribed boundary values, and G2P then execute
+on the compact storage-node axis. `DenseMPMNodalStoragePlan` remains the
+semantic reference.
 
-`BlockSparseMPMNodalStoragePlan` stores fixed-capacity compact blocks, maps logical
-nodes/routes to compact slots, and packs/unpacks arbitrary trailing field payloads.
-`DenseMPMNodalStoragePlan` is the semantic reference. Dense/compact values must agree
-exactly on active nodes.
+Block capacity, storage-node capacity, logical grid-node count, route count,
+and topology overflow are separate evidence. A topology candidate is complete
+before nodal mutation. A rejected numerical attempt retains the previous
+accepted block keys and generation. Post-advection routes must resolve in the
+same attempted topology or the attempt rejects.
 
-Activation, compaction, and topology epochs are piecewise structural decisions.
-Rematerialized replay requires identical route, block-ID/slot, field, and topology
-digests.
+The compact realization supports one or multiple velocity fields, K-way field
+contact, and the prepared implicit grid-velocity solve. Implicit Newton
+iterations freeze one compact topology and solve over storage-node unknowns.
+Diffuse phase-field evolution constructs compact logical-neighbor routes and
+accepts only a complete dependency support. A missing required neighbor
+rejects; it is never interpreted as zero.
 
-The initial compact adapter qualifies explicit payload storage. Compact implicit and
-phase-field operators require their own neighbor/preconditioner adapters and are not
-claimed automatically.
+Activation, compaction, and topology epochs are piecewise structural
+decisions. Rematerialized replay requires identical route, logical block,
+storage, and topology digests.

--- a/docs/guides_particle_methods.md
+++ b/docs/guides_particle_methods.md
@@ -26,10 +26,12 @@ Particle IDs are stable physical identities. Logical particle order is distinct 
 
 `DenseParticleNeighborhoodPlan` prepares every canonical same-set pair under an
 explicit `maximum_pairs` budget. `CellListParticleNeighborhoodPlan` instead
-prepares fixed cell geometry, neighboring-cell routes, particle-per-cell
-capacity, candidate-slot capacity, and pair capacity. At runtime it sorts by
-cell and stable particle ID, builds a fixed particle table, and packs canonical
-unordered pairs without changing public logical particle order.
+prepares fixed cell geometry, occupied-cell capacity, neighboring-key offsets,
+particle-per-cell capacity, candidate-slot capacity, and pair capacity. At
+runtime it uses `KeyGroupPlan` to sort by cell and stable particle ID, stores
+only occupied cell keys and ranges, and packs canonical unordered pairs
+without changing public logical particle order. Its memory is independent of
+the number of unoccupied logical cells.
 
 `ParticleNeighborhoodState` carries the realized relation, logical/storage
 permutations, cell counts and offsets, actual pair count, maximum occupancy,
@@ -43,6 +45,11 @@ coincident positions and returns a zero direction there. Methods that require a
 defined contact normal, including DEM, reject an overlapping coincident pair.
 Conservative pair exchange evaluates one unordered interaction and scatters
 equal and opposite endpoint contributions.
+
+Target-grouped particle exchange uses `RelationExecutionPlan`. Independent
+destinations are reduced through one canonical route order; deterministic and
+compensated policies no longer maintain separate cell- or method-specific
+reduction implementations.
 
 `ParticleExecutionPolicy` provides `dense_pairs` and `cell_edge_list`
 realizations with fast, deterministic, or compensated accumulation. Dense

--- a/docs/guides_rendering.md
+++ b/docs/guides_rendering.md
@@ -6,6 +6,20 @@
 
 The generic Gaussian rasterizer, photometric response, camera-stack image formation, and their support/flux evidence live under `phydrax.rendering`. Velocimetry consumes these operators but no longer owns them.
 
+`GaussianRasterExecutionPlan` selects the existing reference scan or a
+tile-major realization. The tiled path emits bounded particle-to-pixel routes,
+maps pixels into padded tile-major storage, and reduces them through
+`RelationExecutionPlan`. Deterministic and compensated modes preserve
+particle-major route order within each pixel. The dense image remains the
+scientific output; tiling changes placement and execution only.
+
+`maximum_tile_routes` is an explicit runtime admission. Exceeding it produces
+`route_overflow`, a zero unusable image candidate, and an unsuccessful result.
+Per-particle support-radius overflow, border clipping, finite-input status, and
+deposited flux remain separate evidence channels. Route indices are
+stopped-gradient; Gaussian values and coordinates retain fixed-support
+derivatives.
+
 ## Exact surface images
 
 `SurfaceImagePlan` binds:

--- a/docs/guides_sparse_spatial_hierarchies.md
+++ b/docs/guides_sparse_spatial_hierarchies.md
@@ -16,6 +16,36 @@ A point cluster, a voxel sample, and an adaptive control volume are not
 interchangeable. Only integer addressing, ordering, bounds, capacities, and
 topology evidence are shared.
 
+## Shared active-key and block substrates
+
+`KeyGroupPlan` is the fixed-capacity active-container authority used by
+particle cells, route reductions, sparse blocks, and other keyed worklists. It
+sorts explicitly by key and stable item ID, stores only active group keys, and
+returns reversible item permutations, group starts/counts, binary lookup, and
+independent group/member overflow evidence. Logical key space size does not
+allocate a dense reverse map.
+
+`TensorGridPlan.prepare_index_space(bounds)` prepares structured axes and
+point/interval entity layouts without materializing tensor-product points,
+measures, or boundary masks. `TensorIndexLayout` evaluates coordinates,
+measure weights, and physical-boundary membership only at requested logical
+IDs. Dense materialization is explicit.
+
+`SparseBlockTopologyPlan` combines one tensor index layout with canonical
+active keys. It stores fixed-capacity outer blocks and dense local sites,
+returns logical-to-storage lookup and topology transitions, and never treats a
+storage slot as physical identity. Closure offsets are explicit physical or
+route-support requirements; execution scratch halos are separate.
+
+`RelationExecutionPlan` groups existing `EdgeRelation` or `RowRelation` routes
+by target. Fast, canonical deterministic, and compensated sums share one
+prepared execution order. Invalid routes are numerically inert, and compact
+target output is available without allocating the full logical target space.
+
+These are execution substrates, not a new field language. Each domain retains
+its own inactive-state, boundary, conservation, and topology-transition
+semantics.
+
 ## Morton addressing
 
 `MortonAddressPlan(lower, upper, maximum_depth)` owns the half-open physical
@@ -154,12 +184,15 @@ adaptation boundary begins a new topology epoch; it is not smoothed implicitly.
 
 ## Choosing a substrate
 
-Use a dense tensor grid for dense regular stencils. Use a flat cell list for
-uniform short-range particle interactions. Use LBVH for dynamic primitive broad
-phase. Use a Morton point hierarchy for clustered or long-range particles. Add
-primitive bounds for finite-support points such as surfels. Use a sparse voxel
-grid for sparse fixed-resolution fields. Use a dyadic topology when physical
-cell resolution and conservative coarse/fine interfaces are part of the model.
+Use a dense tensor grid for dense regular stencils. Use a tensor index space
+when logical structured addressing is required without a dense field. Use the
+occupied-key cell list for uniform short-range particle interactions. Use LBVH
+for dynamic primitive broad phase. Use a Morton point hierarchy for clustered
+or long-range particles. Add primitive bounds for finite-support points such
+as surfels. Use a sparse voxel grid for sparse fixed-resolution samples. Use a
+sparse block topology for block-major fields on a virtual structured layout.
+Use a dyadic topology when physical cell resolution and conservative
+coarse/fine interfaces are part of the model.
 
 ## Qualification tools
 
@@ -173,6 +206,9 @@ cell resolution and conservative coarse/fine interfaces are part of the model.
   primitive-bound refit, and ray-query behavior.
 - `tools/surfel_voxel_benchmarks.py` records bounded overlap routes, local
   implicit reconstruction, and plane error.
+- `tools/sparse_execution_benchmarks.py` records active-key grouping,
+  prepared relation reduction, tile-major rasterization, and compact LBM,
+  MPM, and FLIP execution.
 
 Small systems should continue to use direct or dense authorities when the
 measured crossover favors them.

--- a/examples/material_point_domains_sparse.py
+++ b/examples/material_point_domains_sparse.py
@@ -10,33 +10,45 @@ import phydrax as phx
 
 
 def run():
-    grid = phx.discretization.TensorGridPlan(
+    grid_plan = phx.discretization.TensorGridPlan(
         tuple(
             phx.discretization.UniformAxisSpec(16, periodic=True, endpoint=False)
             for _ in range(2)
         ),
         axis_names=("x", "y"),
-    ).prepare(jnp.asarray([[0.0, 0.0], [1.0, 1.0]]))
+    )
+    bounds = jnp.asarray([[0.0, 0.0], [1.0, 1.0]])
+    index = grid_plan.prepare_index_space(bounds)
     position = jnp.asarray([[0.27, 0.31], [0.43, 0.38], [0.36, 0.52]])
     particles = phx.discretization.ParticleSetPlan(
         jnp.arange(3), jnp.ones((3,)), ambient_dimension=2
     ).prepare()
     gimp = phx.discretization.UniformGIMPSplatAssignment(jnp.full((3, 2), 0.025))
-    prepared = phx.discretization.ParticleGridSplatPlan(grid, assignment=gimp).prepare(
+    prepared = phx.discretization.ParticleGridSplatPlan(index, assignment=gimp).prepare(
         particles
     )
     routes = prepared.build(position)
-    blocks = phx.discretization.MPMActiveBlockPlan((16, 16), (4, 4), 16)
-    active = blocks.build(routes)
-    storage = phx.discretization.BlockSparseMPMNodalStoragePlan(blocks)
+    topology = phx.discretization.SparseBlockTopologyPlan(
+        index, (4, 4), 16, layout=index.vertices()
+    )
+    storage = phx.discretization.BlockSparseMPMNodalStoragePlan(topology)
+    active = storage.build(routes)
     dense = jnp.arange(16 * 16, dtype=jnp.float64).reshape((16, 16))
     compact = storage.pack(dense, active)
     restored = storage.unpack(compact, active)
-    parity = jnp.max(jnp.abs(jnp.where(active.active_node_mask, restored - dense, 0.0)))
+    parity = jnp.max(
+        jnp.abs(
+            jnp.where(
+                active.materialize_support(),
+                restored - dense,
+                0.0,
+            )
+        )
+    )
     return {
         "partition_defect": float(jnp.max(jnp.abs(routes.partition_sums - 1.0))),
         "gradient_defect": float(jnp.max(jnp.abs(routes.gradient_sums))),
-        "active_blocks": int(active.active_block_count),
+        "active_blocks": int(active.evidence.required_blocks),
         "dense_sparse_parity": float(parity),
     }
 

--- a/phydrax/applications/robotics/_soft_mpm.py
+++ b/phydrax/applications/robotics/_soft_mpm.py
@@ -20,6 +20,7 @@ from ..._strict import StrictModule
 from ..._trainable import NonTrainableState
 from ...backends._types import BackendUnavailableError
 from ...discretization.mpm import (
+    BlockSparseMPMNodalStoragePlan,
     MPMGridState,
     MPMParticleState,
     MPMRunStatus,
@@ -180,7 +181,8 @@ def _validate_initial_runtime(
         raise ValueError("Initial active particles contain invalid material slots.")
     if not bool(np.asarray(jnp.all((~active) | (state.body_ids >= 0)))):
         raise ValueError("Initial active particles contain invalid body IDs.")
-    if (dynamics.active_blocks is None) != (state.storage_state is None):
+    sparse_storage = isinstance(dynamics.nodal_storage, BlockSparseMPMNodalStoragePlan)
+    if sparse_storage != (state.storage_state is not None):
         raise ValueError(
             "Initial MPM sparse storage ownership does not match the prepared dynamics."
         )

--- a/phydrax/discretization/__init__.py
+++ b/phydrax/discretization/__init__.py
@@ -224,6 +224,11 @@ from ._tensor import (
     EigenbasisDiscretization,
 )
 from ._tensor_entities import AxisEntityKind, StructuredAxis, TensorEntityLayout
+from ._tensor_index import (
+    PreparedTensorIndexSpace,
+    TensorIndexLayout,
+    TensorIndexMeasure,
+)
 from ._tensor_support import GridLocation, PreparedTensorGrid
 from ._topology import (
     CellComplexTopology,
@@ -505,6 +510,8 @@ from .fem import (
 )
 from .finite_difference import (
     AxisBoundaryPair,
+    BlockLocalStencilExecutionPlan,
+    BlockLocalStencilResult,
     BoundaryAffineMap,
     BoundaryClosureKind,
     BoundaryConditionKind,
@@ -980,6 +987,9 @@ from .flip import (
     prepare_ale_flip,
     PreparedALEFLIP,
     PreparedFLIPParticleTransfer,
+    PreparedSparseFLIPParticleTransfer,
+    SparseFLIPParticleTransferPlan,
+    SparseFLIPTransferState,
     transition_ale_flip_epoch,
 )
 from .lattice_boltzmann import *  # noqa: F403
@@ -1049,8 +1059,6 @@ from .mpm import (
     locate_event,
     MidpointAdvectionPlan,
     migrate_particles,
-    MPMActiveBlockPlan,
-    MPMActiveBlockState,
     MPMAMRPlan,
     MPMAMRTopologyJournal,
     MPMCapacityBucketPlan,
@@ -2247,6 +2255,8 @@ __all__ = [
     "BlockInterface",
     "BlockSide",
     "BlockDofLayout",
+    "BlockLocalStencilExecutionPlan",
+    "BlockLocalStencilResult",
     "BoundaryClosureKind",
     "BoundaryWorkspace",
     "BoundaryStageContext",
@@ -2823,6 +2833,7 @@ __all__ = [
     "RefinementDecision",
     "PreparedFDAMRHierarchy",
     "PreparedTensorGrid",
+    "PreparedTensorIndexSpace",
     "PreparedFiniteDifferenceDiscretization",
     "PreparedConservativeAdvection",
     "PreparedConservativeDiffusion",
@@ -3108,6 +3119,9 @@ __all__ = [
     "FLIPRuntimeState",
     "FLIPStepResult",
     "FLIPTransferState",
+    "PreparedSparseFLIPParticleTransfer",
+    "SparseFLIPParticleTransferPlan",
+    "SparseFLIPTransferState",
     "PICChargeDepositResult",
     "PICCurrentDepositResult",
     "PICEnergyLedger",
@@ -3313,6 +3327,8 @@ __all__ = [
     "UniformAxisSpec",
     "TensorGridBoundary",
     "TensorEntityLayout",
+    "TensorIndexLayout",
+    "TensorIndexMeasure",
     "TensorGridRestriction",
     "TensorGridStateTransfer",
     "WENOOrder",
@@ -3606,8 +3622,6 @@ __all__ = [
     "MPMMaterialBankEntry",
     "MPMMaterialBankState",
     "MPMFieldPartitionFracturePlan",
-    "MPMActiveBlockPlan",
-    "MPMActiveBlockState",
     "MPMFractureTopologyState",
     "MPMNodalFieldPlan",
     "MPMParticleDomainPlan",

--- a/phydrax/discretization/_axis.py
+++ b/phydrax/discretization/_axis.py
@@ -280,6 +280,12 @@ class TensorGridPlan(AbstractDiscretizationPlan):
 
         return PreparedTensorGrid.from_plan(self, bounds)
 
+    def prepare_index_space(self, bounds: ArrayLike, /):
+        """Materialize tensor axes without dense tensor-product arrays."""
+        from ._tensor_index import PreparedTensorIndexSpace
+
+        return PreparedTensorIndexSpace.from_plan(self, bounds)
+
 
 class UniformAxisSpec(AbstractAxisSpec):
     r"""Uniform grid on \([a,b]\).

--- a/phydrax/discretization/_tensor_index.py
+++ b/phydrax/discretization/_tensor_index.py
@@ -1,0 +1,473 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from fractions import Fraction
+from itertools import product
+from math import prod
+
+import equinox as eqx
+import jax.numpy as jnp
+from jaxtyping import Array, ArrayLike
+
+from .._fingerprint import canonical_fingerprint
+from .._strict import StrictModule
+from .._trainable import NonTrainableState
+from ._axis import AxisDiscretization, TensorGridPlan
+from ._measure import DiscreteMeasure
+from ._tensor_entities import AxisEntityKind, StructuredAxis
+from ._tensor_support import _fraction, GridLocation
+from ._topology import TensorTopology
+
+
+class TensorIndexLayout(StrictModule, NonTrainableState):
+    """Factorized tensor-entity addressing without dense tensor arrays."""
+
+    axis_names: tuple[str, ...] = eqx.field(static=True)
+    axis_entities: tuple[AxisEntityKind, ...] = eqx.field(static=True)
+    shape: tuple[int, ...] = eqx.field(static=True)
+    strides: tuple[int, ...] = eqx.field(static=True)
+    offsets: tuple[Fraction, ...] = eqx.field(static=True)
+    coordinates_by_axis: tuple[Array, ...]
+    measures_by_axis: tuple[Array, ...]
+    lower_boundary_present: tuple[bool, ...] = eqx.field(static=True)
+    upper_boundary_present: tuple[bool, ...] = eqx.field(static=True)
+    location_id: str = eqx.field(static=True)
+    entity_set_id: str = eqx.field(static=True)
+    layout_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        axis_names: Sequence[str],
+        axes: Sequence[StructuredAxis],
+        axis_entities: Sequence[AxisEntityKind],
+        /,
+    ) -> None:
+        names = tuple(str(name) for name in axis_names)
+        axes_ = tuple(axes)
+        entities = tuple(axis_entities)
+        if (
+            not names
+            or len(axes_) != len(names)
+            or len(entities) != len(names)
+            or any(entity not in ("point", "interval") for entity in entities)
+        ):
+            raise ValueError("Tensor index-layout factors must align with axes.")
+        shape = tuple(
+            axis.count(entity) for axis, entity in zip(axes_, entities, strict=True)
+        )
+        strides = tuple(prod(shape[axis + 1 :]) for axis in range(len(shape)))
+        offsets = tuple(
+            Fraction(0, 1) if entity == axis.primary_entity else Fraction(1, 2)
+            for axis, entity in zip(axes_, entities, strict=True)
+        )
+        coordinates = tuple(
+            axis.coordinates(entity) for axis, entity in zip(axes_, entities, strict=True)
+        )
+        measures = tuple(
+            axis.measure(entity) for axis, entity in zip(axes_, entities, strict=True)
+        )
+        lower = tuple(
+            entity == "point"
+            and (
+                axis.lower_endpoint_included
+                or (axis.primary_entity == "interval" and not axis.periodic)
+            )
+            for axis, entity in zip(axes_, entities, strict=True)
+        )
+        upper = tuple(
+            entity == "point"
+            and (
+                axis.upper_endpoint_included
+                or (axis.primary_entity == "interval" and not axis.periodic)
+            )
+            for axis, entity in zip(axes_, entities, strict=True)
+        )
+        location_id = canonical_fingerprint(
+            {
+                "kind": "tensor-entity-location",
+                "axis_names": list(names),
+                "axis_entities": list(entities),
+                "offsets": [[value.numerator, value.denominator] for value in offsets],
+            }
+        )
+        entity_set_id = canonical_fingerprint(
+            {
+                "kind": "tensor-entity-set",
+                "axes": [axis.axis_id for axis in axes_],
+                "entities": list(entities),
+                "shape": list(shape),
+            }
+        )
+        self.axis_names = names
+        self.axis_entities = entities
+        self.shape = shape
+        self.strides = strides
+        self.offsets = offsets
+        self.coordinates_by_axis = coordinates
+        self.measures_by_axis = measures
+        self.lower_boundary_present = lower
+        self.upper_boundary_present = upper
+        self.location_id = location_id
+        self.entity_set_id = entity_set_id
+        self.layout_id = canonical_fingerprint(
+            {
+                "kind": "tensor-entity-layout",
+                "entity_set": entity_set_id,
+                "location": location_id,
+                "measure_shape": list(shape),
+            }
+        )
+
+    @property
+    def size(self) -> int:
+        return prod(self.shape)
+
+    def integer_coordinates(self, flat_indices: ArrayLike, /) -> tuple[Array, Array]:
+        indices = jnp.asarray(flat_indices)
+        if not jnp.issubdtype(indices.dtype, jnp.integer):
+            raise TypeError("flat_indices must have an integer dtype.")
+        supported = (indices >= 0) & (indices < self.size)
+        safe = jnp.clip(indices, 0, self.size - 1)
+        coordinates = jnp.stack(
+            tuple(
+                (safe // stride) % size
+                for stride, size in zip(self.strides, self.shape, strict=True)
+            ),
+            axis=-1,
+        ).astype(jnp.int32)
+        return coordinates, supported
+
+    def flat_indices(self, integer_coordinates: ArrayLike, /) -> tuple[Array, Array]:
+        coordinates = jnp.asarray(integer_coordinates)
+        if not jnp.issubdtype(coordinates.dtype, jnp.integer):
+            raise TypeError("integer_coordinates must have an integer dtype.")
+        if coordinates.ndim < 1 or coordinates.shape[-1] != len(self.shape):
+            raise ValueError(
+                "integer_coordinates must end with the tensor dimension "
+                f"{len(self.shape)}."
+            )
+        supported = jnp.ones(coordinates.shape[:-1], dtype=bool)
+        safe_axes = []
+        for axis, size in enumerate(self.shape):
+            value = coordinates[..., axis]
+            supported = supported & (value >= 0) & (value < size)
+            safe_axes.append(jnp.clip(value, 0, size - 1))
+        flat = sum(
+            value * stride for value, stride in zip(safe_axes, self.strides, strict=True)
+        )
+        return flat.astype(jnp.int32), supported
+
+    def coordinates_at(self, flat_indices: ArrayLike, /) -> tuple[Array, Array]:
+        integer, supported = self.integer_coordinates(flat_indices)
+        coordinates = jnp.stack(
+            tuple(
+                axis_coordinates[integer[..., axis]]
+                for axis, axis_coordinates in enumerate(self.coordinates_by_axis)
+            ),
+            axis=-1,
+        )
+        return coordinates, supported
+
+    def measure_at(self, flat_indices: ArrayLike, /) -> tuple[Array, Array]:
+        integer, supported = self.integer_coordinates(flat_indices)
+        dtype = jnp.result_type(*tuple(value.dtype for value in self.measures_by_axis))
+        measure = jnp.ones(integer.shape[:-1], dtype=dtype)
+        for axis, factors in enumerate(self.measures_by_axis):
+            measure = measure * factors[integer[..., axis]]
+        return jnp.where(
+            supported, measure, jnp.zeros((), dtype=measure.dtype)
+        ), supported
+
+    def boundary_at(
+        self,
+        flat_indices: ArrayLike,
+        axis: str,
+        side: str,
+        /,
+    ) -> tuple[Array, Array]:
+        if axis not in self.axis_names:
+            raise ValueError(f"Unknown tensor-grid axis {axis!r}.")
+        if side not in ("lower", "upper"):
+            raise ValueError("side must be 'lower' or 'upper'.")
+        integer, supported = self.integer_coordinates(flat_indices)
+        dimension = self.axis_names.index(axis)
+        present = (
+            self.lower_boundary_present[dimension]
+            if side == "lower"
+            else self.upper_boundary_present[dimension]
+        )
+        boundary_index = 0 if side == "lower" else self.shape[dimension] - 1
+        selected = supported & present & (integer[..., dimension] == boundary_index)
+        return selected, supported
+
+    def materialize_coordinates(self, /) -> Array:
+        mesh = jnp.meshgrid(*self.coordinates_by_axis, indexing="ij")
+        return jnp.stack(mesh, axis=-1)
+
+    def materialize_measure(self, /) -> Array:
+        measure = jnp.ones(self.shape)
+        for axis, factors in enumerate(self.measures_by_axis):
+            reshape = [1] * len(self.shape)
+            reshape[axis] = self.shape[axis]
+            measure = measure * factors.reshape(reshape)
+        return measure
+
+    def materialize_boundary(self, axis: str, side: str, /) -> Array:
+        flat = jnp.arange(self.size, dtype=jnp.int32)
+        selected, _ = self.boundary_at(flat, axis, side)
+        return selected.reshape(self.shape)
+
+
+class TensorIndexMeasure(StrictModule, NonTrainableState):
+    """Factorized physical measure for one tensor index layout."""
+
+    layout: TensorIndexLayout
+    support_id: str = eqx.field(static=True)
+    measure_id: str = eqx.field(static=True)
+
+    def __init__(self, layout: TensorIndexLayout, support_id: str, /) -> None:
+        if not isinstance(layout, TensorIndexLayout):
+            raise TypeError("layout must be a TensorIndexLayout.")
+        support = str(support_id)
+        if not support:
+            raise ValueError("support_id must be non-empty.")
+        self.layout = layout
+        self.support_id = support
+        self.measure_id = canonical_fingerprint(
+            {
+                "kind": "tensor-index-measure",
+                "support": support,
+                "entity_set": layout.entity_set_id,
+                "layout": layout.layout_id,
+            }
+        )
+
+    @property
+    def total_mass(self) -> Array:
+        value = jnp.asarray(1.0)
+        for factors in self.layout.measures_by_axis:
+            value = value * jnp.sum(factors)
+        return value
+
+    def weights_at(self, flat_indices: ArrayLike, /) -> tuple[Array, Array]:
+        return self.layout.measure_at(flat_indices)
+
+    def materialize(self, /) -> DiscreteMeasure:
+        return DiscreteMeasure(
+            "tensor-" + "-".join(self.layout.axis_entities),
+            self.support_id,
+            self.layout.entity_set_id,
+            self.layout.materialize_measure().reshape((-1,)),
+            normalization="physical",
+        )
+
+
+class PreparedTensorIndexSpace(StrictModule, NonTrainableState):
+    """Virtual tensor grid storing axes and indexed layout metadata only."""
+
+    axes: tuple[AxisDiscretization, ...]
+    structured_axes: tuple[StructuredAxis, ...]
+    entity_layouts: tuple[TensorIndexLayout, ...]
+    primary_entity_layout: TensorIndexLayout
+    measures: tuple[TensorIndexMeasure, ...]
+    measure: TensorIndexMeasure
+    centered_location: GridLocation
+    topology: TensorTopology
+    axis_names: tuple[str, ...] = eqx.field(static=True)
+    periodic_axes: tuple[bool, ...] = eqx.field(static=True)
+    shape: tuple[int, ...] = eqx.field(static=True)
+    support_id: str = eqx.field(static=True)
+    plan_id: str = eqx.field(static=True)
+    prepared_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        axes: Sequence[AxisDiscretization],
+        /,
+        *,
+        axis_names: Sequence[str] | None = None,
+        plan_id: str | None = None,
+    ) -> None:
+        axes_ = tuple(axes)
+        if not axes_ or not all(isinstance(axis, AxisDiscretization) for axis in axes_):
+            raise TypeError("axes must contain one or more AxisDiscretization values.")
+        names = (
+            tuple(f"axis{index}" for index in range(len(axes_)))
+            if axis_names is None
+            else tuple(str(name) for name in axis_names)
+        )
+        if (
+            len(names) != len(axes_)
+            or any(not name for name in names)
+            or len(set(names)) != len(names)
+        ):
+            raise ValueError(
+                "axis_names must contain one unique non-empty name per axis."
+            )
+        structured = tuple(StructuredAxis(axis) for axis in axes_)
+        layouts = tuple(
+            TensorIndexLayout(names, structured, entities)
+            for entities in product(("point", "interval"), repeat=len(names))
+        )
+        primary_kinds = tuple(axis.primary_entity for axis in structured)
+        primary = next(
+            layout for layout in layouts if layout.axis_entities == primary_kinds
+        )
+        periodic = tuple(bool(axis.periodic) for axis in axes_)
+        topology = TensorTopology(names, primary.shape, periodic=periodic)
+        embedding = canonical_fingerprint(
+            {
+                "kind": "structured-tensor-embedding",
+                "axis_names": list(names),
+                "structured_axes": [axis.axis_id for axis in structured],
+            }
+        )
+        support_id = canonical_fingerprint(
+            {
+                "kind": "tensor-index-support",
+                "topology": topology.topology_id,
+                "embedding": embedding,
+            }
+        )
+        measures = tuple(TensorIndexMeasure(layout, support_id) for layout in layouts)
+        measure_by_layout = {
+            layout.layout_id: measure
+            for layout, measure in zip(layouts, measures, strict=True)
+        }
+        identifier = plan_id or canonical_fingerprint(
+            {
+                "kind": "tensor-index-space-plan",
+                "axis_names": list(names),
+                "primary_entities": list(primary_kinds),
+                "shape": list(primary.shape),
+                "periodic": list(periodic),
+            }
+        )
+        prepared_id = canonical_fingerprint(
+            {
+                "kind": "prepared-tensor-index-space",
+                "plan": identifier,
+                "support": support_id,
+                "entity_layouts": [layout.layout_id for layout in layouts],
+            }
+        )
+        self.axes = axes_
+        self.structured_axes = structured
+        self.entity_layouts = layouts
+        self.primary_entity_layout = primary
+        self.measures = measures
+        self.measure = measure_by_layout[primary.layout_id]
+        self.centered_location = GridLocation(
+            names, primary.offsets, location_id=primary.location_id
+        )
+        self.topology = topology
+        self.axis_names = names
+        self.periodic_axes = periodic
+        self.shape = primary.shape
+        self.support_id = support_id
+        self.plan_id = str(identifier)
+        self.prepared_id = prepared_id
+
+    @classmethod
+    def from_plan(
+        cls,
+        plan: TensorGridPlan,
+        bounds: ArrayLike,
+        /,
+    ) -> PreparedTensorIndexSpace:
+        if not isinstance(plan, TensorGridPlan):
+            raise TypeError("plan must be a TensorGridPlan.")
+        limits = jnp.asarray(bounds, dtype=float)
+        if limits.shape != (2, len(plan.axes)):
+            raise ValueError(
+                f"bounds must have shape {(2, len(plan.axes))}; got {limits.shape}."
+            )
+        return cls(
+            tuple(
+                axis.materialize(limits[0, index], limits[1, index])
+                for index, axis in enumerate(plan.axes)
+            ),
+            axis_names=plan.axis_names,
+            plan_id=plan.plan_id,
+        )
+
+    @property
+    def size(self) -> int:
+        return prod(self.shape)
+
+    @property
+    def stored_axis_values(self) -> int:
+        return sum(
+            int(coordinates.size + measures.size)
+            for coordinates, measures in zip(
+                self.primary_entity_layout.coordinates_by_axis,
+                self.primary_entity_layout.measures_by_axis,
+                strict=True,
+            )
+        )
+
+    def entity_layout(
+        self, axis_entities: Sequence[AxisEntityKind], /
+    ) -> TensorIndexLayout:
+        entities = tuple(axis_entities)
+        for layout in self.entity_layouts:
+            if layout.axis_entities == entities:
+                return layout
+        raise KeyError(f"Unknown tensor index layout {entities!r}.")
+
+    def cells(self, /) -> TensorIndexLayout:
+        return self.entity_layout(("interval",) * len(self.axis_names))
+
+    def vertices(self, /) -> TensorIndexLayout:
+        return self.entity_layout(("point",) * len(self.axis_names))
+
+    def faces(self, axis: str, /) -> TensorIndexLayout:
+        if axis not in self.axis_names:
+            raise ValueError(f"Unknown face axis {axis!r}.")
+        entities: list[AxisEntityKind] = ["interval"] * len(self.axis_names)
+        entities[self.axis_names.index(axis)] = "point"
+        return self.entity_layout(entities)
+
+    def location(
+        self,
+        offsets: Sequence[Fraction | int | tuple[int, int]],
+        /,
+    ) -> GridLocation:
+        values = tuple(_fraction(value) for value in offsets)
+        for layout in self.entity_layouts:
+            if layout.offsets == values:
+                return GridLocation(
+                    self.axis_names, values, location_id=layout.location_id
+                )
+        return GridLocation(self.axis_names, values)
+
+    def layout_at(self, location: GridLocation, /) -> TensorIndexLayout:
+        if (
+            not isinstance(location, GridLocation)
+            or location.axis_names != self.axis_names
+        ):
+            raise ValueError("Grid location does not belong to this tensor index space.")
+        for layout in self.entity_layouts:
+            if (
+                layout.location_id == location.location_id
+                or layout.offsets == location.offsets
+            ):
+                return layout
+        raise ValueError("Grid location does not resolve to a tensor index layout.")
+
+    def measure_for(self, layout: TensorIndexLayout, /) -> TensorIndexMeasure:
+        for candidate, measure in zip(self.entity_layouts, self.measures, strict=True):
+            if candidate.layout_id == layout.layout_id:
+                return measure
+        raise KeyError(f"Unknown tensor index measure {layout.layout_id!r}.")
+
+
+__all__ = [
+    "PreparedTensorIndexSpace",
+    "TensorIndexLayout",
+    "TensorIndexMeasure",
+]

--- a/phydrax/discretization/amr/_core.py
+++ b/phydrax/discretization/amr/_core.py
@@ -14,6 +14,7 @@ from jaxtyping import Array, ArrayLike
 from ..._fingerprint import array_tree_fingerprint, canonical_fingerprint
 from ..._strict import StrictModule
 from ..._trainable import NonTrainableState
+from ...sparse import KeyGroupLookup, KeyGroupPlan, KeyGroupState
 
 
 class BlockLevelPlan(StrictModule, NonTrainableState):
@@ -92,6 +93,7 @@ class BlockMetadata(StrictModule, NonTrainableState):
     parent_ids: Array
     logical_indices: Array
     neighbor_slots: Array
+    block_groups: KeyGroupState
     metadata_id: str = eqx.field(static=True)
 
     def __init__(
@@ -132,11 +134,23 @@ class BlockMetadata(StrictModule, NonTrainableState):
             raise ValueError("AMR neighbor slots are out of capacity bounds.")
         if np.any(valid_neighbors & ~mask[neighbors.clip(min=0)]):
             raise ValueError("Active AMR neighbor routes must target active blocks.")
+        key_upper_bound = int(np.max(active_ids, initial=0))
+        block_groups = KeyGroupPlan(
+            capacity,
+            capacity,
+            key_upper_bound,
+            maximum_group_size=1,
+        ).build(
+            jnp.asarray(ids),
+            jnp.asarray(mask),
+            stable_ids=jnp.arange(capacity, dtype=jnp.int32),
+        )
         self.active = jnp.asarray(mask)
         self.block_ids = jnp.asarray(ids)
         self.parent_ids = jnp.asarray(parents)
         self.logical_indices = jnp.asarray(logical)
         self.neighbor_slots = jnp.asarray(neighbors)
+        self.block_groups = block_groups
         self.metadata_id = canonical_fingerprint(
             {
                 "kind": "amr-block-metadata",
@@ -147,6 +161,18 @@ class BlockMetadata(StrictModule, NonTrainableState):
                 "logical_indices": array_tree_fingerprint(logical),
                 "neighbors": array_tree_fingerprint(neighbors),
             }
+        )
+
+    def lookup_block_ids(self, block_ids: ArrayLike, /) -> KeyGroupLookup:
+        """Resolve stable block IDs to current capacity slots."""
+        lookup = self.block_groups.lookup(block_ids)
+        sorted_slots = lookup.group_slots
+        storage_slots = self.block_groups.storage_to_logical[
+            self.block_groups.group_starts[sorted_slots]
+        ]
+        return KeyGroupLookup(
+            group_slots=jnp.where(lookup.supported, storage_slots, 0),
+            supported=lookup.supported,
         )
 
 

--- a/phydrax/discretization/amr/_fd_runtime.py
+++ b/phydrax/discretization/amr/_fd_runtime.py
@@ -530,6 +530,37 @@ class PreparedFDAMRHierarchy(StrictModule, NonTrainableState):
     def precision_evidence(self):
         return self.plan.precision.evidence()
 
+    def validate_stencil_footprints(
+        self,
+        footprints: Sequence[Any],
+        /,
+    ) -> tuple[tuple[int, ...], ...]:
+        """Require every level halo to contain its exact stencil read reach."""
+        from ..finite_difference._stencil import StencilFootprint
+
+        values = tuple(footprints)
+        if len(values) != len(self.plan.hierarchy.levels) or not all(
+            isinstance(value, StencilFootprint) for value in values
+        ):
+            raise ValueError("One StencilFootprint is required per AMR level.")
+        required = []
+        for level, footprint in zip(self.plan.hierarchy.levels, values, strict=True):
+            if len(footprint.axis_names) != len(level.block_shape):
+                raise ValueError("Stencil footprint dimension does not match AMR blocks.")
+            reach = tuple(
+                max(lower, upper)
+                for lower, upper in zip(footprint.lower, footprint.upper, strict=True)
+            )
+            if any(
+                available < needed
+                for available, needed in zip(level.halo_width, reach, strict=True)
+            ):
+                raise ValueError(
+                    "AMR block halo is smaller than the stencil read footprint."
+                )
+            required.append(reach)
+        return tuple(required)
+
     def fill_same_level(
         self,
         state: BlockHierarchyState,

--- a/phydrax/discretization/finite_difference/__init__.py
+++ b/phydrax/discretization/finite_difference/__init__.py
@@ -11,6 +11,7 @@ from ._adjoint import (
     FDCheckpointingMode,
     FDTimeAdjointResult,
 )
+from ._blocked import BlockLocalStencilExecutionPlan, BlockLocalStencilResult
 from ._boundary import (
     AxisBoundaryPair,
     BoundaryAffineMap,
@@ -157,6 +158,8 @@ __all__ = [
     "BoundaryConditionKind",
     "BoundaryClosureKind",
     "BoundaryStencilSet",
+    "BlockLocalStencilExecutionPlan",
+    "BlockLocalStencilResult",
     "BoundaryRealizationKind",
     "BoundaryStageContext",
     "BoundaryWorkspace",

--- a/phydrax/discretization/finite_difference/_blocked.py
+++ b/phydrax/discretization/finite_difference/_blocked.py
@@ -1,0 +1,125 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array
+
+from ..._fingerprint import canonical_fingerprint
+from ..._strict import StrictModule
+from ..._trainable import NonTrainableState
+from ._stencil import StencilFootprint
+
+
+if TYPE_CHECKING:
+    from ..amr._core import BlockLevelPlan
+    from ..amr._fd_halo import FDAMRHaloWorkspace
+
+
+class BlockLocalStencilResult(StrictModule):
+    """Block-interior values and validity after one local stencil program."""
+
+    values: Array
+    valid: Array
+    finite: Array
+    successful: Array
+    execution_id: str = eqx.field(static=True)
+
+
+class BlockLocalStencilExecutionPlan(StrictModule, NonTrainableState):
+    """Execute one footprint-qualified callable over padded AMR blocks."""
+
+    level: BlockLevelPlan
+    footprint: StencilFootprint
+    required_halo: tuple[int, ...] = eqx.field(static=True)
+    execution_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        level: BlockLevelPlan,
+        footprint: StencilFootprint,
+        /,
+    ) -> None:
+        from ..amr._core import BlockLevelPlan
+
+        if not isinstance(level, BlockLevelPlan):
+            raise TypeError("level must be BlockLevelPlan.")
+        if not isinstance(footprint, StencilFootprint):
+            raise TypeError("footprint must be StencilFootprint.")
+        if len(footprint.axis_names) != len(level.block_shape):
+            raise ValueError("Stencil footprint and block dimensions must match.")
+        required = tuple(
+            max(lower, upper)
+            for lower, upper in zip(footprint.lower, footprint.upper, strict=True)
+        )
+        if any(
+            available < needed
+            for available, needed in zip(level.halo_width, required, strict=True)
+        ):
+            raise ValueError("Block halo does not contain the stencil read footprint.")
+        self.level = level
+        self.footprint = footprint
+        self.required_halo = required
+        self.execution_id = canonical_fingerprint(
+            {
+                "kind": "block-local-stencil-execution",
+                "level": level.plan_id,
+                "footprint": footprint.footprint_id,
+                "required_halo": list(required),
+            }
+        )
+
+    def apply(
+        self,
+        workspace: FDAMRHaloWorkspace,
+        block_operator: Callable[[Array], Array],
+        /,
+    ) -> BlockLocalStencilResult:
+        """Apply ``block_operator`` independently to complete padded blocks."""
+        from ..amr._fd_halo import FDAMRHaloWorkspace
+
+        if not isinstance(workspace, FDAMRHaloWorkspace):
+            raise TypeError("workspace must be FDAMRHaloWorkspace.")
+        if not callable(block_operator):
+            raise TypeError("block_operator must be callable.")
+        expected_prefix = (self.level.maximum_blocks,) + tuple(
+            size + 2 * halo
+            for size, halo in zip(
+                self.level.block_shape, self.level.halo_width, strict=True
+            )
+        )
+        if workspace.values.shape[: len(expected_prefix)] != expected_prefix:
+            raise ValueError("Halo workspace does not match the block execution plan.")
+        output = jax.vmap(block_operator)(workspace.values)
+        expected_output_prefix = (self.level.maximum_blocks,) + self.level.block_shape
+        if output.shape[: len(expected_output_prefix)] != expected_output_prefix:
+            raise ValueError(
+                "block_operator output must begin with the unpadded block shape."
+            )
+        center = tuple(
+            slice(halo, halo + size)
+            for size, halo in zip(
+                self.level.block_shape, self.level.halo_width, strict=True
+            )
+        )
+        valid = workspace.valid[(slice(None),) + center]
+        mask = valid.reshape(valid.shape + (1,) * (output.ndim - valid.ndim))
+        values = jnp.where(mask, output, jnp.zeros((), dtype=output.dtype))
+        finite = jnp.all(jnp.where(mask, jnp.isfinite(values), True))
+        return BlockLocalStencilResult(
+            values=values,
+            valid=valid,
+            finite=finite,
+            successful=finite,
+            execution_id=self.execution_id,
+        )
+
+
+__all__ = ["BlockLocalStencilExecutionPlan", "BlockLocalStencilResult"]

--- a/phydrax/discretization/finite_volume/_mac_marker_transfer.py
+++ b/phydrax/discretization/finite_volume/_mac_marker_transfer.py
@@ -14,10 +14,10 @@ import numpy as np
 from jaxtyping import Array, ArrayLike
 
 from ..._fingerprint import canonical_fingerprint
-from ..._numerics._compensated import two_sum
 from ..._strict import StrictModule
 from ..._trainable import NonTrainableState
 from ...linalg import FunctionLinearOperator, OperatorProperties
+from ...sparse import canonical_row_route_ids, EdgeRelation, RelationExecutionPlan
 from .._lagrangian_marker import LagrangianMarkerDiscretization
 from ._incompressible import FaceVelocity, PreparedMACOperators
 
@@ -704,38 +704,23 @@ class PreparedMACMarkerTransfer(StrictModule, NonTrainableState):
                 relation.weights[axis] * active_values[:, axis, None],
                 0.0,
             )
-            flat = jnp.zeros((self.target_sizes[axis],), dtype=active_values.dtype)
-            if self.accumulation == "fast":
-                flat = flat.at[indices.reshape((-1,))].add(payload.reshape((-1,)))
-            else:
-                width = int(indices.shape[1])
-
-                def add_route(route_index, carry):
-                    source_rank = route_index // width
-                    slot = route_index - source_rank * width
-                    source = order[source_rank]
-                    target = indices[source, slot]
-                    value = jnp.where(valid[source, slot], payload[source, slot], 0.0)
-                    if self.accumulation == "deterministic":
-                        return carry.at[target].add(value)
-                    total, correction = carry
-                    updated, error = two_sum(total[target], value)
-                    return (
-                        total.at[target].set(updated),
-                        correction.at[target].add(error),
-                    )
-
-                route_count = int(indices.shape[0]) * width
-                if self.accumulation == "deterministic":
-                    flat = jax.lax.fori_loop(0, route_count, add_route, flat)
-                else:
-                    total, correction = jax.lax.fori_loop(
-                        0,
-                        route_count,
-                        add_route,
-                        (flat, jnp.zeros_like(flat)),
-                    )
-                    flat = total + correction
+            width = int(indices.shape[1])
+            edge = EdgeRelation(
+                jnp.arange(indices.size, dtype=jnp.int32),
+                indices.reshape((-1,)),
+                source_size=indices.size,
+                target_size=self.target_sizes[axis],
+                valid=valid.reshape((-1,)),
+            )
+            execution = RelationExecutionPlan().prepare(
+                edge,
+                stable_route_ids=canonical_row_route_ids(order, width),
+            )
+            flat, _ = execution.reduce(
+                payload.reshape((-1,)),
+                accumulation=self.accumulation,
+                output="dense",
+            )
             output.append(flat.reshape(layout.shape))
         return tuple(output)
 

--- a/phydrax/discretization/flip/__init__.py
+++ b/phydrax/discretization/flip/__init__.py
@@ -22,6 +22,11 @@ from ._multiphase import (
 )
 from ._reseed import FLIPReseedingPlan, FLIPReseedingResult
 from ._solid_boundary import FLIPSolidBoundaryPlan, FLIPSolidBoundaryResult
+from ._sparse_transfer import (
+    PreparedSparseFLIPParticleTransfer,
+    SparseFLIPParticleTransferPlan,
+    SparseFLIPTransferState,
+)
 from ._transfer import FLIPParticleTransferPlan, PreparedFLIPParticleTransfer
 from ._types import (
     FLIPDiagnostics,
@@ -52,6 +57,9 @@ __all__ = [
     "MultiphaseFLIPPlan",
     "MultiphaseFLIPState",
     "MultiphaseFLIPTransferResult",
+    "PreparedSparseFLIPParticleTransfer",
+    "SparseFLIPParticleTransferPlan",
+    "SparseFLIPTransferState",
     "ParticleLevelSetPlan",
     "FLIPDiagnostics",
     "FLIPGridToParticleResult",

--- a/phydrax/discretization/flip/_sparse_transfer.py
+++ b/phydrax/discretization/flip/_sparse_transfer.py
@@ -1,0 +1,478 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import equinox as eqx
+import jax.numpy as jnp
+from jaxtyping import Array, ArrayLike
+
+from ..._fingerprint import canonical_fingerprint
+from ..._strict import StrictModule
+from ..._trainable import NonTrainableState
+from .._tensor_index import PreparedTensorIndexSpace
+from ..particle import ParticleDiscretization, ParticlePrecisionPolicy
+from ..spatial import SparseBlockTopologyPlan, SparseBlockTopologyState
+from ..splatting import (
+    AbstractStructuredSplatAssignment,
+    ParticleGridSplatBudget,
+    ParticleGridSplatPlan,
+    ParticleGridSplatState,
+    PreparedParticleGridSplat,
+    SplatExecutionPolicy,
+    TensorBSplineSplatAssignment,
+)
+from ._types import FLIPGridToParticleResult, FLIPParticleToGridResult
+
+
+class SparseFLIPTransferState(StrictModule):
+    """Logical particle routes plus complete compact cell/face topologies."""
+
+    cell_routes: ParticleGridSplatState
+    face_routes: tuple[ParticleGridSplatState, ...]
+    cell_topology: SparseBlockTopologyState
+    face_topologies: tuple[SparseBlockTopologyState, ...]
+    successful: Array
+    transfer_id: str = eqx.field(static=True)
+
+
+class SparseFLIPParticleTransferPlan(StrictModule, NonTrainableState):
+    """Matched compact cell/face particle transfers on a tensor index space."""
+
+    index_space: PreparedTensorIndexSpace
+    cell_topology: SparseBlockTopologyPlan
+    face_topologies: tuple[SparseBlockTopologyPlan, ...]
+    assignment: AbstractStructuredSplatAssignment
+    execution: SplatExecutionPolicy
+    precision: ParticlePrecisionPolicy
+    budget: ParticleGridSplatBudget
+    plan_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        index_space: PreparedTensorIndexSpace,
+        cell_topology: SparseBlockTopologyPlan,
+        face_topologies: Sequence[SparseBlockTopologyPlan],
+        /,
+        *,
+        assignment: AbstractStructuredSplatAssignment | None = None,
+        execution: SplatExecutionPolicy | None = None,
+        precision: ParticlePrecisionPolicy | None = None,
+        budget: ParticleGridSplatBudget | None = None,
+    ) -> None:
+        if not isinstance(index_space, PreparedTensorIndexSpace):
+            raise TypeError("index_space must be PreparedTensorIndexSpace.")
+        faces = tuple(face_topologies)
+        if len(faces) != len(index_space.axis_names) or not all(
+            isinstance(value, SparseBlockTopologyPlan) for value in faces
+        ):
+            raise TypeError("One sparse face topology is required per tensor axis.")
+        if not isinstance(cell_topology, SparseBlockTopologyPlan):
+            raise TypeError("cell_topology must be SparseBlockTopologyPlan.")
+        if cell_topology.layout.layout_id != index_space.cells().layout_id:
+            raise ValueError("cell_topology must use the index-space cell layout.")
+        for axis, topology in zip(index_space.axis_names, faces, strict=True):
+            if topology.layout.layout_id != index_space.faces(axis).layout_id:
+                raise ValueError("Each face topology must use its axis face layout.")
+        assignment_ = (
+            TensorBSplineSplatAssignment(1) if assignment is None else assignment
+        )
+        execution_ = SplatExecutionPolicy() if execution is None else execution
+        precision_ = ParticlePrecisionPolicy() if precision is None else precision
+        budget_ = ParticleGridSplatBudget() if budget is None else budget
+        if not isinstance(assignment_, AbstractStructuredSplatAssignment):
+            raise TypeError("assignment must be a structured splat assignment.")
+        self.index_space = index_space
+        self.cell_topology = cell_topology
+        self.face_topologies = faces
+        self.assignment = assignment_
+        self.execution = execution_
+        self.precision = precision_
+        self.budget = budget_
+        self.plan_id = canonical_fingerprint(
+            {
+                "kind": "sparse-flip-particle-transfer-plan",
+                "index_space": index_space.prepared_id,
+                "cell_topology": cell_topology.plan_id,
+                "face_topologies": [value.plan_id for value in faces],
+                "assignment": assignment_.assignment_id,
+                "execution": execution_.policy_id,
+                "precision": precision_.policy_id,
+                "budget": budget_.budget_id,
+            }
+        )
+
+    def prepare(
+        self, particles: ParticleDiscretization, /
+    ) -> PreparedSparseFLIPParticleTransfer:
+        return PreparedSparseFLIPParticleTransfer(self, particles)
+
+
+class PreparedSparseFLIPParticleTransfer(StrictModule, NonTrainableState):
+    """Prepared compact FLIP P2G/G2P transfer without a dense MAC allocation."""
+
+    plan: SparseFLIPParticleTransferPlan
+    particles: ParticleDiscretization
+    cell: PreparedParticleGridSplat
+    faces: tuple[PreparedParticleGridSplat, ...]
+    prepared_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        plan: SparseFLIPParticleTransferPlan,
+        particles: ParticleDiscretization,
+        /,
+    ) -> None:
+        if not isinstance(plan, SparseFLIPParticleTransferPlan):
+            raise TypeError("plan must be SparseFLIPParticleTransferPlan.")
+        if not isinstance(particles, ParticleDiscretization):
+            raise TypeError("particles must be ParticleDiscretization.")
+        if particles.ambient_dimension != len(plan.index_space.axis_names):
+            raise ValueError("FLIP particles and tensor index dimensions must match.")
+
+        def prepared_for(layout):
+            return ParticleGridSplatPlan(
+                plan.index_space,
+                location=plan.index_space.location(layout.offsets),
+                assignment=plan.assignment,
+                boundary="reject",
+                execution=plan.execution,
+                precision=plan.precision,
+                budget=plan.budget,
+            ).prepare(particles)
+
+        cell = prepared_for(plan.index_space.cells())
+        faces = tuple(
+            prepared_for(plan.index_space.faces(axis))
+            for axis in plan.index_space.axis_names
+        )
+        self.plan = plan
+        self.particles = particles
+        self.cell = cell
+        self.faces = faces
+        self.prepared_id = canonical_fingerprint(
+            {
+                "kind": "prepared-sparse-flip-particle-transfer",
+                "plan": plan.plan_id,
+                "particles": particles.prepared_id,
+                "cell": cell.prepared_id,
+                "faces": [value.prepared_id for value in faces],
+            }
+        )
+
+    @property
+    def dimension(self) -> int:
+        return self.particles.ambient_dimension
+
+    def build(
+        self,
+        position: ArrayLike,
+        /,
+        *,
+        active_mask: ArrayLike | None = None,
+        previous: SparseFLIPTransferState | None = None,
+    ) -> SparseFLIPTransferState:
+        cell_routes = self.cell.build(position, active_mask=active_mask)
+        face_routes = tuple(
+            value.build(position, active_mask=active_mask) for value in self.faces
+        )
+        if previous is None:
+            cell_topology = self.plan.cell_topology.build(
+                cell_routes.stencil.indices.reshape((-1,)),
+                cell_routes.stencil.valid.reshape((-1,)),
+            )
+            face_topologies = tuple(
+                topology.build(
+                    routes.stencil.indices.reshape((-1,)),
+                    routes.stencil.valid.reshape((-1,)),
+                )
+                for topology, routes in zip(
+                    self.plan.face_topologies, face_routes, strict=True
+                )
+            )
+        else:
+            if not isinstance(previous, SparseFLIPTransferState):
+                raise TypeError("previous must be SparseFLIPTransferState or None.")
+            cell_topology = self.plan.cell_topology.refresh(
+                previous.cell_topology,
+                cell_routes.stencil.indices.reshape((-1,)),
+                cell_routes.stencil.valid.reshape((-1,)),
+            ).candidate
+            face_topologies = tuple(
+                topology.refresh(
+                    old,
+                    routes.stencil.indices.reshape((-1,)),
+                    routes.stencil.valid.reshape((-1,)),
+                ).candidate
+                for topology, old, routes in zip(
+                    self.plan.face_topologies,
+                    previous.face_topologies,
+                    face_routes,
+                    strict=True,
+                )
+            )
+        successful = (
+            cell_routes.successful
+            & cell_topology.evidence.successful
+            & jnp.all(
+                jnp.stack(
+                    tuple(
+                        routes.successful & topology.evidence.successful
+                        for routes, topology in zip(
+                            face_routes, face_topologies, strict=True
+                        )
+                    )
+                )
+            )
+        )
+        return SparseFLIPTransferState(
+            cell_routes=cell_routes,
+            face_routes=face_routes,
+            cell_topology=cell_topology,
+            face_topologies=face_topologies,
+            successful=successful,
+            transfer_id=self.prepared_id,
+        )
+
+    def build_fixed(
+        self,
+        position: ArrayLike,
+        topology: SparseFLIPTransferState,
+        /,
+        *,
+        active_mask: ArrayLike | None = None,
+    ) -> SparseFLIPTransferState:
+        """Build numeric routes against one already allocated topology."""
+        if not isinstance(topology, SparseFLIPTransferState):
+            raise TypeError("topology must be SparseFLIPTransferState.")
+        cell_routes = self.cell.build(position, active_mask=active_mask)
+        face_routes = tuple(
+            value.build(position, active_mask=active_mask) for value in self.faces
+        )
+        cell_stencil = self._mapped_stencil(
+            self.cell, cell_routes, topology.cell_topology
+        )
+        face_stencils = tuple(
+            self._mapped_stencil(transfer, routes, state)
+            for transfer, routes, state in zip(
+                self.faces,
+                face_routes,
+                topology.face_topologies,
+                strict=True,
+            )
+        )
+        successful = (
+            topology.successful
+            & cell_routes.successful
+            & jnp.all(~cell_routes.stencil.valid | cell_stencil.valid)
+            & jnp.all(
+                jnp.stack(
+                    tuple(
+                        routes.successful & jnp.all(~routes.stencil.valid | stencil.valid)
+                        for routes, stencil in zip(
+                            face_routes, face_stencils, strict=True
+                        )
+                    )
+                )
+            )
+        )
+        return SparseFLIPTransferState(
+            cell_routes=cell_routes,
+            face_routes=face_routes,
+            cell_topology=topology.cell_topology,
+            face_topologies=topology.face_topologies,
+            successful=successful,
+            transfer_id=self.prepared_id,
+        )
+
+    def particle_to_grid(
+        self,
+        state: SparseFLIPTransferState,
+        velocity: ArrayLike,
+        reference_density: ArrayLike,
+        /,
+        *,
+        masses: ArrayLike | None = None,
+    ) -> FLIPParticleToGridResult:
+        self._validate_state(state)
+        values = jnp.asarray(velocity, dtype=self.particles.safe_masses.dtype)
+        expected = (self.particles.capacity, self.dimension)
+        if values.shape != expected:
+            raise ValueError(f"velocity must have shape {expected}.")
+        density = jnp.asarray(reference_density, dtype=values.dtype).reshape(())
+        density = eqx.error_if(
+            density,
+            ~jnp.isfinite(density) | (density <= 0.0),
+            "reference_density must be positive and finite.",
+        )
+        masses_ = (
+            self.particles.masses.astype(values.dtype)
+            if masses is None
+            else jnp.asarray(masses, dtype=values.dtype)
+        )
+        if masses_.shape != (self.particles.capacity,):
+            raise ValueError("masses must have particle-capacity shape.")
+        particle_volume = masses_ / density
+        cell_stencil = self._mapped_stencil(
+            self.cell, state.cell_routes, state.cell_topology
+        )
+        cell_measure = self._measure(
+            self.plan.cell_topology, state.cell_topology, values.dtype
+        )
+        cell = self.cell.deposit_content_mapped(
+            state.cell_routes,
+            particle_volume,
+            cell_stencil,
+            cell_measure,
+        )
+        cell_valid = state.cell_topology.node_valid.reshape((-1,))
+        liquid_fraction = jnp.where(
+            cell_valid,
+            cell.content / jnp.where(cell_valid, cell_measure, 1.0),
+            0.0,
+        )
+        face_mass = []
+        face_momentum = []
+        face_velocity = []
+        face_support = []
+        momentum_defect = jnp.asarray(0.0, dtype=values.dtype)
+        successful = state.successful & cell.successful
+        for axis, (transfer, routes, topology_plan, topology) in enumerate(
+            zip(
+                self.faces,
+                state.face_routes,
+                self.plan.face_topologies,
+                state.face_topologies,
+                strict=True,
+            )
+        ):
+            stencil = self._mapped_stencil(transfer, routes, topology)
+            measure = self._measure(topology_plan, topology, values.dtype)
+            payload = jnp.stack((masses_, masses_ * values[:, axis]), axis=-1)
+            result = transfer.deposit_content_mapped(
+                routes,
+                payload,
+                stencil,
+                measure,
+            )
+            mass = result.content[..., 0]
+            momentum = result.content[..., 1]
+            scale = jnp.maximum(jnp.max(jnp.abs(mass), initial=0.0), 1.0)
+            tolerance = jnp.finfo(mass.dtype).eps * max(16, transfer.route_count) * scale
+            support = topology.node_valid.reshape((-1,)) & (mass > tolerance)
+            velocity_component = jnp.where(
+                support, momentum / jnp.where(support, mass, 1.0), 0.0
+            )
+            face_mass.append(mass)
+            face_momentum.append(momentum)
+            face_velocity.append(velocity_component)
+            face_support.append(support)
+            momentum_defect = jnp.maximum(
+                momentum_defect, result.balance.maximum_absolute_balance_defect
+            )
+            successful = successful & result.successful
+        finite = jnp.all(jnp.isfinite(liquid_fraction)) & jnp.all(
+            jnp.stack(tuple(jnp.all(jnp.isfinite(value)) for value in face_velocity))
+        )
+        return FLIPParticleToGridResult(
+            cell.content,
+            liquid_fraction,
+            tuple(face_mass),
+            tuple(face_momentum),
+            tuple(face_velocity),
+            tuple(face_support),
+            cell.balance.maximum_absolute_balance_defect,
+            momentum_defect,
+            finite,
+            successful & finite,
+            "",
+            self.prepared_id,
+        )
+
+    def grid_to_particle(
+        self,
+        state: SparseFLIPTransferState,
+        old_velocity: Sequence[ArrayLike],
+        new_velocity: Sequence[ArrayLike],
+        /,
+    ) -> FLIPGridToParticleResult:
+        self._validate_state(state)
+        old = tuple(jnp.asarray(value) for value in old_velocity)
+        new = tuple(jnp.asarray(value) for value in new_velocity)
+        if len(old) != self.dimension or len(new) != self.dimension:
+            raise ValueError("One old/new compact face field is required per axis.")
+        pic = []
+        increment = []
+        supports = []
+        for transfer, routes, topology, previous, current in zip(
+            self.faces,
+            state.face_routes,
+            state.face_topologies,
+            old,
+            new,
+            strict=True,
+        ):
+            stencil = self._mapped_stencil(transfer, routes, topology)
+            pic_result = transfer.gather_mapped(routes, current, stencil)
+            delta_result = transfer.gather_mapped(routes, current - previous, stencil)
+            pic.append(pic_result.values)
+            increment.append(delta_result.values)
+            supports.append(pic_result.support & delta_result.support)
+        pic_values = jnp.stack(tuple(pic), axis=-1)
+        increments = jnp.stack(tuple(increment), axis=-1)
+        support = jnp.all(jnp.stack(tuple(supports), axis=-1), axis=-1)
+        finite = jnp.all(jnp.isfinite(pic_values)) & jnp.all(jnp.isfinite(increments))
+        return FLIPGridToParticleResult(
+            pic_values,
+            increments,
+            support,
+            finite,
+            state.successful & finite,
+            "",
+            self.prepared_id,
+        )
+
+    @staticmethod
+    def _measure(
+        plan: SparseBlockTopologyPlan,
+        topology: SparseBlockTopologyState,
+        dtype,
+    ) -> Array:
+        logical = topology.logical_node_ids.reshape((-1,))
+        valid = topology.node_valid.reshape((-1,))
+        measure, supported = plan.layout.measure_at(logical)
+        return jnp.where(valid & supported, measure.astype(dtype), 1.0)
+
+    @staticmethod
+    def _mapped_stencil(
+        transfer: PreparedParticleGridSplat,
+        routes: ParticleGridSplatState,
+        topology: SparseBlockTopologyState,
+    ):
+        lookup = topology.lookup(routes.stencil.indices, routes.stencil.valid)
+        from ..._interpolation import GatherStencil
+
+        return GatherStencil(
+            indices=lookup.storage_slots,
+            weights=routes.stencil.weights,
+            source_size=topology.plan.storage_capacity,
+            valid=routes.stencil.valid & lookup.supported,
+            support=routes.stencil.support & jnp.all(lookup.supported, axis=-1),
+            case_shape=routes.stencil.case_shape,
+        )
+
+    def _validate_state(self, state: SparseFLIPTransferState, /) -> None:
+        if not isinstance(state, SparseFLIPTransferState):
+            raise TypeError("state must be SparseFLIPTransferState.")
+        if state.transfer_id != self.prepared_id:
+            raise ValueError("Sparse FLIP state belongs to another prepared transfer.")
+
+
+__all__ = [
+    "PreparedSparseFLIPParticleTransfer",
+    "SparseFLIPParticleTransferPlan",
+    "SparseFLIPTransferState",
+]

--- a/phydrax/discretization/lattice_boltzmann/__init__.py
+++ b/phydrax/discretization/lattice_boltzmann/__init__.py
@@ -251,6 +251,15 @@ from ._program import (
     transport_population_manifest,
 )
 from ._scaling import LatticeBoltzmannScaling
+from ._sparse import (
+    PreparedSparseLatticeBoltzmann,
+    SparseLatticeBoltzmannDiagnostics,
+    SparseLatticeBoltzmannPlan,
+    SparseLatticeBoltzmannState,
+    SparseLatticeBoltzmannStepResult,
+    SparseLatticeBoltzmannTransitionEvidence,
+    SparseLatticeBoltzmannTransitionResult,
+)
 from ._species import (
     SpeciesBoundaryCondition,
     SpeciesBoundaryKind,

--- a/phydrax/discretization/lattice_boltzmann/_sparse.py
+++ b/phydrax/discretization/lattice_boltzmann/_sparse.py
@@ -1,0 +1,545 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import equinox as eqx
+import jax.numpy as jnp
+import numpy as np
+from jaxtyping import Array, ArrayLike
+
+import phydrax.ein as ein
+
+from ..._fingerprint import canonical_fingerprint
+from ..._strict import StrictModule
+from ..._trainable import NonTrainableState
+from .._tensor_index import PreparedTensorIndexSpace, TensorIndexLayout
+from ..spatial import SparseBlockTopologyPlan, SparseBlockTopologyState
+from ._collision import (
+    BGKCollisionPlan,
+    collide_detailed,
+    LatticeBoltzmannCollisionDiagnostics,
+    LatticeBoltzmannCollisionPlan,
+    macroscopic_raw_moments,
+    prepare_lattice_boltzmann_collision,
+    PreparedLatticeBoltzmannCollision,
+    quadratic_equilibrium,
+)
+from ._lattice import LatticeBoltzmannVelocitySet
+from ._precision import LatticeBoltzmannPrecisionPolicy
+
+
+class SparseLatticeBoltzmannDiagnostics(StrictModule):
+    """Compact-fluid conservation and admissibility evidence."""
+
+    minimum_density: Array
+    minimum_population: Array
+    maximum_mach: Array
+    total_mass: Array
+    mass_defect: Array
+    total_momentum: Array
+    finite: Array
+
+
+class SparseLatticeBoltzmannState(StrictModule):
+    """Populations on one fixed sparse fluid topology."""
+
+    populations: Array
+    topology: SparseBlockTopologyState
+    fluid_valid: Array
+    prepared_id: str = eqx.field(static=True)
+
+
+class SparseLatticeBoltzmannStepResult(StrictModule):
+    """Transactional collide-stream result on a fixed sparse topology."""
+
+    candidate_state: SparseLatticeBoltzmannState
+    accepted_state: SparseLatticeBoltzmannState
+    density: Array
+    velocity: Array
+    diagnostics: SparseLatticeBoltzmannDiagnostics
+    collision_diagnostics: LatticeBoltzmannCollisionDiagnostics
+    successful: Array
+
+
+class SparseLatticeBoltzmannTransitionEvidence(StrictModule):
+    """Conservative logical-cell alignment for one sparse geometry epoch."""
+
+    retained_cells: Array
+    activated_cells: Array
+    retired_cells: Array
+    activated_mass: Array
+    retired_mass: Array
+    successful: Array
+
+
+class SparseLatticeBoltzmannTransitionResult(StrictModule):
+    """Prepared sparse geometry and state after an explicit epoch transition."""
+
+    prepared: PreparedSparseLatticeBoltzmann
+    state: SparseLatticeBoltzmannState
+    evidence: SparseLatticeBoltzmannTransitionEvidence
+
+
+class SparseLatticeBoltzmannPlan(StrictModule, NonTrainableState):
+    """Static sparse collide-stream plan over explicit fluid-cell IDs."""
+
+    index_space: PreparedTensorIndexSpace
+    velocity_set: LatticeBoltzmannVelocitySet
+    collision: LatticeBoltzmannCollisionPlan
+    precision: LatticeBoltzmannPrecisionPolicy
+    block_shape: tuple[int, ...] = eqx.field(static=True)
+    block_capacity: int = eqx.field(static=True)
+    plan_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        index_space: PreparedTensorIndexSpace,
+        velocity_set: LatticeBoltzmannVelocitySet,
+        block_shape: Sequence[int],
+        block_capacity: int,
+        /,
+        *,
+        collision: LatticeBoltzmannCollisionPlan | None = None,
+        precision: LatticeBoltzmannPrecisionPolicy | None = None,
+    ) -> None:
+        if not isinstance(index_space, PreparedTensorIndexSpace):
+            raise TypeError("index_space must be PreparedTensorIndexSpace.")
+        if not isinstance(velocity_set, LatticeBoltzmannVelocitySet):
+            raise TypeError("velocity_set must be LatticeBoltzmannVelocitySet.")
+        if velocity_set.dimension != len(index_space.axis_names):
+            raise ValueError("Velocity-set and tensor-index dimensions must match.")
+        collision_ = BGKCollisionPlan() if collision is None else collision
+        precision_ = LatticeBoltzmannPrecisionPolicy() if precision is None else precision
+        if not isinstance(precision_, LatticeBoltzmannPrecisionPolicy):
+            raise TypeError("precision must be LatticeBoltzmannPrecisionPolicy.")
+        blocks = tuple(int(size) for size in block_shape)
+        capacity = int(block_capacity)
+        if len(blocks) != velocity_set.dimension or any(size <= 0 for size in blocks):
+            raise ValueError("block_shape must match the lattice dimension.")
+        if capacity <= 0:
+            raise ValueError("block_capacity must be positive.")
+        prepare_lattice_boltzmann_collision(collision_, velocity_set, precision_)
+        self.index_space = index_space
+        self.velocity_set = velocity_set
+        self.collision = collision_
+        self.precision = precision_
+        self.block_shape = blocks
+        self.block_capacity = capacity
+        self.plan_id = canonical_fingerprint(
+            {
+                "kind": "sparse-lattice-boltzmann-plan",
+                "index_space": index_space.prepared_id,
+                "lattice": velocity_set.lattice_id,
+                "collision": collision_.collision_id,
+                "precision": precision_.policy_id,
+                "block_shape": list(blocks),
+                "block_capacity": capacity,
+                "boundary": "halfway-bounceback-on-missing-fluid-neighbor",
+            }
+        )
+
+    def prepare(self, fluid_cell_ids: ArrayLike, /) -> PreparedSparseLatticeBoltzmann:
+        return PreparedSparseLatticeBoltzmann(self, fluid_cell_ids)
+
+
+class PreparedSparseLatticeBoltzmann(StrictModule, NonTrainableState):
+    """Prepared static sparse fluid cells, streaming routes, and collision."""
+
+    plan: SparseLatticeBoltzmannPlan
+    layout: TensorIndexLayout
+    topology_plan: SparseBlockTopologyPlan
+    topology: SparseBlockTopologyState
+    fluid_valid: Array
+    stream_source_slots: Array
+    stream_source_valid: Array
+    collision: PreparedLatticeBoltzmannCollision
+    coordinates: Array
+    prepared_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        plan: SparseLatticeBoltzmannPlan,
+        fluid_cell_ids: ArrayLike,
+        /,
+    ) -> None:
+        if not isinstance(plan, SparseLatticeBoltzmannPlan):
+            raise TypeError("plan must be SparseLatticeBoltzmannPlan.")
+        cells = np.asarray(fluid_cell_ids)
+        if cells.ndim != 1 or not np.issubdtype(cells.dtype, np.integer):
+            raise TypeError("fluid_cell_ids must be a rank-1 integer array.")
+        if cells.size == 0:
+            raise ValueError("Sparse LBM requires at least one fluid cell.")
+        if np.any(cells < 0) or np.any(cells >= plan.index_space.cells().size):
+            raise ValueError("fluid_cell_ids contain out-of-domain cells.")
+        if np.unique(cells).size != cells.size:
+            raise ValueError("fluid_cell_ids must be unique.")
+        cells = np.sort(cells.astype(np.int32))
+        layout = plan.index_space.cells()
+        topology_plan = SparseBlockTopologyPlan(
+            plan.index_space,
+            plan.block_shape,
+            plan.block_capacity,
+            layout=layout,
+        )
+        topology = topology_plan.build(
+            jnp.asarray(cells),
+            jnp.ones((cells.size,), dtype=bool),
+            stable_site_ids=jnp.asarray(cells),
+        )
+        if not bool(np.asarray(topology.evidence.successful)):
+            raise ValueError(
+                "Sparse LBM fluid cells exceed block capacity or index support."
+            )
+        fluid_lookup = topology.lookup(jnp.asarray(cells))
+        storage_capacity = topology_plan.storage_capacity
+        fluid_valid = (
+            jnp.zeros((storage_capacity,), dtype=bool)
+            .at[fluid_lookup.storage_slots]
+            .set(fluid_lookup.supported)
+        )
+        logical_ids = topology.logical_node_ids.reshape((-1,))
+        storage_valid = topology.node_valid.reshape((-1,))
+        integer, _ = layout.integer_coordinates(logical_ids)
+        velocities = jnp.asarray(plan.velocity_set.velocities, dtype=jnp.int32)
+        source_coordinates = integer[:, None, :] - velocities[None, :, :]
+        source_in_domain = jnp.broadcast_to(
+            storage_valid[:, None], source_coordinates.shape[:-1]
+        )
+        resolved_axes = []
+        for axis, size in enumerate(layout.shape):
+            coordinate = source_coordinates[..., axis]
+            if plan.index_space.periodic_axes[axis]:
+                coordinate = jnp.mod(coordinate, size)
+            else:
+                source_in_domain = source_in_domain & (
+                    (coordinate >= 0) & (coordinate < size)
+                )
+                coordinate = jnp.clip(coordinate, 0, size - 1)
+            resolved_axes.append(coordinate)
+        resolved_source = jnp.stack(resolved_axes, axis=-1)
+        source_ids, source_layout_valid = layout.flat_indices(resolved_source)
+        source_lookup = topology.lookup(
+            source_ids,
+            source_in_domain & source_layout_valid,
+        )
+        source_slots = source_lookup.storage_slots
+        source_fluid = (
+            source_lookup.supported & fluid_valid[source_slots] & fluid_valid[:, None]
+        )
+        coordinates, coordinate_valid = layout.coordinates_at(logical_ids)
+        coordinates = jnp.where(
+            (storage_valid & coordinate_valid)[:, None], coordinates, 0.0
+        )
+        collision = prepare_lattice_boltzmann_collision(
+            plan.collision,
+            plan.velocity_set,
+            plan.precision,
+        )
+        prepared_id = canonical_fingerprint(
+            {
+                "kind": "prepared-sparse-lattice-boltzmann",
+                "plan": plan.plan_id,
+                "fluid_cell_ids": cells.tolist(),
+                "topology": topology_plan.plan_id,
+                "collision": collision.prepared_id,
+            }
+        )
+        self.plan = plan
+        self.layout = layout
+        self.topology_plan = topology_plan
+        self.topology = topology
+        self.fluid_valid = fluid_valid
+        self.stream_source_slots = source_slots
+        self.stream_source_valid = source_fluid
+        self.collision = collision
+        self.coordinates = coordinates
+        self.prepared_id = prepared_id
+
+    @property
+    def storage_capacity(self) -> int:
+        return self.topology_plan.storage_capacity
+
+    @property
+    def population_shape(self) -> tuple[int, int]:
+        return self.storage_capacity, self.plan.velocity_set.population_count
+
+    def initialize_state(
+        self,
+        density: ArrayLike,
+        velocity: ArrayLike,
+        /,
+    ) -> SparseLatticeBoltzmannState:
+        dtype = jnp.dtype(self.plan.precision.population_dtype)
+        rho = jnp.asarray(density, dtype=dtype)
+        if rho.shape == ():
+            rho = jnp.broadcast_to(rho, (self.storage_capacity,))
+        if rho.shape != (self.storage_capacity,):
+            raise ValueError(
+                "density must be scalar or have sparse storage-cell capacity."
+            )
+        velocity_value = jnp.asarray(velocity, dtype=dtype)
+        dimension = self.plan.velocity_set.dimension
+        if velocity_value.shape == (dimension,):
+            velocity_value = jnp.broadcast_to(
+                velocity_value, (self.storage_capacity, dimension)
+            )
+        if velocity_value.shape != (self.storage_capacity, dimension):
+            raise ValueError(
+                "velocity must be one vector or one vector per sparse storage cell."
+            )
+        rho = jnp.where(self.fluid_valid, rho, 1.0)
+        velocity_value = jnp.where(self.fluid_valid[:, None], velocity_value, 0.0)
+        populations = quadratic_equilibrium(
+            rho,
+            velocity_value,
+            self.plan.velocity_set,
+            self.plan.precision,
+        )
+        populations = self.plan.precision.population(
+            jnp.where(self.fluid_valid[:, None], populations, 0.0)
+        )
+        return SparseLatticeBoltzmannState(
+            populations=populations,
+            topology=self.topology,
+            fluid_valid=self.fluid_valid,
+            prepared_id=self.prepared_id,
+        )
+
+    def macroscopic(self, state: SparseLatticeBoltzmannState, /) -> tuple[Array, Array]:
+        self._validate_state(state)
+        density, momentum = macroscopic_raw_moments(
+            state.populations,
+            self.plan.velocity_set,
+            self.plan.precision,
+        )
+        safe_density = jnp.where(self.fluid_valid & (density > 0.0), density, 1.0)
+        velocity = momentum / safe_density[:, None]
+        return (
+            jnp.where(self.fluid_valid, density, 0.0),
+            jnp.where(self.fluid_valid[:, None], velocity, 0.0),
+        )
+
+    def step(
+        self,
+        state: SparseLatticeBoltzmannState,
+        relaxation_rate: ArrayLike,
+        /,
+    ) -> SparseLatticeBoltzmannStepResult:
+        self._validate_state(state)
+        dtype = state.populations.dtype
+        rate = jnp.asarray(relaxation_rate, dtype=dtype)
+        if rate.shape == ():
+            rate = jnp.broadcast_to(rate, (self.storage_capacity,))
+        if rate.shape != (self.storage_capacity,):
+            raise ValueError(
+                "relaxation_rate must be scalar or have sparse storage-cell capacity."
+            )
+        rate = eqx.error_if(
+            rate,
+            jnp.any(
+                self.fluid_valid & (~jnp.isfinite(rate) | (rate <= 0.0) | (rate >= 2.0))
+            ),
+            "Fluid relaxation rates must lie in (0, 2).",
+        )
+        density_before, velocity_before = self.macroscopic(state)
+        safe_density = jnp.where(self.fluid_valid, density_before, 1.0)
+        safe_velocity = jnp.where(self.fluid_valid[:, None], velocity_before, 0.0)
+        equilibrium = quadratic_equilibrium(
+            safe_density,
+            safe_velocity,
+            self.plan.velocity_set,
+            self.plan.precision,
+        )
+        safe_populations = jnp.where(
+            self.fluid_valid[:, None], state.populations, equilibrium
+        )
+        collision = collide_detailed(
+            self.collision,
+            safe_populations,
+            equilibrium,
+            jnp.zeros_like(safe_populations),
+            jnp.where(self.fluid_valid, rate, 1.0),
+            safe_velocity,
+            self.plan.velocity_set,
+            self.plan.precision,
+        )
+        post_collision = collision.candidate_populations
+        q = self.plan.velocity_set.population_count
+        directions = jnp.arange(q, dtype=jnp.int32)[None, :]
+        streamed = post_collision[self.stream_source_slots, directions]
+        reflected = post_collision[:, self.plan.velocity_set.opposite]
+        candidate_populations = jnp.where(
+            self.stream_source_valid,
+            streamed,
+            reflected,
+        )
+        candidate_populations = self.plan.precision.population(
+            jnp.where(self.fluid_valid[:, None], candidate_populations, 0.0)
+        )
+        candidate_state = SparseLatticeBoltzmannState(
+            populations=candidate_populations,
+            topology=self.topology,
+            fluid_valid=self.fluid_valid,
+            prepared_id=self.prepared_id,
+        )
+        density, velocity = self.macroscopic(candidate_state)
+        finite = (
+            jnp.all(
+                jnp.where(
+                    self.fluid_valid[:, None], jnp.isfinite(candidate_populations), True
+                )
+            )
+            & jnp.all(jnp.where(self.fluid_valid, density > 0.0, True))
+            & jnp.all(jnp.isfinite(velocity))
+        )
+        successful = collision.successful & finite
+        accepted_populations = jnp.where(
+            successful, candidate_populations, state.populations
+        )
+        accepted_state = SparseLatticeBoltzmannState(
+            populations=accepted_populations,
+            topology=self.topology,
+            fluid_valid=self.fluid_valid,
+            prepared_id=self.prepared_id,
+        )
+        mass_before = jnp.sum(jnp.where(self.fluid_valid, density_before, 0.0))
+        mass_after = jnp.sum(jnp.where(self.fluid_valid, density, 0.0))
+        momentum = ein.contract(
+            "sq,qd->d",
+            jnp.where(self.fluid_valid[:, None], candidate_populations, 0.0),
+            jnp.asarray(self.plan.velocity_set.velocities, dtype=dtype),
+        )
+        sound_speed = jnp.sqrt(
+            jnp.asarray(self.plan.velocity_set.sound_speed_squared, dtype=dtype)
+        )
+        speed = jnp.sqrt(jnp.sum(velocity * velocity, axis=-1))
+        diagnostics = SparseLatticeBoltzmannDiagnostics(
+            minimum_density=jnp.min(
+                jnp.where(self.fluid_valid, density, jnp.inf), initial=jnp.inf
+            ),
+            minimum_population=jnp.min(
+                jnp.where(self.fluid_valid[:, None], candidate_populations, jnp.inf),
+                initial=jnp.inf,
+            ),
+            maximum_mach=jnp.max(
+                jnp.where(self.fluid_valid, speed / sound_speed, 0.0), initial=0.0
+            ),
+            total_mass=mass_after,
+            mass_defect=mass_after - mass_before,
+            total_momentum=momentum,
+            finite=finite,
+        )
+        return SparseLatticeBoltzmannStepResult(
+            candidate_state=candidate_state,
+            accepted_state=accepted_state,
+            density=density,
+            velocity=velocity,
+            diagnostics=diagnostics,
+            collision_diagnostics=collision.diagnostics,
+            successful=successful,
+        )
+
+    def refresh_geometry(
+        self,
+        state: SparseLatticeBoltzmannState,
+        fluid_cell_ids: ArrayLike,
+        /,
+        *,
+        activated_density: ArrayLike = 1.0,
+        activated_velocity: ArrayLike | None = None,
+    ) -> SparseLatticeBoltzmannTransitionResult:
+        """Prepare a new fixed topology and align populations by logical cell ID."""
+        self._validate_state(state)
+        candidate = self.plan.prepare(fluid_cell_ids)
+        velocity = (
+            jnp.zeros((self.plan.velocity_set.dimension,))
+            if activated_velocity is None
+            else jnp.asarray(activated_velocity)
+        )
+        initialized = candidate.initialize_state(activated_density, velocity)
+        new_logical_ids = candidate.topology.logical_node_ids.reshape((-1,))
+        old_lookup = self.topology.lookup(
+            new_logical_ids,
+            candidate.fluid_valid,
+        )
+        retained = (
+            candidate.fluid_valid
+            & old_lookup.supported
+            & self.fluid_valid[old_lookup.storage_slots]
+        )
+        aligned_populations = jnp.where(
+            retained[:, None],
+            state.populations[old_lookup.storage_slots],
+            initialized.populations,
+        )
+        old_logical_ids = self.topology.logical_node_ids.reshape((-1,))
+        new_lookup = candidate.topology.lookup(
+            old_logical_ids,
+            self.fluid_valid,
+        )
+        old_retained = (
+            self.fluid_valid
+            & new_lookup.supported
+            & candidate.fluid_valid[new_lookup.storage_slots]
+        )
+        retired = self.fluid_valid & ~old_retained
+        activated = candidate.fluid_valid & ~retained
+        topology_changed = jnp.any(activated) | jnp.any(retired)
+        next_topology = eqx.tree_at(
+            lambda topology: topology.generation,
+            candidate.topology,
+            self.topology.generation + topology_changed.astype(jnp.int32),
+        )
+        candidate = eqx.tree_at(
+            lambda prepared: prepared.topology,
+            candidate,
+            next_topology,
+        )
+        next_state = SparseLatticeBoltzmannState(
+            populations=aligned_populations,
+            topology=next_topology,
+            fluid_valid=candidate.fluid_valid,
+            prepared_id=candidate.prepared_id,
+        )
+        evidence = SparseLatticeBoltzmannTransitionEvidence(
+            retained_cells=jnp.sum(retained, dtype=jnp.int32),
+            activated_cells=jnp.sum(activated, dtype=jnp.int32),
+            retired_cells=jnp.sum(retired, dtype=jnp.int32),
+            activated_mass=jnp.sum(
+                jnp.where(
+                    activated[:, None],
+                    initialized.populations,
+                    0.0,
+                )
+            ),
+            retired_mass=jnp.sum(jnp.where(retired[:, None], state.populations, 0.0)),
+            successful=jnp.asarray(True),
+        )
+        return SparseLatticeBoltzmannTransitionResult(
+            prepared=candidate,
+            state=next_state,
+            evidence=evidence,
+        )
+
+    def _validate_state(self, state: SparseLatticeBoltzmannState, /) -> None:
+        if not isinstance(state, SparseLatticeBoltzmannState):
+            raise TypeError("state must be SparseLatticeBoltzmannState.")
+        if state.prepared_id != self.prepared_id:
+            raise ValueError("Sparse LBM state belongs to another prepared plan.")
+        if state.populations.shape != self.population_shape:
+            raise ValueError("Sparse LBM population shape is incompatible.")
+
+
+__all__ = [
+    "PreparedSparseLatticeBoltzmann",
+    "SparseLatticeBoltzmannDiagnostics",
+    "SparseLatticeBoltzmannPlan",
+    "SparseLatticeBoltzmannTransitionEvidence",
+    "SparseLatticeBoltzmannTransitionResult",
+    "SparseLatticeBoltzmannState",
+    "SparseLatticeBoltzmannStepResult",
+]

--- a/phydrax/discretization/mpm/__init__.py
+++ b/phydrax/discretization/mpm/__init__.py
@@ -126,8 +126,6 @@ from ._storage import (
     AbstractMPMNodalStoragePlan,
     BlockSparseMPMNodalStoragePlan,
     DenseMPMNodalStoragePlan,
-    MPMActiveBlockPlan,
-    MPMActiveBlockState,
 )
 from ._transfer import APICGatherResult
 from ._types import (

--- a/phydrax/discretization/mpm/_boundary.py
+++ b/phydrax/discretization/mpm/_boundary.py
@@ -90,5 +90,61 @@ class PrescribedGridVelocityPlan(StrictModule, NonTrainableState):
             successful,
         )
 
+    def apply_indexed(
+        self,
+        velocity: ArrayLike,
+        mass: ArrayLike,
+        step_size: ArrayLike,
+        logical_node_ids: ArrayLike,
+        node_valid: ArrayLike,
+        /,
+    ) -> PrescribedGridVelocityResult:
+        """Apply a dense logical boundary declaration on compact nodal storage."""
+        value = jnp.asarray(velocity)
+        mass_ = jnp.asarray(mass)
+        logical = jnp.asarray(logical_node_ids, dtype=jnp.int32)
+        valid = jnp.asarray(node_valid, dtype=bool)
+        if value.ndim != 2 or value.shape[-1] != self.mask.shape[-1]:
+            raise ValueError(
+                "Compact grid velocity must have shape (storage, dimension)."
+            )
+        if mass_.shape != value.shape[:-1] or logical.shape != mass_.shape:
+            raise ValueError("Compact mass and logical node IDs must match velocity.")
+        if valid.shape != mass_.shape:
+            raise ValueError("node_valid must match compact storage capacity.")
+        logical_size = int(np.prod(self.mask.shape[:-1], dtype=int))
+        if logical_size == 0:
+            raise ValueError("Prescribed boundary logical grid cannot be empty.")
+        safe = jnp.clip(logical, 0, logical_size - 1)
+        mask = self.mask.reshape((logical_size, self.mask.shape[-1]))[safe]
+        prescribed = self.values.reshape((logical_size, self.values.shape[-1]))[safe]
+        mask = mask & valid[:, None]
+        dt = jnp.asarray(step_size, dtype=value.dtype)
+        next_velocity = jnp.where(mask, prescribed.astype(value.dtype), value)
+        delta = mass_[:, None] * (next_velocity - value)
+        impulse = compensated_sum(delta, axis=0)
+        kinetic_change = (
+            0.5
+            * mass_
+            * (
+                jnp.sum(next_velocity * next_velocity, axis=-1)
+                - jnp.sum(value * value, axis=-1)
+            )
+        )
+        work = compensated_sum(kinetic_change)
+        successful = (
+            jnp.isfinite(dt)
+            & (dt > 0.0)
+            & jnp.all(jnp.isfinite(next_velocity))
+            & jnp.all(jnp.isfinite(impulse))
+            & jnp.isfinite(work)
+        )
+        return PrescribedGridVelocityResult(
+            next_velocity,
+            impulse,
+            work,
+            successful,
+        )
+
 
 __all__ = ["PrescribedGridVelocityPlan", "PrescribedGridVelocityResult"]

--- a/phydrax/discretization/mpm/_dynamics.py
+++ b/phydrax/discretization/mpm/_dynamics.py
@@ -40,7 +40,11 @@ from ._schedule import (
     PostAdvectionMUSLMPMSchedule,
     USFMPMSchedule,
 )
-from ._storage import MPMActiveBlockPlan
+from ._storage import (
+    AbstractMPMNodalStoragePlan,
+    BlockSparseMPMNodalStoragePlan,
+    DenseMPMNodalStoragePlan,
+)
 from ._transfer import (
     apic_particle_angular_momentum,
     apic_particle_kinetic_energy,
@@ -100,12 +104,14 @@ class PreparedMPMDynamics(StrictModule, NonTrainableState):
     boundary: PrescribedGridVelocityPlan | None
     contact: RigidMPMContactPlan | None
     nodal_fields: MPMNodalFieldPlan
-    active_blocks: MPMActiveBlockPlan | None
+    nodal_storage: AbstractMPMNodalStoragePlan
     external_acceleration: ExternalMPMAcceleration | None
     external_acceleration_id: str | None = eqx.field(static=True)
     resource_policy: MPMResourcePolicy
     key: DiscretizationKey
     grid_coordinates: Array
+    nodal_shape: tuple[int, ...] = eqx.field(static=True)
+    grid_count: int = eqx.field(static=True)
     minimum_spacing: float = eqx.field(static=True)
     preparation: PreparationReport
     resource_evidence: MPMPreparationEvidence
@@ -123,7 +129,7 @@ class PreparedMPMDynamics(StrictModule, NonTrainableState):
         boundary: PrescribedGridVelocityPlan | None = None,
         contact: RigidMPMContactPlan | None = None,
         nodal_fields: MPMNodalFieldPlan | None = None,
-        active_blocks: MPMActiveBlockPlan | None = None,
+        nodal_storage: AbstractMPMNodalStoragePlan | None = None,
         external_acceleration: ExternalMPMAcceleration | None = None,
         external_acceleration_id: str | None = None,
         resource_policy: MPMResourcePolicy | None = None,
@@ -152,12 +158,25 @@ class PreparedMPMDynamics(StrictModule, NonTrainableState):
             raise TypeError("nodal_fields must be MPMNodalFieldPlan or None.")
         if fields.initial_particle_field_slots.shape != (particles.capacity,):
             raise ValueError("Nodal field slots must match particle capacity.")
-        if active_blocks is not None and not isinstance(
-            active_blocks, MPMActiveBlockPlan
-        ):
-            raise TypeError("active_blocks must be MPMActiveBlockPlan or None.")
-        if active_blocks is not None and active_blocks.grid_shape != splat.target_shape:
-            raise ValueError("Active-block logical grid must match the splat target.")
+        storage = (
+            DenseMPMNodalStoragePlan(splat.target_shape)
+            if nodal_storage is None
+            else nodal_storage
+        )
+        if not isinstance(storage, AbstractMPMNodalStoragePlan):
+            raise TypeError("nodal_storage must be AbstractMPMNodalStoragePlan or None.")
+        if isinstance(storage, DenseMPMNodalStoragePlan):
+            if storage.grid_shape != splat.target_shape:
+                raise ValueError("Dense nodal storage must match the splat target.")
+            if not splat.materialized_target:
+                raise ValueError(
+                    "A virtual splat target requires block-sparse nodal storage."
+                )
+        elif isinstance(storage, BlockSparseMPMNodalStoragePlan):
+            if storage.grid_shape != splat.target_shape:
+                raise ValueError("Sparse nodal storage must match the splat target.")
+            if storage.topology_plan.layout.layout_id != splat.layout.layout_id:
+                raise ValueError("Sparse nodal storage and splat layouts differ.")
         if splat.particles.prepared_id != particles.prepared_id:
             raise ValueError("MPM splat was prepared for a different particle support.")
         dimension = particles.ambient_dimension
@@ -225,15 +244,26 @@ class PreparedMPMDynamics(StrictModule, NonTrainableState):
                         "Nonperiodic MPM needs the assignment's complete declared "
                         "support halo."
                     )
-        mesh = jnp.meshgrid(*coordinates, indexing="ij")
-        grid_coordinates = jnp.stack(mesh, axis=-1).reshape((-1, dimension))
+        if isinstance(storage, DenseMPMNodalStoragePlan):
+            mesh = jnp.meshgrid(*coordinates, indexing="ij")
+            grid_coordinates = jnp.stack(mesh, axis=-1).reshape((-1, dimension))
+            nodal_shape = splat.target_shape
+        else:
+            grid_coordinates = jnp.empty((0, dimension), dtype=coordinates[0].dtype)
+            nodal_shape = (storage.storage_capacity,)
         if boundary is not None and boundary.mask.shape != splat.target_shape + (
             dimension,
         ):
             raise ValueError("Prescribed boundary layout must match the MPM nodal grid.")
 
         if boundary is not None and contact is not None:
-            overlap = np.asarray(contact.prospective_mask(grid_coordinates)).reshape(
+            overlap_coordinates = grid_coordinates
+            if isinstance(storage, BlockSparseMPMNodalStoragePlan):
+                overlap_mesh = jnp.meshgrid(*coordinates, indexing="ij")
+                overlap_coordinates = jnp.stack(overlap_mesh, axis=-1).reshape(
+                    (-1, dimension)
+                )
+            overlap = np.asarray(contact.prospective_mask(overlap_coordinates)).reshape(
                 splat.target_shape
             )
             if np.any(overlap[..., None] & np.asarray(boundary.mask)):
@@ -245,7 +275,7 @@ class PreparedMPMDynamics(StrictModule, NonTrainableState):
             raise TypeError("resource_policy must be MPMResourcePolicy or None.")
         itemsize = np.dtype(splat.plan.precision.evaluation_dtype).itemsize
         particle_count = particles.capacity
-        grid_count = splat.target_size
+        grid_count = storage.storage_capacity
         route_payload_width = 3 * dimension
         step_values = (
             splat.route_count * route_payload_width
@@ -279,7 +309,8 @@ class PreparedMPMDynamics(StrictModule, NonTrainableState):
             ),
             resource_counts={
                 "particle_capacity": particle_count,
-                "grid_node_count": grid_count,
+                "logical_grid_node_count": splat.target_size,
+                "storage_node_count": grid_count,
                 "route_count": splat.route_count,
                 "route_payload_width": route_payload_width,
                 "step_workspace_bytes": workspace_bytes,
@@ -308,12 +339,14 @@ class PreparedMPMDynamics(StrictModule, NonTrainableState):
         self.boundary = boundary
         self.contact = contact
         self.nodal_fields = fields
-        self.active_blocks = active_blocks
+        self.nodal_storage = storage
         self.external_acceleration = external_acceleration
         self.external_acceleration_id = external_acceleration_id
         self.resource_policy = resource
         self.key = key
         self.grid_coordinates = grid_coordinates
+        self.nodal_shape = nodal_shape
+        self.grid_count = grid_count
         self.minimum_spacing = min(spacings)
         self.preparation = preparation
         self.resource_evidence = resource_evidence
@@ -329,9 +362,7 @@ class PreparedMPMDynamics(StrictModule, NonTrainableState):
                 "boundary": None if boundary is None else boundary.plan_id,
                 "contact": None if contact is None else contact.plan_id,
                 "nodal_fields": fields.plan_id,
-                "active_blocks": (
-                    None if active_blocks is None else active_blocks.plan_id
-                ),
+                "nodal_storage": storage.storage_id,
                 "external_acceleration": external_acceleration_id,
                 "resource": resource.policy_id,
                 "preparation": preparation.report_id,
@@ -349,6 +380,55 @@ class PreparedMPMDynamics(StrictModule, NonTrainableState):
     @property
     def resource_evidence_id(self) -> str:
         return self.resource_evidence.evidence_id
+
+    @property
+    def compact_storage(self) -> bool:
+        return isinstance(self.nodal_storage, BlockSparseMPMNodalStoragePlan)
+
+    def _build_storage(self, routes, previous=None):
+        if isinstance(self.nodal_storage, BlockSparseMPMNodalStoragePlan):
+            return self.nodal_storage.build(routes, previous)
+        return None
+
+    def _mapped_routes(self, routes, storage_state):
+        if isinstance(self.nodal_storage, BlockSparseMPMNodalStoragePlan):
+            return self.nodal_storage.mapped_routes(routes, storage_state)
+        return routes
+
+    def _deposit_content(self, routes, storage_state, content):
+        if isinstance(self.nodal_storage, BlockSparseMPMNodalStoragePlan):
+            return self.nodal_storage.deposit_content(
+                self.splat, routes, storage_state, content
+            )
+        return self.splat.deposit_content(routes, content)
+
+    def _scatter_route_payload(self, routes, storage_state, payload):
+        if isinstance(self.nodal_storage, BlockSparseMPMNodalStoragePlan):
+            return self.nodal_storage.scatter_route_payload(
+                self.splat, routes, storage_state, payload
+            )
+        return self.splat.scatter_route_payload(routes, payload)
+
+    def _storage_coordinates(self, storage_state):
+        if isinstance(self.nodal_storage, BlockSparseMPMNodalStoragePlan):
+            return self.nodal_storage.coordinates(storage_state)
+        return self.grid_coordinates
+
+    def _storage_node_valid(self, storage_state):
+        if isinstance(self.nodal_storage, BlockSparseMPMNodalStoragePlan):
+            return storage_state.node_valid.reshape((-1,))
+        return jnp.ones((self.grid_count,), dtype=bool)
+
+    def _storage_boundary_data(self, storage_state):
+        if self.boundary is None:
+            return None
+        if isinstance(self.nodal_storage, BlockSparseMPMNodalStoragePlan):
+            logical = storage_state.logical_node_ids.reshape((-1,))
+            valid = storage_state.node_valid.reshape((-1,))
+            mask = self.boundary.mask.reshape((-1, self.dimension))[logical]
+            values = self.boundary.values.reshape((-1, self.dimension))[logical]
+            return mask & valid[:, None], values
+        return self.boundary.mask, self.boundary.values
 
     def _vector(self, name: str, value: ArrayLike) -> Array:
         array = self.splat.plan.precision.evaluation(value)
@@ -435,13 +515,15 @@ class PreparedMPMDynamics(StrictModule, NonTrainableState):
             position_, deformation, assignment_input
         )
         routes = self.splat.build(position_, assignment_input=runtime_assignment)
-        storage_state = (
-            None if self.active_blocks is None else self.active_blocks.build(routes)
-        )
+        storage_state = self._build_storage(routes)
         valid = (
             jnp.all((~active) | self.particle_domain.contains(position_))
             & routes.successful
-            & (jnp.asarray(True) if storage_state is None else storage_state.successful)
+            & (
+                jnp.asarray(True)
+                if storage_state is None
+                else storage_state.evidence.successful
+            )
             & jnp.all((~active) | (jnp.isfinite(volume) & (volume > 0.0)))
             & jnp.all((~active) | response.successful)
             & jnp.all((~active) | response.admissible)
@@ -502,7 +584,7 @@ class PreparedMPMDynamics(StrictModule, NonTrainableState):
         finite = jnp.all(jnp.where(active, jnp.isfinite(value), True))
         return jnp.where(active, value, 0.0), finite
 
-    def _apply_contact(self, velocity, mass, time, step_size, arguments):
+    def _apply_contact(self, velocity, mass, time, step_size, arguments, storage_state):
         if self.contact is None:
             return MPMGridConstraintResult(
                 velocity,
@@ -514,8 +596,8 @@ class PreparedMPMDynamics(StrictModule, NonTrainableState):
                 jnp.zeros(mass.shape, dtype=jnp.int32),
                 jnp.asarray(True),
             )
-        coordinates = self.grid_coordinates.reshape(
-            self.splat.target_shape + (self.dimension,)
+        coordinates = self._storage_coordinates(storage_state).reshape(
+            self.nodal_shape + (self.dimension,)
         )
         return self.contact.apply(
             coordinates,
@@ -528,13 +610,11 @@ class PreparedMPMDynamics(StrictModule, NonTrainableState):
 
     def _empty_grid(self, dtype) -> MPMGridState:
         scalar = jnp.zeros(
-            (self.nodal_fields.field_count,) + self.splat.target_shape,
+            (self.nodal_fields.field_count,) + self.nodal_shape,
             dtype=dtype,
         )
         vector = jnp.zeros(
-            (self.nodal_fields.field_count,)
-            + self.splat.target_shape
-            + (self.dimension,),
+            (self.nodal_fields.field_count,) + self.nodal_shape + (self.dimension,),
             dtype=dtype,
         )
         return MPMGridState(
@@ -658,11 +738,7 @@ class PreparedMPMDynamics(StrictModule, NonTrainableState):
             state.particles.position,
             assignment_input=state.assignment_input,
         )
-        storage_state = (
-            None
-            if self.active_blocks is None
-            else self.active_blocks.build(routes, state.storage_state)
-        )
+        storage_state = self._build_storage(routes, state.storage_state)
         domain_ok = jnp.all(
             (~active) | self.particle_domain.contains(state.particles.position)
         )
@@ -670,7 +746,11 @@ class PreparedMPMDynamics(StrictModule, NonTrainableState):
         route_ok = (
             routes.successful
             & ~jnp.any(routes.truncated_support_mask)
-            & (jnp.asarray(True) if storage_state is None else storage_state.successful)
+            & (
+                jnp.asarray(True)
+                if storage_state is None
+                else storage_state.evidence.successful
+            )
         )
 
         def invalid(_):
@@ -703,6 +783,7 @@ class PreparedMPMDynamics(StrictModule, NonTrainableState):
         def execute(_):
             if self.nodal_fields.field_count > 1:
                 return multifield_step_detailed(self, state, dt, arguments, routes)
+            execution_routes = self._mapped_routes(routes, storage_state)
             particle = state.particles
             mass = (
                 self.particles.safe_masses.astype(particle.position.dtype)
@@ -712,14 +793,14 @@ class PreparedMPMDynamics(StrictModule, NonTrainableState):
             acceleration_external, external_ok = self._external(
                 state.time, particle, arguments
             )
-            mass_result = self.splat.deposit_content(routes, mass)
+            mass_result = self._deposit_content(routes, storage_state, mass)
             p2g_affine = (
                 particle.affine_velocity
                 if self.method.transfer.requires_affine_state
                 else jnp.zeros_like(particle.affine_velocity)
             )
             route_payload = build_apic_route_payload(
-                routes,
+                execution_routes,
                 mass,
                 particle.velocity,
                 p2g_affine,
@@ -729,7 +810,7 @@ class PreparedMPMDynamics(StrictModule, NonTrainableState):
                 acceleration_external,
                 active,
             )
-            scattered = self.splat.scatter_route_payload(routes, route_payload)
+            scattered = self._scatter_route_payload(routes, storage_state, route_payload)
             dimension = self.dimension
             grid_mass = mass_result.content
             grid_momentum = scattered.values[..., :dimension]
@@ -742,14 +823,14 @@ class PreparedMPMDynamics(StrictModule, NonTrainableState):
             )
             grid_active = normalized_grid.active
             velocity_before = normalized_grid.velocity
-            if storage_state is not None:
-                grid_active = grid_active & storage_state.active_node_mask
-                velocity_before = jnp.where(grid_active[..., None], velocity_before, 0.0)
-                normalized_grid = eqx.tree_at(
-                    lambda value: (value.active, value.velocity),
-                    normalized_grid,
-                    (grid_active, velocity_before),
-                )
+            node_valid = self._storage_node_valid(storage_state).reshape(self.nodal_shape)
+            grid_active = grid_active & node_valid
+            velocity_before = jnp.where(grid_active[..., None], velocity_before, 0.0)
+            normalized_grid = eqx.tree_at(
+                lambda value: (value.active, value.velocity),
+                normalized_grid,
+                (grid_active, velocity_before),
+            )
             density = mass / jnp.where(active, particle.reference_volume, 1.0)
             identity = jnp.broadcast_to(
                 jnp.eye(dimension, dtype=particle.position.dtype),
@@ -758,8 +839,8 @@ class PreparedMPMDynamics(StrictModule, NonTrainableState):
             schedule_p2g_success = jnp.asarray(True)
             if isinstance(self.method.schedule, USFMPMSchedule):
                 first_gather = gather_apic(
-                    routes,
-                    velocity_before.reshape((self.splat.target_size, dimension)),
+                    execution_routes,
+                    velocity_before.reshape((self.grid_count, dimension)),
                     active,
                     self.method.transfer.maximum_condition,
                 )
@@ -777,7 +858,7 @@ class PreparedMPMDynamics(StrictModule, NonTrainableState):
                     dt,
                 )
                 scheduled_payload = build_apic_route_payload(
-                    routes,
+                    execution_routes,
                     mass,
                     particle.velocity,
                     p2g_affine,
@@ -787,8 +868,8 @@ class PreparedMPMDynamics(StrictModule, NonTrainableState):
                     acceleration_external,
                     active,
                 )
-                scheduled_scatter = self.splat.scatter_route_payload(
-                    routes, scheduled_payload
+                scheduled_scatter = self._scatter_route_payload(
+                    routes, storage_state, scheduled_payload
                 )
                 internal_force = scheduled_scatter.values[..., dimension : 2 * dimension]
                 external_force = scheduled_scatter.values[..., 2 * dimension :]
@@ -801,7 +882,6 @@ class PreparedMPMDynamics(StrictModule, NonTrainableState):
                 external_force,
                 dt,
             )
-            grid_acceleration = grid_update.acceleration
             wave_speed = (
                 scheduled_material.maximum_wave_speed
                 if isinstance(self.method.schedule, USFMPMSchedule)
@@ -910,7 +990,12 @@ class PreparedMPMDynamics(StrictModule, NonTrainableState):
             def advance(_):
                 velocity_trial = grid_update.velocity
                 contact_result = self._apply_contact(
-                    velocity_trial, grid_mass, state.time, dt, arguments
+                    velocity_trial,
+                    grid_mass,
+                    state.time,
+                    dt,
+                    arguments,
+                    storage_state,
                 )
                 if self.boundary is None:
                     boundary_result = PrescribedGridVelocityResult(
@@ -920,14 +1005,23 @@ class PreparedMPMDynamics(StrictModule, NonTrainableState):
                         jnp.asarray(True),
                     )
                 else:
-                    boundary_result = self.boundary.apply(
-                        contact_result.velocity, grid_mass, dt
-                    )
+                    if isinstance(self.nodal_storage, BlockSparseMPMNodalStoragePlan):
+                        boundary_result = self.boundary.apply_indexed(
+                            contact_result.velocity,
+                            grid_mass,
+                            dt,
+                            storage_state.logical_node_ids.reshape((-1,)),
+                            storage_state.node_valid.reshape((-1,)),
+                        )
+                    else:
+                        boundary_result = self.boundary.apply(
+                            contact_result.velocity, grid_mass, dt
+                        )
                 grid_after = boundary_result.velocity
                 gathered = apply_velocity_transfer(
                     self.method.transfer,
                     self.method.advection,
-                    routes,
+                    execution_routes,
                     velocity_before,
                     grid_after,
                     particle.velocity,
@@ -954,7 +1048,12 @@ class PreparedMPMDynamics(StrictModule, NonTrainableState):
                             candidate_position,
                             assignment_input=second_input,
                         )
-                    second_mass = self.splat.deposit_content(second_routes, mass)
+                    second_execution_routes = self._mapped_routes(
+                        second_routes, storage_state
+                    )
+                    second_mass = self._deposit_content(
+                        second_routes, storage_state, mass
+                    )
                     if (
                         isinstance(
                             self.method.schedule,
@@ -966,7 +1065,7 @@ class PreparedMPMDynamics(StrictModule, NonTrainableState):
                         zero_tensor = jnp.zeros_like(particle.first_piola)
                         zero_acceleration = jnp.zeros_like(particle.velocity)
                         second_payload = build_apic_route_payload(
-                            second_routes,
+                            second_execution_routes,
                             mass,
                             gathered.velocity,
                             gathered.affine_velocity,
@@ -976,8 +1075,8 @@ class PreparedMPMDynamics(StrictModule, NonTrainableState):
                             zero_acceleration,
                             active,
                         )
-                        second_momentum_result = self.splat.scatter_route_payload(
-                            second_routes, second_payload
+                        second_momentum_result = self._scatter_route_payload(
+                            second_routes, storage_state, second_payload
                         )
                         second_particle_momentum = mass[:, None] * gathered.velocity
                         second_momentum_content = second_momentum_result.values[
@@ -986,8 +1085,10 @@ class PreparedMPMDynamics(StrictModule, NonTrainableState):
                         second_momentum_successful = second_momentum_result.successful
                     else:
                         second_particle_momentum = mass[:, None] * gathered.velocity
-                        second_momentum_result = self.splat.deposit_content(
-                            second_routes, second_particle_momentum
+                        second_momentum_result = self._deposit_content(
+                            second_routes,
+                            storage_state,
+                            second_particle_momentum,
                         )
                         second_momentum_content = second_momentum_result.content
                         second_momentum_successful = second_momentum_result.successful
@@ -1002,6 +1103,7 @@ class PreparedMPMDynamics(StrictModule, NonTrainableState):
                         state.time,
                         dt,
                         arguments,
+                        storage_state,
                     )
                     if self.boundary is None:
                         second_boundary = PrescribedGridVelocityResult(
@@ -1011,17 +1113,24 @@ class PreparedMPMDynamics(StrictModule, NonTrainableState):
                             jnp.asarray(True),
                         )
                     else:
-                        second_boundary = self.boundary.apply(
-                            second_contact.velocity, second_mass.content, dt
-                        )
+                        if isinstance(self.nodal_storage, BlockSparseMPMNodalStoragePlan):
+                            second_boundary = self.boundary.apply_indexed(
+                                second_contact.velocity,
+                                second_mass.content,
+                                dt,
+                                storage_state.logical_node_ids.reshape((-1,)),
+                                storage_state.node_valid.reshape((-1,)),
+                            )
+                        else:
+                            second_boundary = self.boundary.apply(
+                                second_contact.velocity, second_mass.content, dt
+                            )
                     second_contact_work = second_contact.work
                     second_contact_dissipation = second_contact.dissipation
                     second_contact_limit = second_contact.contact_step_limit
                     second_gather = gather_apic(
-                        second_routes,
-                        second_boundary.velocity.reshape(
-                            (self.splat.target_size, dimension)
-                        ),
+                        second_execution_routes,
+                        second_boundary.velocity.reshape((self.grid_count, dimension)),
                         active,
                         (
                             self.method.transfer.maximum_condition
@@ -1049,7 +1158,7 @@ class PreparedMPMDynamics(StrictModule, NonTrainableState):
                     )
                     second_constraint_work = second_boundary.work
                     second_successful = (
-                        second_routes.successful
+                        second_execution_routes.successful
                         & second_mass.successful
                         & second_momentum_successful
                         & second_contact.successful
@@ -1209,12 +1318,22 @@ class PreparedMPMDynamics(StrictModule, NonTrainableState):
                     successful, storage_state, state.storage_state
                 )
                 accepted_particle = tree_where(successful, candidate_particle, particle)
+                candidate_generation = (
+                    state.topology_generation
+                    if storage_state is None
+                    else storage_state.generation
+                )
+                accepted_generation = jnp.where(
+                    successful,
+                    candidate_generation,
+                    state.topology_generation,
+                )
                 accepted_state = MPMRuntimeState(
                     accepted_particle,
                     jnp.where(successful, state.time + dt, state.time),
                     jnp.where(successful, state.accepted_step + 1, state.accepted_step),
                     status,
-                    state.topology_generation,
+                    accepted_generation,
                     accepted_assignment,
                     state.material_slots,
                     state.body_ids,
@@ -1227,7 +1346,7 @@ class PreparedMPMDynamics(StrictModule, NonTrainableState):
                     state.time + dt,
                     state.accepted_step + 1,
                     status,
-                    state.topology_generation,
+                    candidate_generation,
                     candidate_assignment,
                     state.material_slots,
                     state.body_ids,
@@ -1253,7 +1372,7 @@ class PreparedMPMDynamics(StrictModule, NonTrainableState):
                     active,
                 )
                 target_angular = grid_angular_momentum(
-                    self.grid_coordinates,
+                    self._storage_coordinates(storage_state),
                     grid_momentum.reshape((-1, dimension)),
                     grid_active.reshape((-1,)),
                 )

--- a/phydrax/discretization/mpm/_multifield_dynamics.py
+++ b/phydrax/discretization/mpm/_multifield_dynamics.py
@@ -90,11 +90,8 @@ def multifield_step_detailed(dynamics, state, dt, arguments, routes):
         if dynamics.method.transfer.requires_affine_state
         else jnp.zeros_like(particle.affine_velocity)
     )
-    storage_state = (
-        None
-        if dynamics.active_blocks is None
-        else dynamics.active_blocks.build(routes, state.storage_state)
-    )
+    storage_state = dynamics._build_storage(routes, state.storage_state)
+    execution_routes = dynamics._mapped_routes(routes, storage_state)
     mass_results = []
     momenta = []
     internal_forces = []
@@ -105,9 +102,9 @@ def multifield_step_detailed(dynamics, state, dt, arguments, routes):
     for field in range(field_count):
         owned = active & (slots == field)
         field_mass = jnp.where(owned, mass, 0.0)
-        mass_result = dynamics.splat.deposit_content(routes, field_mass)
+        mass_result = dynamics._deposit_content(routes, storage_state, field_mass)
         payload = build_apic_route_payload(
-            routes,
+            execution_routes,
             mass,
             particle.velocity,
             p2g_affine,
@@ -117,14 +114,16 @@ def multifield_step_detailed(dynamics, state, dt, arguments, routes):
             external,
             owned,
         )
-        scattered = dynamics.splat.scatter_route_payload(routes, payload)
+        scattered = dynamics._scatter_route_payload(routes, storage_state, payload)
         momentum = scattered.values[..., :dimension]
         internal = scattered.values[..., dimension : 2 * dimension]
         field_external = scattered.values[..., 2 * dimension :]
         gradient_payload = (
             mass[:, None, None] * routes.weight_gradients * owned[:, None, None]
         )
-        gradient = dynamics.splat.scatter_route_payload(routes, gradient_payload).values
+        gradient = dynamics._scatter_route_payload(
+            routes, storage_state, gradient_payload
+        ).values
         normalized_field = normalize_grid_momentum(
             mass_result.content,
             momentum,
@@ -148,10 +147,8 @@ def multifield_step_detailed(dynamics, state, dt, arguments, routes):
         for field in range(field_count):
             owned = active & (slots == field)
             gathered = gather_apic(
-                routes,
-                normalized[field].velocity.reshape(
-                    (dynamics.splat.target_size, dimension)
-                ),
+                execution_routes,
+                normalized[field].velocity.reshape((dynamics.grid_count, dimension)),
                 owned,
                 (
                     dynamics.method.transfer.maximum_condition
@@ -182,7 +179,7 @@ def multifield_step_detailed(dynamics, state, dt, arguments, routes):
         for field in range(field_count):
             owned = active & (slots == field)
             payload = build_apic_route_payload(
-                routes,
+                execution_routes,
                 mass,
                 particle.velocity,
                 p2g_affine,
@@ -192,7 +189,7 @@ def multifield_step_detailed(dynamics, state, dt, arguments, routes):
                 external,
                 owned,
             )
-            scattered = dynamics.splat.scatter_route_payload(routes, payload)
+            scattered = dynamics._scatter_route_payload(routes, storage_state, payload)
             internal = scattered.values[..., dimension : 2 * dimension]
             internal_forces.append(internal)
             updates.append(
@@ -212,19 +209,23 @@ def multifield_step_detailed(dynamics, state, dt, arguments, routes):
     grid_active = jnp.stack(tuple(value.active for value in normalized))
     grid_acceleration = jnp.stack(tuple(value.acceleration for value in updates))
     velocity_trial = jnp.stack(tuple(value.velocity for value in updates))
-    if storage_state is not None:
-        node_mask = storage_state.active_node_mask
-        grid_active = grid_active & node_mask[None, ...]
-        velocity_before = jnp.where(grid_active[..., None], velocity_before, 0.0)
-        grid_acceleration = jnp.where(grid_active[..., None], grid_acceleration, 0.0)
-        velocity_trial = jnp.where(grid_active[..., None], velocity_trial, 0.0)
+    node_mask = dynamics._storage_node_valid(storage_state).reshape(dynamics.nodal_shape)
+    grid_active = grid_active & node_mask[None, ...]
+    velocity_before = jnp.where(grid_active[..., None], velocity_before, 0.0)
+    grid_acceleration = jnp.where(grid_active[..., None], grid_acceleration, 0.0)
+    velocity_trial = jnp.where(grid_active[..., None], velocity_trial, 0.0)
 
     rigid_results = []
     rigid_velocity = []
     for field in range(field_count):
         result = (
             dynamics._apply_contact(
-                velocity_trial[field], grid_mass[field], state.time, dt, arguments
+                velocity_trial[field],
+                grid_mass[field],
+                state.time,
+                dt,
+                arguments,
+                storage_state,
             )
             if dynamics.contact is not None
             else _zero_constraint(velocity_trial[field], grid_mass[field], dimension)
@@ -233,17 +234,18 @@ def multifield_step_detailed(dynamics, state, dt, arguments, routes):
         rigid_velocity.append(result.velocity)
     constrained = jnp.stack(tuple(rigid_velocity))
     contact_plan = dynamics.nodal_fields.contact_plan
+    boundary_data = dynamics._storage_boundary_data(storage_state)
     if contact_plan is not None:
         essential_mask = (
             None
-            if dynamics.boundary is None
-            else jnp.broadcast_to(dynamics.boundary.mask, constrained.shape)
+            if boundary_data is None
+            else jnp.broadcast_to(boundary_data[0], constrained.shape)
         )
         essential_values = (
             None
-            if dynamics.boundary is None
+            if boundary_data is None
             else jnp.broadcast_to(
-                dynamics.boundary.values.astype(constrained.dtype),
+                boundary_data[1].astype(constrained.dtype),
                 constrained.shape,
             )
         )
@@ -292,7 +294,18 @@ def multifield_step_detailed(dynamics, state, dt, arguments, routes):
                     jnp.asarray(True),
                 )
             else:
-                result = dynamics.boundary.apply(constrained[field], grid_mass[field], dt)
+                if dynamics.compact_storage:
+                    result = dynamics.boundary.apply_indexed(
+                        constrained[field],
+                        grid_mass[field],
+                        dt,
+                        storage_state.logical_node_ids.reshape((-1,)),
+                        storage_state.node_valid.reshape((-1,)),
+                    )
+                else:
+                    result = dynamics.boundary.apply(
+                        constrained[field], grid_mass[field], dt
+                    )
             boundary_results.append(result)
             boundary_velocity.append(result.velocity)
         grid_after = jnp.stack(tuple(boundary_velocity))
@@ -301,7 +314,7 @@ def multifield_step_detailed(dynamics, state, dt, arguments, routes):
         apply_velocity_transfer(
             dynamics.method.transfer,
             dynamics.method.advection,
-            routes,
+            execution_routes,
             velocity_before[field],
             grid_after[field],
             particle.velocity,
@@ -349,6 +362,7 @@ def multifield_step_detailed(dynamics, state, dt, arguments, routes):
             second_routes = dynamics.splat.build(
                 trial_position, assignment_input=second_input
             )
+        second_execution_routes = dynamics._mapped_routes(second_routes, storage_state)
         second_masses = []
         second_momenta = []
         second_normalized = []
@@ -356,7 +370,9 @@ def multifield_step_detailed(dynamics, state, dt, arguments, routes):
         for field in range(field_count):
             owned = active & (slots == field)
             field_mass = jnp.where(owned, mass, 0.0)
-            mass_result = dynamics.splat.deposit_content(second_routes, field_mass)
+            mass_result = dynamics._deposit_content(
+                second_routes, storage_state, field_mass
+            )
             if (
                 isinstance(
                     dynamics.method.schedule,
@@ -366,7 +382,7 @@ def multifield_step_detailed(dynamics, state, dt, arguments, routes):
                 == "apic-affine-momentum"
             ):
                 payload = build_apic_route_payload(
-                    second_routes,
+                    second_execution_routes,
                     mass,
                     next_velocity,
                     next_affine,
@@ -376,15 +392,16 @@ def multifield_step_detailed(dynamics, state, dt, arguments, routes):
                     jnp.zeros_like(particle.velocity),
                     owned,
                 )
-                momentum_result = dynamics.splat.scatter_route_payload(
-                    second_routes, payload
+                momentum_result = dynamics._scatter_route_payload(
+                    second_routes, storage_state, payload
                 )
                 momentum = momentum_result.values[..., :dimension]
                 momentum_successful = momentum_result.successful
             else:
                 source_momentum = mass[:, None] * next_velocity
-                momentum_result = dynamics.splat.deposit_content(
+                momentum_result = dynamics._deposit_content(
                     second_routes,
+                    storage_state,
                     jnp.where(owned[:, None], source_momentum, 0.0),
                 )
                 momentum = momentum_result.content
@@ -414,6 +431,7 @@ def multifield_step_detailed(dynamics, state, dt, arguments, routes):
                 state.time,
                 dt,
                 arguments,
+                storage_state,
             )
             second_rigid_results.append(result)
             second_rigid_velocity.append(result.velocity)
@@ -425,14 +443,14 @@ def multifield_step_detailed(dynamics, state, dt, arguments, routes):
             )
             essential_mask = (
                 None
-                if dynamics.boundary is None
-                else jnp.broadcast_to(dynamics.boundary.mask, second_constrained.shape)
+                if boundary_data is None
+                else jnp.broadcast_to(boundary_data[0], second_constrained.shape)
             )
             essential_values = (
                 None
-                if dynamics.boundary is None
+                if boundary_data is None
                 else jnp.broadcast_to(
-                    dynamics.boundary.values.astype(second_constrained.dtype),
+                    boundary_data[1].astype(second_constrained.dtype),
                     second_constrained.shape,
                 )
             )
@@ -455,9 +473,18 @@ def multifield_step_detailed(dynamics, state, dt, arguments, routes):
                 if dynamics.boundary is None:
                     second_values.append(second_constrained[field])
                 else:
-                    boundary = dynamics.boundary.apply(
-                        second_constrained[field], second_mass_grid[field], dt
-                    )
+                    if dynamics.compact_storage:
+                        boundary = dynamics.boundary.apply_indexed(
+                            second_constrained[field],
+                            second_mass_grid[field],
+                            dt,
+                            storage_state.logical_node_ids.reshape((-1,)),
+                            storage_state.node_valid.reshape((-1,)),
+                        )
+                    else:
+                        boundary = dynamics.boundary.apply(
+                            second_constrained[field], second_mass_grid[field], dt
+                        )
                     second_values.append(boundary.velocity)
                     second_constraint_work = second_constraint_work + boundary.work
                     second_successful = second_successful & boundary.successful
@@ -466,8 +493,8 @@ def multifield_step_detailed(dynamics, state, dt, arguments, routes):
         for field in range(field_count):
             owned = active & (slots == field)
             gathered = gather_apic(
-                second_routes,
-                second_after[field].reshape((dynamics.splat.target_size, dimension)),
+                second_execution_routes,
+                second_after[field].reshape((dynamics.grid_count, dimension)),
                 owned,
                 (
                     dynamics.method.transfer.maximum_condition
@@ -480,7 +507,11 @@ def multifield_step_detailed(dynamics, state, dt, arguments, routes):
                 gathered.velocity_gradient,
                 second_gradient,
             )
-            second_successful = second_successful & gathered.successful
+            second_successful = (
+                second_successful
+                & second_execution_routes.successful
+                & gathered.successful
+            )
         next_gradient = second_gradient
         total_particle_mass = jnp.sum(jnp.where(active, mass, 0.0))
         total_second_mass = jnp.sum(second_mass_grid)
@@ -585,7 +616,13 @@ def multifield_step_detailed(dynamics, state, dt, arguments, routes):
     )
     finite = tree_allfinite(candidate)
     successful = (
-        external_ok
+        execution_routes.successful
+        & (
+            jnp.asarray(True)
+            if storage_state is None
+            else storage_state.evidence.successful
+        )
+        & external_ok
         & gather_successful
         & schedule_pre_successful
         & second_successful
@@ -602,6 +639,12 @@ def multifield_step_detailed(dynamics, state, dt, arguments, routes):
     )
     accepted_input = tree_where(successful, candidate_input, state.assignment_input)
     accepted_storage = tree_where(successful, storage_state, state.storage_state)
+    candidate_generation = (
+        state.topology_generation if storage_state is None else storage_state.generation
+    )
+    accepted_generation = jnp.where(
+        successful, candidate_generation, state.topology_generation
+    )
     status = jnp.where(
         successful,
         int(MPMRunStatus.SUCCESS),
@@ -624,7 +667,7 @@ def multifield_step_detailed(dynamics, state, dt, arguments, routes):
         jnp.where(successful, state.time + dt, state.time),
         jnp.where(successful, state.accepted_step + 1, state.accepted_step),
         status,
-        state.topology_generation,
+        accepted_generation,
         accepted_input,
         state.material_slots,
         state.body_ids,
@@ -637,7 +680,7 @@ def multifield_step_detailed(dynamics, state, dt, arguments, routes):
         state.time + dt,
         state.accepted_step + 1,
         status,
-        state.topology_generation,
+        candidate_generation,
         candidate_input,
         state.material_slots,
         state.body_ids,
@@ -662,7 +705,7 @@ def multifield_step_detailed(dynamics, state, dt, arguments, routes):
         active,
     )
     target_angular = grid_angular_momentum(
-        dynamics.grid_coordinates,
+        dynamics._storage_coordinates(storage_state),
         aggregate_momentum.reshape((-1, dimension)),
         aggregate_active.reshape((-1,)),
     )

--- a/phydrax/discretization/mpm/_storage.py
+++ b/phydrax/discretization/mpm/_storage.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 import abc
-from itertools import product
 from math import prod
 
 import equinox as eqx
@@ -13,279 +12,228 @@ import jax.numpy as jnp
 from jaxtyping import Array, ArrayLike
 
 from ..._fingerprint import canonical_fingerprint
+from ..._interpolation import GatherStencil
 from ..._strict import AbstractAttribute, StrictModule
 from ..._trainable import NonTrainableState
-from ..splatting import ParticleGridSplatState
-
-
-class MPMActiveBlockState(StrictModule):
-    active_block_ids: Array
-    active_block_count: Array
-    active_block_mask: Array
-    current_previous_union: Array
-    active_node_mask: Array
-    overflow: Array
-    successful: Array
-
-
-class MPMActiveBlockPlan(StrictModule, NonTrainableState):
-    grid_shape: tuple[int, ...] = eqx.field(static=True)
-    block_shape: tuple[int, ...] = eqx.field(static=True)
-    block_grid_shape: tuple[int, ...] = eqx.field(static=True)
-    maximum_active_blocks: int = eqx.field(static=True)
-    halo_blocks: int = eqx.field(static=True)
-    plan_id: str = eqx.field(static=True)
-
-    def __init__(
-        self,
-        grid_shape,
-        block_shape,
-        maximum_active_blocks: int,
-        /,
-        *,
-        halo_blocks: int = 1,
-    ):
-        grid = tuple(int(value) for value in grid_shape)
-        block = tuple(int(value) for value in block_shape)
-        maximum = int(maximum_active_blocks)
-        halo = int(halo_blocks)
-        if (
-            not grid
-            or len(grid) != len(block)
-            or any(value <= 0 for value in grid + block)
-            or any(g % b != 0 for g, b in zip(grid, block, strict=True))
-            or maximum <= 0
-            or halo < 0
-        ):
-            raise ValueError("MPM active-block plan is invalid.")
-        block_grid = tuple(g // b for g, b in zip(grid, block, strict=True))
-        if maximum > prod(block_grid):
-            raise ValueError("maximum_active_blocks exceeds the logical block grid.")
-        self.grid_shape = grid
-        self.block_shape = block
-        self.block_grid_shape = block_grid
-        self.maximum_active_blocks = maximum
-        self.halo_blocks = halo
-        self.plan_id = canonical_fingerprint(
-            {
-                "kind": "mpm-active-block-plan",
-                "grid_shape": grid,
-                "block_shape": block,
-                "maximum_active_blocks": maximum,
-                "halo_blocks": halo,
-            }
-        )
-
-    @property
-    def block_count(self) -> int:
-        return prod(self.block_grid_shape)
-
-    @property
-    def nodes_per_block(self) -> int:
-        return prod(self.block_shape)
-
-    def _block_ids(self, logical_indices):
-        coordinates = jnp.stack(
-            jnp.unravel_index(logical_indices, self.grid_shape), axis=-1
-        )
-        block_coordinates = coordinates // jnp.asarray(self.block_shape)
-        block_id = block_coordinates[..., 0]
-        for axis in range(1, len(self.grid_shape)):
-            block_id = (
-                block_id * self.block_grid_shape[axis] + block_coordinates[..., axis]
-            )
-        return block_id.astype(jnp.int32), block_coordinates
-
-    def build(
-        self,
-        routes: ParticleGridSplatState,
-        previous: MPMActiveBlockState | None = None,
-        /,
-    ) -> MPMActiveBlockState:
-        logical = routes.stencil.indices.reshape((-1,))
-        valid = routes.stencil.valid.reshape((-1,))
-        block_ids, _ = self._block_ids(logical)
-        mask = (
-            jnp.zeros((self.block_count,), dtype=bool)
-            .at[jnp.where(valid, block_ids, 0)]
-            .set(valid)
-        )
-        block_coordinates = jnp.stack(
-            jnp.unravel_index(
-                jnp.arange(self.block_count, dtype=jnp.int32), self.block_grid_shape
-            ),
-            axis=-1,
-        )
-        dilated = mask
-        for offset in product(
-            range(-self.halo_blocks, self.halo_blocks + 1),
-            repeat=len(self.grid_shape),
-        ):
-            shifted = block_coordinates + jnp.asarray(offset)
-            inside = jnp.all(
-                (shifted >= 0) & (shifted < jnp.asarray(self.block_grid_shape)),
-                axis=-1,
-            )
-            flat = shifted[..., 0]
-            for axis in range(1, len(self.grid_shape)):
-                flat = flat * self.block_grid_shape[axis] + shifted[..., axis]
-            source = jnp.where(inside, jnp.clip(flat, 0, self.block_count - 1), 0)
-            dilated = dilated | (inside & mask[source])
-        count = jnp.sum(dilated, dtype=jnp.int32)
-        overflow = count > self.maximum_active_blocks
-        ids = jnp.nonzero(
-            dilated,
-            size=self.maximum_active_blocks,
-            fill_value=0,
-        )[0].astype(jnp.int32)
-        union = dilated if previous is None else (dilated | previous.active_block_mask)
-        node_ids = jnp.arange(prod(self.grid_shape), dtype=jnp.int32)
-        node_blocks, _ = self._block_ids(node_ids)
-        node_mask = dilated[node_blocks].reshape(self.grid_shape)
-        return MPMActiveBlockState(
-            ids,
-            count,
-            dilated,
-            union,
-            node_mask,
-            overflow,
-            routes.successful & ~overflow,
-        )
+from ..spatial import SparseBlockTopologyPlan, SparseBlockTopologyState
+from ..splatting import (
+    ParticleGridSplatState,
+    PreparedParticleGridSplat,
+    SplatDepositResult,
+    SplatRouteScatterResult,
+)
 
 
 class AbstractMPMNodalStoragePlan(StrictModule, NonTrainableState):
+    """Static MPM nodal placement policy."""
+
     storage_id: AbstractAttribute[str]
 
+    @property
     @abc.abstractmethod
-    def pack(self, dense: Array, active: MPMActiveBlockState, /) -> Array:
+    def storage_capacity(self) -> int:
         raise NotImplementedError
 
     @abc.abstractmethod
-    def unpack(self, compact: Array, active: MPMActiveBlockState, /) -> Array:
+    def pack(self, dense: Array, topology: SparseBlockTopologyState | None, /) -> Array:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def unpack(
+        self, compact: Array, topology: SparseBlockTopologyState | None, /
+    ) -> Array:
         raise NotImplementedError
 
 
 class DenseMPMNodalStoragePlan(AbstractMPMNodalStoragePlan):
+    """Identity storage over the complete logical nodal grid."""
+
     grid_shape: tuple[int, ...] = eqx.field(static=True)
     storage_id: str = eqx.field(static=True)
 
     def __init__(self, grid_shape, /):
-        self.grid_shape = tuple(int(value) for value in grid_shape)
+        shape = tuple(int(value) for value in grid_shape)
+        if not shape or any(size <= 0 for size in shape):
+            raise ValueError("grid_shape must contain positive dimensions.")
+        self.grid_shape = shape
         self.storage_id = canonical_fingerprint(
-            {"kind": "dense-mpm-nodal-storage", "grid_shape": self.grid_shape}
+            {"kind": "dense-mpm-nodal-storage", "grid_shape": shape}
         )
 
-    def pack(self, dense, active, /):
-        del active
+    @property
+    def storage_capacity(self) -> int:
+        return prod(self.grid_shape)
+
+    def pack(self, dense, topology, /):
+        del topology
         return jnp.asarray(dense)
 
-    def unpack(self, compact, active, /):
-        del active
+    def unpack(self, compact, topology, /):
+        del topology
         return jnp.asarray(compact)
 
 
 class BlockSparseMPMNodalStoragePlan(AbstractMPMNodalStoragePlan):
-    blocks: MPMActiveBlockPlan
+    """Operational MPM storage on canonical sparse tensor blocks."""
+
+    topology_plan: SparseBlockTopologyPlan
     storage_id: str = eqx.field(static=True)
 
-    def __init__(self, blocks: MPMActiveBlockPlan, /):
-        if not isinstance(blocks, MPMActiveBlockPlan):
-            raise TypeError("blocks must be MPMActiveBlockPlan.")
-        self.blocks = blocks
+    def __init__(self, topology_plan: SparseBlockTopologyPlan, /):
+        if not isinstance(topology_plan, SparseBlockTopologyPlan):
+            raise TypeError("topology_plan must be SparseBlockTopologyPlan.")
+        self.topology_plan = topology_plan
         self.storage_id = canonical_fingerprint(
-            {"kind": "block-sparse-mpm-storage", "blocks": blocks.plan_id}
+            {
+                "kind": "block-sparse-mpm-storage",
+                "topology": topology_plan.plan_id,
+            }
         )
 
-    def _block_coordinates(self, ids):
-        return jnp.stack(jnp.unravel_index(ids, self.blocks.block_grid_shape), axis=-1)
+    @property
+    def storage_capacity(self) -> int:
+        return self.topology_plan.storage_capacity
 
-    def _logical_indices(self, block_ids):
-        dimension = len(self.blocks.grid_shape)
-        block_coordinates = self._block_coordinates(block_ids)
-        local = jnp.stack(
-            jnp.unravel_index(
-                jnp.arange(self.blocks.nodes_per_block), self.blocks.block_shape
-            ),
-            axis=-1,
-        )
-        coordinates = (
-            block_coordinates[:, None, :] * jnp.asarray(self.blocks.block_shape)
-            + local[None, :, :]
-        )
-        flat = coordinates[..., 0]
-        for axis in range(1, dimension):
-            flat = flat * self.blocks.grid_shape[axis] + coordinates[..., axis]
-        return flat.astype(jnp.int32)
+    @property
+    def grid_shape(self) -> tuple[int, ...]:
+        return self.topology_plan.layout.shape
 
-    def pack(self, dense: ArrayLike, active: MPMActiveBlockState, /) -> Array:
+    def build(
+        self,
+        routes: ParticleGridSplatState,
+        previous: SparseBlockTopologyState | None = None,
+        /,
+    ) -> SparseBlockTopologyState:
+        logical = routes.stencil.indices.reshape((-1,))
+        valid = routes.stencil.valid.reshape((-1,))
+        if previous is None:
+            return self.topology_plan.build(logical, valid)
+        return self.topology_plan.refresh(previous, logical, valid).candidate
+
+    def mapped_stencil(
+        self,
+        routes: ParticleGridSplatState,
+        topology: SparseBlockTopologyState,
+        /,
+    ) -> GatherStencil:
+        lookup = topology.lookup(
+            routes.stencil.indices,
+            routes.stencil.valid,
+        )
+        return GatherStencil(
+            indices=lookup.storage_slots,
+            weights=routes.stencil.weights,
+            source_size=self.storage_capacity,
+            valid=routes.stencil.valid & lookup.supported,
+            support=routes.stencil.support & jnp.all(lookup.supported, axis=-1),
+            case_shape=routes.stencil.case_shape,
+        )
+
+    def mapped_routes(
+        self,
+        routes: ParticleGridSplatState,
+        topology: SparseBlockTopologyState,
+        /,
+    ) -> ParticleGridSplatState:
+        stencil = self.mapped_stencil(routes, topology)
+        successful = (
+            routes.successful
+            & topology.evidence.successful
+            & jnp.all(~routes.stencil.valid | stencil.valid)
+        )
+        mapped = eqx.tree_at(lambda value: value.stencil, routes, stencil)
+        return eqx.tree_at(lambda value: value.successful, mapped, successful)
+
+    def target_measure(self, topology: SparseBlockTopologyState, /) -> Array:
+        logical = topology.logical_node_ids.reshape((-1,))
+        valid = topology.node_valid.reshape((-1,))
+        measure, supported = self.topology_plan.layout.measure_at(logical)
+        return jnp.where(valid & supported, measure, 1.0)
+
+    def coordinates(self, topology: SparseBlockTopologyState, /) -> Array:
+        logical = topology.logical_node_ids.reshape((-1,))
+        valid = topology.node_valid.reshape((-1,))
+        coordinates, supported = self.topology_plan.layout.coordinates_at(logical)
+        return jnp.where((valid & supported)[:, None], coordinates, 0.0)
+
+    def deposit_content(
+        self,
+        splat: PreparedParticleGridSplat,
+        routes: ParticleGridSplatState,
+        topology: SparseBlockTopologyState,
+        content: ArrayLike,
+        /,
+    ) -> SplatDepositResult:
+        mapped = self.mapped_stencil(routes, topology)
+        return splat.deposit_content_mapped(
+            routes,
+            content,
+            mapped,
+            self.target_measure(topology),
+        )
+
+    def scatter_route_payload(
+        self,
+        splat: PreparedParticleGridSplat,
+        routes: ParticleGridSplatState,
+        topology: SparseBlockTopologyState,
+        payload: ArrayLike,
+        /,
+    ) -> SplatRouteScatterResult:
+        return splat.scatter_route_payload_mapped(
+            routes,
+            payload,
+            self.mapped_stencil(routes, topology),
+        )
+
+    def pack(
+        self,
+        dense: ArrayLike,
+        topology: SparseBlockTopologyState | None,
+        /,
+    ) -> Array:
+        if topology is None:
+            raise ValueError("Block-sparse packing requires a topology state.")
         value = jnp.asarray(dense)
-        if value.shape[: len(self.blocks.grid_shape)] != self.blocks.grid_shape:
+        if value.shape[: len(self.grid_shape)] != self.grid_shape:
             raise ValueError("Dense MPM storage has the wrong grid prefix.")
-        flat = value.reshape(
-            (prod(self.blocks.grid_shape),) + value.shape[len(self.blocks.grid_shape) :]
-        )
-        logical = self._logical_indices(active.active_block_ids)
+        trailing = value.shape[len(self.grid_shape) :]
+        flat = value.reshape((prod(self.grid_shape),) + trailing)
+        logical = topology.logical_node_ids.reshape((-1,))
+        valid = topology.node_valid.reshape((-1,))
         packed = flat[logical]
-        valid_blocks = (
-            jnp.arange(self.blocks.maximum_active_blocks, dtype=jnp.int32)
-            < active.active_block_count
-        )
         return jnp.where(
-            valid_blocks.reshape(valid_blocks.shape + (1,) * (packed.ndim - 1)),
+            valid.reshape(valid.shape + (1,) * len(trailing)),
             packed,
-            0.0,
+            jnp.zeros((), dtype=packed.dtype),
         )
 
-    def unpack(self, compact: ArrayLike, active: MPMActiveBlockState, /) -> Array:
+    def unpack(
+        self,
+        compact: ArrayLike,
+        topology: SparseBlockTopologyState | None,
+        /,
+    ) -> Array:
+        if topology is None:
+            raise ValueError("Block-sparse unpacking requires a topology state.")
         value = jnp.asarray(compact)
-        expected = (
-            self.blocks.maximum_active_blocks,
-            self.blocks.nodes_per_block,
+        if value.ndim < 1 or value.shape[0] != self.storage_capacity:
+            raise ValueError("Compact MPM storage has the wrong storage capacity.")
+        logical = topology.logical_node_ids.reshape((-1,))
+        valid = topology.node_valid.reshape((-1,))
+        trailing = value.shape[1:]
+        flat = jnp.zeros((prod(self.grid_shape),) + trailing, dtype=value.dtype)
+        payload = jnp.where(
+            valid.reshape(valid.shape + (1,) * len(trailing)),
+            value,
+            jnp.zeros((), dtype=value.dtype),
         )
-        if value.shape[:2] != expected:
-            raise ValueError("Compact MPM storage has the wrong block prefix.")
-        logical = self._logical_indices(active.active_block_ids).reshape((-1,))
-        flat_values = value.reshape((logical.size,) + value.shape[2:])
-        valid_blocks = (
-            jnp.arange(self.blocks.maximum_active_blocks, dtype=jnp.int32)
-            < active.active_block_count
-        )
-        valid = jnp.repeat(valid_blocks, self.blocks.nodes_per_block)
-        flat = (
-            jnp.zeros(
-                (prod(self.blocks.grid_shape),) + value.shape[2:], dtype=value.dtype
-            )
-            .at[jnp.where(valid, logical, 0)]
-            .add(
-                jnp.where(
-                    valid.reshape(valid.shape + (1,) * (flat_values.ndim - 1)),
-                    flat_values,
-                    0.0,
-                )
-            )
-        )
-        return flat.reshape(self.blocks.grid_shape + value.shape[2:])
-
-    def map_route_indices(
-        self, routes: ParticleGridSplatState, active: MPMActiveBlockState, /
-    ) -> tuple[Array, Array]:
-        block_ids, coordinates = self.blocks._block_ids(routes.stencil.indices)
-        matches = block_ids[..., None] == active.active_block_ids
-        block_slot = jnp.argmax(matches, axis=-1).astype(jnp.int32)
-        block_found = jnp.any(matches, axis=-1)
-        local_coordinates = coordinates % jnp.asarray(self.blocks.block_shape)
-        local = local_coordinates[..., 0]
-        for axis in range(1, len(self.blocks.grid_shape)):
-            local = local * self.blocks.block_shape[axis] + local_coordinates[..., axis]
-        compact = block_slot * self.blocks.nodes_per_block + local
-        valid = routes.stencil.valid & block_found & ~active.overflow
-        return compact.astype(jnp.int32), valid
+        flat = flat.at[jnp.where(valid, logical, 0)].add(payload)
+        return flat.reshape(self.grid_shape + trailing)
 
 
 __all__ = [
     "AbstractMPMNodalStoragePlan",
     "BlockSparseMPMNodalStoragePlan",
     "DenseMPMNodalStoragePlan",
-    "MPMActiveBlockPlan",
-    "MPMActiveBlockState",
 ]

--- a/phydrax/discretization/particle/_cell_list.py
+++ b/phydrax/discretization/particle/_cell_list.py
@@ -14,7 +14,7 @@ import numpy as np
 from jaxtyping import Array, ArrayLike
 
 from ..._fingerprint import canonical_fingerprint
-from ...sparse import EdgeRelation, RowRelation
+from ...sparse import EdgeRelation, KeyGroupPlan
 from .._core import (
     DiscretizationCapability,
     DiscretizationKey,
@@ -34,41 +34,6 @@ from ._precision import ParticleRealization
 
 def _cell_strides(shape: tuple[int, ...], /) -> tuple[int, ...]:
     return tuple(prod(shape[axis + 1 :]) for axis in range(len(shape)))
-
-
-def _neighbor_cell_relation(
-    shape: tuple[int, ...], periodic_axes: tuple[bool, ...], /
-) -> RowRelation:
-    count = prod(shape)
-    rows: list[tuple[int, ...]] = []
-    offsets = tuple(product((-1, 0, 1), repeat=len(shape)))
-    for cell_id in range(count):
-        coordinate = np.unravel_index(cell_id, shape)
-        neighbors: set[int] = set()
-        for offset in offsets:
-            candidate = []
-            valid = True
-            for axis, (index, shift, size, periodic) in enumerate(
-                zip(coordinate, offset, shape, periodic_axes, strict=True)
-            ):
-                del axis
-                value = index + shift
-                if periodic:
-                    value %= size
-                elif value < 0 or value >= size:
-                    valid = False
-                    break
-                candidate.append(value)
-            if valid:
-                neighbors.add(int(np.ravel_multi_index(tuple(candidate), shape)))
-        rows.append(tuple(sorted(neighbors)))
-    width = max(len(row) for row in rows)
-    indices = np.zeros((count, width), dtype=np.int32)
-    valid = np.zeros((count, width), dtype=bool)
-    for cell_id, row in enumerate(rows):
-        indices[cell_id, : len(row)] = row
-        valid[cell_id, : len(row)] = True
-    return RowRelation(indices, source_size=count, valid=valid)
 
 
 class CellListParticleNeighborhoodPlan(AbstractParticleNeighborhoodPlan):
@@ -141,14 +106,15 @@ class CellListParticleNeighborhoodPlan(AbstractParticleNeighborhoodPlan):
 
 
 class PreparedCellListParticleNeighborhood(AbstractPreparedParticleNeighborhood):
-    """Prepared cell topology with pure-JAX runtime edge construction."""
+    """Prepared occupied-cell topology with pure-JAX edge construction."""
 
     plan: CellListParticleNeighborhoodPlan
     particle_ids: Array
     active_mask: Array
     cell_widths: Array
     cell_strides: Array
-    neighbor_cells: RowRelation
+    neighbor_offsets: Array
+    key_groups: KeyGroupPlan
     preparation: PreparationReport
     key: DiscretizationKey
     box: ParticleBox
@@ -193,15 +159,26 @@ class PreparedCellListParticleNeighborhood(AbstractPreparedParticleNeighborhood)
                 "Multi-cell axes must cover the search radius in adjacent cells."
             )
         cell_count = prod(shape)
-        neighbor_cells = _neighbor_cell_relation(shape, plan.box.periodic_axes)
+        neighbor_offsets = np.asarray(
+            tuple(product((-1, 0, 1), repeat=particles.ambient_dimension)),
+            dtype=np.int32,
+        )
+        neighbor_cell_capacity = int(neighbor_offsets.shape[0])
         candidate_slots = (
-            particles.capacity * neighbor_cells.width * plan.maximum_particles_per_cell
+            particles.capacity * neighbor_cell_capacity * plan.maximum_particles_per_cell
         )
         if candidate_slots > plan.maximum_candidate_slots:
             raise ValueError(
                 f"Cell-list relation requires {candidate_slots} candidate slots, "
                 f"exceeding maximum_candidate_slots={plan.maximum_candidate_slots}."
             )
+        occupied_cell_capacity = min(particles.capacity, cell_count)
+        key_groups = KeyGroupPlan(
+            particles.capacity,
+            max(occupied_cell_capacity, 1),
+            cell_count - 1,
+            maximum_group_size=plan.maximum_particles_per_cell,
+        )
         relation_schema_id = canonical_fingerprint(
             {
                 "kind": "cell-list-particle-pair-relation-schema",
@@ -218,18 +195,21 @@ class PreparedCellListParticleNeighborhood(AbstractPreparedParticleNeighborhood)
             ),
             diagnostics=(
                 "cell and pair capacities are fixed",
+                "only occupied cell keys are materialized",
                 "cell and edge selection are frozen branchwise decisions",
                 "overflow and nonperiodic domain violations fail closed",
                 "public particle state remains in logical order",
             ),
             resource_counts={
                 "particle_capacity": particles.capacity,
-                "cell_count": cell_count,
-                "neighbor_cell_capacity": neighbor_cells.width,
+                "logical_cell_count": cell_count,
+                "occupied_cell_capacity": occupied_cell_capacity,
+                "neighbor_cell_capacity": neighbor_cell_capacity,
                 "maximum_particles_per_cell": plan.maximum_particles_per_cell,
                 "candidate_slot_count": candidate_slots,
                 "pair_capacity": plan.maximum_pairs,
-                "particle_table_slots": cell_count * plan.maximum_particles_per_cell,
+                "particle_table_slots": particles.capacity,
+                "dense_cell_slots": 0,
             },
         )
         prepared_id = canonical_fingerprint(
@@ -239,11 +219,8 @@ class PreparedCellListParticleNeighborhood(AbstractPreparedParticleNeighborhood)
                 "particles": particles.prepared_id,
                 "cell_shape": list(shape),
                 "cell_widths": widths.tolist(),
-                "neighbor_cells": {
-                    "shape": list(neighbor_cells.route_shape),
-                    "indices": np.asarray(neighbor_cells.source_indices).tolist(),
-                    "valid": np.asarray(neighbor_cells.valid).tolist(),
-                },
+                "neighbor_offsets": neighbor_offsets.tolist(),
+                "key_group_plan": key_groups.plan_id,
                 "relation_schema": relation_schema_id,
                 "preparation": preparation.report_id,
                 "numeric_version": particles.numeric_version,
@@ -254,14 +231,15 @@ class PreparedCellListParticleNeighborhood(AbstractPreparedParticleNeighborhood)
         self.active_mask = particles.active_mask
         self.cell_widths = jnp.asarray(widths, dtype=plan.box.lengths.dtype)
         self.cell_strides = jnp.asarray(_cell_strides(shape), dtype=jnp.int32)
-        self.neighbor_cells = neighbor_cells
+        self.neighbor_offsets = jnp.asarray(neighbor_offsets)
+        self.key_groups = key_groups
         self.preparation = preparation
         self.key = plan.key
         self.box = plan.box
         self.backend = plan.backend
         self.cell_shape = shape
         self.cell_count = cell_count
-        self.neighbor_cell_capacity = neighbor_cells.width
+        self.neighbor_cell_capacity = neighbor_cell_capacity
         self.maximum_particles_per_cell = plan.maximum_particles_per_cell
         self.pair_capacity = plan.maximum_pairs
         self.candidate_slot_count = candidate_slots
@@ -276,7 +254,7 @@ class PreparedCellListParticleNeighborhood(AbstractPreparedParticleNeighborhood)
 
     def _logical_cell_ids(
         self, position: Array, active_mask: Array, /
-    ) -> tuple[Array, Array]:
+    ) -> tuple[Array, Array, Array]:
         finite = jnp.all(jnp.isfinite(position), axis=-1)
         safe = jnp.where(finite[:, None], position, self.box.lower)
         relative = (safe - self.box.lower.astype(safe.dtype)) / self.cell_widths.astype(
@@ -299,7 +277,41 @@ class PreparedCellListParticleNeighborhood(AbstractPreparedParticleNeighborhood)
         coordinate_array = jnp.stack(resolved_coordinates, axis=-1)
         cell_ids = jnp.sum(coordinate_array * self.cell_strides, axis=-1)
         active_valid = active_mask & domain_valid
-        return jnp.where(active_valid, cell_ids, -1), active_mask & ~domain_valid
+        return (
+            jnp.where(active_valid, cell_ids, -1),
+            coordinate_array,
+            active_mask & ~domain_valid,
+        )
+
+    def _neighbor_cell_ids(
+        self, coordinates: Array, active_valid: Array, /
+    ) -> tuple[Array, Array]:
+        candidates = coordinates[:, None, :] + self.neighbor_offsets[None, :, :]
+        valid = jnp.broadcast_to(active_valid[:, None], candidates.shape[:-1])
+        resolved = []
+        for axis, size in enumerate(self.cell_shape):
+            coordinate = candidates[..., axis]
+            if self.box.periodic_axes[axis]:
+                coordinate = jnp.mod(coordinate, size)
+            else:
+                valid = valid & (coordinate >= 0) & (coordinate < size)
+                coordinate = jnp.clip(coordinate, 0, size - 1)
+            resolved.append(coordinate)
+        coordinate_array = jnp.stack(resolved, axis=-1)
+        cell_ids = jnp.sum(coordinate_array * self.cell_strides, axis=-1)
+        sortable = jnp.where(valid, cell_ids, self.cell_count)
+        order = jnp.argsort(sortable, axis=-1)
+        sorted_ids = jnp.take_along_axis(sortable, order, axis=-1)
+        sorted_valid = sorted_ids < self.cell_count
+        previous = jnp.concatenate(
+            (
+                jnp.full(sorted_ids.shape[:-1] + (1,), self.cell_count),
+                sorted_ids[..., :-1],
+            ),
+            axis=-1,
+        )
+        unique = sorted_valid & (sorted_ids != previous)
+        return jnp.where(unique, sorted_ids, 0), unique
 
     def build(
         self, position: ArrayLike, /, *, active_mask: ArrayLike | None = None
@@ -314,71 +326,34 @@ class PreparedCellListParticleNeighborhood(AbstractPreparedParticleNeighborhood)
             if requested.shape != (self.particle_capacity,):
                 raise ValueError("active_mask must have particle-capacity shape.")
             active = active & requested
-        cell_ids, domain_violations = self._logical_cell_ids(value, active)
+        cell_ids, cell_coordinates, domain_violations = self._logical_cell_ids(
+            value, active
+        )
         active_valid = active & ~domain_violations
-        sentinel_cell = self.cell_count
-        sortable_cells = jnp.where(active_valid, cell_ids, sentinel_cell)
-        storage_to_logical = jax.lax.stop_gradient(
-            jnp.lexsort((self.particle_ids, sortable_cells)).astype(jnp.int32)
+        groups = self.key_groups.build(
+            cell_ids,
+            active_valid,
+            stable_ids=self.particle_ids,
         )
-        logical_to_storage = (
-            jnp.zeros((self.particle_capacity,), dtype=jnp.int32)
-            .at[storage_to_logical]
-            .set(jnp.arange(self.particle_capacity, dtype=jnp.int32))
+        neighbor_ids, neighbor_valid = self._neighbor_cell_ids(
+            cell_coordinates, active_valid
         )
-        sorted_cells = sortable_cells[storage_to_logical]
-        sorted_valid = active_valid[storage_to_logical]
-        counts_with_sentinel = jnp.bincount(
-            sortable_cells,
-            weights=active_valid.astype(jnp.int32),
-            length=self.cell_count + 1,
-        ).astype(jnp.int32)
-        offsets_with_sentinel = (
-            jnp.cumsum(counts_with_sentinel, dtype=jnp.int32) - counts_with_sentinel
+        neighbor_lookup = groups.lookup(neighbor_ids, valid=neighbor_valid)
+        safe_groups = neighbor_lookup.group_slots
+        group_starts = groups.group_starts[safe_groups]
+        group_counts = groups.group_counts[safe_groups]
+        member_rank = jnp.arange(self.maximum_particles_per_cell, dtype=jnp.int32)
+        sorted_positions = group_starts[..., None] + member_rank
+        sorted_positions = jnp.clip(sorted_positions, 0, self.particle_capacity - 1)
+        right_indices = groups.storage_to_logical[sorted_positions]
+        right_valid = neighbor_lookup.supported[..., None] & (
+            member_rank < group_counts[..., None]
         )
-        rank = (
-            jnp.arange(self.particle_capacity, dtype=jnp.int32)
-            - offsets_with_sentinel[sorted_cells]
-        )
-        cell_counts = counts_with_sentinel[: self.cell_count]
-        cell_offsets = offsets_with_sentinel[: self.cell_count]
-        maximum_occupancy = jnp.max(cell_counts, initial=0)
-        excess = jnp.maximum(cell_counts - self.maximum_particles_per_cell, 0)
-        cell_overflow_count = jnp.sum(excess, dtype=jnp.int32)
-        cell_overflow = cell_overflow_count > 0
-        occupant_shape = (
-            self.cell_count + 1,
-            self.maximum_particles_per_cell + 1,
-        )
-        occupant_indices = jnp.zeros(occupant_shape, dtype=jnp.int32)
-        occupant_valid = jnp.zeros(occupant_shape, dtype=bool)
-        accepted_occupant = sorted_valid & (rank < self.maximum_particles_per_cell)
-        write_cell = jnp.where(accepted_occupant, sorted_cells, self.cell_count)
-        write_rank = jnp.where(accepted_occupant, rank, self.maximum_particles_per_cell)
-        occupant_indices = occupant_indices.at[write_cell, write_rank].set(
-            storage_to_logical
-        )
-        occupant_valid = occupant_valid.at[write_cell, write_rank].set(accepted_occupant)
-        occupant_indices = occupant_indices[
-            : self.cell_count, : self.maximum_particles_per_cell
-        ]
-        occupant_valid = occupant_valid[
-            : self.cell_count, : self.maximum_particles_per_cell
-        ]
-        safe_particle_cells = jnp.where(cell_ids >= 0, cell_ids, 0)
-        neighbor_ids = self.neighbor_cells.source_indices[safe_particle_cells]
-        neighbor_valid = self.neighbor_cells.valid[safe_particle_cells] & (
-            cell_ids[:, None] >= 0
-        )
-        right_indices = occupant_indices[neighbor_ids]
-        right_valid = occupant_valid[neighbor_ids]
         left_indices = jnp.broadcast_to(
             jnp.arange(self.particle_capacity, dtype=jnp.int32)[:, None, None],
             right_indices.shape,
         )
-        candidate_valid = (
-            active_valid[:, None, None] & neighbor_valid[:, :, None] & right_valid
-        )
+        candidate_valid = active_valid[:, None, None] & right_valid
         left_ids = self.particle_ids[left_indices]
         right_ids = self.particle_ids[right_indices]
         candidate_valid = candidate_valid & (left_ids < right_ids)
@@ -419,18 +394,25 @@ class PreparedCellListParticleNeighborhood(AbstractPreparedParticleNeighborhood)
             unordered=True,
             relation_schema_id=self.relation_schema_id,
         )
+        excess = jnp.maximum(groups.group_counts - self.maximum_particles_per_cell, 0)
+        cell_overflow_count = jnp.sum(excess, dtype=jnp.int32)
+        cell_overflow = (
+            groups.evidence.group_overflow
+            | groups.evidence.member_overflow
+            | (groups.evidence.duplicate_stable_ids > 0)
+        )
         domain_violation_count = jnp.sum(domain_violations, dtype=jnp.int32)
         return ParticleNeighborhoodState(
             pair_relation,
             box=self.box,
-            storage_to_logical=storage_to_logical,
-            logical_to_storage=logical_to_storage,
+            storage_to_logical=groups.storage_to_logical,
+            logical_to_storage=groups.logical_to_storage,
             cell_ids=cell_ids,
-            cell_counts=cell_counts,
-            cell_offsets=cell_offsets,
+            cell_counts=groups.group_counts,
+            cell_offsets=groups.group_starts,
             candidate_pair_count=candidate_pair_count,
             pair_count=pair_count,
-            maximum_cell_occupancy=maximum_occupancy,
+            maximum_cell_occupancy=groups.evidence.maximum_group_size,
             cell_overflow=cell_overflow,
             cell_overflow_count=cell_overflow_count,
             pair_overflow=pair_overflow,

--- a/phydrax/discretization/particle/_hierarchical_cell_list.py
+++ b/phydrax/discretization/particle/_hierarchical_cell_list.py
@@ -14,7 +14,7 @@ import numpy as np
 from jaxtyping import Array, ArrayLike
 
 from ..._fingerprint import array_tree_fingerprint, canonical_fingerprint
-from ...sparse import EdgeRelation
+from ...sparse import EdgeRelation, KeyGroupPlan
 from .._core import (
     DiscretizationCapability,
     DiscretizationKey,
@@ -143,6 +143,7 @@ class PreparedHierarchicalRadiusParticleNeighborhood(
     level_cell_offsets: Array
     neighbor_offsets: Array
     level_members: tuple[Array, ...]
+    key_group_plans: tuple[KeyGroupPlan, ...]
     preparation: PreparationReport
     key: DiscretizationKey
     box: ParticleBox
@@ -258,6 +259,15 @@ class PreparedHierarchicalRadiusParticleNeighborhood(
             )
             for level in range(level_count)
         )
+        self.key_group_plans = tuple(
+            KeyGroupPlan(
+                particles.capacity,
+                max(min(particles.capacity, cell_count), 1),
+                cell_count - 1,
+                maximum_group_size=plan.maximum_particles_per_cell,
+            )
+            for cell_count in cell_counts
+        )
         self.preparation = preparation
         self.key = plan.key
         self.box = plan.box
@@ -358,8 +368,7 @@ class PreparedHierarchicalRadiusParticleNeighborhood(
             active = active & requested
         level_coordinates = []
         level_cells = []
-        sorted_indices = []
-        sorted_keys = []
+        level_groups = []
         domain_violations = jnp.zeros((self.particle_capacity,), dtype=bool)
         maximum_occupancy = jnp.zeros((), dtype=jnp.int32)
         cell_overflow_count = jnp.zeros((), dtype=jnp.int32)
@@ -368,27 +377,24 @@ class PreparedHierarchicalRadiusParticleNeighborhood(
             coordinates, cell_ids, violations = self._level_cells(position, active, level)
             domain_violations = domain_violations | violations
             target_valid = active & ~violations & (self.plan.level_ids == level)
-            sentinel = self.cell_counts_by_level[level]
-            sortable = jnp.where(target_valid, cell_ids, sentinel)
-            order = jax.lax.stop_gradient(
-                jnp.lexsort((self.particle_ids, sortable)).astype(jnp.int32)
+            groups = self.key_group_plans[level].build(
+                cell_ids,
+                target_valid,
+                stable_ids=self.particle_ids,
             )
-            keys = sortable[order]
-            valid_sorted = keys < sentinel
-            starts = jnp.where((indices == 0) | (keys != jnp.roll(keys, 1)), indices, 0)
-            starts = jax.lax.associative_scan(jnp.maximum, starts)
-            rank = indices - starts
-            occupancy = jnp.max(jnp.where(valid_sorted, rank + 1, 0), initial=0)
+            occupancy = groups.evidence.maximum_group_size
             overflow = jnp.sum(
-                valid_sorted & (rank >= self.plan.maximum_particles_per_cell),
+                jnp.maximum(
+                    groups.group_counts - self.plan.maximum_particles_per_cell,
+                    0,
+                ),
                 dtype=jnp.int32,
             )
             maximum_occupancy = jnp.maximum(maximum_occupancy, occupancy)
             cell_overflow_count = cell_overflow_count + overflow
             level_coordinates.append(coordinates)
             level_cells.append(cell_ids)
-            sorted_indices.append(order)
-            sorted_keys.append(keys)
+            level_groups.append(groups)
 
         candidate_left = []
         candidate_right = []
@@ -404,17 +410,18 @@ class PreparedHierarchicalRadiusParticleNeighborhood(
                     query_valid,
                     target_level,
                 )
-                starts = jnp.searchsorted(
-                    sorted_keys[target_level], keys, side="left"
-                ).astype(jnp.int32)
+                groups = level_groups[target_level]
+                lookup = groups.lookup(keys, valid=neighbor_valid)
+                starts = groups.group_starts[lookup.group_slots]
+                counts = groups.group_counts[lookup.group_slots]
                 slots = starts[:, :, None] + occupant_rank[None, None, :]
                 in_bounds = slots < self.particle_capacity
                 safe_slots = jnp.clip(slots, 0, self.particle_capacity - 1)
-                right = sorted_indices[target_level][safe_slots]
+                right = groups.storage_to_logical[safe_slots]
                 matched = (
                     in_bounds
-                    & neighbor_valid[:, :, None]
-                    & (sorted_keys[target_level][safe_slots] == keys[:, :, None])
+                    & lookup.supported[:, :, None]
+                    & (occupant_rank[None, None, :] < counts[:, :, None])
                 )
                 left = jnp.broadcast_to(query_indices[:, None, None], right.shape)
                 left_ids = self.particle_ids[left]

--- a/phydrax/discretization/particle/_pairwise.py
+++ b/phydrax/discretization/particle/_pairwise.py
@@ -13,10 +13,9 @@ import numpy as np
 from jaxtyping import Array, ArrayLike
 
 from ..._fingerprint import array_tree_fingerprint, canonical_fingerprint
-from ..._numerics._compensated import two_sum
 from ..._strict import StrictModule
 from ..._trainable import NonTrainableState
-from ...sparse import EdgeRelation
+from ...sparse import EdgeRelation, RelationExecutionPlan
 from .._periodic_cell import PeriodicCell
 from ._precision import ParticleAccumulation
 
@@ -303,68 +302,6 @@ def _masked_pair_values(values: ArrayLike, valid: ArrayLike, /) -> Array:
     return jnp.where(mask, array, 0.0)
 
 
-def _scatter_deterministic(
-    left_indices: Array,
-    right_indices: Array,
-    left_values: Array,
-    right_values: Array,
-    size: int,
-    /,
-) -> Array:
-    output_shape = (size,) + left_values.shape[1:]
-
-    def step(index, total):
-        total = total.at[left_indices[index]].add(left_values[index])
-        return total.at[right_indices[index]].add(right_values[index])
-
-    return jax.lax.fori_loop(
-        0,
-        int(left_indices.shape[0]),
-        step,
-        jnp.zeros(output_shape, dtype=left_values.dtype),
-    )
-
-
-def _scatter_compensated(
-    left_indices: Array,
-    right_indices: Array,
-    left_values: Array,
-    right_values: Array,
-    size: int,
-    /,
-) -> Array:
-    output_shape = (size,) + left_values.shape[1:]
-    zeros = jnp.zeros(output_shape, dtype=left_values.dtype)
-
-    def add_one(total, correction, index, value):
-        current = total[index]
-        next_total, error = two_sum(current, value)
-        total = total.at[index].set(next_total)
-        correction = correction.at[index].add(error)
-        return total, correction
-
-    def step(index, carry):
-        total, correction = carry
-        total, correction = add_one(
-            total,
-            correction,
-            left_indices[index],
-            left_values[index],
-        )
-        return add_one(
-            total,
-            correction,
-            right_indices[index],
-            right_values[index],
-        )
-
-    total, correction = jax.lax.fori_loop(
-        0,
-        int(left_indices.shape[0]),
-        step,
-        (zeros, zeros),
-    )
-    return total + correction
 
 
 def scatter_pair_sum(
@@ -386,28 +323,30 @@ def scatter_pair_sum(
         raise ValueError("Left and right pair values must have matching shapes.")
     if left.shape[0] == 0:
         return jnp.zeros((int(size),) + left.shape[1:], dtype=left.dtype)
-    if accumulation == "fast":
-        output_shape = (int(size),) + left.shape[1:]
-        result = jnp.zeros(output_shape, dtype=left.dtype)
-        result = result.at[pairs.left_indices].add(left)
-        return result.at[pairs.right_indices].add(right)
-    if accumulation == "deterministic":
-        return _scatter_deterministic(
-            pairs.left_indices,
-            pairs.right_indices,
-            left,
-            right,
-            int(size),
-        )
-    if accumulation == "compensated":
-        return _scatter_compensated(
-            pairs.left_indices,
-            pairs.right_indices,
-            left,
-            right,
-            int(size),
-        )
-    raise ValueError("Unknown particle accumulation policy.")
+    route_count = int(left.shape[0])
+    endpoint_indices = jnp.stack(
+        (pairs.left_indices, pairs.right_indices), axis=1
+    ).reshape((-1,))
+    endpoint_values = jnp.stack((left, right), axis=1).reshape(
+        (2 * route_count,) + left.shape[1:]
+    )
+    endpoint_valid = jnp.broadcast_to(
+        route_valid[:, None], (route_count, 2)
+    ).reshape((-1,))
+    relation = EdgeRelation(
+        jnp.arange(2 * route_count, dtype=jnp.int32),
+        endpoint_indices,
+        source_size=2 * route_count,
+        target_size=int(size),
+        valid=endpoint_valid,
+    )
+    execution = RelationExecutionPlan().prepare(relation)
+    result, _ = execution.reduce(
+        endpoint_values,
+        accumulation=accumulation,
+        output="dense",
+    )
+    return result
 
 
 def scatter_pair_exchange(

--- a/phydrax/discretization/particle/_production_data_plane.py
+++ b/phydrax/discretization/particle/_production_data_plane.py
@@ -16,7 +16,7 @@ from jaxtyping import Array, ArrayLike
 from ..._fingerprint import canonical_fingerprint
 from ..._strict import StrictModule
 from ..._trainable import NonTrainableState
-from ...sparse import EdgeRelation
+from ...sparse import EdgeRelation, KeyGroupPlan, KeyGroupState
 from ._assembly import ParticlePopulation
 from ._bipartite_neighborhood import (
     BipartiteNeighborhoodState,
@@ -56,12 +56,7 @@ class ParticleSearchKey(StrictModule, NonTrainableState):
 
 class PopulationCellView(StrictModule, NonTrainableState):
     cell_ids: Array
-    storage_to_logical: Array
-    logical_to_storage: Array
-    cell_counts: Array
-    cell_offsets: Array
-    cell_particles: Array
-    cell_particle_valid: Array
+    groups: KeyGroupState
     maximum_occupancy: Array
     overflow: Array
     domain_violation: Array
@@ -120,6 +115,7 @@ class PreparedMultiPopulationCells(StrictModule, NonTrainableState):
     populations: tuple[ParticlePopulation, ...]
     widths: Array
     strides: Array
+    key_group_plans: tuple[KeyGroupPlan, ...]
     prepared_id: str = eqx.field(static=True)
 
     def __init__(
@@ -143,6 +139,17 @@ class PreparedMultiPopulationCells(StrictModule, NonTrainableState):
         self.populations = values
         self.widths = plan.box.lengths / jnp.asarray(plan.cell_shape)
         self.strides = jnp.asarray(strides, dtype=jnp.int32)
+        self.key_group_plans = tuple(
+            KeyGroupPlan(
+                population.particles.capacity,
+                max(min(population.particles.capacity, plan.cell_count), 1),
+                plan.cell_count - 1,
+                maximum_group_size=capacity,
+            )
+            for population, capacity in zip(
+                values, plan.maximum_particles_per_cell, strict=True
+            )
+        )
         self.prepared_id = canonical_fingerprint(
             {
                 "kind": "prepared-multi-population-cells",
@@ -176,45 +183,21 @@ class PreparedMultiPopulationCells(StrictModule, NonTrainableState):
             resolved.append(coordinate)
         cell = jnp.sum(jnp.stack(resolved, axis=-1) * self.strides, axis=-1)
         active_valid = particles.active_mask & domain_valid
-        sentinel = self.plan.cell_count
-        sortable = jnp.where(active_valid, cell, sentinel)
-        order = jax.lax.stop_gradient(
-            jnp.lexsort((particles.particle_ids, sortable)).astype(jnp.int32)
+        groups = self.key_group_plans[population_index].build(
+            jnp.where(active_valid, cell, -1),
+            active_valid,
+            stable_ids=particles.particle_ids,
         )
-        inverse = (
-            jnp.zeros((particles.capacity,), dtype=jnp.int32)
-            .at[order]
-            .set(jnp.arange(particles.capacity, dtype=jnp.int32))
+        overflow = (
+            groups.evidence.group_overflow
+            | groups.evidence.member_overflow
+            | (groups.evidence.duplicate_stable_ids > 0)
         )
-        sorted_cell = sortable[order]
-        sorted_valid = active_valid[order]
-        counts_all = jnp.bincount(
-            sortable,
-            weights=active_valid.astype(jnp.int32),
-            length=self.plan.cell_count + 1,
-        ).astype(jnp.int32)
-        offsets_all = jnp.cumsum(counts_all) - counts_all
-        rank = jnp.arange(particles.capacity, dtype=jnp.int32) - offsets_all[sorted_cell]
-        counts = counts_all[: self.plan.cell_count]
-        offsets = offsets_all[: self.plan.cell_count]
-        accepted = sorted_valid & (rank < capacity)
-        table = jnp.zeros((self.plan.cell_count + 1, capacity + 1), dtype=jnp.int32)
-        table_valid = jnp.zeros_like(table, dtype=bool)
-        write_cell = jnp.where(accepted, sorted_cell, self.plan.cell_count)
-        write_rank = jnp.where(accepted, rank, capacity)
-        table = table.at[write_cell, write_rank].set(order)
-        table_valid = table_valid.at[write_cell, write_rank].set(accepted)
-        overflow = jnp.any(counts > capacity)
         violation = jnp.any(particles.active_mask & ~domain_valid)
         return PopulationCellView(
             jnp.where(active_valid, cell, -1),
-            order,
-            inverse,
-            counts,
-            offsets,
-            table[: self.plan.cell_count, :capacity],
-            table_valid[: self.plan.cell_count, :capacity],
-            jnp.max(counts, initial=0),
+            groups,
+            groups.evidence.maximum_group_size,
             overflow,
             violation,
         )
@@ -277,8 +260,30 @@ class PreparedMultiPopulationCells(StrictModule, NonTrainableState):
                 coordinate = jnp.clip(coordinate, 0, count - 1)
             resolved.append(coordinate)
         neighbor_cell = jnp.sum(jnp.stack(resolved, axis=-1) * self.strides, axis=-1)
-        source_candidates = source_view.cell_particles[neighbor_cell]
-        source_valid = source_view.cell_particle_valid[neighbor_cell]
+        sortable_neighbor = jnp.where(neighbor_valid, neighbor_cell, self.plan.cell_count)
+        neighbor_order = jnp.argsort(sortable_neighbor, axis=-1)
+        neighbor_cell = jnp.take_along_axis(sortable_neighbor, neighbor_order, axis=-1)
+        neighbor_valid = neighbor_cell < self.plan.cell_count
+        previous_neighbor = jnp.concatenate(
+            (
+                jnp.full(neighbor_cell.shape[:-1] + (1,), self.plan.cell_count),
+                neighbor_cell[..., :-1],
+            ),
+            axis=-1,
+        )
+        neighbor_valid = neighbor_valid & (neighbor_cell != previous_neighbor)
+        lookup = source_view.groups.lookup(neighbor_cell, valid=neighbor_valid)
+        group_starts = source_view.groups.group_starts[lookup.group_slots]
+        group_counts = source_view.groups.group_counts[lookup.group_slots]
+        source_rank = jnp.arange(
+            self.plan.maximum_particles_per_cell[source_index], dtype=jnp.int32
+        )
+        source_slots = group_starts[..., None] + source_rank
+        source_slots = jnp.clip(source_slots, 0, source_population.particles.capacity - 1)
+        source_candidates = source_view.groups.storage_to_logical[source_slots]
+        source_valid = lookup.supported[..., None] & (
+            source_rank < group_counts[..., None]
+        )
         target_candidates = jnp.broadcast_to(
             jnp.arange(target_population.particles.capacity, dtype=jnp.int32)[
                 :, None, None

--- a/phydrax/discretization/spatial/__init__.py
+++ b/phydrax/discretization/spatial/__init__.py
@@ -4,6 +4,14 @@
 
 """Canonical sparse spatial addressing, point hierarchies, and voxel grids."""
 
+from ._block_sparse import (
+    BlockKeyOrdering,
+    SparseBlockBuildEvidence,
+    SparseBlockLookup,
+    SparseBlockTopologyPlan,
+    SparseBlockTopologyState,
+    SparseBlockTransition,
+)
 from ._dyadic import (
     AdaptiveDyadicGridPlan,
     DyadicAdaptationEvidence,
@@ -51,6 +59,7 @@ from ._voxel import (
 
 
 __all__ = [
+    "BlockKeyOrdering",
     "AdaptiveDyadicGridPlan",
     "DyadicAdaptationEvidence",
     "DyadicCellTopology",
@@ -68,6 +77,11 @@ __all__ = [
     "MortonPrimitiveBoundsEvidence",
     "MortonPrimitiveBoundsPlan",
     "MortonPrimitiveBoundsState",
+    "SparseBlockBuildEvidence",
+    "SparseBlockLookup",
+    "SparseBlockTopologyPlan",
+    "SparseBlockTopologyState",
+    "SparseBlockTransition",
     "PreparedSparseVoxelGrid",
     "SparseVoxelBuildEvidence",
     "SparseVoxelDepositResult",

--- a/phydrax/discretization/spatial/_block_sparse.py
+++ b/phydrax/discretization/spatial/_block_sparse.py
@@ -1,0 +1,428 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from itertools import product
+from math import prod
+from typing import Literal, TYPE_CHECKING
+
+import equinox as eqx
+import jax.numpy as jnp
+import numpy as np
+from jaxtyping import Array, ArrayLike
+
+from ..._fingerprint import canonical_fingerprint
+from ..._strict import StrictModule
+from ..._trainable import NonTrainableState
+from ...sparse import (
+    align_key_groups,
+    KeyGroupPlan,
+    KeyGroupState,
+    KeyGroupTransition,
+)
+from ._morton import morton_decode_integer, morton_encode_integer
+
+
+if TYPE_CHECKING:
+    from .._tensor_index import PreparedTensorIndexSpace, TensorIndexLayout
+
+BlockKeyOrdering = Literal["row-major", "morton"]
+
+
+class SparseBlockBuildEvidence(NonTrainableState, StrictModule):
+    """Complete capacity and support evidence for one block candidate."""
+
+    requested_sites: Array
+    valid_sites: Array
+    invalid_sites: Array
+    raw_required_blocks: Array
+    required_blocks: Array
+    block_capacity: Array
+    closure_complete: Array
+    overflow: Array
+    successful: Array
+
+
+class SparseBlockLookup(NonTrainableState, StrictModule):
+    """Map logical sites to compact block and node storage slots."""
+
+    block_slots: Array
+    local_slots: Array
+    storage_slots: Array
+    in_domain: Array
+    supported: Array
+
+
+class SparseBlockTopologyPlan(StrictModule, NonTrainableState):
+    """Fixed-capacity sparse outer blocks with dense local tensor sites."""
+
+    index_space: PreparedTensorIndexSpace
+    layout: TensorIndexLayout
+    closure_offsets: Array
+    block_shape: tuple[int, ...] = eqx.field(static=True)
+    block_grid_shape: tuple[int, ...] = eqx.field(static=True)
+    block_strides: tuple[int, ...] = eqx.field(static=True)
+    local_strides: tuple[int, ...] = eqx.field(static=True)
+    periodic_axes: tuple[bool, ...] = eqx.field(static=True)
+    block_capacity: int = eqx.field(static=True)
+    key_ordering: BlockKeyOrdering = eqx.field(static=True)
+    morton_depth: int | None = eqx.field(static=True)
+    plan_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        index_space: PreparedTensorIndexSpace,
+        block_shape: Sequence[int],
+        block_capacity: int,
+        /,
+        *,
+        layout: TensorIndexLayout | None = None,
+        closure_offsets: Sequence[Sequence[int]] | None = None,
+        key_ordering: BlockKeyOrdering = "row-major",
+    ) -> None:
+        from .._tensor_index import PreparedTensorIndexSpace, TensorIndexLayout
+
+        if not isinstance(index_space, PreparedTensorIndexSpace):
+            raise TypeError("index_space must be PreparedTensorIndexSpace.")
+        layout_ = index_space.primary_entity_layout if layout is None else layout
+        if not isinstance(layout_, TensorIndexLayout) or not any(
+            candidate.layout_id == layout_.layout_id
+            for candidate in index_space.entity_layouts
+        ):
+            raise ValueError("layout must belong to index_space.")
+        blocks = tuple(int(size) for size in block_shape)
+        if len(blocks) != len(layout_.shape) or any(size <= 0 for size in blocks):
+            raise ValueError("block_shape must contain one positive size per axis.")
+        if any(
+            size % block != 0 for size, block in zip(layout_.shape, blocks, strict=True)
+        ):
+            raise ValueError("Every logical axis must be divisible by its block size.")
+        capacity = int(block_capacity)
+        if capacity <= 0:
+            raise ValueError("block_capacity must be positive.")
+        block_grid = tuple(
+            size // block for size, block in zip(layout_.shape, blocks, strict=True)
+        )
+        if capacity > prod(block_grid):
+            raise ValueError("block_capacity cannot exceed the logical block count.")
+        if key_ordering not in ("row-major", "morton"):
+            raise ValueError("key_ordering must be 'row-major' or 'morton'.")
+        morton_depth: int | None = None
+        if key_ordering == "morton":
+            if len(block_grid) not in (1, 2, 3) or len(set(block_grid)) != 1:
+                raise ValueError(
+                    "Morton block ordering requires one equal grid size per axis."
+                )
+            resolution = block_grid[0]
+            if resolution <= 1 or resolution & (resolution - 1):
+                raise ValueError(
+                    "Morton block ordering requires power-of-two resolution."
+                )
+            morton_depth = int(np.log2(resolution))
+            if morton_depth * len(block_grid) > 63:
+                raise ValueError("Morton block keys exceed the uint64 code budget.")
+        offsets = (
+            ((0,) * len(blocks),)
+            if closure_offsets is None
+            else tuple(
+                tuple(int(value) for value in offset) for offset in closure_offsets
+            )
+        )
+        if not offsets or any(len(offset) != len(blocks) for offset in offsets):
+            raise ValueError(
+                "closure_offsets must contain complete block-coordinate offsets."
+            )
+        offsets = tuple(sorted(set(offsets)))
+        if (0,) * len(blocks) not in offsets:
+            raise ValueError("closure_offsets must include the zero offset.")
+        self.index_space = index_space
+        self.layout = layout_
+        self.closure_offsets = jnp.asarray(offsets, dtype=jnp.int32)
+        self.block_shape = blocks
+        self.block_grid_shape = block_grid
+        self.block_strides = tuple(
+            prod(block_grid[axis + 1 :]) for axis in range(len(block_grid))
+        )
+        self.local_strides = tuple(
+            prod(blocks[axis + 1 :]) for axis in range(len(blocks))
+        )
+        self.periodic_axes = index_space.periodic_axes
+        self.block_capacity = capacity
+        self.key_ordering = key_ordering
+        self.morton_depth = morton_depth
+        self.plan_id = canonical_fingerprint(
+            {
+                "kind": "sparse-block-topology-plan",
+                "index_space": index_space.prepared_id,
+                "layout": layout_.layout_id,
+                "block_shape": list(blocks),
+                "block_capacity": capacity,
+                "block_grid_shape": list(block_grid),
+                "periodic_axes": list(self.periodic_axes),
+                "closure_offsets": [list(offset) for offset in offsets],
+                "key_ordering": key_ordering,
+            }
+        )
+
+    @property
+    def dimension(self) -> int:
+        return len(self.block_shape)
+
+    @property
+    def logical_block_count(self) -> int:
+        return prod(self.block_grid_shape)
+
+    @property
+    def sites_per_block(self) -> int:
+        return prod(self.block_shape)
+
+    @property
+    def storage_capacity(self) -> int:
+        return self.block_capacity * self.sites_per_block
+
+    @property
+    def key_upper_bound(self) -> int:
+        return self.logical_block_count - 1
+
+    def _encode_block_coordinates(self, coordinates: Array, /) -> Array:
+        if self.key_ordering == "morton":
+            assert self.morton_depth is not None
+            return morton_encode_integer(coordinates, self.morton_depth)
+        return jnp.sum(
+            coordinates.astype(jnp.int64)
+            * jnp.asarray(self.block_strides, dtype=jnp.int64),
+            axis=-1,
+        )
+
+    def _decode_block_keys(self, keys: Array, /) -> Array:
+        if self.key_ordering == "morton":
+            assert self.morton_depth is not None
+            return morton_decode_integer(keys, self.dimension, self.morton_depth).astype(
+                jnp.int32
+            )
+        values = jnp.asarray(keys, dtype=jnp.int64)
+        return jnp.stack(
+            tuple(
+                ((values // stride) % size).astype(jnp.int32)
+                for stride, size in zip(
+                    self.block_strides, self.block_grid_shape, strict=True
+                )
+            ),
+            axis=-1,
+        )
+
+    def _site_parts(self, logical_indices: Array, /) -> tuple[Array, Array, Array, Array]:
+        integer, in_domain = self.layout.integer_coordinates(logical_indices)
+        block_coordinates = integer // jnp.asarray(self.block_shape, dtype=jnp.int32)
+        local_coordinates = integer % jnp.asarray(self.block_shape, dtype=jnp.int32)
+        keys = self._encode_block_coordinates(block_coordinates)
+        local_slots = jnp.sum(
+            local_coordinates * jnp.asarray(self.local_strides, dtype=jnp.int32),
+            axis=-1,
+        ).astype(jnp.int32)
+        return keys, local_slots, block_coordinates, in_domain
+
+    def build(
+        self,
+        logical_indices: ArrayLike,
+        valid: ArrayLike | None = None,
+        /,
+        *,
+        stable_site_ids: ArrayLike | None = None,
+        generation: ArrayLike = 0,
+    ) -> SparseBlockTopologyState:
+        """Build one complete candidate from logical tensor-site IDs."""
+        indices = jnp.asarray(logical_indices)
+        if indices.ndim != 1 or not jnp.issubdtype(indices.dtype, jnp.integer):
+            raise TypeError("logical_indices must be a rank-1 integer array.")
+        requested = (
+            jnp.ones(indices.shape, dtype=bool)
+            if valid is None
+            else jnp.asarray(valid, dtype=bool)
+        )
+        if requested.shape != indices.shape:
+            raise ValueError("valid must match logical_indices.")
+        keys, _, _, in_domain = self._site_parts(indices)
+        site_valid = requested & in_domain
+        raw_groups = KeyGroupPlan(
+            indices.size,
+            self.block_capacity,
+            self.key_upper_bound,
+        ).build(keys, site_valid, stable_ids=stable_site_ids)
+        safe_raw_keys = jnp.where(raw_groups.group_active, raw_groups.group_keys, 0)
+        raw_coordinates = self._decode_block_keys(safe_raw_keys)
+        expanded = raw_coordinates[:, None, :] + self.closure_offsets[None, :, :]
+        expanded_valid = jnp.broadcast_to(
+            raw_groups.group_active[:, None], expanded.shape[:-1]
+        )
+        resolved_axes = []
+        for axis, size in enumerate(self.block_grid_shape):
+            coordinate = expanded[..., axis]
+            if self.periodic_axes[axis]:
+                coordinate = jnp.mod(coordinate, size)
+            else:
+                expanded_valid = expanded_valid & (coordinate >= 0) & (coordinate < size)
+                coordinate = jnp.clip(coordinate, 0, size - 1)
+            resolved_axes.append(coordinate)
+        expanded_coordinates = jnp.stack(resolved_axes, axis=-1)
+        expanded_keys = self._encode_block_coordinates(expanded_coordinates).reshape(
+            (-1,)
+        )
+        expanded_valid = expanded_valid.reshape((-1,))
+        closure_groups = KeyGroupPlan(
+            expanded_keys.size,
+            self.block_capacity,
+            self.key_upper_bound,
+        ).build(expanded_keys, expanded_valid)
+        raw_success = raw_groups.evidence.successful
+        closure_success = closure_groups.evidence.successful
+        domain_success = jnp.all(~requested | in_domain)
+        successful = raw_success & closure_success & domain_success
+        safe_block_keys = jnp.where(
+            closure_groups.group_active & successful,
+            closure_groups.group_keys,
+            0,
+        )
+        block_coordinates = self._decode_block_keys(safe_block_keys)
+        local_coordinates = jnp.asarray(
+            tuple(product(*(range(size) for size in self.block_shape))),
+            dtype=jnp.int32,
+        )
+        logical_coordinates = (
+            block_coordinates[:, None, :]
+            * jnp.asarray(self.block_shape, dtype=jnp.int32)[None, None, :]
+            + local_coordinates[None, :, :]
+        )
+        logical_node_ids, node_in_domain = self.layout.flat_indices(logical_coordinates)
+        node_valid = closure_groups.group_active[:, None] & node_in_domain & successful
+        logical_node_ids = jnp.where(node_valid, logical_node_ids, 0)
+        evidence = SparseBlockBuildEvidence(
+            requested_sites=jnp.sum(requested, dtype=jnp.int32),
+            valid_sites=jnp.sum(site_valid, dtype=jnp.int32),
+            invalid_sites=jnp.sum(requested & ~in_domain, dtype=jnp.int32),
+            raw_required_blocks=raw_groups.evidence.required_groups,
+            required_blocks=closure_groups.evidence.required_groups,
+            block_capacity=jnp.asarray(self.block_capacity, dtype=jnp.int32),
+            closure_complete=raw_success & closure_success,
+            overflow=(
+                raw_groups.evidence.group_overflow
+                | closure_groups.evidence.group_overflow
+            ),
+            successful=successful,
+        )
+        return SparseBlockTopologyState(
+            plan=self,
+            groups=closure_groups,
+            block_coordinates=block_coordinates,
+            logical_node_ids=logical_node_ids,
+            node_valid=node_valid,
+            generation=jnp.asarray(generation, dtype=jnp.int32),
+            evidence=evidence,
+        )
+
+    def refresh(
+        self,
+        previous: SparseBlockTopologyState,
+        logical_indices: ArrayLike,
+        valid: ArrayLike | None = None,
+        /,
+        *,
+        stable_site_ids: ArrayLike | None = None,
+    ) -> SparseBlockTransition:
+        """Build and align a candidate without committing it."""
+        if not isinstance(previous, SparseBlockTopologyState):
+            raise TypeError("previous must be SparseBlockTopologyState.")
+        if previous.plan.plan_id != self.plan_id:
+            raise ValueError("previous topology belongs to another plan.")
+        candidate = self.build(
+            logical_indices,
+            valid,
+            stable_site_ids=stable_site_ids,
+            generation=previous.generation,
+        )
+        key_transition = align_key_groups(previous.groups, candidate.groups)
+        next_generation = previous.generation + (
+            key_transition.topology_changed & candidate.evidence.successful
+        ).astype(jnp.int32)
+        candidate = eqx.tree_at(
+            lambda topology: topology.generation,
+            candidate,
+            next_generation,
+        )
+        return SparseBlockTransition(
+            previous=previous,
+            candidate=candidate,
+            key_transition=key_transition,
+            successful=candidate.evidence.successful,
+        )
+
+
+class SparseBlockTopologyState(NonTrainableState, StrictModule):
+    """Fixed-shape sparse blocks and their dense local logical sites."""
+
+    plan: SparseBlockTopologyPlan
+    groups: KeyGroupState
+    block_coordinates: Array
+    logical_node_ids: Array
+    node_valid: Array
+    generation: Array
+    evidence: SparseBlockBuildEvidence
+
+    def lookup(
+        self,
+        logical_indices: ArrayLike,
+        valid: ArrayLike | None = None,
+        /,
+    ) -> SparseBlockLookup:
+        indices = jnp.asarray(logical_indices)
+        requested = (
+            jnp.ones(indices.shape, dtype=bool)
+            if valid is None
+            else jnp.asarray(valid, dtype=bool)
+        )
+        if requested.shape != indices.shape:
+            raise ValueError("valid must match logical_indices.")
+        keys, local_slots, _, in_domain = self.plan._site_parts(indices)
+        group_lookup = self.groups.lookup(keys, valid=requested & in_domain)
+        supported = (
+            group_lookup.supported & requested & in_domain & self.evidence.successful
+        )
+        storage_slots = (
+            group_lookup.group_slots * self.plan.sites_per_block + local_slots
+        ).astype(jnp.int32)
+        return SparseBlockLookup(
+            block_slots=jnp.where(supported, group_lookup.group_slots, 0),
+            local_slots=jnp.where(supported, local_slots, 0),
+            storage_slots=jnp.where(supported, storage_slots, 0),
+            in_domain=in_domain,
+            supported=supported,
+        )
+
+    def materialize_support(self, /) -> Array:
+        flat = jnp.zeros((self.plan.layout.size,), dtype=bool)
+        ids = self.logical_node_ids.reshape((-1,))
+        valid = self.node_valid.reshape((-1,))
+        flat = flat.at[jnp.where(valid, ids, 0)].max(valid)
+        return flat.reshape(self.plan.layout.shape)
+
+
+class SparseBlockTransition(NonTrainableState, StrictModule):
+    """Uncommitted logical-key transition for persistent block fields."""
+
+    previous: SparseBlockTopologyState
+    candidate: SparseBlockTopologyState
+    key_transition: KeyGroupTransition
+    successful: Array
+
+
+__all__ = [
+    "BlockKeyOrdering",
+    "SparseBlockBuildEvidence",
+    "SparseBlockLookup",
+    "SparseBlockTopologyPlan",
+    "SparseBlockTopologyState",
+    "SparseBlockTransition",
+]

--- a/phydrax/discretization/spatial/_voxel.py
+++ b/phydrax/discretization/spatial/_voxel.py
@@ -15,11 +15,14 @@ from jaxtyping import ArrayLike
 from phydrax._fingerprint import canonical_fingerprint
 from phydrax._strict import StrictModule
 from phydrax._trainable import NonTrainableState
+from phydrax.sparse import (
+    EdgeRelation,
+    KeyGroupPlan,
+    KeyGroupState,
+    RelationExecutionPlan,
+)
 
 from ._morton import morton_decode_integer, morton_encode_integer, MortonAddressPlan
-
-
-_UINT64_MAX = np.iinfo(np.uint64).max
 
 
 class SparseVoxelBuildEvidence(NonTrainableState, StrictModule):
@@ -64,8 +67,7 @@ class PreparedSparseVoxelGrid(NonTrainableState, StrictModule):
     """Fixed-capacity canonical topology for sparse, fixed-resolution voxels."""
 
     address_plan: MortonAddressPlan
-    brick_codes: jax.Array
-    brick_active: jax.Array
+    brick_groups: KeyGroupState
     voxel_active: jax.Array
     evidence: SparseVoxelBuildEvidence
     brick_size: int = eqx.field(static=True)
@@ -79,7 +81,7 @@ class PreparedSparseVoxelGrid(NonTrainableState, StrictModule):
 
     @property
     def brick_capacity(self) -> int:
-        return int(self.brick_codes.shape[0])
+        return self.brick_groups.plan.group_capacity
 
     def lookup_integer(self, integer_coordinates: jax.Array) -> SparseVoxelLookup:
         coordinates = jnp.asarray(integer_coordinates, dtype=jnp.int64)
@@ -100,15 +102,9 @@ class PreparedSparseVoxelGrid(NonTrainableState, StrictModule):
             brick_codes = jnp.zeros(coordinates.shape[:-1], dtype=jnp.uint64)
         else:
             brick_codes = morton_encode_integer(brick_coordinates, self.brick_depth)
-        brick_slots = jnp.searchsorted(self.brick_codes, brick_codes, side="left").astype(
-            jnp.int32
-        )
-        safe_bricks = jnp.minimum(brick_slots, self.brick_capacity - 1)
-        brick_found = (
-            (brick_slots < self.brick_capacity)
-            & self.brick_active[safe_bricks]
-            & (self.brick_codes[safe_bricks] == brick_codes)
-        )
+        group_lookup = self.brick_groups.lookup(brick_codes, valid=in_domain)
+        safe_bricks = group_lookup.group_slots
+        brick_found = group_lookup.supported
         local_coordinates = jnp.mod(safe_coordinates, self.brick_size)
         local_slots = jnp.zeros(coordinates.shape[:-1], dtype=jnp.int32)
         for axis in range(self.dimension):
@@ -118,7 +114,7 @@ class PreparedSparseVoxelGrid(NonTrainableState, StrictModule):
             ) * jnp.int32(stride)
         supported = in_domain & brick_found & self.voxel_active[safe_bricks, local_slots]
         return SparseVoxelLookup(
-            brick_slots=jnp.where(supported, brick_slots, -1),
+            brick_slots=jnp.where(supported, safe_bricks, -1),
             local_slots=jnp.where(supported, local_slots, -1),
             supported=supported,
             in_domain=in_domain,
@@ -132,7 +128,7 @@ class PreparedSparseVoxelGrid(NonTrainableState, StrictModule):
             )
         else:
             brick_coordinates = morton_decode_integer(
-                self.brick_codes,
+                self.brick_groups.group_keys,
                 self.dimension,
                 self.brick_depth,
             )
@@ -207,24 +203,26 @@ class PreparedSparseVoxelGrid(NonTrainableState, StrictModule):
             0.0,
         )
         flat_capacity = self.brick_capacity * self.voxels_per_brick
-        flat_values = jnp.zeros(
-            (flat_capacity,) + trailing_shape,
-            dtype=amount_values.dtype,
-        )
         flat_indices = flat_slots.reshape((-1,))
         flat_contributions = contributions.reshape(
             (flat_indices.shape[0],) + trailing_shape
         )
-        if deterministic:
-
-            def add_one(index, current):
-                return current.at[flat_indices[index]].add(flat_contributions[index])
-
-            flat_values = jax.lax.fori_loop(
-                0, flat_indices.shape[0], add_one, flat_values
-            )
-        else:
-            flat_values = flat_values.at[flat_indices].add(flat_contributions)
+        route_valid = jnp.broadcast_to(
+            stencil_complete[:, None], flat_slots.shape
+        ).reshape((-1,))
+        relation = EdgeRelation(
+            jnp.arange(flat_indices.size, dtype=jnp.int32),
+            flat_indices,
+            source_size=flat_indices.size,
+            target_size=flat_capacity,
+            valid=route_valid,
+        )
+        execution = RelationExecutionPlan().prepare(relation)
+        flat_values, _ = execution.reduce(
+            flat_contributions,
+            accumulation="deterministic" if deterministic else "fast",
+            output="dense",
+        )
         return SparseVoxelDepositResult(
             values=flat_values.reshape(
                 (self.brick_capacity, self.voxels_per_brick) + trailing_shape
@@ -397,10 +395,15 @@ class SparseVoxelGridPlan(StrictModule):
                 f"Sparse voxel topology requires {required_bricks} bricks but "
                 f"capacity is {self.brick_capacity}."
             )
-        brick_codes = np.full((self.brick_capacity,), _UINT64_MAX, dtype=np.uint64)
-        brick_codes[:required_bricks] = unique_brick_codes
-        brick_active = np.zeros((self.brick_capacity,), dtype=bool)
-        brick_active[:required_bricks] = True
+        key_upper_bound = (1 << (self.address_plan.dimension * self.brick_depth)) - 1
+        brick_groups = KeyGroupPlan(
+            required_bricks,
+            self.brick_capacity,
+            key_upper_bound,
+        ).build(
+            jnp.asarray(unique_brick_codes),
+            jnp.ones((required_bricks,), dtype=bool),
+        )
         voxel_active = np.zeros((self.brick_capacity, self.voxels_per_brick), dtype=bool)
         local = unique_coordinates % self.brick_size
         strides = np.asarray(
@@ -428,8 +431,7 @@ class SparseVoxelGridPlan(StrictModule):
         )
         return PreparedSparseVoxelGrid(
             address_plan=self.address_plan,
-            brick_codes=jnp.asarray(brick_codes),
-            brick_active=jnp.asarray(brick_active),
+            brick_groups=brick_groups,
             voxel_active=jnp.asarray(voxel_active),
             evidence=evidence,
             brick_size=self.brick_size,

--- a/phydrax/discretization/splatting/_assignment.py
+++ b/phydrax/discretization/splatting/_assignment.py
@@ -17,6 +17,7 @@ from ..._fingerprint import canonical_fingerprint
 from ..._strict import AbstractAttribute, StrictModule
 from ..._trainable import NonTrainableState
 from .._tensor_entities import StructuredAxis, TensorEntityLayout
+from .._tensor_index import TensorIndexLayout
 
 
 class SplatAssignmentCapabilities(StrictModule, NonTrainableState):
@@ -183,7 +184,7 @@ class AbstractStructuredSplatAssignment(StrictModule, NonTrainableState):
     @abc.abstractmethod
     def validate(
         self,
-        layout: TensorEntityLayout,
+        layout: TensorEntityLayout | TensorIndexLayout,
         axes: tuple[StructuredAxis, ...],
         /,
     ) -> None:
@@ -212,7 +213,7 @@ class AbstractStructuredSplatAssignment(StrictModule, NonTrainableState):
     @abc.abstractmethod
     def build(
         self,
-        layout: TensorEntityLayout,
+        layout: TensorEntityLayout | TensorIndexLayout,
         axes: tuple[StructuredAxis, ...],
         axis_bounds: tuple[tuple[float, float], ...],
         position: Array,
@@ -479,7 +480,7 @@ class MultilinearSplatAssignment(AbstractStructuredSplatAssignment):
 
     def validate(
         self,
-        layout: TensorEntityLayout,
+        layout: TensorEntityLayout | TensorIndexLayout,
         axes: tuple[StructuredAxis, ...],
         /,
     ) -> None:
@@ -509,7 +510,7 @@ class MultilinearSplatAssignment(AbstractStructuredSplatAssignment):
 
     def build(
         self,
-        layout: TensorEntityLayout,
+        layout: TensorEntityLayout | TensorIndexLayout,
         axes: tuple[StructuredAxis, ...],
         axis_bounds: tuple[tuple[float, float], ...],
         position: Array,

--- a/phydrax/discretization/splatting/_reduction.py
+++ b/phydrax/discretization/splatting/_reduction.py
@@ -4,13 +4,12 @@
 
 from __future__ import annotations
 
-import jax
 import jax.numpy as jnp
 from jaxtyping import Array, ArrayLike
 
 from ..._interpolation import GatherStencil
-from ..._numerics._compensated import compensated_sum, two_sum
-from ...sparse import linear_transpose_apply, route_reduce
+from ..._numerics._compensated import compensated_sum
+from ...sparse import canonical_row_route_ids, RelationExecutionPlan
 from ._types import SplatAccumulation
 
 
@@ -30,49 +29,27 @@ def cast_stage(value: ArrayLike, real_dtype: str, /) -> Array:
     return jnp.asarray(value).astype(stage_dtype(value, real_dtype))
 
 
-def _canonical_route_sum(
+def _reduce_routes(
     stencil: GatherStencil,
-    values: Array,
+    route_values: Array,
     stable_source_order: Array,
     target_size: int,
+    accumulation: SplatAccumulation,
     /,
-    *,
-    compensated: bool,
 ) -> Array:
-    indices = stencil.indices
-    valid = stencil.valid
-    weights = stencil.weights.astype(values.dtype)
-    source_count, width = indices.shape
-    output_shape = (int(target_size),) + values.shape[1:]
-    zeros = jnp.zeros(output_shape, dtype=values.dtype)
-
-    def step(route_index: int, carry):
-        source_rank = route_index // width
-        slot = route_index - source_rank * width
-        source = stable_source_order[source_rank]
-        target = indices[source, slot]
-        route_valid = valid[source, slot]
-        weight = weights[source, slot]
-        payload = values[source] * weight
-        payload = jnp.where(route_valid, payload, jnp.zeros((), dtype=payload.dtype))
-        if not compensated:
-            return carry.at[target].add(payload)
-        total, correction = carry
-        next_total, error = two_sum(total[target], payload)
-        total = total.at[target].set(next_total)
-        correction = correction.at[target].add(error)
-        return total, correction
-
-    route_count = source_count * width
-    if compensated:
-        total, correction = jax.lax.fori_loop(
-            0,
-            route_count,
-            step,
-            (zeros, zeros),
-        )
-        return total + correction
-    return jax.lax.fori_loop(0, route_count, step, zeros)
+    edge = stencil.relation.as_edge_relation().transpose()
+    if edge.target_size != int(target_size):
+        raise ValueError("target_size does not match the stencil source space.")
+    stable_route_ids = canonical_row_route_ids(
+        stable_source_order, stencil.indices.shape[1]
+    )
+    execution = RelationExecutionPlan().prepare(edge, stable_route_ids=stable_route_ids)
+    reduced, _ = execution.reduce(
+        route_values.reshape((edge.capacity,) + route_values.shape[2:]),
+        accumulation=accumulation,
+        output="dense",
+    )
+    return reduced
 
 
 def deposit_routes(
@@ -90,69 +67,10 @@ def deposit_routes(
     order = jnp.asarray(stable_source_order, dtype=jnp.int32)
     if order.shape != (values.shape[0],):
         raise ValueError("Stable source order must contain every source exactly once.")
-    if accumulation == "fast":
-        return linear_transpose_apply(stencil.relation, stencil.weights, values)
-    if accumulation == "deterministic":
-        return _canonical_route_sum(
-            stencil,
-            values,
-            order,
-            target_size,
-            compensated=False,
-        )
-    if accumulation == "compensated":
-        return _canonical_route_sum(
-            stencil,
-            values,
-            order,
-            target_size,
-            compensated=True,
-        )
-    raise ValueError("Unknown splat accumulation policy.")
-
-
-def _canonical_route_payload_sum(
-    stencil: GatherStencil,
-    route_values: Array,
-    stable_source_order: Array,
-    target_size: int,
-    /,
-    *,
-    compensated: bool,
-) -> Array:
-    source_count, width = stencil.indices.shape
-    payload_shape = route_values.shape[2:]
-    zeros = jnp.zeros((int(target_size),) + payload_shape, dtype=route_values.dtype)
-
-    def step(route_index: int, carry):
-        source_rank = route_index // width
-        slot = route_index - source_rank * width
-        source = stable_source_order[source_rank]
-        target = stencil.indices[source, slot]
-        route_valid = stencil.valid[source, slot]
-        payload = jnp.where(
-            route_valid,
-            route_values[source, slot],
-            jnp.zeros((), dtype=route_values.dtype),
-        )
-        if not compensated:
-            return carry.at[target].add(payload)
-        total, correction = carry
-        next_total, error = two_sum(total[target], payload)
-        total = total.at[target].set(next_total)
-        correction = correction.at[target].add(error)
-        return total, correction
-
-    route_count = source_count * width
-    if compensated:
-        total, correction = jax.lax.fori_loop(
-            0,
-            route_count,
-            step,
-            (zeros, zeros),
-        )
-        return total + correction
-    return jax.lax.fori_loop(0, route_count, step, zeros)
+    payload = values[:, None] * stencil.weights.astype(values.dtype).reshape(
+        stencil.weights.shape + (1,) * (values.ndim - 1)
+    )
+    return _reduce_routes(stencil, payload, order, target_size, accumulation)
 
 
 def _scatter_route_payload(
@@ -173,27 +91,7 @@ def _scatter_route_payload(
     order = jnp.asarray(stable_source_order, dtype=jnp.int32)
     if order.shape != (route_shape[0],):
         raise ValueError("Stable source order must contain every source exactly once.")
-    if accumulation == "fast":
-        edge = stencil.relation.as_edge_relation().transpose()
-        flattened = values.reshape((edge.capacity,) + values.shape[2:])
-        return route_reduce(edge, flattened)
-    if accumulation == "deterministic":
-        return _canonical_route_payload_sum(
-            stencil,
-            values,
-            order,
-            target_size,
-            compensated=False,
-        )
-    if accumulation == "compensated":
-        return _canonical_route_payload_sum(
-            stencil,
-            values,
-            order,
-            target_size,
-            compensated=True,
-        )
-    raise ValueError("Unknown splat accumulation policy.")
+    return _reduce_routes(stencil, values, order, target_size, accumulation)
 
 
 def certified_sum(value: ArrayLike, real_dtype: str, /, *, axis: int) -> Array:

--- a/phydrax/discretization/splatting/_structured.py
+++ b/phydrax/discretization/splatting/_structured.py
@@ -20,6 +20,11 @@ from ..._trainable import NonTrainableState
 from .._core import DiscretizationCapability, PreparationReport, resolved_identifier
 from .._measure import DiscreteMeasure
 from .._tensor_entities import TensorEntityLayout
+from .._tensor_index import (
+    PreparedTensorIndexSpace,
+    TensorIndexLayout,
+    TensorIndexMeasure,
+)
 from .._tensor_support import GridLocation, PreparedTensorGrid
 from .._transfer import TransferProperties
 from ..particle._core import ParticleDiscretization
@@ -166,7 +171,7 @@ class ParticleGridSplatState(StrictModule):
 class ParticleGridSplatPlan(StrictModule, NonTrainableState):
     """Particle transfer onto one structured tensor-grid layout."""
 
-    target: PreparedTensorGrid
+    target: PreparedTensorGrid | PreparedTensorIndexSpace
     location: GridLocation
     assignment: AbstractStructuredSplatAssignment
     boundary: SplatBoundaryPolicy = eqx.field(static=True)
@@ -177,7 +182,7 @@ class ParticleGridSplatPlan(StrictModule, NonTrainableState):
 
     def __init__(
         self,
-        target: PreparedTensorGrid,
+        target: PreparedTensorGrid | PreparedTensorIndexSpace,
         /,
         *,
         location: GridLocation | None = None,
@@ -188,8 +193,10 @@ class ParticleGridSplatPlan(StrictModule, NonTrainableState):
         budget: ParticleGridSplatBudget | None = None,
         plan_id: str | None = None,
     ):
-        if not isinstance(target, PreparedTensorGrid):
-            raise TypeError("target must be PreparedTensorGrid.")
+        if not isinstance(target, (PreparedTensorGrid, PreparedTensorIndexSpace)):
+            raise TypeError(
+                "target must be PreparedTensorGrid or PreparedTensorIndexSpace."
+            )
         selected_location = (
             target.location((0,) * len(target.axis_names))
             if location is None
@@ -243,8 +250,8 @@ class PreparedParticleGridSplat(StrictModule, NonTrainableState):
 
     plan: ParticleGridSplatPlan
     particles: ParticleDiscretization
-    layout: TensorEntityLayout
-    target_measure: DiscreteMeasure
+    layout: TensorEntityLayout | TensorIndexLayout
+    target_measure: DiscreteMeasure | TensorIndexMeasure
     stable_source_order: Array
     axis_bounds: tuple[tuple[float, float], ...] = eqx.field(static=True)
     target_shape: tuple[int, ...] = eqx.field(static=True)
@@ -255,6 +262,7 @@ class PreparedParticleGridSplat(StrictModule, NonTrainableState):
     preparation: PreparationReport
     prepared_id: str = eqx.field(static=True)
     artifact_kind: str = eqx.field(static=True)
+    materialized_target: bool = eqx.field(static=True)
 
     def __init__(
         self,
@@ -272,8 +280,20 @@ class PreparedParticleGridSplat(StrictModule, NonTrainableState):
         axes = plan.target.structured_axes
         plan.assignment.validate(layout, axes)
         target_measure = plan.target.measure_for(layout)
-        target_weights = np.asarray(target_measure.weights)
-        if np.any(~np.isfinite(target_weights)) or np.any(target_weights <= 0.0):
+        if isinstance(target_measure, DiscreteMeasure):
+            target_weights = np.asarray(target_measure.weights)
+            finite_positive_measure = bool(
+                np.all(np.isfinite(target_weights)) & np.all(target_weights > 0.0)
+            )
+        else:
+            finite_positive_measure = all(
+                bool(
+                    np.all(np.isfinite(np.asarray(factors)))
+                    & np.all(np.asarray(factors) > 0.0)
+                )
+                for factors in target_measure.layout.measures_by_axis
+            )
+        if not finite_positive_measure:
             raise ValueError("Splat target measure must be finite and strictly positive.")
         source_count = particles.capacity
         target_size = prod(layout.shape)
@@ -290,8 +310,11 @@ class PreparedParticleGridSplat(StrictModule, NonTrainableState):
         source_values = (dimension * dimension + 2 * dimension + 2) * evaluation_itemsize
         source_values += 4
         relation_bytes = route_count * route_values + source_count * source_values
-        scalar_workspace = target_size * accumulation_itemsize
-        if plan.execution.accumulation == "compensated":
+        materialized_target = isinstance(plan.target, PreparedTensorGrid)
+        scalar_workspace = (
+            target_size * accumulation_itemsize if materialized_target else 0
+        )
+        if materialized_target and plan.execution.accumulation == "compensated":
             scalar_workspace *= 2
         plan.budget.admit(
             sources=source_count,
@@ -320,6 +343,11 @@ class PreparedParticleGridSplat(StrictModule, NonTrainableState):
                 "fixed assignment route width",
                 "piecewise geometry differentiation with frozen route indices",
                 f"nonperiodic boundary policy: {plan.boundary}",
+                (
+                    "dense target materialized"
+                    if materialized_target
+                    else "virtual target requires explicit storage for projection"
+                ),
                 "workspace bytes are reported per scalar payload",
             ),
             resource_counts={
@@ -377,6 +405,7 @@ class PreparedParticleGridSplat(StrictModule, NonTrainableState):
         self.properties = properties
         self.preparation = preparation
         self.prepared_id = prepared_id
+        self.materialized_target = materialized_target
         self.artifact_kind = "particle-grid-splat"
 
     @property
@@ -386,6 +415,13 @@ class PreparedParticleGridSplat(StrictModule, NonTrainableState):
     @property
     def resource_evidence_id(self) -> str:
         return self.preparation.report_id
+
+    def _require_materialized_target(self) -> None:
+        if not self.materialized_target:
+            raise ValueError(
+                "This splat uses a virtual tensor index space; bind an explicit "
+                "target storage before projection or reconstruction."
+            )
 
     def build(
         self,
@@ -528,6 +564,7 @@ class PreparedParticleGridSplat(StrictModule, NonTrainableState):
         source_values: Array,
         /,
     ) -> Array:
+        self._require_materialized_target()
         accumulated = cast_stage(source_values, self.plan.precision.accumulation_dtype)
         target = deposit_routes(
             state.stencil,
@@ -538,6 +575,116 @@ class PreparedParticleGridSplat(StrictModule, NonTrainableState):
         )
         return state.require_success(target)
 
+    def deposit_content_mapped(
+        self,
+        state: ParticleGridSplatState,
+        content: ArrayLike,
+        target_stencil: GatherStencil,
+        target_measure: ArrayLike,
+        /,
+    ) -> SplatDepositResult:
+        """Deposit onto an explicit logical-to-storage stencil without dense output."""
+        self._require_state(state)
+        if not isinstance(target_stencil, GatherStencil):
+            raise TypeError("target_stencil must be GatherStencil.")
+        if target_stencil.relation.output_shape != state.stencil.relation.output_shape:
+            raise ValueError("target_stencil must preserve the particle output shape.")
+        source = self._source_payload(state, content, "content")
+        accumulated = cast_stage(source, self.plan.precision.accumulation_dtype)
+        target_flat = deposit_routes(
+            target_stencil,
+            accumulated,
+            self.stable_source_order,
+            target_stencil.source_size,
+            self.plan.execution.accumulation,
+        )
+        target_content = cast_stage(target_flat, self.plan.precision.output_dtype)
+        measure = jnp.asarray(target_measure, dtype=target_content.real.dtype)
+        if measure.shape != (target_stencil.source_size,):
+            raise ValueError("target_measure must have one value per storage site.")
+        measure_shape = measure.shape + (1,) * (target_content.ndim - 1)
+        density = target_content / measure.reshape(measure_shape)
+        balance = self._balance_evidence(
+            state,
+            source,
+            target_flat,
+            target_size=target_stencil.source_size,
+        )
+        successful = (
+            state.successful
+            & jnp.all(jnp.isfinite(target_content))
+            & jnp.all(jnp.isfinite(density))
+            & jnp.isfinite(balance.maximum_absolute_balance_defect)
+        )
+        return SplatDepositResult(target_content, density, balance, successful)
+
+    def scatter_route_payload_mapped(
+        self,
+        state: ParticleGridSplatState,
+        payload: ArrayLike,
+        target_stencil: GatherStencil,
+        /,
+    ) -> SplatRouteScatterResult:
+        """Reduce route payloads onto an explicit compact storage stencil."""
+        self._require_state(state)
+        values = jnp.asarray(payload)
+        if values.ndim < 2 or values.shape[:2] != target_stencil.indices.shape:
+            raise ValueError("Mapped route payload and stencil route shapes must match.")
+        evaluated = cast_stage(values, self.plan.precision.evaluation_dtype)
+        payload_shape = evaluated.shape[2:]
+        active = self.particles.active_mask.reshape(
+            (self.particles.capacity, 1) + (1,) * len(payload_shape)
+        )
+        evaluated = eqx.error_if(
+            evaluated,
+            jnp.any(jnp.where(active, ~jnp.isfinite(evaluated), False)),
+            "Active route payload values must be finite.",
+        )
+        accumulated = cast_stage(
+            jnp.where(active, evaluated, jnp.zeros((), dtype=evaluated.dtype)),
+            self.plan.precision.accumulation_dtype,
+        )
+        target = _scatter_route_payload(
+            target_stencil,
+            accumulated,
+            self.stable_source_order,
+            target_stencil.source_size,
+            self.plan.execution.accumulation,
+        )
+        target = cast_stage(target, self.plan.precision.output_dtype)
+        successful = state.successful & jnp.all(jnp.isfinite(target))
+        return SplatRouteScatterResult(
+            state.require_success(target),
+            state.valid_route_count,
+            successful,
+            execution_policy_id=self.plan.execution.policy_id,
+            precision_policy_id=self.plan.precision.policy_id,
+        )
+
+    def gather_mapped(
+        self,
+        state: ParticleGridSplatState,
+        target_values: ArrayLike,
+        target_stencil: GatherStencil,
+        /,
+    ) -> InterpolationResult:
+        """Gather from explicit compact storage while preserving route geometry."""
+        self._require_state(state)
+        values = jnp.asarray(target_values)
+        if values.ndim < 1 or values.shape[0] != target_stencil.source_size:
+            raise ValueError("target_values must begin with compact storage capacity.")
+        result = apply_gather_stencil(
+            cast_stage(values, self.plan.precision.evaluation_dtype),
+            target_stencil,
+        )
+        return InterpolationResult(
+            cast_stage(
+                state.require_success(result.values),
+                self.plan.precision.output_dtype,
+            ),
+            result.support,
+        )
+
     def scatter_route_payload(
         self,
         state: ParticleGridSplatState,
@@ -546,6 +693,7 @@ class PreparedParticleGridSplat(StrictModule, NonTrainableState):
     ) -> SplatRouteScatterResult:
         """Reduce an already weighted payload for every particle-grid route."""
         self._require_state(state)
+        self._require_materialized_target()
         values = jnp.asarray(payload)
         route_shape = state.stencil.indices.shape
         if (
@@ -598,11 +746,14 @@ class PreparedParticleGridSplat(StrictModule, NonTrainableState):
     ) -> SplatDepositResult:
         """Deposit extensive particle content and derive target density."""
         self._require_state(state)
+        self._require_materialized_target()
         source = self._source_payload(state, content, "content")
         target_flat = self._deposit_flat(state, source)
         payload_shape = source.shape[1:]
         target_content = target_flat.reshape(self.target_shape + payload_shape)
         target_content = cast_stage(target_content, self.plan.precision.output_dtype)
+        if not isinstance(self.target_measure, DiscreteMeasure):
+            raise AssertionError("Materialized splats require a DiscreteMeasure.")
         measure = self.target_measure.weights.reshape(
             self.target_shape + (1,) * len(payload_shape)
         ).astype(target_content.real.dtype)
@@ -622,6 +773,8 @@ class PreparedParticleGridSplat(StrictModule, NonTrainableState):
         source: Array,
         target_flat: Array,
         /,
+        *,
+        target_size: int | None = None,
     ) -> SplatBalanceEvidence:
         active = self.particles.active_mask
         active_mask = active.reshape(active.shape + (1,) * (source.ndim - 1))
@@ -659,9 +812,8 @@ class PreparedParticleGridSplat(StrictModule, NonTrainableState):
         )
         real_dtype = jnp.asarray(active_total).real.dtype
         epsilon = jnp.finfo(real_dtype).eps
-        operation_count = max(
-            2, self.route_count + self.particles.capacity + self.target_size
-        )
+        output_size = self.target_size if target_size is None else int(target_size)
+        operation_count = max(2, self.route_count + self.particles.capacity + output_size)
         accumulated_epsilon = operation_count * epsilon
         roundoff_model_valid = accumulated_epsilon < 0.5
         gamma = accumulated_epsilon / jnp.maximum(1.0 - accumulated_epsilon, epsilon)
@@ -701,6 +853,7 @@ class PreparedParticleGridSplat(StrictModule, NonTrainableState):
         /,
     ) -> SplatReconstructionResult:
         """Reconstruct one intensive field with explicit nonnegative sample weights."""
+        self._require_materialized_target()
         self._require_state(state)
         source_values = self._source_payload(state, values, "sample")
         weights = jnp.asarray(sample_weights)

--- a/phydrax/equations/__init__.py
+++ b/phydrax/equations/__init__.py
@@ -24,6 +24,12 @@ from ..discretization.discrete_velocity._smooth_compressible import (
     SmoothCompressibleRealizabilityEvidence,
 )
 from . import advanced, fem, trefftz, vem
+from ._ablating_material import (
+    AblatingMaterialAdvance,
+    AblatingMaterialEvaluation,
+    AblatingMaterialState,
+    PorousAblatingMaterialPlan,
+)
 from ._additional_entropy import (
     ideal_mhd_entropy_pair,
     shallow_water_energy_pair,
@@ -269,6 +275,11 @@ from ._homogeneous_thermodynamics import (
     ThermodynamicDomainEvidence,
     ZeroResidualHelmholtzTerm,
 )
+from ._hybrid_turbulence import (
+    DelayedDetachedEddyPlan,
+    HybridRANSLESGridScalePlan,
+    HybridTurbulenceEvaluation,
+)
 from ._hyperbolic_systems import (
     AbstractAdmissibleSystem,
     AbstractCharacteristicSystem,
@@ -296,6 +307,13 @@ from ._integral_rewrite import (
     IntegralResidualProgram,
     rewrite_strong_to_integral,
     StrongToIntegralRewriteSpec,
+)
+from ._ionized_gas import (
+    IonizedMixtureThermodynamicsPlan,
+    IonizedMultitemperatureEulerSystem,
+    IonizedMultitemperatureNavierStokesSystem,
+    IonizedThermodynamicEvaluation,
+    PlasmaQuasiNeutralityEvidence,
 )
 from ._ir import (
     as_expression,
@@ -480,6 +498,21 @@ from ._mechanical_load_action import (
     MechanicalLoadActionEvaluation,
     NeuralCoordinateTrace,
 )
+from ._mixed_dimensional import (
+    BulkDGTransportEvidence,
+    BulkDGTransportPlan,
+    MixedDimensionalMassLedger,
+    MixedDimensionalSources,
+    MixedDimensionalStepResult,
+    MixedDimensionalTransportPlan,
+    MixedDimensionalTransportState,
+    NetworkTransportPlan,
+    PermeabilityExchangePlan,
+    PreparedBulkDGTransport,
+    PreparedMixedDimensionalTransport,
+    PreparedNetworkTransport,
+    ReservoirCouplingPlan,
+)
 from ._mixture_transport import (
     MixtureAveragedTransportPlan,
     MixtureTransportEvaluation,
@@ -517,6 +550,14 @@ from ._nonequilibrium_gas import (
     TwoTemperatureRecovery,
     TwoTemperatureThermodynamicEvaluation,
     TwoTemperatureThermodynamicsPlan,
+)
+from ._nonlte_radiation import (
+    AVOGADRO_CONSTANT,
+    NonLTELevelPopulationPlan,
+    NonLTEPopulationEvaluation,
+    NonLTERadiationCoefficientEvaluation,
+    NonLTERadiationCoefficientPlan,
+    PLANCK_CONSTANT,
 )
 from ._particle_conversion import (
     compile_particle_conversion_problem,
@@ -577,6 +618,15 @@ from ._phase_field import (
     double_well_free_energy_density,
     DoubleWellFreeEnergy,
     evaluate_binary_free_energy,
+)
+from ._plasma_chemistry import (
+    PlasmaChemicalRateEvaluation,
+    PreparedPlasmaMechanism,
+    ReactionTemperatureSpec,
+)
+from ._plasma_transport import (
+    AmbipolarPlasmaTransportPlan,
+    PlasmaTransportEvaluation,
 )
 from ._radiation_material import (
     radiation_means,
@@ -643,6 +693,13 @@ from ._spalart_allmaras import (
     SpalartAllmarasEvaluation,
     SpalartAllmarasNegativePlan,
 )
+from ._sparse_flip import (
+    compile_sparse_flip_problem,
+    CompiledSparseFLIPProblem,
+    SparseFLIPDiagnostics,
+    SparseFLIPRuntimeState,
+    SparseFLIPStepResult,
+)
 from ._spectral_compile import (
     compile_spectral_pde,
     CompiledSpectralDynamics,
@@ -657,10 +714,18 @@ from ._spectral_residual import (
     SpectralResidualDataLayout,
     SpectralResidualScope,
 )
+from ._sst import SSTEvaluation, SSTTurbulencePlan
 from ._stencil_compile import (
     compile_stencil_dynamics,
     CompiledStencilDynamics,
     StencilStateLayout,
+)
+from ._surface_chemistry import (
+    GasSurfaceChemicalEvaluation,
+    GasSurfaceReactionSpec,
+    PreparedGasSurfaceMechanism,
+    SurfaceChemicalState,
+    SurfaceSpeciesSchema,
 )
 from ._thermal_modes import (
     ThermalModeEvaluation,
@@ -700,21 +765,6 @@ from ._unstructured_les import (
     UnstructuredLowMachLESState,
 )
 from ._validate import infer_expression_type, PDEValueType, validate_pde_ir
-from ._mixed_dimensional import (
-    BulkDGTransportEvidence,
-    BulkDGTransportPlan,
-    MixedDimensionalMassLedger,
-    MixedDimensionalSources,
-    MixedDimensionalStepResult,
-    MixedDimensionalTransportPlan,
-    MixedDimensionalTransportState,
-    NetworkTransportPlan,
-    PermeabilityExchangePlan,
-    PreparedBulkDGTransport,
-    PreparedMixedDimensionalTransport,
-    PreparedNetworkTransport,
-    ReservoirCouplingPlan,
-)
 from ._variational import (
     BoundaryLoadAction,
     coefficient,
@@ -826,50 +876,6 @@ from .vem import (
 )
 
 
-from ._ablating_material import (
-    AblatingMaterialAdvance,
-    AblatingMaterialEvaluation,
-    AblatingMaterialState,
-    PorousAblatingMaterialPlan,
-)
-from ._hybrid_turbulence import (
-    DelayedDetachedEddyPlan,
-    HybridRANSLESGridScalePlan,
-    HybridTurbulenceEvaluation,
-)
-from ._ionized_gas import (
-    IonizedMixtureThermodynamicsPlan,
-    IonizedMultitemperatureEulerSystem,
-    IonizedMultitemperatureNavierStokesSystem,
-    IonizedThermodynamicEvaluation,
-    PlasmaQuasiNeutralityEvidence,
-)
-from ._nonlte_radiation import (
-    AVOGADRO_CONSTANT,
-    NonLTELevelPopulationPlan,
-    NonLTEPopulationEvaluation,
-    NonLTERadiationCoefficientEvaluation,
-    NonLTERadiationCoefficientPlan,
-    PLANCK_CONSTANT,
-)
-from ._plasma_chemistry import (
-    PlasmaChemicalRateEvaluation,
-    PreparedPlasmaMechanism,
-    ReactionTemperatureSpec,
-)
-from ._plasma_transport import (
-    AmbipolarPlasmaTransportPlan,
-    PlasmaTransportEvaluation,
-)
-from ._sst import SSTEvaluation, SSTTurbulencePlan
-from ._surface_chemistry import (
-    GasSurfaceChemicalEvaluation,
-    GasSurfaceReactionSpec,
-    PreparedGasSurfaceMechanism,
-    SurfaceChemicalState,
-    SurfaceSpeciesSchema,
-)
-
 __all__ = [
     "BulkDGTransportEvidence",
     "BulkDGTransportPlan",
@@ -928,6 +934,7 @@ __all__ = [
     "CompiledMACVariableDensityDynamics",
     "CompiledIncompressibleSpectralDynamics",
     "CompiledFLIPProblem",
+    "CompiledSparseFLIPProblem",
     "CompiledSpectralDynamics",
     "CompiledSpectralResidual",
     "CompiledFiniteDifferenceDynamics",
@@ -943,8 +950,12 @@ __all__ = [
     "MPMLinearizedConstitutiveResponse",
     "MPMKinematics",
     "compile_flip_problem",
+    "compile_sparse_flip_problem",
     "flip_inspection_frames",
     "FLIPProblemIR",
+    "SparseFLIPDiagnostics",
+    "SparseFLIPRuntimeState",
+    "SparseFLIPStepResult",
     "compile_material_point_problem",
     "CompiledMaterialPointProblem",
     "ExternalMPMAcceleration",

--- a/phydrax/equations/_material_point.py
+++ b/phydrax/equations/_material_point.py
@@ -22,8 +22,8 @@ from ..discretization import (
     DiscretizationRole,
 )
 from ..discretization.mpm import (
+    AbstractMPMNodalStoragePlan,
     ExplicitMPMMethodPlan,
-    MPMActiveBlockPlan,
     MPMNodalFieldPlan,
     MPMParticleDomainPlan,
     MPMResourcePolicy,
@@ -370,7 +370,7 @@ def compile_material_point_problem(
     boundary: PrescribedGridVelocityPlan | None = None,
     contact: RigidMPMContactPlan | None = None,
     nodal_fields: MPMNodalFieldPlan | None = None,
-    active_blocks: MPMActiveBlockPlan | None = None,
+    nodal_storage: AbstractMPMNodalStoragePlan | None = None,
     resource_policy: MPMResourcePolicy | None = None,
     support_decision: MPMSupportDecision | None = None,
 ) -> CompiledMaterialPointProblem:
@@ -385,7 +385,7 @@ def compile_material_point_problem(
         boundary=boundary,
         contact=contact,
         nodal_fields=nodal_fields,
-        active_blocks=active_blocks,
+        nodal_storage=nodal_storage,
         external_acceleration=problem.external_acceleration,
         external_acceleration_id=problem.external_acceleration_id,
         resource_policy=resource_policy,

--- a/phydrax/equations/_sparse_flip.py
+++ b/phydrax/equations/_sparse_flip.py
@@ -1,0 +1,366 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import equinox as eqx
+import jax.numpy as jnp
+from jaxtyping import Array, ArrayLike
+
+from .._fingerprint import canonical_fingerprint
+from .._strict import StrictModule
+from .._trainable import NonTrainableState
+from .._tree_math import tree_where
+from ..discretization.flip import (
+    FLIPMethodPlan,
+    FLIPParticleState,
+    FLIPRejectionReason,
+    FLIPRunStatus,
+    PreparedSparseFLIPParticleTransfer,
+    SparseFLIPTransferState,
+)
+from ._flip import FLIPProblemIR
+
+
+if TYPE_CHECKING:
+    from ..solver._sparse_flip import (
+        SparseMACFreeSurfaceProjectionPlan,
+        SparseMACFreeSurfaceProjectionResult,
+    )
+
+
+class SparseFLIPRuntimeState(StrictModule):
+    particles: FLIPParticleState
+    pressure: Array
+    transfer: SparseFLIPTransferState
+    time: Array
+    accepted_step: Array
+    status: Array
+
+
+class SparseFLIPDiagnostics(StrictModule):
+    liquid_count: Array
+    air_count: Array
+    classification_margin: Array
+    mass_balance_defect: Array
+    momentum_balance_defect: Array
+    projection_residual: Array
+    divergence_norm: Array
+    maximum_displacement_fraction: Array
+    energy_before: Array
+    energy_after: Array
+    topology_generation: Array
+    rejection_reason: Array
+    successful: Array
+
+
+class SparseFLIPStepResult(StrictModule):
+    candidate_state: SparseFLIPRuntimeState
+    accepted_state: SparseFLIPRuntimeState
+    pre_grid_velocity: tuple[Array, ...]
+    post_grid_velocity: tuple[Array, ...]
+    liquid_fraction: Array
+    projection: SparseMACFreeSurfaceProjectionResult
+    diagnostics: SparseFLIPDiagnostics
+    successful: Array
+
+
+class CompiledSparseFLIPProblem(StrictModule, NonTrainableState):
+    """Transactional compact FLIP transfer, pressure projection, and advection."""
+
+    problem: FLIPProblemIR
+    transfer: PreparedSparseFLIPParticleTransfer
+    projection: SparseMACFreeSurfaceProjectionPlan
+    method: FLIPMethodPlan
+    compilation_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        problem: FLIPProblemIR,
+        transfer: PreparedSparseFLIPParticleTransfer,
+        projection: SparseMACFreeSurfaceProjectionPlan,
+        method: FLIPMethodPlan,
+        /,
+    ) -> None:
+        from ..solver._sparse_flip import SparseMACFreeSurfaceProjectionPlan
+
+        if not isinstance(problem, FLIPProblemIR):
+            raise TypeError("problem must be FLIPProblemIR.")
+        if not isinstance(transfer, PreparedSparseFLIPParticleTransfer):
+            raise TypeError("transfer must be PreparedSparseFLIPParticleTransfer.")
+        if not isinstance(projection, SparseMACFreeSurfaceProjectionPlan):
+            raise TypeError("projection must be SparseMACFreeSurfaceProjectionPlan.")
+        if not isinstance(method, FLIPMethodPlan):
+            raise TypeError("method must be FLIPMethodPlan.")
+        if projection.transfer.prepared_id != transfer.prepared_id:
+            raise ValueError("Sparse FLIP transfer and projection must match.")
+        if problem.acceleration.shape != (transfer.dimension,):
+            raise ValueError("FLIP acceleration dimension must match the transfer.")
+        self.problem = problem
+        self.transfer = transfer
+        self.projection = projection
+        self.method = method
+        self.compilation_id = canonical_fingerprint(
+            {
+                "kind": "compiled-sparse-flip-problem",
+                "problem": problem.problem_id,
+                "transfer": transfer.prepared_id,
+                "projection": projection.plan_id,
+                "method": method.method_id,
+            }
+        )
+
+    def initialize_state(
+        self,
+        position: ArrayLike,
+        velocity: ArrayLike,
+        /,
+        *,
+        time: ArrayLike = 0.0,
+    ) -> SparseFLIPRuntimeState:
+        position_ = jnp.asarray(position, dtype=self.transfer.particles.safe_masses.dtype)
+        velocity_ = jnp.asarray(velocity, dtype=position_.dtype)
+        expected = (self.transfer.particles.capacity, self.transfer.dimension)
+        if position_.shape != expected or velocity_.shape != expected:
+            raise ValueError(f"FLIP position and velocity must have shape {expected}.")
+        active = self.transfer.particles.active_mask[:, None]
+        particles = FLIPParticleState(
+            jnp.where(active, position_, 0.0),
+            jnp.where(active, velocity_, 0.0),
+        )
+        routes = self.transfer.build(particles.position)
+        pressure = jnp.zeros(
+            (self.transfer.plan.cell_topology.storage_capacity,),
+            dtype=position_.dtype,
+        )
+        return SparseFLIPRuntimeState(
+            particles=particles,
+            pressure=pressure,
+            transfer=routes,
+            time=jnp.asarray(time, dtype=position_.dtype).reshape(()),
+            accepted_step=jnp.asarray(0, dtype=jnp.int32),
+            status=jnp.asarray(int(FLIPRunStatus.SUCCESS), dtype=jnp.int32),
+        )
+
+    @staticmethod
+    def _align_pressure(
+        previous: SparseFLIPRuntimeState,
+        candidate_transfer: SparseFLIPTransferState,
+    ) -> Array:
+        logical = candidate_transfer.cell_topology.logical_node_ids.reshape((-1,))
+        valid = candidate_transfer.cell_topology.node_valid.reshape((-1,))
+        lookup = previous.transfer.cell_topology.lookup(logical, valid)
+        retained = (
+            lookup.supported
+            & previous.transfer.cell_topology.node_valid.reshape((-1,))[
+                lookup.storage_slots
+            ]
+        )
+        return jnp.where(retained, previous.pressure[lookup.storage_slots], 0.0)
+
+    def step_detailed(
+        self,
+        state: SparseFLIPRuntimeState,
+        step_size: ArrayLike,
+        /,
+    ) -> SparseFLIPStepResult:
+        if not isinstance(state, SparseFLIPRuntimeState):
+            raise TypeError("state must be SparseFLIPRuntimeState.")
+        dt = jnp.asarray(step_size, dtype=state.time.dtype).reshape(())
+        routes = self.transfer.build(
+            state.particles.position,
+            previous=state.transfer,
+        )
+        pressure = self._align_pressure(state, routes)
+        p2g = self.transfer.particle_to_grid(
+            routes,
+            state.particles.velocity,
+            self.problem.reference_density,
+        )
+        liquid = jnp.asarray(
+            p2g.liquid_fraction >= self.method.liquid_fraction_threshold,
+            dtype=bool,
+        )
+        classification_margin = jnp.min(
+            jnp.abs(p2g.liquid_fraction - self.method.liquid_fraction_threshold),
+            initial=jnp.inf,
+        )
+        pre_grid = tuple(
+            jnp.where(support, value, 0.0)
+            for value, support in zip(p2g.velocity, p2g.face_support, strict=True)
+        )
+        forced = tuple(
+            value + dt * self.problem.acceleration[axis]
+            for axis, value in enumerate(pre_grid)
+        )
+        projected = self.projection.project(
+            routes,
+            forced,
+            liquid,
+            dt,
+            pressure=pressure,
+        )
+        g2p = self.transfer.grid_to_particle(
+            routes,
+            pre_grid,
+            projected.velocity,
+        )
+        beta = self.method.pic_fraction
+        next_velocity = (1.0 - beta) * (
+            state.particles.velocity + g2p.flip_increment
+        ) + beta * g2p.pic_velocity
+        midpoint = state.particles.position + 0.5 * dt * next_velocity
+        midpoint_routes = self.transfer.build_fixed(midpoint, routes)
+        midpoint_sample = self.transfer.grid_to_particle(
+            midpoint_routes,
+            projected.velocity,
+            projected.velocity,
+        )
+        displacement = dt * midpoint_sample.pic_velocity
+        active = self.transfer.particles.active_mask
+        next_particles = FLIPParticleState(
+            jnp.where(active[:, None], state.particles.position + displacement, 0.0),
+            jnp.where(active[:, None], next_velocity, 0.0),
+        )
+        widths = jnp.asarray(
+            [
+                jnp.min(axis.interval_widths)
+                for axis in self.transfer.plan.index_space.structured_axes
+            ],
+            dtype=dt.dtype,
+        )
+        maximum_fraction = jnp.max(
+            jnp.where(active[:, None], jnp.abs(displacement) / widths, 0.0),
+            initial=0.0,
+        )
+        masses = self.transfer.particles.masses.astype(dt.dtype)
+        energy_before = 0.5 * jnp.sum(
+            jnp.where(
+                active,
+                masses * jnp.sum(state.particles.velocity**2, axis=-1),
+                0.0,
+            )
+        )
+        energy_after = 0.5 * jnp.sum(
+            jnp.where(
+                active,
+                masses * jnp.sum(next_particles.velocity**2, axis=-1),
+                0.0,
+            )
+        )
+        finite = (
+            jnp.isfinite(dt)
+            & (dt > 0.0)
+            & jnp.all(jnp.isfinite(next_particles.position))
+            & jnp.all(jnp.isfinite(next_particles.velocity))
+        )
+        transfer_successful = (
+            routes.successful
+            & p2g.successful
+            & g2p.successful
+            & midpoint_routes.successful
+            & midpoint_sample.successful
+        )
+        stable = maximum_fraction <= self.method.cfl_fraction
+        successful = transfer_successful & projected.successful & stable & finite
+        reason = jnp.asarray(int(FLIPRejectionReason.NONE), dtype=jnp.int32)
+        reason = jnp.where(
+            transfer_successful,
+            reason,
+            reason | int(FLIPRejectionReason.TRANSFER),
+        )
+        reason = jnp.where(
+            projected.successful,
+            reason,
+            reason | int(FLIPRejectionReason.PROJECTION),
+        )
+        reason = jnp.where(stable, reason, reason | int(FLIPRejectionReason.STABILITY))
+        reason = jnp.where(finite, reason, reason | int(FLIPRejectionReason.NONFINITE))
+        failed_status = jnp.where(
+            ~transfer_successful,
+            int(FLIPRunStatus.TRANSFER_FAILED),
+            jnp.where(
+                ~projected.successful,
+                int(FLIPRunStatus.PROJECTION_FAILED),
+                jnp.where(
+                    ~stable,
+                    int(FLIPRunStatus.STABILITY_LIMIT_EXCEEDED),
+                    int(FLIPRunStatus.NONFINITE_STATE),
+                ),
+            ),
+        ).astype(jnp.int32)
+        status = jnp.where(successful, int(FLIPRunStatus.SUCCESS), failed_status).astype(
+            jnp.int32
+        )
+        candidate = SparseFLIPRuntimeState(
+            particles=next_particles,
+            pressure=projected.pressure,
+            transfer=routes,
+            time=state.time + dt,
+            accepted_step=state.accepted_step + 1,
+            status=status,
+        )
+        accepted = SparseFLIPRuntimeState(
+            particles=FLIPParticleState(
+                jnp.where(
+                    successful, candidate.particles.position, state.particles.position
+                ),
+                jnp.where(
+                    successful, candidate.particles.velocity, state.particles.velocity
+                ),
+            ),
+            pressure=jnp.where(successful, candidate.pressure, state.pressure),
+            transfer=tree_where(successful, routes, state.transfer),
+            time=jnp.where(successful, candidate.time, state.time),
+            accepted_step=jnp.where(
+                successful, candidate.accepted_step, state.accepted_step
+            ),
+            status=status,
+        )
+        diagnostics = SparseFLIPDiagnostics(
+            liquid_count=projected.liquid_count,
+            air_count=projected.air_count,
+            classification_margin=classification_margin,
+            mass_balance_defect=p2g.mass_balance_defect,
+            momentum_balance_defect=p2g.momentum_balance_defect,
+            projection_residual=projected.residual_norm,
+            divergence_norm=projected.active_divergence_norm,
+            maximum_displacement_fraction=maximum_fraction,
+            energy_before=energy_before,
+            energy_after=energy_after,
+            topology_generation=routes.cell_topology.generation,
+            rejection_reason=reason,
+            successful=successful,
+        )
+        return SparseFLIPStepResult(
+            candidate_state=candidate,
+            accepted_state=accepted,
+            pre_grid_velocity=pre_grid,
+            post_grid_velocity=projected.velocity,
+            liquid_fraction=p2g.liquid_fraction,
+            projection=projected,
+            diagnostics=diagnostics,
+            successful=successful,
+        )
+
+
+def compile_sparse_flip_problem(
+    problem: FLIPProblemIR,
+    transfer: PreparedSparseFLIPParticleTransfer,
+    projection: SparseMACFreeSurfaceProjectionPlan,
+    method: FLIPMethodPlan,
+    /,
+) -> CompiledSparseFLIPProblem:
+    return CompiledSparseFLIPProblem(problem, transfer, projection, method)
+
+
+__all__ = [
+    "CompiledSparseFLIPProblem",
+    "SparseFLIPDiagnostics",
+    "SparseFLIPRuntimeState",
+    "SparseFLIPStepResult",
+    "compile_sparse_flip_problem",
+]

--- a/phydrax/geometry/_voxel_sampling.py
+++ b/phydrax/geometry/_voxel_sampling.py
@@ -101,7 +101,7 @@ class VoxelGeometrySamplingPlan(StrictModule, NonTrainableState):
         sampled = geometry.boundary_field(flat_centers).reshape(
             (self.grid.brick_capacity, self.grid.voxels_per_brick)
         )
-        active = self.grid.voxel_active & self.grid.brick_active[:, None]
+        active = self.grid.voxel_active & self.grid.brick_groups.group_active[:, None]
         sampled = jnp.where(active, sampled, 0.0)
         finite_samples = active & jnp.isfinite(sampled)
         finite = jnp.all(~active | finite_samples)

--- a/phydrax/meshing/providers/_openvdb.py
+++ b/phydrax/meshing/providers/_openvdb.py
@@ -178,7 +178,10 @@ class OpenVDBProvider:
         revision = str(source_revision).strip()
         if not source or not revision:
             raise ValueError("Sparse-volume source identities must be non-empty.")
-        active = np.asarray(grid.voxel_active) & np.asarray(grid.brick_active)[:, None]
+        active = (
+            np.asarray(grid.voxel_active)
+            & np.asarray(grid.brick_groups.group_active)[:, None]
+        )
         brick_slots, local_slots = np.nonzero(active)
         values = np.asarray(field.values)[active]
         if np.iscomplexobj(values) or np.iscomplexobj(field.background_value):
@@ -211,7 +214,7 @@ class OpenVDBProvider:
         if grid.brick_depth:
             brick_coordinates = np.asarray(
                 morton_decode_integer(
-                    grid.brick_codes[brick_slots],
+                    grid.brick_groups.group_keys[brick_slots],
                     3,
                     grid.brick_depth,
                 )

--- a/phydrax/rendering/__init__.py
+++ b/phydrax/rendering/__init__.py
@@ -16,8 +16,11 @@ from ._lidar_waveform import (
     TimeResolvedMultipleScatteringPlan,
 )
 from ._point import (
+    GaussianRasterAccumulation,
     GaussianRasterEvidence,
+    GaussianRasterExecutionPlan,
     GaussianRasterizer,
+    GaussianRasterKind,
     GaussianRasterResult,
     RASTER_CLIPPED,
     RASTER_COMPLETE,
@@ -46,7 +49,10 @@ from ._surface import (
 __all__ = [
     "AtmosphericLidarPlan",
     "CameraStackRenderResult",
+    "GaussianRasterAccumulation",
     "GaussianRasterEvidence",
+    "GaussianRasterExecutionPlan",
+    "GaussianRasterKind",
     "GaussianRasterResult",
     "GaussianRasterizer",
     "ImageRenderResult",

--- a/phydrax/rendering/_point.py
+++ b/phydrax/rendering/_point.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 from math import isfinite
+from typing import Literal
 
 import equinox as eqx
 import jax
@@ -15,6 +16,7 @@ from .._fingerprint import canonical_fingerprint
 from .._strict import StrictModule
 from .._trainable import NonTrainableState
 from ..imaging import ImagePlaneSupport
+from ..sparse import EdgeRelation, RelationExecutionPlan
 
 
 RASTER_INACTIVE = 0
@@ -22,6 +24,51 @@ RASTER_COMPLETE = 1
 RASTER_CLIPPED = 2
 RASTER_SUPPORT_OVERFLOW = 3
 RASTER_INVALID = 4
+
+GaussianRasterKind = Literal["reference", "tiled"]
+GaussianRasterAccumulation = Literal["fast", "deterministic", "compensated"]
+
+
+class GaussianRasterExecutionPlan(StrictModule, NonTrainableState):
+    """Static reference or tile-major Gaussian accumulation policy."""
+
+    kind: GaussianRasterKind = eqx.field(static=True)
+    tile_shape: tuple[int, int] = eqx.field(static=True)
+    maximum_tile_routes: int | None = eqx.field(static=True)
+    accumulation: GaussianRasterAccumulation = eqx.field(static=True)
+    plan_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        kind: GaussianRasterKind = "reference",
+        *,
+        tile_shape: tuple[int, int] = (16, 16),
+        maximum_tile_routes: int | None = None,
+        accumulation: GaussianRasterAccumulation = "deterministic",
+    ) -> None:
+        if kind not in ("reference", "tiled"):
+            raise ValueError("kind must be 'reference' or 'tiled'.")
+        tiles = tuple(int(size) for size in tile_shape)
+        if len(tiles) != 2 or any(size <= 0 for size in tiles):
+            raise ValueError("tile_shape must contain two positive sizes.")
+        capacity = None if maximum_tile_routes is None else int(maximum_tile_routes)
+        if capacity is not None and capacity <= 0:
+            raise ValueError("maximum_tile_routes must be positive when provided.")
+        if accumulation not in ("fast", "deterministic", "compensated"):
+            raise ValueError("Unknown Gaussian raster accumulation policy.")
+        self.kind = kind
+        self.tile_shape = tiles
+        self.maximum_tile_routes = capacity
+        self.accumulation = accumulation
+        self.plan_id = canonical_fingerprint(
+            {
+                "kind": "gaussian-raster-execution-plan",
+                "realization": kind,
+                "tile_shape": list(tiles),
+                "maximum_tile_routes": capacity,
+                "accumulation": accumulation,
+            }
+        )
 
 
 class GaussianRasterEvidence(StrictModule):
@@ -37,6 +84,9 @@ class GaussianRasterEvidence(StrictModule):
     supported_count: Array
     truncated_count: Array
     overflow_count: Array
+    route_count: Array
+    route_capacity: Array
+    route_overflow: Array
     status: Array
 
 
@@ -50,14 +100,28 @@ class GaussianRasterResult(StrictModule):
     geometry_id: str = eqx.field(static=True)
 
 
+class _GaussianRoutes(StrictModule):
+    rows: Array
+    columns: Array
+    contributions: Array
+    routed: Array
+    supported: Array
+    truncated: Array
+    overflow: Array
+    nonfinite: Array
+    deposited_flux: Array
+    status: Array
+
+
 class GaussianRasterizer(StrictModule, NonTrainableState):
-    """Deterministic, bounded-memory Gaussian point-particle rasterizer.
+    """Bounded-memory Gaussian point-particle rasterizer.
 
     ``amplitude`` is integrated irradiance over the configured discrete support.
     Image coordinates are ``(row_down, column_right)``. Route indices are
     discrete; derivatives are piecewise derivatives for a fixed route topology.
     """
 
+    execution: GaussianRasterExecutionPlan
     maximum_support_radius: int = eqx.field(static=True)
     cutoff: float = eqx.field(static=True)
     rasterizer_id: str = eqx.field(static=True)
@@ -67,13 +131,18 @@ class GaussianRasterizer(StrictModule, NonTrainableState):
         maximum_support_radius: int = 6,
         *,
         cutoff: float = 3.5,
-    ):
+        execution: GaussianRasterExecutionPlan | None = None,
+    ) -> None:
         radius = int(maximum_support_radius)
         cutoff_ = float(cutoff)
+        execution_ = GaussianRasterExecutionPlan() if execution is None else execution
         if radius < 1:
             raise ValueError("maximum_support_radius must be positive.")
         if not isfinite(cutoff_) or cutoff_ <= 0.0:
             raise ValueError("cutoff must be finite and positive.")
+        if not isinstance(execution_, GaussianRasterExecutionPlan):
+            raise TypeError("execution must be GaussianRasterExecutionPlan.")
+        self.execution = execution_
         self.maximum_support_radius = radius
         self.cutoff = cutoff_
         self.rasterizer_id = canonical_fingerprint(
@@ -82,19 +151,19 @@ class GaussianRasterizer(StrictModule, NonTrainableState):
                 "maximum_support_radius": radius,
                 "cutoff": cutoff_,
                 "coordinate_convention": "row-down-column-right",
+                "execution": execution_.plan_id,
             }
         )
 
-    def render(
+    def _routes(
         self,
         geometry: ImagePlaneSupport,
         row_column: ArrayLike,
         amplitude: ArrayLike,
         sigma: ArrayLike,
-        active: ArrayLike | None = None,
+        active: ArrayLike | None,
         /,
-    ) -> GaussianRasterResult:
-        """Render one fixed-capacity particle set into ``geometry``."""
+    ) -> tuple[_GaussianRoutes, Array, Array, Array]:
         if not isinstance(geometry, ImagePlaneSupport):
             raise TypeError("geometry must be ImagePlaneSupport.")
         coordinates = jnp.asarray(row_column)
@@ -128,104 +197,227 @@ class GaussianRasterizer(StrictModule, NonTrainableState):
 
         height, width = geometry.image_shape
         dtype = jnp.result_type(coordinates, amplitudes, sigmas)
-        image = jnp.zeros((height, width), dtype=dtype)
         radius = self.maximum_support_radius
         offsets = jnp.arange(-radius, radius + 1, dtype=jnp.int32)
         offset_rows, offset_columns = jnp.meshgrid(offsets, offsets, indexing="ij")
         offset_rows = offset_rows.reshape((-1,))
         offset_columns = offset_columns.reshape((-1,))
-
-        def deposit_one(current: Array, particle: tuple[Array, ...]):
-            center, flux, spread, enabled = particle
-            finite = (
-                jnp.all(jnp.isfinite(center))
-                & jnp.isfinite(flux)
-                & jnp.all(jnp.isfinite(spread))
-                & (flux >= 0.0)
-                & jnp.all(spread > 0.0)
-            )
-            usable = enabled & finite
-            safe_center = jnp.where(finite, center, jnp.zeros_like(center))
-            safe_flux = jnp.where(finite, flux, jnp.zeros_like(flux))
-            safe_spread = jnp.where(finite, spread, jnp.ones_like(spread))
-            anchor = jnp.floor(safe_center).astype(jnp.int32)
-            rows = anchor[0] + offset_rows
-            columns = anchor[1] + offset_columns
-            delta_row = rows.astype(dtype) - safe_center[0]
-            delta_column = columns.astype(dtype) - safe_center[1]
-            local_support = (jnp.abs(delta_row) <= self.cutoff * safe_spread[0]) & (
-                jnp.abs(delta_column) <= self.cutoff * safe_spread[1]
-            )
-            inside = (rows >= 0) & (rows < height) & (columns >= 0) & (columns < width)
-            squared_distance = (delta_row / safe_spread[0]) ** 2 + (
-                delta_column / safe_spread[1]
-            ) ** 2
-            weights = jnp.exp(-0.5 * squared_distance) * local_support
-            weight_sum = jnp.maximum(jnp.sum(weights), jnp.finfo(dtype).tiny)
-            contributions = safe_flux * weights / weight_sum
-            routed = usable & local_support & inside
-            contributions = jnp.where(routed, contributions, 0.0)
-            flat_indices = jnp.clip(rows, 0, height - 1) * width + jnp.clip(
-                columns, 0, width - 1
-            )
-            updated = current.reshape((-1,)).at[flat_indices].add(contributions)
-            supported = usable & jnp.any(local_support & inside)
-            required_radius = jnp.ceil(self.cutoff * jnp.max(safe_spread)).astype(
-                jnp.int32
-            )
-            overflow = usable & (required_radius > radius)
-            border_truncated = usable & jnp.any(local_support & ~inside)
-            truncated = overflow | border_truncated
-            deposited = jnp.sum(contributions)
-            status = jnp.where(
-                ~enabled,
-                RASTER_INACTIVE,
-                jnp.where(
-                    ~finite,
-                    RASTER_INVALID,
-                    jnp.where(
-                        overflow,
-                        RASTER_SUPPORT_OVERFLOW,
-                        jnp.where(truncated, RASTER_CLIPPED, RASTER_COMPLETE),
-                    ),
-                ),
-            )
-            evidence = (
-                supported,
-                truncated,
-                overflow,
-                enabled & ~finite,
-                deposited,
-                status,
-            )
-            return updated.reshape((height, width)), evidence
-
-        image, history = jax.lax.scan(
-            deposit_one,
-            image,
-            (coordinates, amplitudes, sigmas, active_),
+        finite = (
+            jnp.all(jnp.isfinite(coordinates), axis=-1)
+            & jnp.isfinite(amplitudes)
+            & jnp.all(jnp.isfinite(sigmas), axis=-1)
+            & (amplitudes >= 0.0)
+            & jnp.all(sigmas > 0.0, axis=-1)
         )
-        supported, truncated, overflow, nonfinite, deposited_flux, status = history
-        evidence = GaussianRasterEvidence(
+        usable = active_ & finite
+        safe_center = jnp.where(finite[:, None], coordinates, 0.0)
+        safe_flux = jnp.where(finite, amplitudes, 0.0)
+        safe_spread = jnp.where(finite[:, None], sigmas, 1.0)
+        anchor = jnp.floor(safe_center).astype(jnp.int32)
+        rows = anchor[:, 0, None] + offset_rows[None, :]
+        columns = anchor[:, 1, None] + offset_columns[None, :]
+        delta_row = rows.astype(dtype) - safe_center[:, 0, None]
+        delta_column = columns.astype(dtype) - safe_center[:, 1, None]
+        local_support = (jnp.abs(delta_row) <= self.cutoff * safe_spread[:, 0, None]) & (
+            jnp.abs(delta_column) <= self.cutoff * safe_spread[:, 1, None]
+        )
+        inside = (rows >= 0) & (rows < height) & (columns >= 0) & (columns < width)
+        squared_distance = (delta_row / safe_spread[:, 0, None]) ** 2 + (
+            delta_column / safe_spread[:, 1, None]
+        ) ** 2
+        weights = jnp.exp(-0.5 * squared_distance) * local_support
+        weight_sum = jnp.maximum(jnp.sum(weights, axis=-1), jnp.finfo(dtype).tiny)
+        contributions = safe_flux[:, None] * weights / weight_sum[:, None]
+        routed = usable[:, None] & local_support & inside
+        contributions = jnp.where(routed, contributions, 0.0)
+        supported = usable & jnp.any(local_support & inside, axis=-1)
+        required_radius = jnp.ceil(self.cutoff * jnp.max(safe_spread, axis=-1)).astype(
+            jnp.int32
+        )
+        overflow = usable & (required_radius > radius)
+        truncated = overflow | (usable & jnp.any(local_support & ~inside, axis=-1))
+        nonfinite = active_ & ~finite
+        deposited = jnp.sum(contributions, axis=-1)
+        status = jnp.where(
+            ~active_,
+            RASTER_INACTIVE,
+            jnp.where(
+                ~finite,
+                RASTER_INVALID,
+                jnp.where(
+                    overflow,
+                    RASTER_SUPPORT_OVERFLOW,
+                    jnp.where(truncated, RASTER_CLIPPED, RASTER_COMPLETE),
+                ),
+            ),
+        )
+        return (
+            _GaussianRoutes(
+                rows=rows,
+                columns=columns,
+                contributions=contributions,
+                routed=routed,
+                supported=supported,
+                truncated=truncated,
+                overflow=overflow,
+                nonfinite=nonfinite,
+                deposited_flux=deposited,
+                status=status.astype(jnp.int32),
+            ),
             active_,
-            supported,
-            truncated,
-            overflow,
-            nonfinite,
-            deposited_flux,
-            jnp.sum(active_, dtype=jnp.int32),
-            jnp.sum(supported, dtype=jnp.int32),
-            jnp.sum(truncated, dtype=jnp.int32),
-            jnp.sum(overflow, dtype=jnp.int32),
-            status.astype(jnp.int32),
+            jnp.asarray(height, dtype=jnp.int32),
+            jnp.asarray(width, dtype=jnp.int32),
+        )
+
+    def render(
+        self,
+        geometry: ImagePlaneSupport,
+        row_column: ArrayLike,
+        amplitude: ArrayLike,
+        sigma: ArrayLike,
+        active: ArrayLike | None = None,
+        /,
+    ) -> GaussianRasterResult:
+        """Render one fixed-capacity particle set into ``geometry``."""
+        routes, active_, height_array, width_array = self._routes(
+            geometry, row_column, amplitude, sigma, active
+        )
+        height = int(geometry.image_shape[0])
+        width = int(geometry.image_shape[1])
+        del height_array, width_array
+        route_count = jnp.sum(routes.routed, dtype=jnp.int32)
+        candidate_capacity = int(routes.routed.size)
+        declared_capacity = (
+            candidate_capacity
+            if self.execution.maximum_tile_routes is None
+            else self.execution.maximum_tile_routes
+        )
+        route_overflow = route_count > declared_capacity
+        usable_routes = routes.routed & ~route_overflow
+        if self.execution.kind == "reference":
+            image = self._render_reference(
+                height,
+                width,
+                routes.contributions,
+                routes.rows,
+                routes.columns,
+                usable_routes,
+            )
+        else:
+            image = self._render_tiled(
+                height,
+                width,
+                routes.contributions,
+                routes.rows,
+                routes.columns,
+                usable_routes,
+            )
+        evidence = GaussianRasterEvidence(
+            active=active_,
+            supported=routes.supported,
+            truncated=routes.truncated,
+            overflow=routes.overflow,
+            nonfinite=routes.nonfinite,
+            deposited_flux=jnp.where(route_overflow, 0.0, routes.deposited_flux),
+            active_count=jnp.sum(active_, dtype=jnp.int32),
+            supported_count=jnp.sum(routes.supported, dtype=jnp.int32),
+            truncated_count=jnp.sum(routes.truncated, dtype=jnp.int32),
+            overflow_count=jnp.sum(routes.overflow, dtype=jnp.int32),
+            route_count=route_count,
+            route_capacity=jnp.asarray(declared_capacity, dtype=jnp.int32),
+            route_overflow=route_overflow,
+            status=routes.status,
         )
         return GaussianRasterResult(
-            image,
-            evidence,
-            ~jnp.any(nonfinite | overflow),
-            self.rasterizer_id,
-            geometry.geometry_id,
+            image=image,
+            evidence=evidence,
+            successful=~jnp.any(routes.nonfinite | routes.overflow) & ~route_overflow,
+            rasterizer_id=self.rasterizer_id,
+            geometry_id=geometry.geometry_id,
         )
+
+    @staticmethod
+    def _render_reference(
+        height: int,
+        width: int,
+        contributions: Array,
+        rows: Array,
+        columns: Array,
+        routed: Array,
+        /,
+    ) -> Array:
+        dtype = contributions.dtype
+        image = jnp.zeros((height, width), dtype=dtype)
+
+        def deposit_one(current: Array, particle: tuple[Array, ...]):
+            values, row, column, valid = particle
+            indices = jnp.clip(row, 0, height - 1) * width + jnp.clip(
+                column, 0, width - 1
+            )
+            payload = jnp.where(valid, values, 0.0)
+            updated = current.reshape((-1,)).at[indices].add(payload)
+            return updated.reshape((height, width)), None
+
+        image, _ = jax.lax.scan(
+            deposit_one,
+            image,
+            (contributions, rows, columns, routed),
+        )
+        return image
+
+    def _render_tiled(
+        self,
+        height: int,
+        width: int,
+        contributions: Array,
+        rows: Array,
+        columns: Array,
+        routed: Array,
+        /,
+    ) -> Array:
+        tile_height, tile_width = self.execution.tile_shape
+        tile_rows = (height + tile_height - 1) // tile_height
+        tile_columns = (width + tile_width - 1) // tile_width
+        tile_area = tile_height * tile_width
+        safe_rows = jnp.clip(rows, 0, height - 1)
+        safe_columns = jnp.clip(columns, 0, width - 1)
+        tile_row = safe_rows // tile_height
+        tile_column = safe_columns // tile_width
+        local_row = safe_rows % tile_height
+        local_column = safe_columns % tile_width
+        tile_slots = (
+            (tile_row * tile_columns + tile_column) * tile_area
+            + local_row * tile_width
+            + local_column
+        ).reshape((-1,))
+        route_values = contributions.reshape((-1,))
+        route_valid = routed.reshape((-1,))
+        route_capacity = int(tile_slots.size)
+        relation = EdgeRelation(
+            jnp.arange(route_capacity, dtype=jnp.int32),
+            tile_slots,
+            source_size=route_capacity,
+            target_size=tile_rows * tile_columns * tile_area,
+            valid=route_valid,
+        )
+        execution = RelationExecutionPlan().prepare(relation)
+        tile_values, _ = execution.reduce(
+            route_values,
+            accumulation=self.execution.accumulation,
+            output="dense",
+        )
+        image_rows, image_columns = jnp.meshgrid(
+            jnp.arange(height, dtype=jnp.int32),
+            jnp.arange(width, dtype=jnp.int32),
+            indexing="ij",
+        )
+        image_tile_slots = (
+            ((image_rows // tile_height) * tile_columns + image_columns // tile_width)
+            * tile_area
+            + (image_rows % tile_height) * tile_width
+            + image_columns % tile_width
+        )
+        return tile_values[image_tile_slots]
 
 
 def rasterize_gaussians(
@@ -244,7 +436,10 @@ def rasterize_gaussians(
 
 
 __all__ = [
+    "GaussianRasterAccumulation",
     "GaussianRasterEvidence",
+    "GaussianRasterExecutionPlan",
+    "GaussianRasterKind",
     "GaussianRasterResult",
     "GaussianRasterizer",
     "RASTER_CLIPPED",

--- a/phydrax/solver/__init__.py
+++ b/phydrax/solver/__init__.py
@@ -1944,6 +1944,10 @@ from ._separated_fokker_planck import (
     SeparatedFokkerPlanckPlan,
     solve_separated_fokker_planck,
 )
+from ._sparse_flip import (
+    SparseMACFreeSurfaceProjectionPlan,
+    SparseMACFreeSurfaceProjectionResult,
+)
 from ._spde import (
     SemidiscreteSPDE,
     semidiscretize_reaction_diffusion,
@@ -2870,6 +2874,8 @@ __all__ = [
     "MACPressureSolveMethod",
     "MACFreeSurfaceProjectionPlan",
     "MACFreeSurfaceProjectionResult",
+    "SparseMACFreeSurfaceProjectionPlan",
+    "SparseMACFreeSurfaceProjectionResult",
     "LinearImplicitFreeSurfacePlan",
     "MACReplayCertification",
     "MACDeformableImmersedBackwardEulerMethod",

--- a/phydrax/solver/_material_point_commercial_implicit.py
+++ b/phydrax/solver/_material_point_commercial_implicit.py
@@ -19,9 +19,9 @@ from .._trainable import NonTrainableState
 from ..discretization.mpm import (
     BlockSparseMPMNodalStoragePlan,
     KWayMPMContactPlan,
-    MPMActiveBlockState,
     MPMContactGraph,
 )
+from ..discretization.spatial import SparseBlockTopologyState
 from ..discretization.splatting import ParticleGridSplatState, PreparedParticleGridSplat
 
 
@@ -290,18 +290,20 @@ class MPMCompactOperatorResult(StrictModule):
 
 class MPMCompactImplicitOperator(StrictModule, NonTrainableState):
     storage: BlockSparseMPMNodalStoragePlan
-    active: MPMActiveBlockState
+    active: SparseBlockTopologyState
     operator_id: str = eqx.field(static=True)
 
     def __init__(
         self,
         storage: BlockSparseMPMNodalStoragePlan,
-        active: MPMActiveBlockState,
+        active: SparseBlockTopologyState,
         /,
     ):
         if not isinstance(storage, BlockSparseMPMNodalStoragePlan):
             raise TypeError("storage must be BlockSparseMPMNodalStoragePlan.")
-        if not isinstance(active, MPMActiveBlockState) or not bool(active.successful):
+        if not isinstance(active, SparseBlockTopologyState) or not bool(
+            active.evidence.successful
+        ):
             raise ValueError("Compact implicit operator requires successful block state.")
         self.storage = storage
         self.active = active
@@ -309,7 +311,7 @@ class MPMCompactImplicitOperator(StrictModule, NonTrainableState):
             {
                 "kind": "mpm-compact-implicit-operator",
                 "storage": storage.storage_id,
-                "active_count": int(active.active_block_count),
+                "active_count": int(active.evidence.required_blocks),
             }
         )
 
@@ -466,14 +468,14 @@ def linearize_kway_contact(
 
 class MPMSparseContactOperator(StrictModule, NonTrainableState):
     storage: BlockSparseMPMNodalStoragePlan
-    active: MPMActiveBlockState
+    active: SparseBlockTopologyState
     contact: KWayMPMContactPlan
 
     def __init__(self, storage, active, contact, /):
         if not isinstance(storage, BlockSparseMPMNodalStoragePlan):
             raise TypeError("storage must be BlockSparseMPMNodalStoragePlan.")
-        if not isinstance(active, MPMActiveBlockState):
-            raise TypeError("active must be MPMActiveBlockState.")
+        if not isinstance(active, SparseBlockTopologyState):
+            raise TypeError("active must be SparseBlockTopologyState.")
         if not isinstance(contact, KWayMPMContactPlan):
             raise TypeError("contact must be KWayMPMContactPlan.")
         self.storage = storage
@@ -488,38 +490,17 @@ class MPMSparseContactOperator(StrictModule, NonTrainableState):
         step_size,
         /,
     ):
-        mass = jnp.stack(
-            tuple(
-                self.storage.unpack(value, self.active)
-                for value in jnp.asarray(compact_mass)
-            )
-        )
-        velocity = jnp.stack(
-            tuple(
-                self.storage.unpack(value, self.active)
-                for value in jnp.asarray(compact_velocity)
-            )
-        )
-        gradient = jnp.stack(
-            tuple(
-                self.storage.unpack(value, self.active)
-                for value in jnp.asarray(compact_mass_gradient)
-            )
-        )
+        mass = jnp.asarray(compact_mass)
+        velocity = jnp.asarray(compact_velocity)
+        gradient = jnp.asarray(compact_mass_gradient)
         graph = self.contact.build_graph(mass, gradient)
         result = self.contact.solve(mass, velocity, graph, step_size)
-        compact = jnp.stack(
-            tuple(
-                self.storage.pack(result.velocity[field], self.active)
-                for field in range(self.contact.field_count)
-            )
-        )
-        return compact, result
+        return result.velocity, result
 
 
 class MPMSparsePhaseFieldOperator(StrictModule, NonTrainableState):
     storage: BlockSparseMPMNodalStoragePlan
-    active: MPMActiveBlockState
+    active: SparseBlockTopologyState
     spacing: tuple[float, ...] = eqx.field(static=True)
     periodic: tuple[bool, ...] = eqx.field(static=True)
 
@@ -530,7 +511,7 @@ class MPMSparsePhaseFieldOperator(StrictModule, NonTrainableState):
         self.active = active
         self.spacing = tuple(float(value) for value in spacing)
         self.periodic = tuple(bool(value) for value in periodic)
-        if len(self.spacing) != len(self.storage.blocks.grid_shape):
+        if len(self.spacing) != len(self.storage.grid_shape):
             raise ValueError("Sparse phase-field spacing dimension changed.")
 
     def apply(self, compact_damage, compact_history, gc, length_scale, /):

--- a/phydrax/solver/_material_point_fracture.py
+++ b/phydrax/solver/_material_point_fracture.py
@@ -13,7 +13,12 @@ from jaxtyping import Array, ArrayLike
 from .._fingerprint import canonical_fingerprint
 from .._strict import StrictModule
 from .._trainable import NonTrainableState
-from ..discretization.mpm import MPMParticleState, MPMRuntimeState, PreparedMPMDynamics
+from ..discretization.mpm import (
+    BlockSparseMPMNodalStoragePlan,
+    MPMParticleState,
+    MPMRuntimeState,
+    PreparedMPMDynamics,
+)
 from ..equations import MaterialPointArguments
 
 
@@ -141,12 +146,47 @@ class PreparedMPMPhaseFieldDynamics(StrictModule, NonTrainableState):
             raise ValueError("Phase-field material history width must be two.")
         return MPMPhaseFieldRuntimeState(mechanics_state, history[:, 0], history[:, 1])
 
-    def _grid_field(self, routes, volume, value):
-        measure = self.mechanics.splat.deposit_content(routes, volume).content
-        content = self.mechanics.splat.deposit_content(routes, volume * value).content
+    def _grid_field(self, routes, storage_state, volume, value):
+        measure = self.mechanics._deposit_content(routes, storage_state, volume).content
+        content = self.mechanics._deposit_content(
+            routes, storage_state, volume * value
+        ).content
         return jnp.where(measure > 0.0, content / measure, 0.0), measure
 
-    def _damage_solve(self, old_damage, history, parameters):
+    def _compact_neighbors(self, storage_state):
+        if not self.mechanics.compact_storage:
+            return None, jnp.asarray(True)
+        storage = self.mechanics.nodal_storage
+        if not isinstance(storage, BlockSparseMPMNodalStoragePlan):
+            raise TypeError("Compact MPM requires block-sparse storage.")
+        topology = storage_state
+        logical = topology.logical_node_ids.reshape((-1,))
+        node_valid = topology.node_valid.reshape((-1,))
+        integer, _ = storage.topology_plan.layout.integer_coordinates(logical)
+        neighbor_slots = []
+        complete = jnp.asarray(True)
+        for axis, size in enumerate(storage.grid_shape):
+            axis_slots = []
+            for offset in (-1, 1):
+                candidate = integer.at[:, axis].add(offset)
+                if self.mechanics.particle_domain.periodic[axis]:
+                    candidate = candidate.at[:, axis].set(
+                        jnp.mod(candidate[:, axis], size)
+                    )
+                else:
+                    candidate = candidate.at[:, axis].set(
+                        jnp.clip(candidate[:, axis], 0, size - 1)
+                    )
+                neighbor_ids, in_domain = storage.topology_plan.layout.flat_indices(
+                    candidate
+                )
+                lookup = topology.lookup(neighbor_ids, node_valid & in_domain)
+                complete = complete & jnp.all(~node_valid | lookup.supported)
+                axis_slots.append(lookup.storage_slots)
+            neighbor_slots.append(tuple(axis_slots))
+        return tuple(neighbor_slots), complete
+
+    def _damage_solve(self, old_damage, history, parameters, storage_state):
         coefficient = tuple(
             parameters.critical_energy_release_rate * parameters.length_scale / spacing**2
             for spacing in self.spacing
@@ -157,37 +197,51 @@ class PreparedMPMPhaseFieldDynamics(StrictModule, NonTrainableState):
             + 2.0 * history
             + 2.0 * neighbor_coefficient
         )
+        compact_neighbors, stencil_complete = self._compact_neighbors(storage_state)
+        node_valid = self.mechanics._storage_node_valid(storage_state).reshape(
+            old_damage.shape
+        )
+
+        def neighbor_values(damage):
+            neighbor = jnp.zeros_like(damage)
+            unweighted = jnp.zeros_like(damage)
+            for axis, value in enumerate(coefficient):
+                if compact_neighbors is None:
+                    if self.mechanics.particle_domain.periodic[axis]:
+                        lower = jnp.roll(damage, 1, axis=axis)
+                        upper = jnp.roll(damage, -1, axis=axis)
+                    else:
+                        lower = jnp.take(
+                            damage,
+                            jnp.maximum(jnp.arange(damage.shape[axis]) - 1, 0),
+                            axis=axis,
+                        )
+                        upper = jnp.take(
+                            damage,
+                            jnp.minimum(
+                                jnp.arange(damage.shape[axis]) + 1,
+                                damage.shape[axis] - 1,
+                            ),
+                            axis=axis,
+                        )
+                else:
+                    lower = damage[compact_neighbors[axis][0]]
+                    upper = damage[compact_neighbors[axis][1]]
+                pair = lower + upper
+                neighbor = neighbor + value * pair
+                unweighted = unweighted + pair
+            return neighbor, unweighted
 
         def iterate(_, damage):
-            neighbor = jnp.zeros_like(damage)
-            for axis, value in enumerate(coefficient):
-                if self.mechanics.particle_domain.periodic[axis]:
-                    neighbors = jnp.roll(damage, 1, axis=axis) + jnp.roll(
-                        damage, -1, axis=axis
-                    )
-                else:
-                    lower = jnp.take(
-                        damage,
-                        jnp.maximum(jnp.arange(damage.shape[axis]) - 1, 0),
-                        axis=axis,
-                    )
-                    upper = jnp.take(
-                        damage,
-                        jnp.minimum(
-                            jnp.arange(damage.shape[axis]) + 1,
-                            damage.shape[axis] - 1,
-                        ),
-                        axis=axis,
-                    )
-                    neighbors = lower + upper
-                neighbor = neighbor + value * neighbors
+            neighbor, _ = neighbor_values(damage)
             candidate = (2.0 * history + neighbor) / diagonal
-            return jnp.clip(jnp.maximum(old_damage, candidate), 0.0, 1.0)
+            candidate = jnp.clip(jnp.maximum(old_damage, candidate), 0.0, 1.0)
+            return jnp.where(node_valid, candidate, 0.0)
 
         damage = jax.lax.fori_loop(
             0, self.plan.maximum_damage_iterations, iterate, old_damage
         )
-        neighbor = _neighbor_sum(damage, self.mechanics.particle_domain.periodic)
+        _, neighbor = neighbor_values(damage)
         average_coefficient = neighbor_coefficient / len(self.spacing)
         residual = (
             parameters.critical_energy_release_rate / parameters.length_scale * damage
@@ -196,7 +250,12 @@ class PreparedMPMPhaseFieldDynamics(StrictModule, NonTrainableState):
             + 2.0 * neighbor_coefficient * damage
             - average_coefficient * neighbor
         )
-        return damage, jnp.linalg.norm(residual.reshape((-1,)))
+        residual = jnp.where(node_valid, residual, 0.0)
+        return (
+            damage,
+            jnp.linalg.norm(residual.reshape((-1,))),
+            stencil_complete,
+        )
 
     def step_detailed(
         self,
@@ -219,14 +278,29 @@ class PreparedMPMPhaseFieldDynamics(StrictModule, NonTrainableState):
             candidate_mechanics.particles.position,
             assignment_input=candidate_mechanics.assignment_input,
         )
+        storage_state = candidate_mechanics.storage_state
+        execution_routes = self.mechanics._mapped_routes(routes, storage_state)
         volume = candidate_mechanics.particles.reference_volume
         trial_history = candidate_mechanics.particles.material_state[:, 1]
-        grid_damage, grid_measure = self._grid_field(routes, volume, state.damage)
-        grid_history, _ = self._grid_field(routes, volume, trial_history)
-        damage_grid, residual = self._damage_solve(
-            grid_damage, grid_history, arguments.material_parameters
+        grid_damage, _ = self._grid_field(routes, storage_state, volume, state.damage)
+        grid_history, _ = self._grid_field(routes, storage_state, volume, trial_history)
+        damage_grid, residual, stencil_complete = self._damage_solve(
+            grid_damage,
+            grid_history,
+            arguments.material_parameters,
+            storage_state,
         )
-        damage = self.mechanics.splat.gather(routes, damage_grid).values
+        if self.mechanics.compact_storage:
+            storage = self.mechanics.nodal_storage
+            if not isinstance(storage, BlockSparseMPMNodalStoragePlan):
+                raise AssertionError("Compact MPM requires block-sparse storage.")
+            damage = self.mechanics.splat.gather_mapped(
+                routes,
+                damage_grid,
+                storage.mapped_stencil(routes, storage_state),
+            ).values
+        else:
+            damage = self.mechanics.splat.gather(routes, damage_grid).values
         damage = jnp.clip(jnp.maximum(state.damage, damage), 0.0, 1.0)
         history = jnp.maximum(state.history, trial_history)
         material_state = jnp.stack((damage, history), axis=-1)
@@ -277,6 +351,8 @@ class PreparedMPMPhaseFieldDynamics(StrictModule, NonTrainableState):
         )
         successful = (
             mechanics_result.successful
+            & execution_routes.successful
+            & stencil_complete
             & material.successful.all()
             & material.admissible.all()
             & irreversibility
@@ -289,10 +365,16 @@ class PreparedMPMPhaseFieldDynamics(StrictModule, NonTrainableState):
             state,
         )
         gradients = []
+        compact_neighbors, _ = self._compact_neighbors(storage_state)
+        node_valid = self.mechanics._storage_node_valid(storage_state).reshape(
+            damage_grid.shape
+        )
         for axis, spacing in enumerate(self.spacing):
-            gradients.append(
-                (jnp.roll(damage_grid, -1, axis=axis) - damage_grid) / spacing
-            )
+            if compact_neighbors is None:
+                upper = jnp.roll(damage_grid, -1, axis=axis)
+            else:
+                upper = damage_grid[compact_neighbors[axis][1]]
+            gradients.append(jnp.where(node_valid, (upper - damage_grid) / spacing, 0.0))
         gradient_norm = sum(jnp.sum(value * value) for value in gradients)
         cell_measure = float(np.prod(self.spacing))
         fracture_energy = cell_measure * (

--- a/phydrax/solver/_material_point_implicit.py
+++ b/phydrax/solver/_material_point_implicit.py
@@ -133,12 +133,12 @@ class PreparedImplicitMPMDynamics(StrictModule, NonTrainableState):
             raise TypeError("Implicit MPM requires an implicit constitutive plan.")
         if explicit.nodal_fields.field_count != 1:
             raise ValueError(
-                "The dense single-field implicit adapter requires one nodal field; "
-                "use MPMImplicitTopologyPlan for K-way field layouts."
+                "The single-field implicit adapter requires one nodal field; "
+                "use MPMImplicitTopologyPlan for K-way implicit field layouts."
             )
         if explicit.contact is not None:
             raise ValueError(
-                "The dense single-field implicit adapter excludes sharp rigid contact; "
+                "The single-field implicit adapter excludes sharp rigid contact; "
                 "use MPMImplicitContactOperator for complementarity coupling."
             )
         if explicit.splat.plan.assignment.capabilities.source_geometry_kind not in (
@@ -146,7 +146,7 @@ class PreparedImplicitMPMDynamics(StrictModule, NonTrainableState):
             "uGIMP",
         ):
             raise ValueError(
-                "The dense single-field implicit adapter requires point or fixed uGIMP "
+                "The single-field implicit adapter requires point or fixed uGIMP "
                 "routes; use MPMRouteSupersetPlan for moving-domain derivatives."
             )
         self.explicit = explicit
@@ -174,10 +174,12 @@ class PreparedImplicitMPMDynamics(StrictModule, NonTrainableState):
         routes = dynamics.splat.build(
             particle.position, assignment_input=state.assignment_input
         )
+        storage_state = dynamics._build_storage(routes, state.storage_state)
+        execution_routes = dynamics._mapped_routes(routes, storage_state)
         external, external_ok = dynamics._external(state.time, particle, arguments)
-        mass_result = dynamics.splat.deposit_content(routes, mass)
+        mass_result = dynamics._deposit_content(routes, storage_state, mass)
         initial_payload = build_apic_route_payload(
-            routes,
+            execution_routes,
             mass,
             particle.velocity,
             particle.affine_velocity,
@@ -187,7 +189,9 @@ class PreparedImplicitMPMDynamics(StrictModule, NonTrainableState):
             external,
             active_particles,
         )
-        initial_scatter = dynamics.splat.scatter_route_payload(routes, initial_payload)
+        initial_scatter = dynamics._scatter_route_payload(
+            routes, storage_state, initial_payload
+        )
         dimension = dynamics.dimension
         grid_mass = mass_result.content
         grid_momentum = initial_scatter.values[..., :dimension]
@@ -196,15 +200,41 @@ class PreparedImplicitMPMDynamics(StrictModule, NonTrainableState):
             grid_momentum,
             mass_tolerance_factor=dynamics.method.mass_tolerance_factor,
         )
+        node_valid = dynamics._storage_node_valid(storage_state).reshape(
+            dynamics.nodal_shape
+        )
+        normalized = eqx.tree_at(
+            lambda value: (value.active, value.velocity),
+            normalized,
+            (
+                normalized.active & node_valid,
+                jnp.where(
+                    (normalized.active & node_valid)[..., None],
+                    normalized.velocity,
+                    0.0,
+                ),
+            ),
+        )
         initial_guess = normalized.velocity
         if dynamics.boundary is not None:
-            initial_guess = dynamics.boundary.apply(initial_guess, grid_mass, dt).velocity
+            if dynamics.compact_storage:
+                initial_guess = dynamics.boundary.apply_indexed(
+                    initial_guess,
+                    grid_mass,
+                    dt,
+                    storage_state.logical_node_ids.reshape((-1,)),
+                    storage_state.node_valid.reshape((-1,)),
+                ).velocity
+            else:
+                initial_guess = dynamics.boundary.apply(
+                    initial_guess, grid_mass, dt
+                ).velocity
         density = mass / jnp.where(active_particles, particle.reference_volume, 1.0)
 
         def residual(grid_velocity, _):
             gathered = gather_apic(
-                routes,
-                grid_velocity.reshape((dynamics.splat.target_size, dimension)),
+                execution_routes,
+                grid_velocity.reshape((dynamics.grid_count, dimension)),
                 active_particles,
                 dynamics.method.transfer.maximum_condition,
             )
@@ -221,7 +251,7 @@ class PreparedImplicitMPMDynamics(StrictModule, NonTrainableState):
             )
             material = linearized_material.response
             payload = build_apic_route_payload(
-                routes,
+                execution_routes,
                 mass,
                 particle.velocity,
                 particle.affine_velocity,
@@ -231,7 +261,7 @@ class PreparedImplicitMPMDynamics(StrictModule, NonTrainableState):
                 external,
                 active_particles,
             )
-            scattered = dynamics.splat.scatter_route_payload(routes, payload)
+            scattered = dynamics._scatter_route_payload(routes, storage_state, payload)
             force = (
                 scattered.values[..., dimension : 2 * dimension]
                 + scattered.values[..., 2 * dimension :]
@@ -241,11 +271,20 @@ class PreparedImplicitMPMDynamics(StrictModule, NonTrainableState):
             )
             value = jnp.where(normalized.active[..., None], value, grid_velocity)
             if dynamics.boundary is not None:
-                value = jnp.where(
-                    dynamics.boundary.mask,
-                    grid_velocity - dynamics.boundary.values.astype(grid_velocity.dtype),
-                    value,
-                )
+                if dynamics.compact_storage:
+                    logical = storage_state.logical_node_ids.reshape((-1,))
+                    valid_nodes = storage_state.node_valid.reshape((-1,))
+                    mask = (
+                        dynamics.boundary.mask.reshape((-1, dimension))[logical]
+                        & valid_nodes[:, None]
+                    )
+                    prescribed = dynamics.boundary.values.reshape((-1, dimension))[
+                        logical
+                    ].astype(grid_velocity.dtype)
+                else:
+                    mask = dynamics.boundary.mask
+                    prescribed = dynamics.boundary.values.astype(grid_velocity.dtype)
+                value = jnp.where(mask, grid_velocity - prescribed, value)
             valid = (
                 gathered.successful
                 & material.successful.all()
@@ -269,8 +308,8 @@ class PreparedImplicitMPMDynamics(StrictModule, NonTrainableState):
         )
         root = nonlinear.state
         gathered = gather_apic(
-            routes,
-            root.reshape((dynamics.splat.target_size, dimension)),
+            execution_routes,
+            root.reshape((dynamics.grid_count, dimension)),
             active_particles,
             dynamics.method.transfer.maximum_condition,
         )
@@ -321,7 +360,7 @@ class PreparedImplicitMPMDynamics(StrictModule, NonTrainableState):
         finite = tree_allfinite(candidate_particle)
         successful = (
             nonlinear.successful
-            & routes.successful
+            & execution_routes.successful
             & external_ok
             & gathered.successful
             & material_ok
@@ -334,6 +373,15 @@ class PreparedImplicitMPMDynamics(StrictModule, NonTrainableState):
         )
         accepted_particle = tree_where(successful, candidate_particle, particle)
         accepted_input = tree_where(successful, candidate_input, state.assignment_input)
+        accepted_storage = tree_where(successful, storage_state, state.storage_state)
+        candidate_generation = (
+            state.topology_generation
+            if storage_state is None
+            else storage_state.generation
+        )
+        accepted_generation = jnp.where(
+            successful, candidate_generation, state.topology_generation
+        )
         status = jnp.where(
             successful,
             int(MPMRunStatus.SUCCESS),
@@ -344,12 +392,12 @@ class PreparedImplicitMPMDynamics(StrictModule, NonTrainableState):
             jnp.where(successful, state.time + dt, state.time),
             jnp.where(successful, state.accepted_step + 1, state.accepted_step),
             status,
-            state.topology_generation,
+            accepted_generation,
             accepted_input,
             state.material_slots,
             state.body_ids,
             state.velocity_field_slots,
-            state.storage_state,
+            accepted_storage,
             state.lifecycle_state,
         )
         candidate_state = MPMRuntimeState(
@@ -357,12 +405,12 @@ class PreparedImplicitMPMDynamics(StrictModule, NonTrainableState):
             state.time + dt,
             state.accepted_step + 1,
             status,
-            state.topology_generation,
+            candidate_generation,
             candidate_input,
             state.material_slots,
             state.body_ids,
             state.velocity_field_slots,
-            state.storage_state,
+            storage_state,
             state.lifecycle_state,
         )
         residual_norm = jnp.linalg.norm(nonlinear.residual.reshape((-1,)))

--- a/phydrax/solver/_sparse_flip.py
+++ b/phydrax/solver/_sparse_flip.py
@@ -1,0 +1,551 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import equinox as eqx
+import jax.numpy as jnp
+import numpy as np
+from jaxtyping import Array, ArrayLike
+
+from .._fingerprint import canonical_fingerprint
+from .._strict import StrictModule
+from .._trainable import NonTrainableState
+from ..discretization.flip import (
+    PreparedSparseFLIPParticleTransfer,
+    SparseFLIPTransferState,
+)
+from ..linalg import (
+    ArraySpace,
+    ConjugateGradient,
+    FunctionLinearOperator,
+    LinearSolvePolicy,
+    LinearSolveResult,
+    LinearSystem,
+    OperatorProperties,
+    prepare,
+    PreparedLinearSolve,
+    refresh,
+    solve,
+    TolerancePolicy,
+)
+
+
+class _SparseMACRelations(StrictModule, NonTrainableState):
+    cell_lower_faces: tuple[Array, ...]
+    cell_upper_faces: tuple[Array, ...]
+    face_lower_cells: tuple[Array, ...]
+    face_upper_cells: tuple[Array, ...]
+    face_lower_supported: tuple[Array, ...]
+    face_upper_supported: tuple[Array, ...]
+    cell_valid: Array
+    face_valid: tuple[Array, ...]
+    complete: Array
+
+
+def _gradient(
+    pressure: Array,
+    liquid: Array,
+    relations: _SparseMACRelations,
+    spacing: tuple[float, ...],
+) -> tuple[Array, ...]:
+    values = []
+    for axis, width in enumerate(spacing):
+        lower = relations.face_lower_cells[axis]
+        upper = relations.face_upper_cells[axis]
+        lower_value = jnp.where(
+            relations.face_lower_supported[axis] & liquid[lower],
+            pressure[lower],
+            0.0,
+        )
+        upper_value = jnp.where(
+            relations.face_upper_supported[axis] & liquid[upper],
+            pressure[upper],
+            0.0,
+        )
+        values.append(
+            jnp.where(
+                relations.face_valid[axis],
+                (upper_value - lower_value) / width,
+                0.0,
+            )
+        )
+    return tuple(values)
+
+
+def _divergence(
+    velocity: tuple[Array, ...],
+    relations: _SparseMACRelations,
+    spacing: tuple[float, ...],
+) -> Array:
+    result = jnp.zeros(relations.cell_valid.shape, dtype=velocity[0].dtype)
+    for axis, width in enumerate(spacing):
+        lower = velocity[axis][relations.cell_lower_faces[axis]]
+        upper = velocity[axis][relations.cell_upper_faces[axis]]
+        result = result + (upper - lower) / width
+    return jnp.where(relations.cell_valid, result, 0.0)
+
+
+class _SparseMACPressureAction(StrictModule, NonTrainableState):
+    relations: _SparseMACRelations
+    liquid: Array
+    coefficient: Array
+    cell_measure: Array
+    spacing: tuple[float, ...] = eqx.field(static=True)
+
+    def __call__(self, pressure: Array, /) -> Array:
+        all_liquid = jnp.all(self.liquid | ~self.relations.cell_valid)
+        denominator = jnp.sum(jnp.where(self.liquid, self.cell_measure, 0.0))
+        mean = jnp.where(
+            denominator > 0.0,
+            jnp.sum(self.cell_measure * jnp.where(self.liquid, pressure, 0.0))
+            / jnp.where(denominator > 0.0, denominator, 1.0),
+            0.0,
+        )
+        restricted = jnp.where(
+            all_liquid,
+            jnp.where(self.liquid, pressure - mean, 0.0),
+            jnp.where(self.liquid, pressure, 0.0),
+        )
+        gradient = _gradient(
+            restricted,
+            self.liquid,
+            self.relations,
+            self.spacing,
+        )
+        weighted = tuple(self.coefficient * value for value in gradient)
+        core = -_divergence(weighted, self.relations, self.spacing)
+        return jnp.where(
+            all_liquid,
+            jnp.where(self.liquid, core + mean, pressure),
+            jnp.where(self.liquid, core, pressure),
+        )
+
+
+class SparseMACFreeSurfaceProjectionResult(StrictModule):
+    velocity: tuple[Array, ...]
+    pressure: Array
+    liquid_mask: Array
+    divergence_before: Array
+    divergence_after: Array
+    residual_norm: Array
+    active_divergence_norm: Array
+    energy_before: Array
+    energy_after: Array
+    liquid_count: Array
+    air_count: Array
+    linear: LinearSolveResult
+    topology_complete: Array
+    finite: Array
+    successful: Array
+    projection_id: str = eqx.field(static=True)
+
+
+class SparseMACFreeSurfaceProjectionPlan(StrictModule, NonTrainableState):
+    """Compact atmospheric pressure projection over sparse cell/face layouts."""
+
+    transfer: PreparedSparseFLIPParticleTransfer
+    density: float = eqx.field(static=True)
+    tolerance: float = eqx.field(static=True)
+    spacing: tuple[float, ...] = eqx.field(static=True)
+    linear_policy: LinearSolvePolicy
+    prepared_linear: PreparedLinearSolve
+    operator_id: str = eqx.field(static=True)
+    problem_id: str = eqx.field(static=True)
+    plan_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        transfer: PreparedSparseFLIPParticleTransfer,
+        /,
+        *,
+        density: float = 1.0,
+        tolerance: float = 1.0e-9,
+        maximum_iterations: int = 500,
+        linear_policy: LinearSolvePolicy | None = None,
+    ) -> None:
+        if not isinstance(transfer, PreparedSparseFLIPParticleTransfer):
+            raise TypeError("transfer must be PreparedSparseFLIPParticleTransfer.")
+        density_ = float(density)
+        tolerance_ = float(tolerance)
+        iterations = int(maximum_iterations)
+        if (
+            not np.isfinite(density_)
+            or density_ <= 0.0
+            or not np.isfinite(tolerance_)
+            or tolerance_ <= 0.0
+            or iterations <= 0
+        ):
+            raise ValueError("Projection density, tolerance, and iterations are invalid.")
+        spacing = tuple(
+            float(np.min(np.asarray(axis.interval_widths)))
+            for axis in transfer.plan.index_space.structured_axes
+        )
+        cell_capacity = transfer.plan.cell_topology.storage_capacity
+        face_capacities = tuple(
+            value.storage_capacity for value in transfer.plan.face_topologies
+        )
+        dummy_relations = _SparseMACRelations(
+            cell_lower_faces=tuple(
+                jnp.zeros((cell_capacity,), dtype=jnp.int32) for _ in spacing
+            ),
+            cell_upper_faces=tuple(
+                jnp.zeros((cell_capacity,), dtype=jnp.int32) for _ in spacing
+            ),
+            face_lower_cells=tuple(
+                jnp.zeros((capacity,), dtype=jnp.int32) for capacity in face_capacities
+            ),
+            face_upper_cells=tuple(
+                jnp.zeros((capacity,), dtype=jnp.int32) for capacity in face_capacities
+            ),
+            cell_valid=jnp.ones((cell_capacity,), dtype=bool),
+            face_lower_supported=tuple(
+                jnp.ones((capacity,), dtype=bool) for capacity in face_capacities
+            ),
+            face_upper_supported=tuple(
+                jnp.ones((capacity,), dtype=bool) for capacity in face_capacities
+            ),
+            face_valid=tuple(
+                jnp.ones((capacity,), dtype=bool) for capacity in face_capacities
+            ),
+            complete=jnp.ones((cell_capacity,), dtype=bool),
+        )
+        dtype = jnp.dtype(transfer.plan.precision.output_dtype)
+        dummy_action = _SparseMACPressureAction(
+            dummy_relations,
+            jnp.ones((cell_capacity,), dtype=bool),
+            jnp.asarray(1.0, dtype=dtype),
+            jnp.ones((cell_capacity,), dtype=dtype),
+            spacing,
+        )
+        operator_id = canonical_fingerprint(
+            {
+                "kind": "sparse-mac-free-surface-pressure-operator",
+                "transfer": transfer.prepared_id,
+                "cell_capacity": cell_capacity,
+                "face_capacities": list(face_capacities),
+            }
+        )
+        space = ArraySpace((cell_capacity,), dtype=dtype)
+        operator = FunctionLinearOperator(
+            dummy_action,
+            source=space,
+            target=space,
+            properties=OperatorProperties(
+                self_adjoint=True,
+                positive_definite=True,
+                evidence={
+                    "self_adjoint": "construction",
+                    "positive_definite": "construction",
+                },
+            ),
+            operator_id=operator_id,
+        )
+        problem_id = canonical_fingerprint(
+            {"kind": "sparse-mac-free-surface-system", "operator": operator_id}
+        )
+        policy = (
+            LinearSolvePolicy(
+                ConjugateGradient(),
+                tolerance=TolerancePolicy(
+                    relative=0.1 * tolerance_,
+                    absolute=0.1 * tolerance_,
+                    max_steps=iterations,
+                ),
+            )
+            if linear_policy is None
+            else linear_policy
+        )
+        if not isinstance(policy, LinearSolvePolicy):
+            raise TypeError("linear_policy must be LinearSolvePolicy or None.")
+        self.transfer = transfer
+        self.density = density_
+        self.tolerance = tolerance_
+        self.spacing = spacing
+        self.linear_policy = policy
+        self.prepared_linear = prepare(
+            LinearSystem(operator, problem_id=problem_id), policy
+        )
+        self.operator_id = operator_id
+        self.problem_id = problem_id
+        self.plan_id = canonical_fingerprint(
+            {
+                "kind": "sparse-mac-free-surface-projection",
+                "transfer": transfer.prepared_id,
+                "density": density_,
+                "tolerance": tolerance_,
+                "linear": self.prepared_linear.plan.plan_id,
+            }
+        )
+
+    def _relations(self, state: SparseFLIPTransferState) -> _SparseMACRelations:
+        cell_topology = state.cell_topology
+        cell_layout = self.transfer.plan.index_space.cells()
+        cell_ids = cell_topology.logical_node_ids.reshape((-1,))
+        cell_valid = cell_topology.node_valid.reshape((-1,))
+        cell_coordinates, _ = cell_layout.integer_coordinates(cell_ids)
+        cell_lower_faces = []
+        cell_upper_faces = []
+        face_lower_cells = []
+        face_upper_cells = []
+        face_lower_supported = []
+        face_upper_supported = []
+        face_valid = []
+        complete = cell_valid
+        for axis, (name, face_topology) in enumerate(
+            zip(
+                self.transfer.plan.index_space.axis_names,
+                state.face_topologies,
+                strict=True,
+            )
+        ):
+            face_layout = self.transfer.plan.index_space.faces(name)
+            lower_face_coordinates = cell_coordinates
+            upper_face_coordinates = cell_coordinates.at[:, axis].add(1)
+            if self.transfer.plan.index_space.periodic_axes[axis]:
+                upper_face_coordinates = upper_face_coordinates.at[:, axis].set(
+                    jnp.mod(upper_face_coordinates[:, axis], face_layout.shape[axis])
+                )
+            else:
+                upper_face_coordinates = upper_face_coordinates.at[:, axis].set(
+                    jnp.clip(
+                        upper_face_coordinates[:, axis], 0, face_layout.shape[axis] - 1
+                    )
+                )
+            lower_face_ids, lower_face_domain = face_layout.flat_indices(
+                lower_face_coordinates
+            )
+            upper_face_ids, upper_face_domain = face_layout.flat_indices(
+                upper_face_coordinates
+            )
+            lower_face_lookup = face_topology.lookup(
+                lower_face_ids, cell_valid & lower_face_domain
+            )
+            upper_face_lookup = face_topology.lookup(
+                upper_face_ids, cell_valid & upper_face_domain
+            )
+            cell_lower_faces.append(lower_face_lookup.storage_slots)
+            cell_upper_faces.append(upper_face_lookup.storage_slots)
+            complete = complete & (
+                lower_face_lookup.supported & upper_face_lookup.supported
+            )
+
+            face_ids = face_topology.logical_node_ids.reshape((-1,))
+            current_face_valid = face_topology.node_valid.reshape((-1,))
+            face_coordinates, _ = face_layout.integer_coordinates(face_ids)
+            lower_cell_coordinates = face_coordinates.at[:, axis].add(-1)
+            upper_cell_coordinates = face_coordinates
+            if self.transfer.plan.index_space.periodic_axes[axis]:
+                lower_cell_coordinates = lower_cell_coordinates.at[:, axis].set(
+                    jnp.mod(lower_cell_coordinates[:, axis], cell_layout.shape[axis])
+                )
+                upper_cell_coordinates = upper_cell_coordinates.at[:, axis].set(
+                    jnp.mod(upper_cell_coordinates[:, axis], cell_layout.shape[axis])
+                )
+            else:
+                lower_cell_coordinates = lower_cell_coordinates.at[:, axis].set(
+                    jnp.clip(
+                        lower_cell_coordinates[:, axis], 0, cell_layout.shape[axis] - 1
+                    )
+                )
+                upper_cell_coordinates = upper_cell_coordinates.at[:, axis].set(
+                    jnp.clip(
+                        upper_cell_coordinates[:, axis], 0, cell_layout.shape[axis] - 1
+                    )
+                )
+            lower_cell_ids, lower_cell_domain = cell_layout.flat_indices(
+                lower_cell_coordinates
+            )
+            upper_cell_ids, upper_cell_domain = cell_layout.flat_indices(
+                upper_cell_coordinates
+            )
+            lower_cell_lookup = cell_topology.lookup(
+                lower_cell_ids, current_face_valid & lower_cell_domain
+            )
+            upper_cell_lookup = cell_topology.lookup(
+                upper_cell_ids, current_face_valid & upper_cell_domain
+            )
+            face_lower_cells.append(lower_cell_lookup.storage_slots)
+            face_upper_cells.append(upper_cell_lookup.storage_slots)
+            face_lower_supported.append(lower_cell_lookup.supported)
+            face_upper_supported.append(upper_cell_lookup.supported)
+            face_valid.append(current_face_valid)
+        return _SparseMACRelations(
+            cell_lower_faces=tuple(cell_lower_faces),
+            cell_upper_faces=tuple(cell_upper_faces),
+            face_lower_cells=tuple(face_lower_cells),
+            face_upper_cells=tuple(face_upper_cells),
+            face_lower_supported=tuple(face_lower_supported),
+            face_upper_supported=tuple(face_upper_supported),
+            cell_valid=cell_valid,
+            face_valid=tuple(face_valid),
+            complete=complete,
+        )
+
+    def project(
+        self,
+        state: SparseFLIPTransferState,
+        velocity: tuple[ArrayLike, ...],
+        liquid_mask: ArrayLike,
+        step_size: ArrayLike,
+        /,
+        *,
+        pressure: ArrayLike | None = None,
+    ) -> SparseMACFreeSurfaceProjectionResult:
+        if not isinstance(state, SparseFLIPTransferState):
+            raise TypeError("state must be SparseFLIPTransferState.")
+        values = tuple(jnp.asarray(value) for value in velocity)
+        expected = tuple(
+            topology.plan.storage_capacity for topology in state.face_topologies
+        )
+        if len(values) != len(expected) or any(
+            value.shape != (size,) for value, size in zip(values, expected, strict=True)
+        ):
+            raise ValueError("velocity must contain one compact field per face axis.")
+        relations = self._relations(state)
+        liquid = jnp.asarray(liquid_mask, dtype=bool)
+        if liquid.shape != relations.cell_valid.shape:
+            raise ValueError("liquid_mask must match compact cell storage.")
+        liquid = liquid & relations.cell_valid
+        dtype = values[0].dtype
+        dt = jnp.asarray(step_size, dtype=dtype).reshape(())
+        incoming = (
+            jnp.zeros(liquid.shape, dtype=dtype)
+            if pressure is None
+            else jnp.asarray(pressure, dtype=dtype)
+        )
+        if incoming.shape != liquid.shape:
+            raise ValueError("pressure must match compact cell storage.")
+        cell_measure, measure_valid = self.transfer.plan.cell_topology.layout.measure_at(
+            state.cell_topology.logical_node_ids.reshape((-1,))
+        )
+        cell_measure = jnp.where(
+            relations.cell_valid & measure_valid, cell_measure.astype(dtype), 1.0
+        )
+        coefficient = dt / self.density
+        divergence_before = _divergence(values, relations, self.spacing)
+        all_liquid = jnp.all(liquid | ~relations.cell_valid)
+        any_liquid = jnp.any(liquid)
+        topology_complete = jnp.all(~liquid | relations.complete)
+
+        def gauge(field):
+            denominator = jnp.sum(jnp.where(liquid, cell_measure, 0.0))
+            mean = jnp.where(
+                denominator > 0.0,
+                jnp.sum(cell_measure * jnp.where(liquid, field, 0.0))
+                / jnp.where(denominator > 0.0, denominator, 1.0),
+                0.0,
+            )
+            return jnp.where(liquid, field - mean, 0.0)
+
+        rhs = jnp.where(liquid, -divergence_before, 0.0)
+        rhs = jnp.where(all_liquid, gauge(rhs), rhs)
+        initial = jnp.where(all_liquid, gauge(incoming), jnp.where(liquid, incoming, 0.0))
+        action = _SparseMACPressureAction(
+            relations,
+            liquid,
+            coefficient,
+            cell_measure,
+            self.spacing,
+        )
+        space = self.prepared_linear.problem.operator.source
+        operator = FunctionLinearOperator(
+            action,
+            source=space,
+            target=space,
+            properties=OperatorProperties(
+                self_adjoint=True,
+                positive_definite=True,
+                evidence={
+                    "self_adjoint": "construction",
+                    "positive_definite": "construction",
+                },
+            ),
+            operator_id=self.operator_id,
+        )
+        prepared = refresh(
+            self.prepared_linear,
+            LinearSystem(operator, problem_id=self.problem_id),
+        )
+        linear = solve(prepared, rhs, initial_guess=initial)
+        pressure_candidate = jnp.where(
+            all_liquid,
+            gauge(linear.value),
+            jnp.where(liquid, linear.value, 0.0),
+        )
+        gradient = _gradient(
+            pressure_candidate,
+            liquid,
+            relations,
+            self.spacing,
+        )
+        corrected = tuple(
+            jnp.where(valid, value - coefficient * derivative, 0.0)
+            for value, derivative, valid in zip(
+                values, gradient, relations.face_valid, strict=True
+            )
+        )
+        divergence_after = _divergence(corrected, relations, self.spacing)
+        residual = action(pressure_candidate) - rhs
+        residual_norm = jnp.sqrt(jnp.sum(cell_measure * residual**2))
+        active_divergence_norm = jnp.sqrt(
+            jnp.sum(cell_measure * jnp.where(liquid, divergence_after, 0.0) ** 2)
+        )
+        energy_before = (
+            0.5
+            * self.density
+            * sum(
+                jnp.sum(jnp.where(valid, value * value, 0.0))
+                for value, valid in zip(values, relations.face_valid, strict=True)
+            )
+        )
+        energy_after = (
+            0.5
+            * self.density
+            * sum(
+                jnp.sum(jnp.where(valid, value * value, 0.0))
+                for value, valid in zip(corrected, relations.face_valid, strict=True)
+            )
+        )
+        rhs_norm = jnp.sqrt(jnp.sum(cell_measure * rhs**2))
+        finite = (
+            jnp.isfinite(dt)
+            & (dt > 0.0)
+            & jnp.all(jnp.isfinite(pressure_candidate))
+            & jnp.all(
+                jnp.stack(tuple(jnp.all(jnp.isfinite(value)) for value in corrected))
+            )
+            & jnp.isfinite(residual_norm)
+            & jnp.isfinite(active_divergence_norm)
+        )
+        converged = linear.successful & (
+            residual_norm <= self.tolerance * jnp.maximum(1.0, rhs_norm)
+        )
+        successful = (
+            state.successful & topology_complete & any_liquid & finite & converged
+        )
+        return SparseMACFreeSurfaceProjectionResult(
+            velocity=corrected,
+            pressure=pressure_candidate,
+            liquid_mask=liquid,
+            divergence_before=divergence_before,
+            divergence_after=divergence_after,
+            residual_norm=residual_norm,
+            active_divergence_norm=active_divergence_norm,
+            energy_before=energy_before,
+            energy_after=energy_after,
+            liquid_count=jnp.sum(liquid, dtype=jnp.int32),
+            air_count=jnp.sum(relations.cell_valid & ~liquid, dtype=jnp.int32),
+            linear=linear,
+            topology_complete=topology_complete,
+            finite=finite,
+            successful=successful,
+            projection_id=self.plan_id,
+        )
+
+
+__all__ = [
+    "SparseMACFreeSurfaceProjectionPlan",
+    "SparseMACFreeSurfaceProjectionResult",
+]

--- a/phydrax/sparse/__init__.py
+++ b/phydrax/sparse/__init__.py
@@ -23,6 +23,23 @@ from ._derivative import (
     SparseHessianContract,
     verify_sparse_derivative,
 )
+from ._execution import (
+    canonical_row_route_ids,
+    RelationAccumulation,
+    RelationExecutionPlan,
+    RelationExecutionState,
+    RelationOutput,
+    RelationReduction,
+    RelationReductionEvidence,
+)
+from ._key_groups import (
+    align_key_groups,
+    KeyGroupEvidence,
+    KeyGroupLookup,
+    KeyGroupPlan,
+    KeyGroupState,
+    KeyGroupTransition,
+)
 from ._linear import LinearAction, SparseCoordinateOperator, SparseLinearMap
 from ._local_tensor import ElementTensorOperator, scatter_local
 from ._ops import (
@@ -39,6 +56,18 @@ from ._relation import EdgeRelation, RowRelation, SparseRelation
 
 
 __all__ = [
+    "KeyGroupEvidence",
+    "KeyGroupLookup",
+    "KeyGroupPlan",
+    "KeyGroupState",
+    "KeyGroupTransition",
+    "canonical_row_route_ids",
+    "RelationAccumulation",
+    "RelationExecutionPlan",
+    "RelationExecutionState",
+    "RelationOutput",
+    "RelationReduction",
+    "RelationReductionEvidence",
     "LinearAction",
     "PreparedSparseDerivative",
     "EdgeRelation",
@@ -60,6 +89,7 @@ __all__ = [
     "SparsePattern",
     "SparsePatternOrigin",
     "SparseRelation",
+    "align_key_groups",
     "compile_sparse_hessian",
     "compile_sparse_jacobian",
     "gather_routes",

--- a/phydrax/sparse/_execution.py
+++ b/phydrax/sparse/_execution.py
@@ -1,0 +1,348 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from typing import Literal
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array, ArrayLike, PyTree
+
+from .._fingerprint import canonical_fingerprint
+from .._numerics._compensated import two_sum
+from .._strict import StrictModule
+from .._trainable import NonTrainableState
+from ._key_groups import KeyGroupPlan, KeyGroupState
+from ._relation import EdgeRelation, RowRelation, SparseRelation
+
+
+RelationAccumulation = Literal["fast", "deterministic", "compensated"]
+RelationReduction = Literal["sum", "mean", "min", "max"]
+RelationOutput = Literal["compact", "dense"]
+
+
+def canonical_row_route_ids(
+    stable_row_order: ArrayLike,
+    route_width: int,
+    /,
+) -> Array:
+    """Return route IDs ordered by stable row rank and then route slot."""
+    order = jnp.asarray(stable_row_order, dtype=jnp.int32)
+    if order.ndim != 1:
+        raise ValueError("stable_row_order must be a rank-1 permutation.")
+    width = int(route_width)
+    if width <= 0:
+        raise ValueError("route_width must be positive.")
+    row_count = int(order.shape[0])
+    inverse = (
+        jnp.zeros((row_count,), dtype=jnp.int32)
+        .at[order]
+        .set(jnp.arange(row_count, dtype=jnp.int32))
+    )
+    return (
+        inverse[:, None] * width + jnp.arange(width, dtype=jnp.int32)[None, :]
+    ).reshape((-1,))
+
+
+class RelationReductionEvidence(NonTrainableState, StrictModule):
+    """Runtime evidence for one grouped route reduction."""
+
+    valid_routes: Array
+    active_targets: Array
+    maximum_target_contention: Array
+    finite: Array
+    successful: Array
+    accumulation: RelationAccumulation = eqx.field(static=True)
+    reduction: RelationReduction = eqx.field(static=True)
+
+
+class RelationExecutionPlan(StrictModule):
+    """Prepare canonical target-grouped execution for a sparse relation."""
+
+    maximum_active_targets: int | None = eqx.field(static=True)
+    plan_id: str = eqx.field(static=True)
+
+    def __init__(self, maximum_active_targets: int | None = None) -> None:
+        if maximum_active_targets is not None and maximum_active_targets <= 0:
+            raise ValueError("maximum_active_targets must be positive when provided.")
+        self.maximum_active_targets = (
+            None if maximum_active_targets is None else int(maximum_active_targets)
+        )
+        self.plan_id = canonical_fingerprint(
+            {
+                "type": "relation-execution-plan",
+                "maximum_active_targets": self.maximum_active_targets,
+            }
+        )
+
+    def prepare(
+        self,
+        relation: SparseRelation,
+        *,
+        stable_route_ids: ArrayLike | None = None,
+    ) -> RelationExecutionState:
+        """Prepare target groups without changing the relation's route semantics."""
+        if isinstance(relation, RowRelation):
+            edge = relation.as_edge_relation()
+            output_shape = relation.output_shape
+        elif isinstance(relation, EdgeRelation):
+            edge = relation
+            output_shape = relation.output_shape
+        else:
+            raise TypeError("relation must be an EdgeRelation or RowRelation.")
+        group_capacity = min(edge.capacity, edge.target_size)
+        if self.maximum_active_targets is not None:
+            group_capacity = min(group_capacity, self.maximum_active_targets)
+        group_capacity = max(group_capacity, 1)
+        grouping = KeyGroupPlan(
+            edge.capacity,
+            group_capacity,
+            max(edge.target_size - 1, 0),
+        ).build(
+            edge.target_indices,
+            edge.valid,
+            stable_ids=stable_route_ids,
+        )
+        execution_id = canonical_fingerprint(
+            {
+                "type": "relation-execution",
+                "plan_id": self.plan_id,
+                "source_size": edge.source_size,
+                "target_size": edge.target_size,
+                "route_capacity": edge.capacity,
+                "output_shape": output_shape,
+            }
+        )
+        return RelationExecutionState(
+            plan=self,
+            relation=edge,
+            groups=grouping,
+            output_shape=output_shape,
+            execution_id=execution_id,
+        )
+
+
+class RelationExecutionState(NonTrainableState, StrictModule):
+    """Target-grouped route order and reduction operations."""
+
+    plan: RelationExecutionPlan
+    relation: EdgeRelation
+    groups: KeyGroupState
+    output_shape: tuple[int, ...] = eqx.field(static=True)
+    execution_id: str = eqx.field(static=True)
+
+    @property
+    def route_capacity(self) -> int:
+        return self.relation.capacity
+
+    @property
+    def compact_target_capacity(self) -> int:
+        return self.groups.plan.group_capacity
+
+    def reduce(
+        self,
+        route_values: PyTree[ArrayLike],
+        *,
+        reduction: RelationReduction = "sum",
+        accumulation: RelationAccumulation = "fast",
+        output: RelationOutput = "dense",
+    ) -> tuple[PyTree[Array], RelationReductionEvidence]:
+        """Reduce route-aligned values to compact groups or the dense target space."""
+        if reduction not in ("sum", "mean", "min", "max"):
+            raise ValueError(f"Unsupported relation reduction {reduction!r}.")
+        if accumulation not in ("fast", "deterministic", "compensated"):
+            raise ValueError(f"Unsupported relation accumulation {accumulation!r}.")
+        if output not in ("compact", "dense"):
+            raise ValueError(f"Unsupported relation output {output!r}.")
+        if accumulation == "compensated" and reduction not in ("sum", "mean"):
+            raise ValueError("Compensated accumulation supports sum and mean only.")
+
+        leaves, treedef = jax.tree_util.tree_flatten(route_values)
+        arrays = [jnp.asarray(leaf) for leaf in leaves]
+        for value in arrays:
+            if value.ndim == 0 or value.shape[0] != self.route_capacity:
+                raise ValueError(
+                    "Every route value leaf must begin with route capacity "
+                    f"{self.route_capacity}; got {value.shape}."
+                )
+        reduced = [
+            self._reduce_leaf(
+                value,
+                reduction=reduction,
+                accumulation=accumulation,
+                output=output,
+            )
+            for value in arrays
+        ]
+        result = jax.tree_util.tree_unflatten(treedef, reduced)
+        finite = jnp.asarray(True)
+        for value in reduced:
+            finite = finite & jnp.all(jnp.isfinite(value))
+        evidence = RelationReductionEvidence(
+            valid_routes=self.groups.evidence.active_items,
+            active_targets=self.groups.evidence.required_groups,
+            maximum_target_contention=self.groups.evidence.maximum_group_size,
+            finite=finite,
+            successful=self.groups.evidence.successful & finite,
+            accumulation=accumulation,
+            reduction=reduction,
+        )
+        return result, evidence
+
+    def _reduce_leaf(
+        self,
+        values: Array,
+        *,
+        reduction: RelationReduction,
+        accumulation: RelationAccumulation,
+        output: RelationOutput,
+    ) -> Array:
+        order = self.groups.storage_to_logical
+        sorted_values = values[order]
+        sorted_valid = self.groups.sorted_item_valid
+        group_slots = self.groups.item_group_slots[order]
+        trailing = values.shape[1:]
+        valid_shape = (self.route_capacity,) + (1,) * len(trailing)
+        safe_values = jnp.where(
+            sorted_valid.reshape(valid_shape), sorted_values, jnp.zeros((), values.dtype)
+        )
+        safe_slots = jnp.where(sorted_valid, group_slots, 0)
+
+        if reduction in ("min", "max") and jnp.issubdtype(
+            values.dtype, jnp.complexfloating
+        ):
+            raise TypeError(
+                "min and max relation reductions do not support complex values."
+            )
+
+        if reduction in ("sum", "mean"):
+            compact = _sum_segments(
+                safe_values,
+                safe_slots,
+                sorted_valid,
+                self.compact_target_capacity,
+                accumulation=accumulation,
+            )
+            if reduction == "mean":
+                counts = self.groups.group_counts.astype(values.dtype)
+                count_shape = counts.shape + (1,) * len(trailing)
+                compact = jnp.where(
+                    self.groups.group_active.reshape(count_shape),
+                    compact / jnp.maximum(counts, 1).reshape(count_shape),
+                    jnp.zeros((), compact.dtype),
+                )
+        else:
+            compact = _extreme_segments(
+                safe_values,
+                safe_slots,
+                sorted_valid,
+                self.compact_target_capacity,
+                reduction=reduction,
+            )
+        active_shape = self.groups.group_active.shape + (1,) * len(trailing)
+        usable = self.groups.group_active & self.groups.evidence.successful
+        compact = jnp.where(
+            usable.reshape(active_shape),
+            compact,
+            jnp.zeros((), compact.dtype),
+        )
+        if output == "compact":
+            return compact
+        dense = jnp.zeros((self.relation.target_size,) + trailing, dtype=compact.dtype)
+        safe_targets = jnp.where(usable, self.groups.group_keys, 0)
+        return (
+            dense.at[safe_targets]
+            .add(
+                jnp.where(
+                    usable.reshape(active_shape),
+                    compact,
+                    jnp.zeros((), compact.dtype),
+                )
+            )
+            .reshape(self.output_shape + trailing)
+        )
+
+
+def _sum_segments(
+    values: Array,
+    group_slots: Array,
+    valid: Array,
+    group_capacity: int,
+    *,
+    accumulation: RelationAccumulation,
+) -> Array:
+    trailing = values.shape[1:]
+    if accumulation == "fast":
+        return jax.ops.segment_sum(
+            values,
+            group_slots,
+            num_segments=group_capacity,
+            indices_are_sorted=True,
+        )
+
+    initial = jnp.zeros((group_capacity,) + trailing, dtype=values.dtype)
+    if accumulation == "deterministic":
+
+        def add_one(index: int, total: Array) -> Array:
+            slot = group_slots[index]
+            value = jnp.where(valid[index], values[index], jnp.zeros((), values.dtype))
+            return total.at[slot].add(value)
+
+        return jax.lax.fori_loop(0, values.shape[0], add_one, initial)
+
+    correction = jnp.zeros_like(initial)
+
+    def add_compensated(index: int, carry: tuple[Array, Array]) -> tuple[Array, Array]:
+        total, residual = carry
+        slot = group_slots[index]
+        value = jnp.where(valid[index], values[index], jnp.zeros((), values.dtype))
+        next_total, error = two_sum(total[slot], value)
+        return total.at[slot].set(next_total), residual.at[slot].add(error)
+
+    total, residual = jax.lax.fori_loop(
+        0, values.shape[0], add_compensated, (initial, correction)
+    )
+    return total + residual
+
+
+def _extreme_segments(
+    values: Array,
+    group_slots: Array,
+    valid: Array,
+    group_capacity: int,
+    *,
+    reduction: Literal["min", "max"],
+) -> Array:
+    if jnp.issubdtype(values.dtype, jnp.floating):
+        identity = jnp.inf if reduction == "min" else -jnp.inf
+    elif jnp.issubdtype(values.dtype, jnp.integer):
+        info = jnp.iinfo(values.dtype)
+        identity = info.max if reduction == "min" else info.min
+    else:
+        raise TypeError("min and max relation reductions require real numeric values.")
+    safe = jnp.where(
+        valid.reshape((valid.shape[0],) + (1,) * (values.ndim - 1)),
+        values,
+        jnp.asarray(identity, dtype=values.dtype),
+    )
+    operation = jax.ops.segment_min if reduction == "min" else jax.ops.segment_max
+    return operation(
+        safe,
+        group_slots,
+        num_segments=group_capacity,
+        indices_are_sorted=True,
+    )
+
+
+__all__ = [
+    "canonical_row_route_ids",
+    "RelationAccumulation",
+    "RelationExecutionPlan",
+    "RelationExecutionState",
+    "RelationOutput",
+    "RelationReduction",
+    "RelationReductionEvidence",
+]

--- a/phydrax/sparse/_key_groups.py
+++ b/phydrax/sparse/_key_groups.py
@@ -1,0 +1,465 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array, ArrayLike
+
+from .._fingerprint import canonical_fingerprint
+from .._strict import StrictModule
+from .._trainable import NonTrainableState
+
+
+class KeyGroupEvidence(NonTrainableState, StrictModule):
+    """Auditable counts and independent capacity failures for key grouping."""
+
+    requested_items: Array
+    active_items: Array
+    invalid_keys: Array
+    duplicate_stable_ids: Array
+    required_groups: Array
+    group_capacity: Array
+    maximum_group_size: Array
+    member_capacity: Array
+    group_overflow: Array
+    member_overflow: Array
+    successful: Array
+
+
+class KeyGroupLookup(NonTrainableState, StrictModule):
+    """Fixed-shape lookup from logical keys to compact group slots."""
+
+    group_slots: Array
+    supported: Array
+
+
+class KeyGroupPlan(StrictModule):
+    """Plan a canonical fixed-capacity grouping of integer-keyed items."""
+
+    item_capacity: int = eqx.field(static=True)
+    group_capacity: int = eqx.field(static=True)
+    maximum_group_size: int | None = eqx.field(static=True)
+    key_upper_bound: int = eqx.field(static=True)
+    case_shape: tuple[int, ...] = eqx.field(static=True)
+    plan_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        item_capacity: int,
+        group_capacity: int,
+        key_upper_bound: int,
+        *,
+        maximum_group_size: int | None = None,
+        case_shape: tuple[int, ...] = (),
+    ) -> None:
+        if item_capacity < 0:
+            raise ValueError("item_capacity must be nonnegative.")
+        if group_capacity <= 0:
+            raise ValueError("group_capacity must be positive.")
+        if key_upper_bound < 0:
+            raise ValueError("key_upper_bound must be nonnegative.")
+        if maximum_group_size is not None and maximum_group_size <= 0:
+            raise ValueError("maximum_group_size must be positive when provided.")
+        if any(size <= 0 for size in case_shape):
+            raise ValueError("case_shape entries must be positive.")
+        self.item_capacity = int(item_capacity)
+        self.group_capacity = int(group_capacity)
+        self.maximum_group_size = (
+            None if maximum_group_size is None else int(maximum_group_size)
+        )
+        self.key_upper_bound = int(key_upper_bound)
+        self.case_shape = tuple(int(size) for size in case_shape)
+        self.plan_id = canonical_fingerprint(
+            {
+                "type": "key-group-plan",
+                "item_capacity": self.item_capacity,
+                "group_capacity": self.group_capacity,
+                "maximum_group_size": self.maximum_group_size,
+                "key_upper_bound": self.key_upper_bound,
+                "case_shape": self.case_shape,
+            }
+        )
+
+    def build(
+        self,
+        keys: ArrayLike,
+        valid: ArrayLike,
+        *,
+        stable_ids: ArrayLike | None = None,
+    ) -> KeyGroupState:
+        """Group valid items by key in canonical ``(key, stable_id)`` order."""
+        key_array = jnp.asarray(keys)
+        if not jnp.issubdtype(key_array.dtype, jnp.integer):
+            raise TypeError("keys must have an integer dtype.")
+        expected_shape = self.case_shape + (self.item_capacity,)
+        if key_array.shape != expected_shape:
+            raise ValueError(
+                f"keys must have shape {expected_shape}; got {key_array.shape}."
+            )
+        valid_array = jnp.asarray(valid, dtype=bool)
+        if valid_array.shape != expected_shape:
+            raise ValueError(
+                f"valid must have shape {expected_shape}; got {valid_array.shape}."
+            )
+        if stable_ids is None:
+            ids = jnp.broadcast_to(
+                jnp.arange(self.item_capacity, dtype=jnp.int32), expected_shape
+            )
+        else:
+            ids = jnp.asarray(stable_ids)
+            if not jnp.issubdtype(ids.dtype, jnp.integer):
+                raise TypeError("stable_ids must have an integer dtype.")
+            if ids.shape != expected_shape:
+                raise ValueError(
+                    f"stable_ids must have shape {expected_shape}; got {ids.shape}."
+                )
+
+        batch_size = 1
+        for size in self.case_shape:
+            batch_size *= size
+        flat_keys = key_array.reshape((batch_size, self.item_capacity))
+        flat_valid = valid_array.reshape((batch_size, self.item_capacity))
+        flat_ids = ids.reshape((batch_size, self.item_capacity))
+        grouped = jax.vmap(
+            lambda case_keys, case_valid, case_ids: _build_one(
+                case_keys,
+                case_valid,
+                case_ids,
+                group_capacity=self.group_capacity,
+                maximum_group_size=self.maximum_group_size,
+                key_upper_bound=self.key_upper_bound,
+            )
+        )(flat_keys, flat_valid, flat_ids)
+
+        item_shape = self.case_shape + (self.item_capacity,)
+        group_shape = self.case_shape + (self.group_capacity,)
+        scalar_shape = self.case_shape
+        return KeyGroupState(
+            plan=self,
+            item_keys=key_array,
+            item_valid=valid_array,
+            stable_ids=ids,
+            storage_to_logical=grouped.storage_to_logical.reshape(item_shape),
+            logical_to_storage=grouped.logical_to_storage.reshape(item_shape),
+            sorted_keys=grouped.sorted_keys.reshape(item_shape),
+            sorted_item_valid=grouped.sorted_item_valid.reshape(item_shape),
+            item_group_slots=grouped.item_group_slots.reshape(item_shape),
+            group_keys=grouped.group_keys.reshape(group_shape),
+            group_active=grouped.group_active.reshape(group_shape),
+            group_starts=grouped.group_starts.reshape(group_shape),
+            group_counts=grouped.group_counts.reshape(group_shape),
+            evidence=KeyGroupEvidence(
+                requested_items=grouped.requested_items.reshape(scalar_shape),
+                active_items=grouped.active_items.reshape(scalar_shape),
+                invalid_keys=grouped.invalid_keys.reshape(scalar_shape),
+                duplicate_stable_ids=grouped.duplicate_stable_ids.reshape(scalar_shape),
+                required_groups=grouped.required_groups.reshape(scalar_shape),
+                group_capacity=jnp.full(
+                    scalar_shape, self.group_capacity, dtype=jnp.int32
+                ),
+                maximum_group_size=grouped.maximum_group_size.reshape(scalar_shape),
+                member_capacity=jnp.full(
+                    scalar_shape,
+                    self.maximum_group_size or self.item_capacity,
+                    dtype=jnp.int32,
+                ),
+                group_overflow=grouped.group_overflow.reshape(scalar_shape),
+                member_overflow=grouped.member_overflow.reshape(scalar_shape),
+                successful=grouped.successful.reshape(scalar_shape),
+            ),
+        )
+
+
+class KeyGroupState(NonTrainableState, StrictModule):
+    """Canonical compact groups and reversible item placement."""
+
+    plan: KeyGroupPlan
+    item_keys: Array
+    item_valid: Array
+    stable_ids: Array
+    storage_to_logical: Array
+    logical_to_storage: Array
+    sorted_keys: Array
+    sorted_item_valid: Array
+    item_group_slots: Array
+    group_keys: Array
+    group_active: Array
+    group_starts: Array
+    group_counts: Array
+    evidence: KeyGroupEvidence
+
+    def lookup(
+        self,
+        keys: ArrayLike,
+        *,
+        valid: ArrayLike | None = None,
+    ) -> KeyGroupLookup:
+        """Look up keys without allocating a dense reverse map."""
+        query = jnp.asarray(keys)
+        if not jnp.issubdtype(query.dtype, jnp.integer):
+            raise TypeError("lookup keys must have an integer dtype.")
+        if query.shape[: len(self.plan.case_shape)] != self.plan.case_shape:
+            raise ValueError(
+                "lookup keys must begin with the grouping case shape "
+                f"{self.plan.case_shape}; got {query.shape}."
+            )
+        if valid is None:
+            query_valid = jnp.ones(query.shape, dtype=bool)
+        else:
+            query_valid = jnp.asarray(valid, dtype=bool)
+            if query_valid.shape != query.shape:
+                raise ValueError(
+                    f"lookup valid must have shape {query.shape}; got "
+                    f"{query_valid.shape}."
+                )
+
+        batch_size = 1
+        for size in self.plan.case_shape:
+            batch_size *= size
+        query_tail = query.shape[len(self.plan.case_shape) :]
+        flat_query = query.reshape((batch_size, -1))
+        flat_valid = query_valid.reshape((batch_size, -1))
+        flat_group_keys = self.group_keys.reshape((batch_size, self.plan.group_capacity))
+        flat_group_active = self.group_active.reshape(
+            (batch_size, self.plan.group_capacity)
+        )
+        slots, supported = jax.vmap(
+            lambda case_groups, case_active, case_query, case_valid: _lookup_one(
+                case_groups,
+                case_active,
+                case_query,
+                case_valid,
+                key_upper_bound=self.plan.key_upper_bound,
+            )
+        )(flat_group_keys, flat_group_active, flat_query, flat_valid)
+        result_shape = self.plan.case_shape + query_tail
+        supported = supported.reshape(result_shape)
+        successful = self.evidence.successful.reshape(
+            self.plan.case_shape + (1,) * len(query_tail)
+        )
+        supported = supported & successful
+        slots = slots.reshape(result_shape)
+        return KeyGroupLookup(
+            group_slots=jnp.where(supported, slots, 0),
+            supported=supported,
+        )
+
+
+class KeyGroupTransition(NonTrainableState, StrictModule):
+    """Logical-key alignment between two fixed-capacity group states."""
+
+    previous: KeyGroupState
+    candidate: KeyGroupState
+    previous_to_candidate: Array
+    previous_retained: Array
+    candidate_to_previous: Array
+    candidate_retained: Array
+    topology_changed: Array
+    successful: Array
+
+
+def align_key_groups(
+    previous: KeyGroupState,
+    candidate: KeyGroupState,
+) -> KeyGroupTransition:
+    """Align group slots by key without treating storage position as identity."""
+    if previous.plan.case_shape != candidate.plan.case_shape:
+        raise ValueError("previous and candidate case shapes must match.")
+    previous_lookup = candidate.lookup(previous.group_keys, valid=previous.group_active)
+    candidate_lookup = previous.lookup(candidate.group_keys, valid=candidate.group_active)
+    changed = (
+        previous.evidence.required_groups != candidate.evidence.required_groups
+    ) | jnp.any(
+        (previous.group_active != candidate.group_active)
+        | (
+            previous.group_active
+            & candidate.group_active
+            & (previous.group_keys != candidate.group_keys)
+        ),
+        axis=-1,
+    )
+    return KeyGroupTransition(
+        previous=previous,
+        candidate=candidate,
+        previous_to_candidate=previous_lookup.group_slots,
+        previous_retained=previous_lookup.supported,
+        candidate_to_previous=candidate_lookup.group_slots,
+        candidate_retained=candidate_lookup.supported,
+        topology_changed=changed,
+        successful=candidate.evidence.successful,
+    )
+
+
+class _GroupedArrays(NamedTuple):
+    storage_to_logical: Array
+    logical_to_storage: Array
+    sorted_keys: Array
+    sorted_item_valid: Array
+    item_group_slots: Array
+    group_keys: Array
+    group_active: Array
+    group_starts: Array
+    group_counts: Array
+    requested_items: Array
+    active_items: Array
+    invalid_keys: Array
+    duplicate_stable_ids: Array
+    required_groups: Array
+    maximum_group_size: Array
+    group_overflow: Array
+    member_overflow: Array
+    successful: Array
+
+
+def _build_one(
+    keys: Array,
+    valid: Array,
+    stable_ids: Array,
+    *,
+    group_capacity: int,
+    maximum_group_size: int | None,
+    key_upper_bound: int,
+) -> _GroupedArrays:
+    item_capacity = keys.shape[0]
+    sentinel = jnp.asarray(key_upper_bound + 1, dtype=keys.dtype)
+    if item_capacity == 0:
+        group_shape = (group_capacity,)
+        return _GroupedArrays(
+            storage_to_logical=jnp.zeros((0,), dtype=jnp.int32),
+            logical_to_storage=jnp.zeros((0,), dtype=jnp.int32),
+            sorted_keys=jnp.zeros((0,), dtype=keys.dtype),
+            sorted_item_valid=jnp.zeros((0,), dtype=bool),
+            item_group_slots=jnp.zeros((0,), dtype=jnp.int32),
+            group_keys=jnp.full(group_shape, sentinel),
+            group_active=jnp.zeros(group_shape, dtype=bool),
+            group_starts=jnp.zeros(group_shape, dtype=jnp.int32),
+            group_counts=jnp.zeros(group_shape, dtype=jnp.int32),
+            requested_items=jnp.asarray(0, dtype=jnp.int32),
+            active_items=jnp.asarray(0, dtype=jnp.int32),
+            invalid_keys=jnp.asarray(0, dtype=jnp.int32),
+            duplicate_stable_ids=jnp.asarray(0, dtype=jnp.int32),
+            required_groups=jnp.asarray(0, dtype=jnp.int32),
+            maximum_group_size=jnp.asarray(0, dtype=jnp.int32),
+            group_overflow=jnp.asarray(False),
+            member_overflow=jnp.asarray(False),
+            successful=jnp.asarray(True),
+        )
+    key_valid = valid & (keys >= 0) & (keys <= key_upper_bound)
+    safe_keys = jnp.where(key_valid, keys, sentinel)
+    original = jnp.arange(item_capacity, dtype=jnp.int32)
+    order = jnp.lexsort(
+        (
+            original,
+            stable_ids,
+            safe_keys,
+            (~key_valid).astype(jnp.int32),
+        )
+    ).astype(jnp.int32)
+    sorted_keys = safe_keys[order]
+    sorted_valid = key_valid[order]
+
+    previous_valid = jnp.concatenate((jnp.zeros((1,), dtype=bool), sorted_valid[:-1]))
+    previous_keys = jnp.concatenate((jnp.full((1,), sentinel), sorted_keys[:-1]))
+    group_start_mask = sorted_valid & ((~previous_valid) | (sorted_keys != previous_keys))
+    sorted_group_slots = jnp.cumsum(group_start_mask.astype(jnp.int32)) - 1
+    sorted_group_slots = jnp.where(sorted_valid, sorted_group_slots, -1)
+    required_groups = jnp.sum(group_start_mask, dtype=jnp.int32)
+    active_items = jnp.sum(sorted_valid, dtype=jnp.int32)
+    start_positions = jnp.nonzero(group_start_mask, size=group_capacity, fill_value=0)[
+        0
+    ].astype(jnp.int32)
+    group_active = jnp.arange(group_capacity, dtype=jnp.int32) < required_groups
+    group_keys = jnp.where(group_active, sorted_keys[start_positions], sentinel)
+    group_starts = jnp.where(group_active, start_positions, 0)
+    following_starts = jnp.concatenate((group_starts[1:], active_items[None]))
+    following_active = jnp.concatenate((group_active[1:], jnp.zeros((1,), dtype=bool)))
+    next_starts = jnp.where(following_active, following_starts, active_items)
+    group_counts = jnp.where(group_active, next_starts - group_starts, 0)
+    maximum_size = jnp.max(group_counts, initial=0)
+
+    logical_to_storage = (
+        jnp.zeros((item_capacity,), dtype=jnp.int32).at[order].set(original)
+    )
+    item_group_slots = (
+        jnp.full((item_capacity,), -1, dtype=jnp.int32).at[order].set(sorted_group_slots)
+    )
+
+    id_order = jnp.lexsort(
+        (
+            original,
+            stable_ids,
+            (~key_valid).astype(jnp.int32),
+        )
+    ).astype(jnp.int32)
+    ids_by_id = stable_ids[id_order]
+    valid_by_id = key_valid[id_order]
+    duplicate_ids = valid_by_id[1:] & valid_by_id[:-1] & (ids_by_id[1:] == ids_by_id[:-1])
+    duplicate_stable_ids = jnp.sum(duplicate_ids, dtype=jnp.int32)
+
+    requested_items = jnp.sum(valid, dtype=jnp.int32)
+    invalid_keys = requested_items - active_items
+    group_overflow = required_groups > group_capacity
+    member_limit = maximum_group_size or item_capacity
+    member_overflow = maximum_size > member_limit
+    successful = (
+        (invalid_keys == 0)
+        & (duplicate_stable_ids == 0)
+        & (~group_overflow)
+        & (~member_overflow)
+    )
+    return _GroupedArrays(
+        storage_to_logical=order,
+        logical_to_storage=logical_to_storage,
+        sorted_keys=sorted_keys,
+        sorted_item_valid=sorted_valid,
+        item_group_slots=item_group_slots,
+        group_keys=group_keys,
+        group_active=group_active,
+        group_starts=group_starts,
+        group_counts=group_counts,
+        requested_items=requested_items,
+        active_items=active_items,
+        invalid_keys=invalid_keys,
+        duplicate_stable_ids=duplicate_stable_ids,
+        required_groups=required_groups,
+        maximum_group_size=maximum_size,
+        group_overflow=group_overflow,
+        member_overflow=member_overflow,
+        successful=successful,
+    )
+
+
+def _lookup_one(
+    group_keys: Array,
+    group_active: Array,
+    query: Array,
+    query_valid: Array,
+    *,
+    key_upper_bound: int,
+) -> tuple[Array, Array]:
+    positions = jnp.searchsorted(group_keys, query, side="left").astype(jnp.int32)
+    safe_positions = jnp.clip(positions, 0, group_keys.shape[0] - 1)
+    valid_keys = query_valid & (query >= 0) & (query <= key_upper_bound)
+    supported = (
+        valid_keys
+        & (positions < group_keys.shape[0])
+        & group_active[safe_positions]
+        & (group_keys[safe_positions] == query)
+    )
+    return jnp.where(supported, safe_positions, 0), supported
+
+
+__all__ = [
+    "KeyGroupEvidence",
+    "KeyGroupLookup",
+    "KeyGroupPlan",
+    "KeyGroupState",
+    "KeyGroupTransition",
+    "align_key_groups",
+]

--- a/phydrax/sparse/_local_tensor.py
+++ b/phydrax/sparse/_local_tensor.py
@@ -5,15 +5,12 @@
 from __future__ import annotations
 
 import equinox as eqx
-import jax
 import jax.numpy as jnp
-import numpy as np
 from jaxtyping import Array, ArrayLike
 
 import phydrax.ein as ein
 
 from .._fingerprint import canonical_fingerprint
-from .._numerics._compensated import compensated_sum
 from .._strict import StrictModule
 from .._trainable import NonTrainableState
 from ..linalg import (
@@ -23,6 +20,7 @@ from ..linalg import (
     LocalEliminationResult,
     OperatorProperties,
 )
+from ._execution import RelationExecutionPlan, RelationExecutionState
 from ._linear import SparseCoordinateOperator
 from ._relation import EdgeRelation
 
@@ -35,43 +33,26 @@ def scatter_local(
     /,
 ) -> Array:
     """Scatter local rows with an explicit reduction-order policy."""
-
-    if accumulation == "fast":
-        return residual.at[dofs].add(local)
-    flat_dofs = dofs.reshape((-1,))
-    component_shape = residual.shape[1:]
-    component_count = int(np.prod(component_shape, dtype=int)) if component_shape else 1
-    flat_local = local.reshape((flat_dofs.size, component_count))
-    if accumulation == "deterministic":
-        grouped = jax.ops.segment_sum(
-            flat_local,
-            flat_dofs,
-            residual.shape[0],
-            indices_are_sorted=False,
-            unique_indices=False,
-        )
-    elif accumulation == "compensated":
-        grouped = jnp.stack(
-            tuple(
-                jnp.stack(
-                    tuple(
-                        compensated_sum(
-                            jnp.where(
-                                flat_dofs == index,
-                                flat_local[:, component],
-                                jnp.zeros((), dtype=flat_local.dtype),
-                            )
-                        )
-                        for index in range(residual.shape[0])
-                    )
-                )
-                for component in range(component_count)
-            ),
-            axis=-1,
-        )
-    else:
-        raise ValueError("Unknown local accumulation policy.")
-    return residual + grouped.reshape(residual.shape)
+    if residual.ndim < 1:
+        raise ValueError("residual must contain a target axis.")
+    if dofs.shape != local.shape[: dofs.ndim]:
+        raise ValueError("Local values must begin with the local DOF shape.")
+    flat_dofs = jnp.asarray(dofs, dtype=jnp.int32).reshape((-1,))
+    trailing = local.shape[dofs.ndim :]
+    flat_local = jnp.asarray(local).reshape((flat_dofs.size,) + trailing)
+    relation = EdgeRelation(
+        jnp.arange(flat_dofs.size, dtype=jnp.int32),
+        flat_dofs,
+        source_size=flat_dofs.size,
+        target_size=residual.shape[0],
+    )
+    execution = RelationExecutionPlan().prepare(relation)
+    grouped, _ = execution.reduce(
+        flat_local,
+        accumulation=accumulation,
+        output="dense",
+    )
+    return residual + grouped
 
 
 class ElementTensorOperator(StrictModule, NonTrainableState):
@@ -81,6 +62,8 @@ class ElementTensorOperator(StrictModule, NonTrainableState):
     input_gathers: Array
     output_gathers: Array
     valid: Array
+    input_execution: RelationExecutionState
+    output_execution: RelationExecutionState
     source_size: int = eqx.field(static=True)
     target_size: int = eqx.field(static=True)
     accumulation: str = eqx.field(static=True)
@@ -130,10 +113,32 @@ class ElementTensorOperator(StrictModule, NonTrainableState):
         properties_ = OperatorProperties() if properties is None else properties
         if not isinstance(properties_, OperatorProperties):
             raise TypeError("properties must be OperatorProperties or None.")
+        output_routes = outputs.reshape((-1,))
+        output_valid = jnp.broadcast_to(valid_[:, None], outputs.shape).reshape((-1,))
+        output_relation = EdgeRelation(
+            jnp.arange(output_routes.size, dtype=jnp.int32),
+            output_routes,
+            source_size=output_routes.size,
+            target_size=target,
+            valid=output_valid,
+        )
+        input_routes = inputs.reshape((-1,))
+        input_valid = jnp.broadcast_to(valid_[:, None], inputs.shape).reshape((-1,))
+        input_relation = EdgeRelation(
+            jnp.arange(input_routes.size, dtype=jnp.int32),
+            input_routes,
+            source_size=input_routes.size,
+            target_size=source,
+            valid=input_valid,
+        )
+        output_execution = RelationExecutionPlan().prepare(output_relation)
+        input_execution = RelationExecutionPlan().prepare(input_relation)
         self.local_matrices = matrices
         self.input_gathers = inputs
         self.output_gathers = outputs
         self.valid = valid_
+        self.input_execution = input_execution
+        self.output_execution = output_execution
         self.source_size = source
         self.target_size = target
         self.accumulation = accumulation_
@@ -157,12 +162,12 @@ class ElementTensorOperator(StrictModule, NonTrainableState):
         local_input = value_[self.input_gathers]
         contribution = ein.contract("eoi,ei->eo", self.local_matrices, local_input)
         contribution = jnp.where(self.valid[:, None], contribution, 0.0)
-        return scatter_local(
-            jnp.zeros((self.target_size,), dtype=contribution.dtype),
-            self.output_gathers,
-            contribution,
-            self.accumulation,
+        reduced, _ = self.output_execution.reduce(
+            contribution.reshape((-1,)),
+            accumulation=self.accumulation,
+            output="dense",
         )
+        return reduced
 
     def transpose_mv(self, value: ArrayLike, /) -> Array:
         value_ = jnp.asarray(value)
@@ -171,12 +176,12 @@ class ElementTensorOperator(StrictModule, NonTrainableState):
         local_input = value_[self.output_gathers]
         contribution = ein.contract("eoi,eo->ei", self.local_matrices, local_input)
         contribution = jnp.where(self.valid[:, None], contribution, 0.0)
-        return scatter_local(
-            jnp.zeros((self.source_size,), dtype=contribution.dtype),
-            self.input_gathers,
-            contribution,
-            self.accumulation,
+        reduced, _ = self.input_execution.reduce(
+            contribution.reshape((-1,)),
+            accumulation=self.accumulation,
+            output="dense",
         )
+        return reduced
 
     def diagonal(self, /) -> Array:
         if self.source_size != self.target_size or not bool(
@@ -185,12 +190,12 @@ class ElementTensorOperator(StrictModule, NonTrainableState):
             raise ValueError("Diagonal requires square operators with identical routes.")
         local = jnp.diagonal(self.local_matrices, axis1=-2, axis2=-1)
         local = jnp.where(self.valid[:, None], local, 0.0)
-        return scatter_local(
-            jnp.zeros((self.source_size,), dtype=local.dtype),
-            self.input_gathers,
-            local,
-            self.accumulation,
+        reduced, _ = self.input_execution.reduce(
+            local.reshape((-1,)),
+            accumulation=self.accumulation,
+            output="dense",
         )
+        return reduced
 
     def as_linear_operator(self, /) -> FunctionLinearOperator:
         source = ArraySpace((self.source_size,), dtype=self.local_matrices.dtype)

--- a/tests/unit/discretization/spatial/test_sparse_blocks.py
+++ b/tests/unit/discretization/spatial/test_sparse_blocks.py
@@ -1,0 +1,75 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+import phydrax as phx
+
+
+def _index_space():
+    plan = phx.discretization.TensorGridPlan(
+        (
+            phx.discretization.UniformAxisSpec(8, periodic=True, endpoint=False),
+            phx.discretization.UniformAxisSpec(8, periodic=True, endpoint=False),
+        ),
+        axis_names=("x", "y"),
+    )
+    bounds = jnp.asarray([[0.0, 0.0], [1.0, 1.0]])
+    return plan.prepare(bounds), plan.prepare_index_space(bounds)
+
+
+def test_tensor_index_space_matches_dense_indexed_geometry_without_dense_points():
+    dense, index = _index_space()
+    logical = jnp.asarray([0, 9, 63], dtype=jnp.int32)
+    coordinates, supported = index.vertices().coordinates_at(logical)
+    measures, measure_supported = index.vertices().measure_at(logical)
+
+    np.testing.assert_allclose(coordinates, dense.points[logical])
+    np.testing.assert_allclose(measures, dense.measure.weights[logical])
+    assert jnp.all(supported & measure_supported)
+    assert index.stored_axis_values == 32
+    assert index.stored_axis_values < index.size
+
+
+def test_sparse_blocks_wrap_periodic_closure_and_align_transitions():
+    _, index = _index_space()
+    plan = phx.discretization.SparseBlockTopologyPlan(
+        index,
+        (2, 2),
+        8,
+        layout=index.vertices(),
+        closure_offsets=((0, 0), (-1, 0), (1, 0)),
+    )
+    first = jax.jit(lambda ids: plan.build(ids))(jnp.asarray([0, 1, 8]))
+    transition = jax.jit(lambda previous, ids: plan.refresh(previous, ids))(
+        first, jnp.asarray([54, 55, 62])
+    )
+    second = transition.candidate
+
+    assert bool(first.evidence.successful)
+    assert bool(second.evidence.successful)
+    assert int(first.evidence.required_blocks) == 3
+    assert int(second.generation) == 1
+    assert bool(transition.key_transition.topology_changed)
+    assert int(first.materialize_support().sum()) == 12
+
+
+def test_sparse_block_overflow_returns_no_usable_node_support():
+    _, index = _index_space()
+    plan = phx.discretization.SparseBlockTopologyPlan(
+        index,
+        (2, 2),
+        1,
+        layout=index.vertices(),
+    )
+    state = plan.build(jnp.asarray([0, 18]))
+
+    assert bool(state.evidence.overflow)
+    assert not bool(state.evidence.successful)
+    assert not jnp.any(state.node_valid)
+    assert not jnp.any(state.lookup(jnp.asarray([0, 18])).supported)

--- a/tests/unit/discretization/test_fd_amr_runtime.py
+++ b/tests/unit/discretization/test_fd_amr_runtime.py
@@ -236,3 +236,22 @@ def test_amr_migration_reorders_active_blocks_and_preserves_inactive_sentinels()
     np.testing.assert_allclose(result.values[0], 2.0)
     np.testing.assert_allclose(result.values[2], 1.0)
     np.testing.assert_allclose(result.values[jnp.asarray([1, 3])], 0.0)
+
+
+def test_block_local_stencil_execution_uses_qualified_halo_and_active_keys():
+    plan = _plan_2d()
+    metadata = _metadata_2d(plan)
+    values = jnp.stack(
+        tuple(jnp.full(plan.block_shape, float(slot)) for slot in range(4))
+    )
+    state = phx.discretization.BlockLevelState(plan, metadata, values)
+    workspace = phx.discretization.FDAMRHaloPlan(plan).fill_same_level(state)
+    footprint = phx.discretization.StencilFootprint(("x", "y"), (1, 1), (1, 1))
+    execution = phx.discretization.BlockLocalStencilExecutionPlan(plan, footprint)
+    result = execution.apply(workspace, lambda block: block[1:-1, 1:-1])
+    lookup = metadata.lookup_block_ids(jnp.asarray([3, 1, 9]))
+
+    assert bool(result.successful)
+    np.testing.assert_allclose(result.values, values)
+    assert jnp.array_equal(lookup.supported, jnp.asarray([True, True, False]))
+    assert jnp.array_equal(lookup.group_slots[:2], jnp.asarray([3, 1]))

--- a/tests/unit/discretization/test_flip_foundation.py
+++ b/tests/unit/discretization/test_flip_foundation.py
@@ -82,3 +82,101 @@ def test_flip_method_validates_explicit_pic_fraction():
         phx.discretization.flip.FLIPMethodPlan(1.1)
     assert phx.discretization.flip.FLIPMethodPlan(0.0).pic_fraction == 0.0
     assert phx.discretization.flip.FLIPMethodPlan(1.0).pic_fraction == 1.0
+
+
+def test_sparse_flip_transfer_uses_compact_cell_and_face_storage():
+    grid_plan = phx.discretization.TensorGridPlan(
+        (
+            phx.discretization.UniformCellAxisSpec(8, periodic=True),
+            phx.discretization.UniformCellAxisSpec(8, periodic=True),
+        ),
+        axis_names=("x", "y"),
+    )
+    index = grid_plan.prepare_index_space(jnp.asarray([[0.0, 0.0], [1.0, 1.0]]))
+    position = jnp.asarray([[0.2, 0.2], [0.25, 0.22]])
+    velocity = jnp.asarray([[0.1, 0.0], [0.1, 0.0]])
+    particles = phx.discretization.ParticleSetPlan(
+        jnp.arange(2), jnp.ones((2,)), ambient_dimension=2
+    ).prepare()
+    cell_topology = phx.discretization.SparseBlockTopologyPlan(
+        index, (2, 2), 8, layout=index.cells()
+    )
+    face_topologies = tuple(
+        phx.discretization.SparseBlockTopologyPlan(
+            index, (2, 2), 8, layout=index.faces(axis)
+        )
+        for axis in index.axis_names
+    )
+    transfer = phx.discretization.SparseFLIPParticleTransferPlan(
+        index, cell_topology, face_topologies
+    ).prepare(particles)
+    routes = transfer.build(position)
+    p2g = transfer.particle_to_grid(routes, velocity, 1.0)
+    g2p = transfer.grid_to_particle(routes, p2g.velocity, p2g.velocity)
+
+    assert bool(routes.successful)
+    assert bool(p2g.successful)
+    assert p2g.particle_volume_content.shape == (32,)
+    assert all(value.shape == (32,) for value in p2g.velocity)
+    np.testing.assert_allclose(g2p.pic_velocity, velocity, atol=1.0e-12)
+    np.testing.assert_allclose(g2p.flip_increment, 0.0, atol=1.0e-14)
+
+
+def test_sparse_flip_pressure_and_particle_step_commit_atomically():
+    grid_plan = phx.discretization.TensorGridPlan(
+        (
+            phx.discretization.UniformCellAxisSpec(8, periodic=True),
+            phx.discretization.UniformCellAxisSpec(8, periodic=True),
+        ),
+        axis_names=("x", "y"),
+    )
+    bounds = jnp.asarray([[0.0, 0.0], [1.0, 1.0]])
+    index = grid_plan.prepare_index_space(bounds)
+    position = jnp.asarray([[0.2, 0.2], [0.25, 0.22]])
+    particles = phx.discretization.ParticleSetPlan(
+        jnp.arange(2), jnp.ones((2,)), ambient_dimension=2
+    ).prepare()
+    closure = tuple((row, column) for row in (-1, 0, 1) for column in (-1, 0, 1))
+    cell = phx.discretization.SparseBlockTopologyPlan(
+        index,
+        (2, 2),
+        16,
+        layout=index.cells(),
+        closure_offsets=closure,
+    )
+    faces = tuple(
+        phx.discretization.SparseBlockTopologyPlan(
+            index,
+            (2, 2),
+            16,
+            layout=index.faces(axis),
+            closure_offsets=closure,
+        )
+        for axis in index.axis_names
+    )
+    transfer = phx.discretization.SparseFLIPParticleTransferPlan(
+        index, cell, faces
+    ).prepare(particles)
+    projection = phx.solver.SparseMACFreeSurfaceProjectionPlan(
+        transfer, tolerance=1.0e-7, maximum_iterations=100
+    )
+    problem = phx.equations.FLIPProblemIR("sparse-flip-step", 1.0, jnp.zeros((2,)))
+    compiled = phx.equations.compile_sparse_flip_problem(
+        problem,
+        transfer,
+        projection,
+        phx.discretization.FLIPMethodPlan(
+            1.0,
+            liquid_fraction_threshold=0.01,
+            cfl_fraction=1.0,
+        ),
+    )
+    state = compiled.initialize_state(
+        position, jnp.broadcast_to(jnp.asarray((0.01, 0.0)), position.shape)
+    )
+    result = compiled.step_detailed(state, 0.001)
+
+    assert bool(result.successful)
+    assert bool(result.projection.topology_complete)
+    assert result.diagnostics.divergence_norm < 1.0e-8
+    assert int(result.accepted_state.accepted_step) == 1

--- a/tests/unit/discretization/test_lattice_boltzmann_sparse.py
+++ b/tests/unit/discretization/test_lattice_boltzmann_sparse.py
@@ -1,0 +1,64 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+
+import phydrax as phx
+
+
+def _index_space():
+    plan = phx.discretization.TensorGridPlan(
+        (
+            phx.discretization.UniformCellAxisSpec(4, periodic=True),
+            phx.discretization.UniformCellAxisSpec(4, periodic=True),
+        ),
+        axis_names=("x", "y"),
+    )
+    return plan.prepare_index_space(jnp.asarray([[0.0, 0.0], [1.0, 1.0]]))
+
+
+def test_periodic_sparse_lbm_conserves_mass_and_is_jit_safe():
+    prepared = phx.discretization.SparseLatticeBoltzmannPlan(
+        _index_space(),
+        phx.discretization.D2Q9(),
+        (2, 2),
+        4,
+    ).prepare(jnp.arange(16))
+    state = prepared.initialize_state(1.0, jnp.asarray((0.03, 0.0)))
+    result = jax.jit(lambda value: prepared.step(value, 1.0))(state)
+
+    assert bool(result.successful)
+    assert result.accepted_state.populations.shape == (16, 9)
+    assert jnp.isclose(result.diagnostics.total_mass, 16.0)
+    assert jnp.abs(result.diagnostics.mass_defect) < 1.0e-12
+    assert jnp.max(jnp.abs(result.velocity - jnp.asarray((0.03, 0.0)))) < 1.0e-12
+
+
+def test_sparse_lbm_wall_streaming_and_geometry_transition_are_conservative():
+    plan = phx.discretization.SparseLatticeBoltzmannPlan(
+        _index_space(),
+        phx.discretization.D2Q9(),
+        (2, 2),
+        3,
+        collision=phx.discretization.TRTCollisionPlan(),
+    )
+    prepared = plan.prepare(jnp.asarray([0, 1, 4, 5]))
+    state = prepared.initialize_state(1.0, jnp.asarray((0.02, 0.01)))
+    step = prepared.step(state, 1.0)
+    transition = prepared.refresh_geometry(
+        step.accepted_state,
+        jnp.asarray([1, 2, 5, 6]),
+        activated_density=2.0,
+    )
+
+    assert bool(step.successful)
+    assert jnp.abs(step.diagnostics.mass_defect) < 1.0e-12
+    assert int(transition.evidence.retained_cells) == 2
+    assert int(transition.evidence.activated_cells) == 2
+    assert int(transition.evidence.retired_cells) == 2
+    assert jnp.isclose(transition.evidence.activated_mass, 4.0)
+    assert int(transition.state.topology.generation) == 1

--- a/tests/unit/discretization/test_mpm_active_integration.py
+++ b/tests/unit/discretization/test_mpm_active_integration.py
@@ -9,23 +9,31 @@ import jax.numpy as jnp
 import phydrax as phx
 
 
-def test_active_block_mask_is_transactional_in_explicit_mpm():
-    grid = phx.discretization.TensorGridPlan(
+def test_sparse_block_topology_is_transactional_in_explicit_mpm():
+    grid_plan = phx.discretization.TensorGridPlan(
         tuple(
             phx.discretization.UniformAxisSpec(16, periodic=True, endpoint=False)
             for _ in range(2)
         ),
         axis_names=("x", "y"),
-    ).prepare(jnp.asarray([[0.0, 0.0], [1.0, 1.0]]))
+    )
+    bounds = jnp.asarray([[0.0, 0.0], [1.0, 1.0]])
+    index_space = grid_plan.prepare_index_space(bounds)
     position = jnp.asarray([[0.2, 0.2], [0.25, 0.22]])
     volume = jnp.full((2,), 0.01)
     particles = phx.discretization.ParticleSetPlan(
         jnp.arange(2), volume, ambient_dimension=2
     ).prepare()
     splat = phx.discretization.ParticleGridSplatPlan(
-        grid, assignment=phx.discretization.TensorBSplineSplatAssignment(2)
+        index_space, assignment=phx.discretization.TensorBSplineSplatAssignment(2)
     ).prepare(particles)
-    blocks = phx.discretization.MPMActiveBlockPlan((16, 16), (4, 4), 12, halo_blocks=1)
+    topology = phx.discretization.SparseBlockTopologyPlan(
+        index_space,
+        (4, 4),
+        12,
+        layout=index_space.vertices(),
+    )
+    storage = phx.discretization.BlockSparseMPMNodalStoragePlan(topology)
     compiled = phx.equations.compile_material_point_problem(
         phx.equations.MaterialPointProblemIR(
             "active-block-integration",
@@ -35,11 +43,11 @@ def test_active_block_mask_is_transactional_in_explicit_mpm():
         splat,
         phx.discretization.ExplicitMPMMethodPlan(),
         phx.discretization.MPMParticleDomainPlan(
-            jnp.asarray([[0.0, 0.0], [1.0, 1.0]]),
+            bounds,
             periodic=(True, True),
             support_margin=0.0,
         ),
-        active_blocks=blocks,
+        nodal_storage=storage,
     )
     arguments = phx.equations.MaterialPointArguments(
         phx.applications.solid_mechanics.NeoHookeanParameters.from_shear_bulk(2.0, 8.0)
@@ -53,9 +61,11 @@ def test_active_block_mask_is_transactional_in_explicit_mpm():
     detail = compiled.dynamics.step_detailed(state, 0.001, arguments)
 
     assert bool(detail.successful)
+    assert dict(splat.preparation.resource_counts)["scalar_workspace_bytes"] == 0
     assert state.storage_state is not None
     assert detail.accepted_state.storage_state is not None
-    assert int(detail.accepted_state.storage_state.active_block_count) <= 12
+    assert int(detail.accepted_state.storage_state.evidence.required_blocks) <= 12
     assert jnp.all(
-        detail.grid.active[0] <= detail.accepted_state.storage_state.active_node_mask
+        detail.grid.active[0]
+        <= detail.accepted_state.storage_state.node_valid.reshape((-1,))
     )

--- a/tests/unit/discretization/test_mpm_multifield.py
+++ b/tests/unit/discretization/test_mpm_multifield.py
@@ -11,14 +11,17 @@ import numpy as np
 import phydrax as phx
 
 
-def _compiled(field_plan=None):
-    grid = phx.discretization.TensorGridPlan(
+def _compiled(field_plan=None, *, compact=False):
+    grid_plan = phx.discretization.TensorGridPlan(
         tuple(
             phx.discretization.UniformAxisSpec(16, periodic=True, endpoint=False)
             for _ in range(2)
         ),
         axis_names=("x", "y"),
-    ).prepare(jnp.asarray([[0.0, 0.0], [1.0, 1.0]]))
+    )
+    bounds = jnp.asarray([[0.0, 0.0], [1.0, 1.0]])
+    grid = grid_plan.prepare(bounds)
+    index = grid_plan.prepare_index_space(bounds)
     position = jnp.asarray([[0.40, 0.47], [0.43, 0.53], [0.57, 0.47], [0.60, 0.53]])
     volume = jnp.full((4,), 0.01)
     particles = phx.discretization.ParticleSetPlan(
@@ -27,6 +30,15 @@ def _compiled(field_plan=None):
     splat = phx.discretization.ParticleGridSplatPlan(
         grid, assignment=phx.discretization.TensorBSplineSplatAssignment(2)
     ).prepare(particles)
+    storage = (
+        phx.discretization.BlockSparseMPMNodalStoragePlan(
+            phx.discretization.SparseBlockTopologyPlan(
+                index, (4, 4), 12, layout=index.vertices()
+            )
+        )
+        if compact
+        else None
+    )
     compiled = phx.equations.compile_material_point_problem(
         phx.equations.MaterialPointProblemIR(
             "multifield",
@@ -36,11 +48,12 @@ def _compiled(field_plan=None):
         splat,
         phx.discretization.ExplicitMPMMethodPlan(),
         phx.discretization.MPMParticleDomainPlan(
-            jnp.asarray([[0.0, 0.0], [1.0, 1.0]]),
+            bounds,
             periodic=(True, True),
             support_margin=0.0,
         ),
         nodal_fields=field_plan,
+        nodal_storage=storage,
     )
     arguments = phx.equations.MaterialPointArguments(
         phx.applications.solid_mechanics.NeoHookeanParameters.from_shear_bulk(2.0, 8.0)
@@ -100,6 +113,38 @@ def test_two_field_contact_preserves_action_reaction_and_separate_grid_fields():
     assert detail.diagnostics.transfer.field_action_reaction_defect < 1e-12
     assert detail.diagnostics.energy.contact_dissipation >= 0.0
     np.testing.assert_array_equal(detail.accepted_state.velocity_field_slots, slots)
+
+
+def test_compact_two_field_mpm_preserves_contact_and_storage_capacity():
+    slots = jnp.asarray((0, 0, 1, 1), dtype=jnp.int32)
+    fields = phx.discretization.MPMNodalFieldPlan(
+        ("left", "right"),
+        slots,
+        contact_plan=phx.discretization.KWayMPMContactPlan(
+            2,
+            friction=phx.discretization.SharpCoulombMPMFrictionPlan(0.2),
+            maximum_steps=40,
+            tolerance=1.0e-8,
+        ),
+    )
+    compiled, arguments, position, volume = _compiled(fields, compact=True)
+    velocity = jnp.asarray([[0.12, 0.02], [0.12, 0.02], [-0.12, -0.01], [-0.12, -0.01]])
+    state = compiled.initialize_state(
+        position,
+        velocity,
+        volume,
+        arguments,
+        velocity_field_slots=slots,
+        body_ids=slots,
+    )
+    result = compiled.dynamics.step_detailed(state, 0.001, arguments)
+
+    assert bool(result.successful)
+    assert result.grid.mass.shape == (
+        2,
+        compiled.dynamics.nodal_storage.storage_capacity,
+    )
+    assert result.diagnostics.transfer.field_action_reaction_defect < 1.0e-12
 
 
 def test_direct_two_field_projection_stops_approach_and_obeys_friction_cone():

--- a/tests/unit/discretization/test_mpm_sparse_storage.py
+++ b/tests/unit/discretization/test_mpm_sparse_storage.py
@@ -11,70 +11,83 @@ import phydrax as phx
 
 
 def _routes(position):
-    grid = phx.discretization.TensorGridPlan(
+    grid_plan = phx.discretization.TensorGridPlan(
         tuple(
             phx.discretization.UniformAxisSpec(16, periodic=True, endpoint=False)
             for _ in range(2)
         ),
         axis_names=("x", "y"),
-    ).prepare(jnp.asarray([[0.0, 0.0], [1.0, 1.0]]))
+    )
+    bounds = jnp.asarray([[0.0, 0.0], [1.0, 1.0]])
+    grid = grid_plan.prepare(bounds)
+    index_space = grid_plan.prepare_index_space(bounds)
     particles = phx.discretization.ParticleSetPlan(
-        jnp.arange(position.shape[0]), jnp.ones((position.shape[0],)), ambient_dimension=2
+        jnp.arange(position.shape[0]),
+        jnp.ones((position.shape[0],)),
+        ambient_dimension=2,
     ).prepare()
     splat = phx.discretization.ParticleGridSplatPlan(
         grid, assignment=phx.discretization.TensorBSplineSplatAssignment(2)
     ).prepare(particles)
-    return splat.build(position)
+    return splat.build(position), index_space
 
 
-def test_active_blocks_follow_routes_halo_and_previous_union():
-    first_routes = _routes(jnp.asarray([[0.15, 0.15], [0.2, 0.2]]))
-    second_routes = _routes(jnp.asarray([[0.75, 0.75], [0.8, 0.8]]))
-    plan = phx.discretization.MPMActiveBlockPlan((16, 16), (4, 4), 16, halo_blocks=1)
-    first = plan.build(first_routes)
-    second = plan.build(second_routes, first)
-
-    assert bool(first.successful)
-    assert bool(second.successful)
-    assert int(first.active_block_count) > 0
-    assert int(second.active_block_count) > 0
-    assert jnp.all(second.current_previous_union >= first.active_block_mask)
-    assert jnp.any(first.active_node_mask)
+def _storage(index_space, capacity):
+    topology = phx.discretization.SparseBlockTopologyPlan(
+        index_space,
+        (4, 4),
+        capacity,
+        layout=index_space.vertices(),
+    )
+    return phx.discretization.BlockSparseMPMNodalStoragePlan(topology)
 
 
-def test_compact_block_pack_unpack_and_route_mapping_match_dense_values():
-    routes = _routes(jnp.asarray([[0.15, 0.15], [0.2, 0.2]]))
-    blocks = phx.discretization.MPMActiveBlockPlan((16, 16), (4, 4), 16)
-    active = blocks.build(routes)
-    storage = phx.discretization.BlockSparseMPMNodalStoragePlan(blocks)
+def test_sparse_blocks_follow_routes_and_transition_by_logical_key():
+    first_routes, index_space = _routes(jnp.asarray([[0.15, 0.15], [0.2, 0.2]]))
+    second_routes, _ = _routes(jnp.asarray([[0.75, 0.75], [0.8, 0.8]]))
+    storage = _storage(index_space, 16)
+    first = storage.build(first_routes)
+    second = storage.build(second_routes, first)
+
+    assert bool(first.evidence.successful)
+    assert bool(second.evidence.successful)
+    assert int(first.evidence.required_blocks) > 0
+    assert int(second.evidence.required_blocks) > 0
+    assert int(second.generation) == 1
+    assert not jnp.array_equal(first.groups.group_keys, second.groups.group_keys)
+
+
+def test_compact_pack_unpack_and_route_mapping_match_supported_dense_values():
+    routes, index_space = _routes(jnp.asarray([[0.15, 0.15], [0.2, 0.2]]))
+    storage = _storage(index_space, 8)
+    topology = storage.build(routes)
     dense = jnp.arange(16 * 16 * 2, dtype=jnp.float64).reshape((16, 16, 2))
-    compact = storage.pack(dense, active)
-    restored = storage.unpack(compact, active)
-    indices, valid = storage.map_route_indices(routes, active)
+    compact = storage.pack(dense, topology)
+    restored = storage.unpack(compact, topology)
+    mapped = storage.mapped_stencil(routes, topology)
+    support = topology.materialize_support()
 
     np.testing.assert_array_equal(
-        jnp.where(active.active_node_mask[..., None], restored, 0.0),
-        jnp.where(active.active_node_mask[..., None], dense, 0.0),
+        jnp.where(support[..., None], restored, 0.0),
+        jnp.where(support[..., None], dense, 0.0),
     )
-    assert indices.shape == routes.stencil.indices.shape
-    assert jnp.all(valid == routes.stencil.valid)
-    assert compact.shape == (16, 16, 2)
+    assert mapped.indices.shape == routes.stencil.indices.shape
+    assert jnp.all(mapped.valid == routes.stencil.valid)
+    assert compact.shape == (8 * 16, 2)
 
 
-def test_active_block_overflow_rejects_before_storage_use():
-    routes = _routes(jnp.asarray([[0.1, 0.1], [0.4, 0.4], [0.7, 0.7], [0.9, 0.9]]))
-    plan = phx.discretization.MPMActiveBlockPlan((16, 16), (4, 4), 1, halo_blocks=0)
-    active = plan.build(routes)
+def test_sparse_block_overflow_rejects_before_storage_use():
+    routes, index_space = _routes(
+        jnp.asarray([[0.1, 0.1], [0.4, 0.4], [0.7, 0.7], [0.9, 0.9]])
+    )
+    topology = _storage(index_space, 1).build(routes)
 
-    assert bool(active.overflow)
-    assert not bool(active.successful)
+    assert bool(topology.evidence.overflow)
+    assert not bool(topology.evidence.successful)
+    assert not jnp.any(topology.node_valid)
 
 
 def test_dense_storage_adapter_is_identity_for_field_payloads():
-    routes = _routes(jnp.asarray([[0.2, 0.2]]))
-    active = phx.discretization.MPMActiveBlockPlan((16, 16), (4, 4), 16).build(routes)
     dense = jnp.ones((16, 16, 2, 3))
     storage = phx.discretization.DenseMPMNodalStoragePlan((16, 16))
-    np.testing.assert_array_equal(
-        storage.unpack(storage.pack(dense, active), active), dense
-    )
+    np.testing.assert_array_equal(storage.unpack(storage.pack(dense, None), None), dense)

--- a/tests/unit/discretization/test_particle_cell_list.py
+++ b/tests/unit/discretization/test_particle_cell_list.py
@@ -30,7 +30,7 @@ def _stable_pairs(state):
     return set(zip(left.tolist(), right.tolist(), strict=True))
 
 
-def test_cell_list_prepares_static_cell_and_neighbor_resources():
+def test_cell_list_prepares_sparse_occupied_cell_resources():
     particles = _particles(range(6))
     box = phx.discretization.ParticleBox([0.0], [1.0])
     prepared = phx.discretization.CellListParticleNeighborhoodPlan(
@@ -48,6 +48,9 @@ def test_cell_list_prepares_static_cell_and_neighbor_resources():
     assert prepared.pair_capacity == 12
     assert prepared.backend == "cell_edge_list"
     assert prepared.resource_evidence_id == prepared.preparation.report_id
+    resources = dict(prepared.preparation.resource_counts)
+    assert resources["dense_cell_slots"] == 0
+    assert resources["occupied_cell_capacity"] == 3
 
     one_cell = phx.discretization.CellListParticleNeighborhoodPlan(
         2.0,
@@ -56,8 +59,8 @@ def test_cell_list_prepares_static_cell_and_neighbor_resources():
         box,
     ).prepare(particles)
     assert one_cell.cell_shape == (1,)
-    assert one_cell.neighbor_cell_capacity == 1
-    assert int(jnp.sum(one_cell.neighbor_cells.valid)) == 1
+    assert one_cell.neighbor_cell_capacity == 3
+    assert dict(one_cell.preparation.resource_counts)["dense_cell_slots"] == 0
 
 
 def test_cell_list_sorting_preserves_logical_identity_and_matches_brute_pairs():

--- a/tests/unit/rendering/test_point_rendering.py
+++ b/tests/unit/rendering/test_point_rendering.py
@@ -12,6 +12,7 @@ import pytest
 from phydrax.imaging import ImagePlaneSupport
 from phydrax.rendering import (
     apply_photometry,
+    GaussianRasterExecutionPlan,
     GaussianRasterizer,
     PhotometricResponse,
     RASTER_CLIPPED,
@@ -71,6 +72,35 @@ def test_fixed_topology_gaussian_raster_has_finite_coordinate_derivative():
     derivative = jax.grad(image_column_moment)(jnp.asarray(8.25))
     assert jnp.isfinite(derivative)
     assert derivative > 0.0
+
+
+def test_tiled_gaussian_raster_matches_reference_and_reports_route_capacity():
+    geometry = ImagePlaneSupport((21, 25))
+    coordinates = jnp.asarray([[10.25, 12.5], [4.0, 6.0]])
+    amplitude = jnp.asarray([7.0, 3.0])
+    sigma = jnp.asarray([1.1, 0.8])
+    reference = GaussianRasterizer(
+        6,
+        cutoff=3.0,
+        execution=GaussianRasterExecutionPlan("reference"),
+    ).render(geometry, coordinates, amplitude, sigma)
+    tiled = GaussianRasterizer(
+        6,
+        cutoff=3.0,
+        execution=GaussianRasterExecutionPlan(
+            "tiled",
+            tile_shape=(8, 8),
+            accumulation="deterministic",
+        ),
+    ).render(geometry, coordinates, amplitude, sigma)
+
+    assert jnp.array_equal(tiled.image, reference.image)
+    assert jnp.array_equal(
+        tiled.evidence.deposited_flux, reference.evidence.deposited_flux
+    )
+    assert tiled.evidence.route_count == reference.evidence.route_count
+    assert not bool(tiled.evidence.route_overflow)
+    assert bool(tiled.successful)
 
 
 def test_photometry_separates_noiseless_response_noise_and_sensor_mask():

--- a/tests/unit/solver/test_mpm_commercial_implicit.py
+++ b/tests/unit/solver/test_mpm_commercial_implicit.py
@@ -10,13 +10,16 @@ import phydrax as phx
 
 
 def _splat():
-    grid = phx.discretization.TensorGridPlan(
+    grid_plan = phx.discretization.TensorGridPlan(
         tuple(
             phx.discretization.UniformAxisSpec(8, periodic=True, endpoint=False)
             for _ in range(2)
         ),
         axis_names=("x", "y"),
-    ).prepare(jnp.asarray([[0.0, 0.0], [1.0, 1.0]]))
+    )
+    bounds = jnp.asarray([[0.0, 0.0], [1.0, 1.0]])
+    grid = grid_plan.prepare(bounds)
+    index_space = grid_plan.prepare_index_space(bounds)
     position = jnp.asarray([[0.27, 0.31], [0.43, 0.38]])
     particles = phx.discretization.ParticleSetPlan(
         jnp.arange(2), jnp.ones((2,)), ambient_dimension=2
@@ -24,11 +27,11 @@ def _splat():
     prepared = phx.discretization.ParticleGridSplatPlan(
         grid, assignment=phx.discretization.TensorBSplineSplatAssignment(2)
     ).prepare(particles)
-    return prepared, position
+    return prepared, position, index_space
 
 
 def test_route_superset_jvp_vjp_and_topology_guard():
-    prepared, position = _splat()
+    prepared, position, _ = _splat()
     deformation = jnp.broadcast_to(jnp.eye(2), (2, 2, 2))
     plan = phx.solver.MPMRouteSupersetPlan(prepared, minimum_margin=1e-10)
     state = plan.build(position)
@@ -55,12 +58,16 @@ def test_route_superset_jvp_vjp_and_topology_guard():
 
 
 def test_compact_residual_jvp_transpose_match_dense_operator():
-    prepared, position = _splat()
+    prepared, position, index_space = _splat()
     routes = prepared.build(position)
-    blocks = phx.discretization.MPMActiveBlockPlan((8, 8), (4, 4), 4).build(routes)
-    storage = phx.discretization.BlockSparseMPMNodalStoragePlan(
-        phx.discretization.MPMActiveBlockPlan((8, 8), (4, 4), 4)
+    topology_plan = phx.discretization.SparseBlockTopologyPlan(
+        index_space,
+        (4, 4),
+        4,
+        layout=index_space.vertices(),
     )
+    storage = phx.discretization.BlockSparseMPMNodalStoragePlan(topology_plan)
+    blocks = storage.build(routes)
     operator = phx.solver.MPMCompactImplicitOperator(storage, blocks)
     dense = jnp.arange(8 * 8.0).reshape((8, 8))
     compact = storage.pack(dense, blocks)
@@ -120,3 +127,54 @@ def test_implicit_unknown_layout_and_contact_generalized_actions():
     assert bool(linearized.successful)
     assert jnp.all(jnp.isfinite(linearized.jvp))
     assert jnp.all(jnp.isfinite(linearized.transpose))
+
+
+def test_compact_implicit_mpm_solves_on_storage_node_unknowns():
+    grid_plan = phx.discretization.TensorGridPlan(
+        tuple(
+            phx.discretization.UniformAxisSpec(8, periodic=True, endpoint=False)
+            for _ in range(2)
+        ),
+        axis_names=("x", "y"),
+    )
+    bounds = jnp.asarray([[0.0, 0.0], [1.0, 1.0]])
+    grid = grid_plan.prepare(bounds)
+    index = grid_plan.prepare_index_space(bounds)
+    position = jnp.asarray([[0.27, 0.31], [0.43, 0.38]])
+    volume = jnp.full((2,), 0.01)
+    particles = phx.discretization.ParticleSetPlan(
+        jnp.arange(2), volume, ambient_dimension=2
+    ).prepare()
+    splat = phx.discretization.ParticleGridSplatPlan(
+        grid, assignment=phx.discretization.TensorBSplineSplatAssignment(2)
+    ).prepare(particles)
+    topology = phx.discretization.SparseBlockTopologyPlan(
+        index, (4, 4), 4, layout=index.vertices()
+    )
+    storage = phx.discretization.BlockSparseMPMNodalStoragePlan(topology)
+    compiled = phx.equations.compile_material_point_problem(
+        phx.equations.MaterialPointProblemIR(
+            "compact-implicit-test",
+            phx.applications.solid_mechanics.NeoHookeanMPMConstitutivePlan(2),
+        ),
+        particles,
+        splat,
+        phx.discretization.ExplicitMPMMethodPlan(),
+        phx.discretization.MPMParticleDomainPlan(
+            bounds, periodic=(True, True), support_margin=0.0
+        ),
+        nodal_storage=storage,
+    )
+    arguments = phx.equations.MaterialPointArguments(
+        phx.applications.solid_mechanics.NeoHookeanParameters.from_shear_bulk(2.0, 8.0)
+    )
+    state = compiled.initialize_state(
+        position, jnp.zeros_like(position), volume, arguments
+    )
+    result = phx.solver.PreparedImplicitMPMDynamics(compiled.dynamics).step_detailed(
+        state, 1.0e-4, arguments
+    )
+
+    assert bool(result.successful)
+    assert result.grid.mass.shape == (1, storage.storage_capacity)
+    assert result.diagnostics.residual_norm < 1.0e-10

--- a/tests/unit/solver/test_mpm_fracture.py
+++ b/tests/unit/solver/test_mpm_fracture.py
@@ -10,14 +10,17 @@ import numpy as np
 import phydrax as phx
 
 
-def _fracture_case():
-    grid = phx.discretization.TensorGridPlan(
+def _fracture_case(*, compact=False):
+    grid_plan = phx.discretization.TensorGridPlan(
         tuple(
             phx.discretization.UniformAxisSpec(10, periodic=True, endpoint=False)
             for _ in range(2)
         ),
         axis_names=("x", "y"),
-    ).prepare(jnp.asarray([[0.0, 0.0], [1.0, 1.0]]))
+    )
+    bounds = jnp.asarray([[0.0, 0.0], [1.0, 1.0]])
+    grid = grid_plan.prepare(bounds)
+    index = grid_plan.prepare_index_space(bounds)
     position = jnp.asarray([[0.3, 0.3], [0.45, 0.35], [0.35, 0.5]])
     volume = jnp.full((3,), 0.01)
     particles = phx.discretization.ParticleSetPlan(
@@ -27,16 +30,32 @@ def _fracture_case():
         grid, assignment=phx.discretization.TensorBSplineSplatAssignment(2)
     ).prepare(particles)
     material = phx.applications.solid_mechanics.PhaseFieldNeoHookeanMPMConstitutivePlan(2)
+    storage = (
+        phx.discretization.BlockSparseMPMNodalStoragePlan(
+            phx.discretization.SparseBlockTopologyPlan(
+                index,
+                (5, 5),
+                4,
+                layout=index.vertices(),
+                closure_offsets=tuple(
+                    (row, column) for row in (-1, 0, 1) for column in (-1, 0, 1)
+                ),
+            )
+        )
+        if compact
+        else None
+    )
     compiled = phx.equations.compile_material_point_problem(
         phx.equations.MaterialPointProblemIR("fracture", material),
         particles,
         splat,
         phx.discretization.ExplicitMPMMethodPlan(),
         phx.discretization.MPMParticleDomainPlan(
-            jnp.asarray([[0.0, 0.0], [1.0, 1.0]]),
+            bounds,
             periodic=(True, True),
             support_margin=0.0,
         ),
+        nodal_storage=storage,
     )
     parameters = phx.applications.solid_mechanics.MPMPhaseFieldParameters(
         phx.applications.solid_mechanics.NeoHookeanParameters.from_shear_bulk(2.0, 8.0),
@@ -85,6 +104,22 @@ def test_phase_field_step_is_irreversible_and_transactional():
     assert bool(detail.evidence.irreversibility_valid)
     assert jnp.all(detail.accepted_state.damage >= state.damage)
     assert detail.evidence.fracture_energy >= 0.0
+
+
+def test_compact_phase_field_step_uses_complete_block_stencil():
+    compiled, arguments, mechanics = _fracture_case(compact=True)
+    prepared = phx.solver.PreparedMPMPhaseFieldDynamics(
+        compiled.dynamics,
+        phx.solver.MPMPhaseFieldFracturePlan(
+            maximum_damage_iterations=200, tolerance=1e-6
+        ),
+    )
+    state = prepared.initialize_state(mechanics)
+    detail = prepared.step_detailed(state, 0.001, arguments)
+
+    assert bool(detail.successful)
+    assert bool(detail.evidence.irreversibility_valid)
+    assert detail.accepted_state.mechanics.storage_state is not None
 
 
 def test_field_partition_and_cpic_are_distinct_topology_paths():

--- a/tests/unit/test_sparse_substrate.py
+++ b/tests/unit/test_sparse_substrate.py
@@ -253,7 +253,9 @@ def test_sparse_plans_reuse_global_asdex_jacobian_and_hessian_patterns():
         contract=phx.sparse.SparseHessianContract("riesz"),
         structure=phx.sparse.SparsePattern.from_coo(
             [0, 0, 1, 1, 1, 2, 2, 2, 3, 3],
-            [0, 1, 0, 1, 2, 1, 2, 3, 2, 3], (4, 4), symmetric=True,
+            [0, 1, 0, 1, 2, 1, 2, 3, 2, 3],
+            (4, 4),
+            symmetric=True,
         ),
         properties=phx.linalg.OperatorProperties(
             self_adjoint=True,
@@ -332,3 +334,51 @@ def test_sparse_diagonal_assembly_and_numeric_refresh_are_jit_safe():
     value, diagonal = jax.jit(refresh_and_solve)(coefficients)
     assert jnp.allclose(diagonal, coefficients)
     assert jnp.allclose(value, right_hand_side / coefficients)
+
+
+def test_key_groups_are_case_local_canonical_and_fail_closed():
+    plan = phx.sparse.KeyGroupPlan(
+        5,
+        3,
+        9,
+        maximum_group_size=2,
+        case_shape=(2,),
+    )
+    keys = jnp.asarray([[4, 1, 4, 2, 9], [3, 3, 8, 2, 9]])
+    valid = jnp.asarray([[True, True, True, True, False], [True] * 5])
+    stable_ids = jnp.asarray([[5, 4, 3, 2, 1], [0, 1, 2, 3, 4]])
+    state = jax.jit(plan.build)(keys, valid, stable_ids=stable_ids)
+    lookup = state.lookup(jnp.asarray([[1, 4, 7], [2, 3, 8]]))
+
+    assert jnp.array_equal(state.group_keys[0], jnp.asarray([1, 2, 4]))
+    assert jnp.array_equal(state.group_counts[0], jnp.asarray([1, 1, 2]))
+    assert bool(state.evidence.successful[0])
+    assert not bool(state.evidence.successful[1])
+    assert bool(state.evidence.group_overflow[1])
+    assert jnp.array_equal(
+        lookup.supported,
+        jnp.asarray([[True, True, False], [False, False, False]]),
+    )
+
+
+def test_prepared_relation_execution_preserves_canonical_complex_reductions():
+    relation = phx.sparse.EdgeRelation(
+        jnp.arange(5, dtype=jnp.int32),
+        jnp.asarray([2, 0, 2, 0, 1], dtype=jnp.int32),
+        source_size=5,
+        target_size=4,
+        valid=jnp.asarray([True, True, True, False, True]),
+    )
+    execution = phx.sparse.RelationExecutionPlan().prepare(relation)
+    values = jnp.asarray([1.0 + 2.0j, 3.0, -2.0j, jnp.nan, 4.0 - 1.0j])
+
+    deterministic, evidence = execution.reduce(
+        values,
+        accumulation="deterministic",
+    )
+    compensated, _ = execution.reduce(values, accumulation="compensated")
+
+    expected = jnp.asarray([3.0, 4.0 - 1.0j, 1.0, 0.0])
+    assert jnp.array_equal(deterministic, expected)
+    assert jnp.array_equal(compensated, expected)
+    assert bool(evidence.successful)

--- a/tools/material_point_advanced_benchmarks.py
+++ b/tools/material_point_advanced_benchmarks.py
@@ -149,10 +149,19 @@ def run(output: Path):
         "linear_iterations": int(result.diagnostics.linear_iterations),
     }
     routes = compiled.dynamics.splat.build(state.particles.position)
-    blocks = phx.discretization.MPMActiveBlockPlan((16, 16), (4, 4), 16)
-    first, steady = _time(lambda _: blocks.build(routes), jnp.asarray(0))
-    active = blocks.build(routes)
-    storage = phx.discretization.BlockSparseMPMNodalStoragePlan(blocks)
+    index = phx.discretization.TensorGridPlan(
+        tuple(
+            phx.discretization.UniformAxisSpec(16, periodic=True, endpoint=False)
+            for _ in range(2)
+        ),
+        axis_names=("x", "y"),
+    ).prepare_index_space(jnp.asarray([[0.0, 0.0], [1.0, 1.0]]))
+    topology = phx.discretization.SparseBlockTopologyPlan(
+        index, (4, 4), 16, layout=index.vertices()
+    )
+    storage = phx.discretization.BlockSparseMPMNodalStoragePlan(topology)
+    first, steady = _time(lambda _: storage.build(routes), jnp.asarray(0))
+    active = storage.build(routes)
     dense = jnp.ones((16, 16, 4))
     _, pack_steady = _time(lambda value: storage.pack(value, active), dense)
     compact = storage.pack(dense, active)
@@ -162,7 +171,7 @@ def run(output: Path):
         "activation_steady_ms": steady,
         "pack_steady_ms": pack_steady,
         "unpack_steady_ms": unpack_steady,
-        "active_blocks": int(active.active_block_count),
+        "active_blocks": int(active.evidence.required_blocks),
         "dense_values": int(dense.size),
         "compact_values": int(compact.size),
     }

--- a/tools/material_point_advanced_qualification.py
+++ b/tools/material_point_advanced_qualification.py
@@ -53,7 +53,7 @@ def _compile(
     assignment=None,
     schedule=None,
     nodal_fields=None,
-    active_blocks=None,
+    nodal_storage=None,
 ):
     grid_points = 10 if dimension == 2 else 6
     grid = phx.discretization.TensorGridPlan(
@@ -89,7 +89,7 @@ def _compile(
             support_margin=0.0,
         ),
         nodal_fields=nodal_fields,
-        active_blocks=active_blocks,
+        nodal_storage=nodal_storage,
     )
     arguments = phx.equations.MaterialPointArguments(parameters)
     velocity = jnp.broadcast_to(jnp.asarray((0.04, -0.015, 0.02))[:dimension], base.shape)
@@ -335,21 +335,36 @@ def _storage_metrics():
     )
     compiled, _, state = _compile(neo, parameters)
     routes = compiled.dynamics.splat.build(state.particles.position)
-    blocks = phx.discretization.MPMActiveBlockPlan((10, 10), (5, 5), 4)
-    active = blocks.build(routes)
-    storage = phx.discretization.BlockSparseMPMNodalStoragePlan(blocks)
+    index = phx.discretization.TensorGridPlan(
+        tuple(
+            phx.discretization.UniformAxisSpec(10, periodic=True, endpoint=False)
+            for _ in range(2)
+        ),
+        axis_names=("x", "y"),
+    ).prepare_index_space(jnp.asarray([[0.0, 0.0], [1.0, 1.0]]))
+    topology = phx.discretization.SparseBlockTopologyPlan(
+        index, (5, 5), 4, layout=index.vertices()
+    )
+    storage = phx.discretization.BlockSparseMPMNodalStoragePlan(topology)
+    active = storage.build(routes)
     dense = jnp.arange(10 * 10 * 2, dtype=jnp.float64).reshape((10, 10, 2))
     compact = storage.pack(dense, active)
     restored = storage.unpack(compact, active)
     parity = float(
         jnp.max(
-            jnp.abs(jnp.where(active.active_node_mask[..., None], restored - dense, 0.0))
+            jnp.abs(
+                jnp.where(
+                    active.materialize_support()[..., None],
+                    restored - dense,
+                    0.0,
+                )
+            )
         )
     )
     active_metrics = {
-        "active_blocks": int(active.active_block_count),
-        "overflow": bool(active.overflow),
-        "active_nodes": int(jnp.sum(active.active_node_mask)),
+        "active_blocks": int(active.evidence.required_blocks),
+        "overflow": bool(active.evidence.overflow),
+        "active_nodes": int(jnp.sum(active.node_valid)),
     }
     sparse_metrics = {
         "dense_sparse_parity": parity,

--- a/tools/material_point_commercial_qualification.py
+++ b/tools/material_point_commercial_qualification.py
@@ -323,9 +323,18 @@ def _implicit_sparse_moving():
         "topology_stable": bool(moving.route_topology_stable),
         "jvp_norm": float(jnp.linalg.norm(moving.weight_jvp)),
     }
-    blocks_plan = phx.discretization.MPMActiveBlockPlan((10, 10), (5, 5), 4)
-    blocks = blocks_plan.build(routes)
-    storage = phx.discretization.BlockSparseMPMNodalStoragePlan(blocks_plan)
+    index = phx.discretization.TensorGridPlan(
+        tuple(
+            phx.discretization.UniformAxisSpec(10, periodic=True, endpoint=False)
+            for _ in range(2)
+        ),
+        axis_names=("x", "y"),
+    ).prepare_index_space(jnp.asarray([[0.0, 0.0], [1.0, 1.0]]))
+    topology = phx.discretization.SparseBlockTopologyPlan(
+        index, (5, 5), 4, layout=index.vertices()
+    )
+    storage = phx.discretization.BlockSparseMPMNodalStoragePlan(topology)
+    blocks = storage.build(routes)
     compact_operator = phx.solver.MPMCompactImplicitOperator(storage, blocks)
     dense = jnp.arange(100.0).reshape((10, 10))
     compact = storage.pack(dense, blocks)

--- a/tools/sparse_execution_benchmarks.py
+++ b/tools/sparse_execution_benchmarks.py
@@ -1,0 +1,335 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from time import perf_counter
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+import phydrax as phx
+
+
+def _ready(value):
+    return jax.block_until_ready(value)
+
+
+def _time(function, *arguments, repeats=3):
+    compiled = jax.jit(function)
+    started = perf_counter()
+    value = _ready(compiled(*arguments))
+    first = (perf_counter() - started) * 1.0e3
+    timings = []
+    for _ in range(repeats):
+        started = perf_counter()
+        value = _ready(compiled(*arguments))
+        timings.append((perf_counter() - started) * 1.0e3)
+    return value, first, float(np.median(timings))
+
+
+def _array_bytes(value):
+    return int(
+        sum(
+            leaf.size * leaf.dtype.itemsize
+            for leaf in jax.tree_util.tree_leaves(value)
+            if isinstance(leaf, jax.Array)
+        )
+    )
+
+
+def _group_case():
+    count = 4096
+    keys = (jnp.arange(count, dtype=jnp.int32) * 17) % 512
+    plan = phx.sparse.KeyGroupPlan(
+        count,
+        512,
+        511,
+        maximum_group_size=8,
+    )
+    state, first, steady = _time(
+        lambda value: plan.build(value, jnp.ones(value.shape, dtype=bool)), keys
+    )
+    return {
+        "items": count,
+        "logical_keys": 512,
+        "active_groups": int(state.evidence.required_groups),
+        "state_bytes": _array_bytes(state),
+        "compile_and_first_ms": first,
+        "steady_ms": steady,
+        "successful": bool(state.evidence.successful),
+    }
+
+
+def _relation_case():
+    count = 4096
+    target_count = 512
+    targets = (jnp.arange(count, dtype=jnp.int32) * 29) % target_count
+    relation = phx.sparse.EdgeRelation(
+        jnp.arange(count, dtype=jnp.int32),
+        targets,
+        source_size=count,
+        target_size=target_count,
+    )
+    execution = phx.sparse.RelationExecutionPlan().prepare(relation)
+    values = jnp.sin(jnp.arange(count, dtype=jnp.float64))
+    fast, fast_first, fast_steady = _time(
+        lambda payload: execution.reduce(payload, accumulation="fast")[0], values
+    )
+    deterministic, deterministic_first, deterministic_steady = _time(
+        lambda payload: execution.reduce(payload, accumulation="deterministic")[0],
+        values,
+    )
+    return {
+        "routes": count,
+        "targets": target_count,
+        "maximum_contention": int(execution.groups.evidence.maximum_group_size),
+        "fast_compile_and_first_ms": fast_first,
+        "fast_steady_ms": fast_steady,
+        "deterministic_compile_and_first_ms": deterministic_first,
+        "deterministic_steady_ms": deterministic_steady,
+        "fast_deterministic_defect": float(jnp.max(jnp.abs(fast - deterministic))),
+    }
+
+
+def _raster_case():
+    image = phx.imaging.ImagePlaneSupport((128, 128))
+    row, column = jnp.meshgrid(
+        jnp.linspace(8.0, 120.0, 16),
+        jnp.linspace(8.0, 120.0, 16),
+        indexing="ij",
+    )
+    coordinates = jnp.stack((row, column), axis=-1).reshape((-1, 2))
+    amplitudes = jnp.ones((coordinates.shape[0],))
+    reference = phx.rendering.GaussianRasterizer(
+        4,
+        cutoff=3.0,
+        execution=phx.rendering.GaussianRasterExecutionPlan("reference"),
+    )
+    tiled = phx.rendering.GaussianRasterizer(
+        4,
+        cutoff=3.0,
+        execution=phx.rendering.GaussianRasterExecutionPlan(
+            "tiled", tile_shape=(16, 16), accumulation="deterministic"
+        ),
+    )
+    reference_result, reference_first, reference_steady = _time(
+        lambda points: reference.render(image, points, amplitudes, 1.0), coordinates
+    )
+    tiled_result, tiled_first, tiled_steady = _time(
+        lambda points: tiled.render(image, points, amplitudes, 1.0), coordinates
+    )
+    return {
+        "particles": int(coordinates.shape[0]),
+        "image_pixels": int(np.prod(image.image_shape)),
+        "routes": int(tiled_result.evidence.route_count),
+        "reference_compile_and_first_ms": reference_first,
+        "reference_steady_ms": reference_steady,
+        "tiled_compile_and_first_ms": tiled_first,
+        "tiled_steady_ms": tiled_steady,
+        "image_defect": float(
+            jnp.max(jnp.abs(reference_result.image - tiled_result.image))
+        ),
+        "successful": bool(reference_result.successful & tiled_result.successful),
+    }
+
+
+def _periodic_index(count):
+    plan = phx.discretization.TensorGridPlan(
+        (
+            phx.discretization.UniformCellAxisSpec(count, periodic=True),
+            phx.discretization.UniformCellAxisSpec(count, periodic=True),
+        ),
+        axis_names=("x", "y"),
+    )
+    return plan.prepare_index_space(jnp.asarray([[0.0, 0.0], [1.0, 1.0]]))
+
+
+def _lbm_case():
+    count = 32
+    index = _periodic_index(count)
+    rows, columns = np.meshgrid(np.arange(8, 24), np.arange(8, 24), indexing="ij")
+    fluid = (rows * count + columns).reshape((-1,))
+    prepared = phx.discretization.SparseLatticeBoltzmannPlan(
+        index,
+        phx.discretization.D2Q9(),
+        (4, 4),
+        16,
+    ).prepare(fluid)
+    state = prepared.initialize_state(1.0, jnp.asarray((0.01, 0.0)))
+    result, first, steady = _time(lambda value: prepared.step(value, 1.0), state)
+    return {
+        "logical_cells": count * count,
+        "fluid_cells": int(fluid.size),
+        "storage_cells": prepared.storage_capacity,
+        "state_bytes": _array_bytes(state),
+        "compile_and_first_ms": first,
+        "steady_ms": steady,
+        "mass_defect": float(jnp.abs(result.diagnostics.mass_defect)),
+        "successful": bool(result.successful),
+    }
+
+
+def _mpm_case():
+    count = 32
+    grid_plan = phx.discretization.TensorGridPlan(
+        (
+            phx.discretization.UniformAxisSpec(count, periodic=True, endpoint=False),
+            phx.discretization.UniformAxisSpec(count, periodic=True, endpoint=False),
+        ),
+        axis_names=("x", "y"),
+    )
+    bounds = jnp.asarray([[0.0, 0.0], [1.0, 1.0]])
+    index = grid_plan.prepare_index_space(bounds)
+    row, column = jnp.meshgrid(
+        jnp.linspace(0.2, 0.3, 4),
+        jnp.linspace(0.2, 0.3, 4),
+        indexing="ij",
+    )
+    position = jnp.stack((row, column), axis=-1).reshape((-1, 2))
+    volume = jnp.full((position.shape[0],), 0.001)
+    particles = phx.discretization.ParticleSetPlan(
+        jnp.arange(position.shape[0]), volume, ambient_dimension=2
+    ).prepare()
+    splat = phx.discretization.ParticleGridSplatPlan(
+        index,
+        assignment=phx.discretization.TensorBSplineSplatAssignment(2),
+    ).prepare(particles)
+    topology = phx.discretization.SparseBlockTopologyPlan(
+        index, (4, 4), 16, layout=index.vertices()
+    )
+    storage = phx.discretization.BlockSparseMPMNodalStoragePlan(topology)
+    compiled = phx.equations.compile_material_point_problem(
+        phx.equations.MaterialPointProblemIR(
+            "sparse-execution-benchmark",
+            phx.applications.solid_mechanics.NeoHookeanMPMConstitutivePlan(2),
+        ),
+        particles,
+        splat,
+        phx.discretization.ExplicitMPMMethodPlan(),
+        phx.discretization.MPMParticleDomainPlan(
+            bounds, periodic=(True, True), support_margin=0.0
+        ),
+        nodal_storage=storage,
+    )
+    arguments = phx.equations.MaterialPointArguments(
+        phx.applications.solid_mechanics.NeoHookeanParameters.from_shear_bulk(2.0, 8.0)
+    )
+    state = compiled.initialize_state(
+        position, jnp.zeros_like(position), volume, arguments
+    )
+    result, first, steady = _time(
+        lambda value: compiled.dynamics.step_detailed(value, 1.0e-4, arguments),
+        state,
+    )
+    return {
+        "logical_nodes": count * count,
+        "storage_nodes": storage.storage_capacity,
+        "active_blocks": int(state.storage_state.evidence.required_blocks),
+        "state_bytes": _array_bytes(state),
+        "compile_and_first_ms": first,
+        "steady_ms": steady,
+        "successful": bool(result.successful),
+    }
+
+
+def _flip_case():
+    count = 32
+    index = _periodic_index(count)
+    row, column = jnp.meshgrid(
+        jnp.linspace(0.2, 0.3, 4),
+        jnp.linspace(0.2, 0.3, 4),
+        indexing="ij",
+    )
+    position = jnp.stack((row, column), axis=-1).reshape((-1, 2))
+    particles = phx.discretization.ParticleSetPlan(
+        jnp.arange(position.shape[0]),
+        jnp.ones((position.shape[0],)),
+        ambient_dimension=2,
+    ).prepare()
+    closure = tuple(
+        (row_offset, column_offset)
+        for row_offset in (-1, 0, 1)
+        for column_offset in (-1, 0, 1)
+    )
+    cell = phx.discretization.SparseBlockTopologyPlan(
+        index,
+        (4, 4),
+        16,
+        layout=index.cells(),
+        closure_offsets=closure,
+    )
+    faces = tuple(
+        phx.discretization.SparseBlockTopologyPlan(
+            index,
+            (4, 4),
+            16,
+            layout=index.faces(axis),
+            closure_offsets=closure,
+        )
+        for axis in index.axis_names
+    )
+    transfer = phx.discretization.SparseFLIPParticleTransferPlan(
+        index, cell, faces
+    ).prepare(particles)
+    projection = phx.solver.SparseMACFreeSurfaceProjectionPlan(
+        transfer, tolerance=1.0e-7, maximum_iterations=100
+    )
+    compiled = phx.equations.compile_sparse_flip_problem(
+        phx.equations.FLIPProblemIR("sparse-execution-benchmark", 1.0, jnp.zeros((2,))),
+        transfer,
+        projection,
+        phx.discretization.FLIPMethodPlan(
+            1.0, liquid_fraction_threshold=0.01, cfl_fraction=1.0
+        ),
+    )
+    velocity = jnp.broadcast_to(jnp.asarray((0.02, 0.0)), position.shape)
+    state = compiled.initialize_state(position, velocity)
+    result, first, steady = _time(
+        lambda value: compiled.step_detailed(value, 1.0e-4), state
+    )
+    return {
+        "logical_cells": count * count,
+        "cell_storage": cell.storage_capacity,
+        "face_storage": [value.storage_capacity for value in faces],
+        "compile_and_first_ms": first,
+        "steady_ms": steady,
+        "mass_defect": float(jnp.abs(result.diagnostics.mass_balance_defect)),
+        "projection_residual": float(result.diagnostics.projection_residual),
+        "successful": bool(result.successful),
+    }
+
+
+def run(output: Path):
+    cases = {
+        "key_groups": _group_case(),
+        "relation_execution": _relation_case(),
+        "gaussian_raster": _raster_case(),
+        "sparse_lbm": _lbm_case(),
+        "sparse_mpm": _mpm_case(),
+        "sparse_flip": _flip_case(),
+    }
+    passed = all(case.get("successful", True) for case in cases.values()) and all(
+        np.isfinite(value)
+        for case in cases.values()
+        for key, value in case.items()
+        if key.endswith("_ms") or key.endswith("_defect")
+    )
+    payload = {
+        "device": str(jax.devices()[0]),
+        "cases": cases,
+        "passed": bool(passed),
+    }
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(payload, indent=2) + "\n")
+    print(json.dumps(payload, indent=2))
+    if not passed:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    run(Path("benchmarks/sparse_execution.json"))


### PR DESCRIPTION
## Summary

- add fixed-capacity active-key grouping with reversible placement, fail-closed capacity evidence, lookup, and topology transitions
- add prepared relation execution for compact or dense target reductions with fast, deterministic, compensated, mean, minimum, and maximum policies
- add virtual tensor index spaces and sparse block topologies that separate logical structured addressing from materialized field storage
- migrate particle neighborhoods, sparse voxels, AMR metadata, particle-grid splats, marker transfers, and element assembly onto the shared execution substrates
- add tile-major Gaussian rasterization with explicit route capacity while retaining the reference realization as the default
- add compact static lattice-Boltzmann collide/stream execution with explicit fluid IDs, periodic pull streaming, halfway wall ownership, collision-family reuse, and conservative topology refresh
- add operational compact MPM storage across explicit schedules, multiple nodal fields, contact, prescribed boundaries, implicit solves, and phase-field neighbor closure
- add compact FLIP cell/face transfer, sparse atmospheric pressure projection, pressure remapping, midpoint advection, and transactional state commit
- add block-local stencil execution over footprint-qualified AMR halo workspaces

## Core contracts

`KeyGroupPlan` is the common bounded worklist authority. It sorts explicitly by key and stable ID, records group/member overflow independently, exposes reversible permutations, and disables lookup when a candidate is incomplete.

`RelationExecutionPlan` composes those groups with existing `EdgeRelation` and `RowRelation` values. Numeric payloads remain ordinary JAX arrays; route topology remains discrete, and deterministic/compensated policies retain canonical route ordering.

`TensorGridPlan.prepare_index_space` materializes only one-dimensional axes and factorized point/interval metadata. `SparseBlockTopologyPlan` then lowers logical IDs into canonical block keys and dense local slots without allocating a full logical reverse map or treating storage slots as physical identity.

## Domain integration

### Particles and sparse relations

Cell-list and multi-population search now store occupied cells rather than arrays proportional to the entire logical cell domain. Hierarchical neighborhoods reuse the same grouping authority. Pair exchange, splatting, MAC marker transfer, and element-tensor assembly use prepared target segments.

### Structured sparse fields

Sparse voxel brick lookup now composes shared active-key grouping. AMR metadata carries the same stable block lookup and validates halo widths against declared stencil footprints. `BlockLocalStencilExecutionPlan` applies qualified local programs to complete padded blocks.

### Lattice Boltzmann

`SparseLatticeBoltzmannPlan` stores compact populations on explicit fluid cells. Missing nonperiodic or nonfluid sources are owned by halfway bounce-back, periodic routes wrap explicitly, and geometry refresh aligns retained populations by logical cell ID while reporting activated and retired mass.

### Material point method

`nodal_storage` replaces the former active-mask-only interface. Block-sparse storage now lowers P2G/G2P routes to compact nodes and participates in the numerical transaction. The same representation is used by explicit single- and multi-field steps, K-way contact, implicit grid solves, and complete-support phase-field stencils. Obsolete dense active masks and the unused MPM page-table surface are removed.

### FLIP

`SparseFLIPParticleTransferPlan` prepares compact cell and staggered-face routes. `SparseMACFreeSurfaceProjectionPlan` builds compact cell/face adjacency, enforces atmospheric air pressure and periodic gauge semantics, and solves through `phydrax.linalg`. `compile_sparse_flip_problem` composes transfer, projection, G2P, midpoint advection, topology refresh, and atomic commit without a dense MAC fallback.

## Numerical and lifecycle behavior

- logical entity IDs remain canonical across storage reordering
- capacities are fixed preparation facts with no in-step allocation
- incomplete worklists, block closures, and route maps fail closed
- topology candidates commit only with their enclosing physical step
- integer keys, permutations, and support decisions are stopped-gradient state
- values, interpolation weights, constitutive responses, and fixed-topology operators retain native JAX differentiation
- dense and compact realizations remain explicit choices; no runtime heuristic silently changes representation

## API and documentation

The public exports include the new grouping, relation execution, tensor index, sparse block, sparse kinetic, compact FLIP, sparse pressure, and block-local stencil contracts. Existing high-use particle and rasterizer types retain their public entry points while selecting the new execution paths through explicit plans.

The sparse hierarchy, particle, rendering, lattice-Boltzmann, FLIP, and MPM guides document the new ownership and support boundaries. The changelog and third-party notice record the native architecture and its conceptual provenance.