### PR TITLE
Eliminate high-impact numerical bottlenecks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2112,6 +2112,12 @@
   resource accounting.
 
 ### Changed
+- Reworked performance-critical numerical paths around stable compiled entry
+  points, homogeneous vectorization, bounded BVH and local-stencil routing,
+  neighborhood-backed many-body potentials, genuinely sparse control programs,
+  batched particle and inference solves, device recurrences, direct panel and
+  Choi assembly, reusable tensor environments, and linear-memory Hawkes
+  likelihood evaluation.
 - Routed contracted coordinate derivatives through exact JVP actions, reused
   prepared primal/JVP/VJP linearizations, preserved matrix-free hydrodynamic
   and manifold solves through `phydrax.linalg`, and moved package contractions

--- a/benchmarks/advanced_solvers/control_campaign.py
+++ b/benchmarks/advanced_solvers/control_campaign.py
@@ -105,6 +105,13 @@ def run_control_horizon_campaign(
             problem,
             compilation_policy=phx.control.LinearControlCompilationPolicy("sparse"),
         )
+        sparse_prepared = phx.control.prepare_linear_quadratic_control(
+            problem,
+            compilation_policy=phx.control.LinearControlCompilationPolicy("sparse"),
+        )
+        sparse_operation = lambda: phx.control.solve_prepared_linear_quadratic_control(
+            sparse_prepared
+        )
         cold_operation = lambda: phx.control.solve_receding_horizon_mpc(
             problem,
             prediction_horizon=prediction,
@@ -120,13 +127,16 @@ def run_control_horizon_campaign(
         )
         cold, cold_timing = _measure(cold_operation, warmup, repeats)
         warm, warm_timing = _measure(warm_operation, warmup, repeats)
-        sparse_quadratic = sparse_compilation.sparse_quadratic
-        sparse_equality = sparse_compilation.sparse_equality
-        sparse_inequality = sparse_compilation.sparse_inequality
-        if (
-            sparse_quadratic is None
-            or sparse_equality is None
-            or sparse_inequality is None
+        sparse_solution, sparse_timing = _measure(sparse_operation, warmup, repeats)
+        dense_program = dense_compilation.program
+        sparse_program = sparse_compilation.program
+        sparse_quadratic = sparse_program.quadratic
+        sparse_constraints = sparse_program.constraint_matrix
+        if not isinstance(
+            sparse_quadratic, phx.linalg.AbstractSparseLinearOperator
+        ) or not isinstance(
+            sparse_constraints,
+            phx.linalg.AbstractSparseLinearOperator,
         ):
             raise RuntimeError("Sparse control compilation did not produce operators.")
         rows.append(
@@ -134,15 +144,19 @@ def run_control_horizon_campaign(
                 "horizon": horizon,
                 "prediction_horizon": prediction,
                 "dense_matrix_bytes": int(
-                    dense_compilation.qp.quadratic.nbytes
-                    + dense_compilation.qp.equality_matrix.nbytes
-                    + dense_compilation.qp.inequality_matrix.nbytes
+                    dense_program.quadratic.nbytes
+                    + dense_program.equality_matrix.nbytes
+                    + dense_program.inequality_matrix.nbytes
                 ),
                 "sparse_value_bytes": int(
-                    sparse_quadratic.coefficients.nbytes
-                    + sparse_equality.coefficients.nbytes
-                    + sparse_inequality.coefficients.nbytes
+                    sparse_quadratic.sparse_storage().values.nbytes
+                    + sparse_constraints.sparse_storage().values.nbytes
                 ),
+                "sparse": {
+                    "timing": sparse_timing,
+                    "successful": bool(sparse_solution.successful),
+                    "objective": float(sparse_solution.objective),
+                },
                 "cold": {
                     "timing": cold_timing,
                     "certificate": _certificate(problem, cold),

--- a/benchmarks/tensor_network_chain.py
+++ b/benchmarks/tensor_network_chain.py
@@ -19,6 +19,7 @@ from _runtime import (
 )
 
 import phydrax as phx
+from phydrax.tensor_network._observables import finite_correlation_matrix
 
 
 def _random_mps(key, sites: int, physical: int, bond: int):
@@ -75,6 +76,17 @@ def _case(sites: int, physical: int, bond: int, repeats: int):
     applied, apply_execution = measure_repeated(
         lambda: compiled_apply(operator, state), warmup=1, repeats=repeats
     )
+    local_operator = jnp.diag(jnp.linspace(-1.0, 1.0, physical))
+    correlation = eqx.filter_jit(finite_correlation_matrix)
+    compiled_correlation, correlation_compilation = measure_lower_and_compile(
+        lambda: correlation.lower(state, local_operator),
+        lambda lowered: lowered.compile(),
+    )
+    correlated, correlation_execution = measure_repeated(
+        lambda: compiled_correlation(state, local_operator),
+        warmup=1,
+        repeats=repeats,
+    )
 
     return {
         "sites": sites,
@@ -93,6 +105,13 @@ def _case(sites: int, physical: int, bond: int, repeats: int):
             "execution": apply_execution.to_milliseconds_dict(),
             "output_bytes": logical_array_bytes(applied),
             "discarded_weight": float(applied[1].accumulated_discarded_weight),
+        },
+        "correlation": {
+            "lowering_seconds": correlation_compilation.lowering_seconds,
+            "compilation_seconds": correlation_compilation.compilation_seconds,
+            "execution": correlation_execution.to_milliseconds_dict(),
+            "output_bytes": logical_array_bytes(correlated),
+            "finite": bool(correlated.valid),
         },
     }
 

--- a/docs/api/atomistic_advanced.md
+++ b/docs/api/atomistic_advanced.md
@@ -71,6 +71,12 @@
 
 ## Soft matter and many-body potentials
 
+Cutoff many-body terms consume the prepared particle neighborhood through an
+explicit particle `AtomisticGraphExecutionPlan`. EAM executes over directed
+edges; Stillinger--Weber and Tersoff execute over bounded per-center neighbor
+slots. `maximum_neighbors` is therefore a correctness resource: overflow
+invalidates the evaluation instead of falling back to dense all-pairs work.
+
 ::: phydrax.atomistic.ScalarWallPotential
 
 ::: phydrax.atomistic.ManifoldConstraintPlan

--- a/docs/api/control.md
+++ b/docs/api/control.md
@@ -374,11 +374,13 @@ State and control boxes compile to native `Bounds`, not synthetic polyhedral row
 terminal rows; `LinearControlBoundLayout` separately retains state/control bound
 coordinates and bound-dual provenance.
 
-`LinearControlCompilationPolicy("dense")` retains dense arrays.
-`LinearControlCompilationPolicy("sparse")` additionally emits shared-pattern
-`SparseLinearMap` representations for the stage-block Hessian and true constraint
-operators. Sparse coefficients may carry case batches while preserving one route
-pattern. Representation choice is explicit; there is no size-based switch.
+`LinearControlCompilationPolicy("dense")` owns one dense `QuadraticProgram`.
+`LinearControlCompilationPolicy("sparse")` instead owns a sparse `ConicProgram`;
+its stage-block Hessian and combined equality/inequality operator are
+shared-pattern `SparseLinearMap` values constructed directly from stage data.
+The sparse compilation does not retain a dense canonical copy. Sparse
+coefficients may carry case batches while preserving one route pattern.
+Representation choice is explicit; there is no size-based switch.
 
 ### Prepared QPs
 
@@ -475,10 +477,12 @@ chance-constraint certificates.
 
 ## Iterative LQR
 
-`solve_ilqr` accepts exactly one unbatched, unconstrained `ControlProblem`. Discrete
-dynamics use their declared transition. Differential dynamics require an explicit
-`DifferentialControlFlow`; iLQR never selects or retries an integration method. The
-initial controls have shape `(num_steps,) + control_shape`.
+`solve_ilqr` accepts unbatched or homogeneous case-shaped unconstrained
+`ControlProblem` values and always composes the same `plan_ilqr`,
+`prepare_ilqr`, and fixed-capacity prepared kernel. Discrete dynamics use their
+declared transition. Differential dynamics require an explicit
+`DifferentialControlFlow`; iLQR never selects or retries an integration method.
+Initial controls have shape `case_shape + (num_steps,) + control_shape`.
 
 The `regularization` value is the exact fixed diagonal shift in every backward pass; it
 is not increased adaptively. A non-positive-definite shifted block, failed initial

--- a/docs/api/imaging.md
+++ b/docs/api/imaging.md
@@ -42,6 +42,13 @@
         - KnifeEdgeSchlierenPlan
         - BackgroundOrientedSchlierenPlan
 
+## Bounded tomography routes
+
+`TetrahedralXRayTransformPlan` uses the shared affine-simplex map and packed
+BVH traversal. `maximum_segments_per_ray` bounds retained ray--cell routes;
+insufficient capacity fails preparation rather than dropping attenuation.
+Voxel and tetrahedral forward/transpose pairs retain matched route weights.
+
 ::: phydrax.imaging.camera
 
 ::: phydrax.spatial_sampling

--- a/docs/api/uq/predictive.md
+++ b/docs/api/uq/predictive.md
@@ -6,6 +6,10 @@ validity masks, and uncertainty-source semantics remain unchanged. Means,
 variances, standard deviations, observation-variance reductions, and quantiles
 execute in summary precision and the field retains resolved precision evidence.
 
+MC-dropout `draw_batch_size` is a real fixed working-set bound. Draw keys are
+derived from absolute draw indices before chunking, so changing the batch size
+changes memory and execution shape but not the sampled whole-function draws.
+
 ::: phydrax.uq.PredictivePrecisionPolicy
 
 ---

--- a/phydrax/_bvh.py
+++ b/phydrax/_bvh.py
@@ -4,31 +4,30 @@
 
 from __future__ import annotations
 
-import dataclasses
-
+import equinox as eqx
 import jax
 import jax.numpy as jnp
 import numpy as np
 from jaxtyping import Array, ArrayLike
 
+from ._strict import StrictModule
+from ._trainable import NonTrainableState
 
-@dataclasses.dataclass(frozen=True)
-class PackedBVH:
+
+class PackedBVH(StrictModule, NonTrainableState):
     """A packed binary AABB BVH with fixed-size leaf payloads."""
 
-    bbox_min: Array  # (nNodes, dim)
-    bbox_max: Array  # (nNodes, dim)
-    left: Array  # (nNodes,) int32, -1 for leaf
-    right: Array  # (nNodes,) int32, -1 for leaf
-    leaf_id: Array  # (nNodes,) int32, >=0 for leaf else -1
-
-    leaf_items: Array  # (nLeaves, leaf_size) int32, padded with -1
-    leaf_node: Array  # (nLeaves,) node index for each leaf id
-    leaf_bbox_min: Array  # (nLeaves, dim)
-    leaf_bbox_max: Array  # (nLeaves, dim)
-
-    leaf_size: int
-    max_depth: int
+    bbox_min: Array
+    bbox_max: Array
+    left: Array
+    right: Array
+    leaf_id: Array
+    leaf_items: Array
+    leaf_node: Array
+    leaf_bbox_min: Array
+    leaf_bbox_max: Array
+    leaf_size: int = eqx.field(static=True)
+    max_depth: int = eqx.field(static=True)
 
 
 def build_packed_bvh(
@@ -304,12 +303,196 @@ def beam_select_leaf_items(
     return safe_items, valid
 
 
+def _bounded_leaf_candidates(
+    overlaps,
+    bvh: PackedBVH,
+    maximum_candidates: int,
+    /,
+) -> tuple[Array, Array, Array]:
+    capacity = int(maximum_candidates)
+    if capacity <= 0:
+        raise ValueError("maximum_candidates must be positive.")
+    node_count = int(bvh.left.shape[0])
+    stack = jnp.full((node_count,), -1, dtype=jnp.int32).at[0].set(0)
+    candidates = jnp.full((capacity,), -1, dtype=jnp.int32)
+
+    def visit_leaf(leaf_items, state):
+        values, count = state
+
+        def append_item(slot, carry):
+            current, current_count = carry
+            item = leaf_items[slot]
+            item_valid = item >= 0
+            has_space = current_count < capacity
+            target = jnp.minimum(current_count, capacity - 1)
+            current = current.at[target].set(
+                jnp.where(item_valid & has_space, item, current[target])
+            )
+            return current, current_count + item_valid.astype(jnp.int32)
+
+        return jax.lax.fori_loop(
+            0,
+            bvh.leaf_size,
+            append_item,
+            (values, count),
+        )
+
+    def traverse(_, state):
+        current_stack, top, values, count = state
+        active = top > 0
+        popped_top = jnp.maximum(top - 1, 0)
+        node = current_stack[popped_top]
+        safe_node = jnp.maximum(node, 0)
+        hit = (
+            active
+            & (node >= 0)
+            & overlaps(
+                bvh.bbox_min[safe_node],
+                bvh.bbox_max[safe_node],
+            )
+        )
+        leaf = hit & (bvh.leaf_id[safe_node] >= 0)
+        internal = hit & ~leaf
+        leaf_index = jnp.maximum(bvh.leaf_id[safe_node], 0)
+        values, count = jax.lax.cond(
+            leaf,
+            lambda carry: visit_leaf(bvh.leaf_items[leaf_index], carry),
+            lambda carry: carry,
+            (values, count),
+        )
+        left = jnp.maximum(bvh.left[safe_node], 0)
+        right = jnp.maximum(bvh.right[safe_node], 0)
+        current_stack = current_stack.at[popped_top].set(
+            jnp.where(internal, left, current_stack[popped_top])
+        )
+        second_slot = jnp.minimum(popped_top + 1, node_count - 1)
+        current_stack = current_stack.at[second_slot].set(
+            jnp.where(internal, right, current_stack[second_slot])
+        )
+        next_top = jnp.where(internal, popped_top + 2, popped_top)
+        return current_stack, next_top, values, count
+
+    _, _, candidates, count = jax.lax.fori_loop(
+        0,
+        node_count,
+        traverse,
+        (
+            stack,
+            jnp.asarray(1, dtype=jnp.int32),
+            candidates,
+            jnp.asarray(0, dtype=jnp.int32),
+        ),
+    )
+    retained = jnp.minimum(count, capacity)
+    valid = jnp.arange(capacity, dtype=jnp.int32) < retained
+    return jnp.maximum(candidates, 0), valid, count <= capacity
+
+
+def point_select_leaf_items(
+    points: ArrayLike,
+    /,
+    *,
+    bvh: PackedBVH,
+    maximum_candidates: int,
+    tolerance: ArrayLike = 0.0,
+) -> tuple[Array, Array, Array]:
+    """Return all bounded leaf candidates whose node boxes contain each point."""
+    values = jnp.asarray(points, dtype=bvh.bbox_min.dtype)
+    single = values.ndim == 1
+    if single:
+        values = values[None, :]
+    if values.ndim != 2 or values.shape[-1] != bvh.bbox_min.shape[-1]:
+        raise ValueError("points must have shape (queries, dimension) or (dimension,).")
+    padding = jnp.asarray(tolerance, dtype=values.dtype)
+    if padding.shape != ():
+        raise ValueError("tolerance must be a scalar.")
+    if isinstance(tolerance, (int, float)) and tolerance < 0.0:
+        raise ValueError("tolerance must be non-negative.")
+
+    def query(point):
+        return _bounded_leaf_candidates(
+            lambda lower, upper: jnp.all(
+                (point >= lower - padding) & (point <= upper + padding)
+            ),
+            bvh,
+            maximum_candidates,
+        )
+
+    candidates, valid, complete = jax.vmap(query)(values)
+    if single:
+        return candidates[0], valid[0], complete[0]
+    return candidates, valid, complete
+
+
+def ray_select_leaf_items(
+    origins: ArrayLike,
+    directions: ArrayLike,
+    /,
+    *,
+    bvh: PackedBVH,
+    maximum_candidates: int,
+    minimum_parameter: ArrayLike = 0.0,
+    maximum_parameter: ArrayLike = jnp.inf,
+) -> tuple[Array, Array, Array]:
+    """Return bounded leaf candidates intersected by each ray."""
+    ray_origins = jnp.asarray(origins, dtype=bvh.bbox_min.dtype)
+    ray_directions = jnp.asarray(directions, dtype=ray_origins.dtype)
+    single = ray_origins.ndim == 1
+    if single:
+        ray_origins = ray_origins[None, :]
+        ray_directions = ray_directions[None, :]
+    if (
+        ray_origins.ndim != 2
+        or ray_origins.shape != ray_directions.shape
+        or ray_origins.shape[-1] != bvh.bbox_min.shape[-1]
+    ):
+        raise ValueError(
+            "origins and directions must share shape (rays, dimension) or (dimension,)."
+        )
+    parameter_shape = (ray_origins.shape[0],)
+    lower_parameter = jnp.broadcast_to(
+        jnp.asarray(minimum_parameter, dtype=ray_origins.dtype),
+        parameter_shape,
+    )
+    upper_parameter = jnp.broadcast_to(
+        jnp.asarray(maximum_parameter, dtype=ray_origins.dtype),
+        parameter_shape,
+    )
+
+    def query(origin, direction, parameter_lower, parameter_upper):
+        def overlaps(lower, upper):
+            parallel = jnp.abs(direction) <= jnp.finfo(direction.dtype).tiny
+            outside = parallel & ((origin < lower) | (origin > upper))
+            inverse = jnp.where(parallel, 1.0, 1.0 / direction)
+            first = (lower - origin) * inverse
+            second = (upper - origin) * inverse
+            axis_lower = jnp.where(parallel, -jnp.inf, jnp.minimum(first, second))
+            axis_upper = jnp.where(parallel, jnp.inf, jnp.maximum(first, second))
+            entry = jnp.maximum(jnp.max(axis_lower), parameter_lower)
+            exit = jnp.minimum(jnp.min(axis_upper), parameter_upper)
+            return ~jnp.any(outside) & (entry <= exit)
+
+        return _bounded_leaf_candidates(overlaps, bvh, maximum_candidates)
+
+    candidates, valid, complete = jax.vmap(query)(
+        ray_origins,
+        ray_directions,
+        lower_parameter,
+        upper_parameter,
+    )
+    if single:
+        return candidates[0], valid[0], complete[0]
+    return candidates, valid, complete
+
+
 __all__ = [
     "PackedBVH",
     "aabb_dist2",
     "beam_select_leaf_items",
     "beam_select_nodes",
     "build_packed_bvh",
-    "refit_packed_bvh_bounds",
     "build_point_bvh",
+    "point_select_leaf_items",
+    "ray_select_leaf_items",
+    "refit_packed_bvh_bounds",
 ]

--- a/phydrax/_variable_projection.py
+++ b/phydrax/_variable_projection.py
@@ -84,10 +84,7 @@ def _whiten(covariance, value):
     ):
         if value.ndim == 1:
             return covariance.whiten(value)
-        return jnp.stack(
-            [covariance.whiten(value[:, column]) for column in range(value.shape[1])],
-            axis=1,
-        )
+        return jax.vmap(covariance.whiten, in_axes=1, out_axes=1)(value)
     return None
 
 
@@ -98,26 +95,22 @@ def _precision_apply(covariance, value):
             # WᴴW action is obtained without materializing W.
             _, pullback = jax.vjp(covariance.whiten, jnp.zeros_like(value))
             return pullback(whitened)[0]
-        return jnp.stack(
-            [
-                _precision_apply(covariance, value[:, column])
-                for column in range(value.shape[1])
-            ],
-            axis=1,
-        )
+        return jax.vmap(
+            lambda column: _precision_apply(covariance, column),
+            in_axes=1,
+            out_axes=1,
+        )(value)
     if isinstance(covariance, PrecisionCovarianceAction):
         return covariance.precision @ value
     if isinstance(covariance, PrecisionOperatorCovarianceAction):
         if value.ndim == 1:
             source = covariance.precision.source.unflatten(value)
             return covariance.precision.target.flatten(covariance.precision.mv(source))
-        return jnp.stack(
-            [
-                _precision_apply(covariance, value[:, column])
-                for column in range(value.shape[1])
-            ],
-            axis=1,
-        )
+        return jax.vmap(
+            lambda column: _precision_apply(covariance, column),
+            in_axes=1,
+            out_axes=1,
+        )(value)
     if isinstance(covariance, LowRankDiagonalCovarianceAction):
         return covariance.solve(value)
     raise TypeError(

--- a/phydrax/applications/_coordinate_generation/_native.py
+++ b/phydrax/applications/_coordinate_generation/_native.py
@@ -535,6 +535,11 @@ class CoordinateProposalBatch:
     )
 
 
+@eqx.filter_jit
+def _sample_prepared_coordinate(sampler, key, context, /):
+    return sampler(key, context)
+
+
 def sample_coordinate_proposals(
     fit,
     key,
@@ -556,7 +561,7 @@ def sample_coordinate_proposals(
         max_steps=max_steps,
     )
     context = jnp.asarray(conditions, dtype=fit.support.template.positions.dtype)
-    raw, valid, status = eqx.filter_jit(sampler)(key, context)
+    raw, valid, status = _sample_prepared_coordinate(sampler, key, context)
     raw_coordinates = (
         raw.reshape((raw.shape[0], fit.model.coordinate_size))
         if isinstance(sampler.decoder, CartesianCoordinateDecoder)

--- a/phydrax/applications/astrodynamics/_gravity_field.py
+++ b/phydrax/applications/astrodynamics/_gravity_field.py
@@ -27,24 +27,36 @@ def _associated_legendre(maximum_degree: int, argument: Array, /) -> Array:
     values = jnp.zeros((maximum_degree + 1, maximum_degree + 1), dtype=argument.dtype)
     values = values.at[0, 0].set(1.0)
     root = jnp.sqrt(jnp.maximum(1.0 - argument * argument, 0.0))
-    for order in range(1, maximum_degree + 1):
-        values = values.at[order, order].set(
-            -(2 * order - 1) * root * values[order - 1, order - 1]
+
+    def diagonal(order, current):
+        return current.at[order, order].set(
+            -(2 * order - 1) * root * current[order - 1, order - 1]
         )
-    for order in range(maximum_degree):
-        values = values.at[order + 1, order].set(
-            (2 * order + 1) * argument * values[order, order]
+
+    values = jax.lax.fori_loop(1, maximum_degree + 1, diagonal, values)
+
+    def adjacent(order, current):
+        return current.at[order + 1, order].set(
+            (2 * order + 1) * argument * current[order, order]
         )
-    for order in range(maximum_degree + 1):
-        for degree in range(order + 2, maximum_degree + 1):
-            values = values.at[degree, order].set(
-                (
-                    (2 * degree - 1) * argument * values[degree - 1, order]
-                    - (degree + order - 1) * values[degree - 2, order]
-                )
-                / (degree - order)
+
+    values = jax.lax.fori_loop(0, maximum_degree, adjacent, values)
+
+    def column(order, current):
+        def recurrence(degree, table):
+            active = degree >= order + 2
+            denominator = jnp.where(active, degree - order, 1)
+            candidate = (
+                (2 * degree - 1) * argument * table[degree - 1, order]
+                - (degree + order - 1) * table[degree - 2, order]
+            ) / denominator
+            return table.at[degree, order].set(
+                jnp.where(active, candidate, table[degree, order])
             )
-    return values
+
+        return jax.lax.fori_loop(0, maximum_degree + 1, recurrence, current)
+
+    return jax.lax.fori_loop(0, maximum_degree + 1, column, values)
 
 
 class SphericalHarmonicGravityField(eqx.Module):
@@ -112,15 +124,16 @@ class SphericalHarmonicGravityField(eqx.Module):
         longitude = jnp.arctan2(position[1], position[0])
         sine_latitude = position[2] / jnp.where(radius > 0.0, radius, 1.0)
         legendre = _associated_legendre(self.maximum_degree, sine_latitude)
-        series = jnp.asarray(0.0, dtype=position.dtype)
-        for degree in range(self.maximum_degree + 1):
-            inner = jnp.asarray(0.0, dtype=position.dtype)
-            for order in range(min(degree, self.maximum_order) + 1):
-                inner = inner + legendre[degree, order] * (
-                    self.cosine[degree, order] * jnp.cos(order * longitude)
-                    + self.sine[degree, order] * jnp.sin(order * longitude)
-                )
-            series = series + (self.reference_radius / radius) ** degree * inner
+        degrees = jnp.arange(self.maximum_degree + 1)
+        orders = jnp.arange(self.maximum_degree + 1)
+        degree_grid = degrees[:, None]
+        order_grid = orders[None, :]
+        mask = (order_grid <= degree_grid) & (order_grid <= self.maximum_order)
+        angular = self.cosine * jnp.cos(order_grid * longitude) + self.sine * jnp.sin(
+            order_grid * longitude
+        )
+        inner = jnp.sum(jnp.where(mask, legendre * angular, 0.0), axis=-1)
+        series = jnp.sum((self.reference_radius / radius) ** degrees * inner)
         return -self.mu / jnp.where(radius > 0.0, radius, 1.0) * series
 
 
@@ -143,8 +156,10 @@ class SphericalHarmonicGravity(AbstractAstrodynamicsForce):
             radius > 0.0
         ) & (self.field.mu > 0.0) & (self.field.reference_radius > 0.0)
         safe_position = jnp.where(valid, position, jnp.asarray((1.0, 0.0, 0.0)))
-        potential = self.field.potential(safe_position)
-        acceleration = -jax.grad(self.field.potential)(safe_position)
+        potential, potential_gradient = jax.value_and_grad(self.field.potential)(
+            safe_position
+        )
+        acceleration = -potential_gradient
         status = jnp.where(
             valid,
             int(AstrodynamicsStatus.SUCCESS),

--- a/phydrax/applications/cardiovascular/_execution.py
+++ b/phydrax/applications/cardiovascular/_execution.py
@@ -2390,11 +2390,10 @@ def _unpack_owned_values(
     /,
 ) -> Array:
     values = jnp.asarray(owned_values)
-    result = jnp.zeros(space.shape, dtype=values.dtype)
-    for part in range(owned_ids.shape[0]):
-        valid = owned_valid[part]
-        result = result.at[owned_ids[part, valid]].set(values[part, valid])
-    return result
+    flat_valid = owned_valid.reshape((-1,))
+    indices = owned_ids.reshape((-1,))[flat_valid]
+    payload = values.reshape((-1,) + values.shape[2:])[flat_valid]
+    return jnp.zeros(space.shape, dtype=values.dtype).at[indices].set(payload)
 
 
 def _validate_distributed_restart(

--- a/phydrax/applications/cardiovascular/electrophysiology/_monodomain.py
+++ b/phydrax/applications/cardiovascular/electrophysiology/_monodomain.py
@@ -910,20 +910,42 @@ def run_monodomain_steps(
 
     if isinstance(step_count, bool) or not isinstance(step_count, int) or step_count < 0:
         raise ValueError("step_count must be a nonnegative integer.")
-    current = state
-    accepted = 0
-    successful = True
-    for _ in range(step_count):
-        candidate = runtime.evaluate(current)
-        if not bool(np.asarray(candidate.evidence.successful)):
-            successful = False
-            break
-        current = runtime.commit(candidate, current)
-        accepted += 1
+
+    def advance(_, carry):
+        current, accepted, successful = carry
+
+        def evaluate(active_carry):
+            active_state, accepted_count, _ = active_carry
+            candidate = runtime.evaluate(active_state)
+            step_successful = candidate.evidence.successful
+            committed = runtime.commit(candidate, active_state)
+            return (
+                committed,
+                accepted_count + step_successful.astype(jnp.int32),
+                step_successful,
+            )
+
+        return jax.lax.cond(
+            successful,
+            evaluate,
+            lambda value: value,
+            carry,
+        )
+
+    current, accepted, successful = jax.lax.fori_loop(
+        0,
+        step_count,
+        advance,
+        (
+            state,
+            jnp.asarray(0, dtype=jnp.int32),
+            jnp.asarray(True),
+        ),
+    )
     return MonodomainReplayResult(
         current,
-        jnp.asarray(accepted, dtype=jnp.int32),
-        jnp.asarray(successful),
+        accepted,
+        successful,
         monodomain_state_identity(runtime, current),
     )
 

--- a/phydrax/applications/cosmology/_native_boltzmann.py
+++ b/phydrax/applications/cosmology/_native_boltzmann.py
@@ -781,22 +781,27 @@ class PreparedScalarEinsteinBoltzmann(StrictModule):
             quadrupole = (
                 state[photon + 2] + state[polarization] + state[polarization + 2]
             ) / 8.0
-            for ell in range(2, layout.photon_order + 1):
-                lower = state[photon + ell - 1]
-                upper = (
-                    state[photon + ell + 1]
-                    if ell < layout.photon_order
-                    else (
-                        (2.0 * ell + 1.0)
-                        * state[photon + ell]
-                        / jnp.maximum(k * self.conformal_times[-1], 1.0)
-                        - lower
-                    )
-                )
-                rate = rate.at[photon + ell].set(
-                    k * (ell * lower - (ell + 1.0) * upper) / (2.0 * ell + 1.0)
-                    - opacity * (state[photon + ell] - (quadrupole if ell == 2 else 0.0))
-                )
+            photon_ell = jnp.arange(2, layout.photon_order + 1)
+            photon_lower = state[photon + photon_ell - 1]
+            photon_upper = state[
+                photon + jnp.minimum(photon_ell + 1, layout.photon_order)
+            ]
+            photon_closure = (2.0 * photon_ell + 1.0) * state[
+                photon + photon_ell
+            ] / jnp.maximum(k * self.conformal_times[-1], 1.0) - photon_lower
+            photon_upper = jnp.where(
+                photon_ell < layout.photon_order,
+                photon_upper,
+                photon_closure,
+            )
+            photon_rates = k * (
+                photon_ell * photon_lower - (photon_ell + 1.0) * photon_upper
+            ) / (2.0 * photon_ell + 1.0) - opacity * (
+                state[photon + photon_ell] - jnp.where(photon_ell == 2, quadrupole, 0.0)
+            )
+            rate = rate.at[photon + 2 : photon + layout.photon_order + 1].set(
+                photon_rates
+            )
             rate = rate.at[polarization].set(
                 -k * state[polarization + 1]
                 - opacity * (state[polarization] - 4.0 * quadrupole)
@@ -805,42 +810,51 @@ class PreparedScalarEinsteinBoltzmann(StrictModule):
                 k * (state[polarization] - 2.0 * state[polarization + 2]) / 3.0
                 - opacity * state[polarization + 1]
             )
-            for ell in range(2, layout.polarization_order + 1):
-                lower = state[polarization + ell - 1]
-                upper = (
-                    state[polarization + ell + 1]
-                    if ell < layout.polarization_order
-                    else (
-                        (2.0 * ell + 1.0)
-                        * state[polarization + ell]
-                        / jnp.maximum(k * self.conformal_times[-1], 1.0)
-                        - lower
-                    )
-                )
-                rate = rate.at[polarization + ell].set(
-                    k * (ell * lower - (ell + 1.0) * upper) / (2.0 * ell + 1.0)
-                    - opacity
-                    * (state[polarization + ell] - (quadrupole if ell == 2 else 0.0))
-                )
+            polarization_ell = jnp.arange(2, layout.polarization_order + 1)
+            polarization_lower = state[polarization + polarization_ell - 1]
+            polarization_upper = state[
+                polarization
+                + jnp.minimum(polarization_ell + 1, layout.polarization_order)
+            ]
+            polarization_closure = (2.0 * polarization_ell + 1.0) * state[
+                polarization + polarization_ell
+            ] / jnp.maximum(k * self.conformal_times[-1], 1.0) - polarization_lower
+            polarization_upper = jnp.where(
+                polarization_ell < layout.polarization_order,
+                polarization_upper,
+                polarization_closure,
+            )
+            polarization_rates = k * (
+                polarization_ell * polarization_lower
+                - (polarization_ell + 1.0) * polarization_upper
+            ) / (2.0 * polarization_ell + 1.0) - opacity * (
+                state[polarization + polarization_ell]
+                - jnp.where(polarization_ell == 2, quadrupole, 0.0)
+            )
+            rate = rate.at[
+                polarization + 2 : polarization + layout.polarization_order + 1
+            ].set(polarization_rates)
             rate = rate.at[relic].set(-k * state[relic + 1] - 2.0 * hdot / 3.0)
             rate = rate.at[relic + 1].set(
                 k * (state[relic] - 2.0 * state[relic + 2]) / 3.0
             )
-            for ell in range(2, layout.relic_order + 1):
-                lower = state[relic + ell - 1]
-                upper = (
-                    state[relic + ell + 1]
-                    if ell < layout.relic_order
-                    else (
-                        (2.0 * ell + 1.0)
-                        * state[relic + ell]
-                        / jnp.maximum(k * self.conformal_times[-1], 1.0)
-                        - lower
-                    )
-                )
-                rate = rate.at[relic + ell].set(
-                    k * (ell * lower - (ell + 1.0) * upper) / (2.0 * ell + 1.0)
-                )
+            relic_ell = jnp.arange(2, layout.relic_order + 1)
+            relic_lower = state[relic + relic_ell - 1]
+            relic_upper = state[relic + jnp.minimum(relic_ell + 1, layout.relic_order)]
+            relic_closure = (2.0 * relic_ell + 1.0) * state[
+                relic + relic_ell
+            ] / jnp.maximum(k * self.conformal_times[-1], 1.0) - relic_lower
+            relic_upper = jnp.where(
+                relic_ell < layout.relic_order,
+                relic_upper,
+                relic_closure,
+            )
+            relic_rates = (
+                k
+                * (relic_ell * relic_lower - (relic_ell + 1.0) * relic_upper)
+                / (2.0 * relic_ell + 1.0)
+            )
+            rate = rate.at[relic + 2 : relic + layout.relic_order + 1].set(relic_rates)
             return rate / denominator
 
         return jax.vmap(one_mode)(plan.wavenumbers, states)

--- a/phydrax/applications/geophysics/potential_fields/_spherical_harmonics.py
+++ b/phydrax/applications/geophysics/potential_fields/_spherical_harmonics.py
@@ -37,24 +37,36 @@ def _associated_legendre(
     values = jnp.zeros((maximum_degree + 1, maximum_degree + 1), dtype=dtype)
     values = values.at[0, 0].set(1.0)
     root = jnp.sqrt(jnp.maximum(1.0 - argument**2, 0.0))
-    for order in range(1, maximum_degree + 1):
-        # Geophysical convention excludes the Condon-Shortley (-1)^m phase.
-        values = values.at[order, order].set(
-            (2 * order - 1) * root * values[order - 1, order - 1]
+
+    def diagonal(order, current):
+        return current.at[order, order].set(
+            (2 * order - 1) * root * current[order - 1, order - 1]
         )
-    for order in range(maximum_degree):
-        values = values.at[order + 1, order].set(
-            (2 * order + 1) * argument * values[order, order]
+
+    values = jax.lax.fori_loop(1, maximum_degree + 1, diagonal, values)
+
+    def adjacent(order, current):
+        return current.at[order + 1, order].set(
+            (2 * order + 1) * argument * current[order, order]
         )
-    for order in range(maximum_degree + 1):
-        for degree in range(order + 2, maximum_degree + 1):
-            values = values.at[degree, order].set(
-                (
-                    (2 * degree - 1) * argument * values[degree - 1, order]
-                    - (degree + order - 1) * values[degree - 2, order]
-                )
-                / (degree - order)
+
+    values = jax.lax.fori_loop(0, maximum_degree, adjacent, values)
+
+    def column(order, current):
+        def recurrence(degree, table):
+            active = degree >= order + 2
+            denominator = jnp.where(active, degree - order, 1)
+            candidate = (
+                (2 * degree - 1) * argument * table[degree - 1, order]
+                - (degree + order - 1) * table[degree - 2, order]
+            ) / denominator
+            return table.at[degree, order].set(
+                jnp.where(active, candidate, table[degree, order])
             )
+
+        return jax.lax.fori_loop(0, maximum_degree + 1, recurrence, current)
+
+    values = jax.lax.fori_loop(0, maximum_degree + 1, column, values)
     factors = jnp.asarray(
         [
             [
@@ -117,25 +129,26 @@ class SphericalHarmonicGravityPlan(StrictModule, NonTrainableState):
         legendre = _associated_legendre(
             self.maximum_degree, latitude_sine, self.normalization
         )
-        total = jnp.asarray(0.0, dtype=position.dtype)
         radial = self.model.reference_radius_m / radius
-        for degree in range(self.maximum_degree + 1):
-            inner = jnp.asarray(0.0, dtype=position.dtype)
-            for order in range(degree + 1):
-                angle = order * longitude
-                inner = inner + legendre[degree, order] * (
-                    self.model.cosine[degree, order] * jnp.cos(angle)
-                    + self.model.sine[degree, order] * jnp.sin(angle)
-                )
-            total = total + radial**degree * inner
+        degrees = jnp.arange(self.maximum_degree + 1)
+        orders = jnp.arange(self.maximum_degree + 1)
+        order_grid = orders[None, :]
+        degree_grid = degrees[:, None]
+        angular = self.model.cosine * jnp.cos(
+            order_grid * longitude
+        ) + self.model.sine * jnp.sin(order_grid * longitude)
+        inner = jnp.sum(
+            jnp.where(order_grid <= degree_grid, legendre * angular, 0.0),
+            axis=-1,
+        )
+        total = jnp.sum(radial**degrees * inner)
         return self.model.gravitational_constant_m3_s2 * total / radius
 
     def evaluate(self, positions_m: ArrayLike, /) -> SphericalGravityResult:
         positions = jnp.asarray(positions_m)
         if positions.ndim != 2 or positions.shape[1] != 3:
             raise ValueError("Spherical gravity positions must have shape (n,3).")
-        potential = jax.vmap(self.potential)(positions)
-        acceleration = jax.vmap(jax.grad(self.potential))(positions)
+        potential, acceleration = jax.vmap(jax.value_and_grad(self.potential))(positions)
         finite = jnp.all(jnp.isfinite(potential)) & jnp.all(jnp.isfinite(acceleration))
         return SphericalGravityResult(potential, acceleration, finite)
 

--- a/phydrax/applications/incompressible_flow/_control.py
+++ b/phydrax/applications/incompressible_flow/_control.py
@@ -1016,14 +1016,21 @@ class PreparedMACFlowControl(StrictModule, NonTrainableState):
         else:
             zero_candidate, zero_success = self._advance(state, step, zeros, args)
             zero_response = self._observable(zero_candidate.state)
-            columns = []
-            influence_success = zero_success
-            for column in range(count):
-                unit = jnp.zeros((count,), dtype=dtype).at[column].set(1.0)
-                unit_candidate, unit_success = self._advance(state, step, unit, args)
-                columns.append(self._observable(unit_candidate.state) - zero_response)
-                influence_success = influence_success & unit_success
-            response = jnp.stack(tuple(columns), axis=1)
+
+            def influence_column(unit):
+                unit_candidate, unit_success = self._advance(
+                    state,
+                    step,
+                    unit,
+                    args,
+                )
+                return self._observable(unit_candidate.state), unit_success
+
+            responses, influence_valid = jax.vmap(influence_column)(
+                jnp.eye(count, dtype=dtype)
+            )
+            response = jnp.swapaxes(responses - zero_response[None, :], 0, 1)
+            influence_success = zero_success & jnp.all(influence_valid)
             control, conditioning = self._conditioning(
                 response, target.astype(dtype) - zero_response
             )

--- a/phydrax/atomistic/_barostat.py
+++ b/phydrax/atomistic/_barostat.py
@@ -135,21 +135,32 @@ def apply_isotropic_monte_carlo_barostat(
     new_vectors = old_vectors * linear_scale
     cell = dynamics.system.cell
     old_unwrapped = dynamics._unwrapped(state.kinematics, old_vectors)
-    proposed_unwrapped = old_unwrapped
+    labels = jnp.asarray(dynamics.system.molecule_labels, dtype=jnp.int32)
+    molecule_indices = jnp.searchsorted(
+        labels,
+        dynamics.system.plan.molecule_ids,
+    )
+    active = dynamics.system.active_mask
     masses = dynamics.system.plan.masses.astype(dtype)
-    for molecule_label in dynamics.system.molecule_labels:
-        mask = dynamics.system.active_mask & (
-            dynamics.system.plan.molecule_ids == molecule_label
-        )
-        weight = jnp.where(mask, masses, 0.0)
-        center = jnp.sum(weight[:, None] * old_unwrapped, axis=0) / jnp.sum(weight)
-        center_fractional = cell.fractional_with_vectors(center, old_vectors)
-        proposed_center = cell.cartesian_with_vectors(center_fractional, new_vectors)
-        proposed_unwrapped = jnp.where(
-            mask[:, None],
-            old_unwrapped + (proposed_center - center),
-            proposed_unwrapped,
-        )
+    molecule_mass = (
+        jnp.zeros((labels.shape[0],), dtype=dtype)
+        .at[molecule_indices]
+        .add(jnp.where(active, masses, 0.0))
+    )
+    weighted_position = (
+        jnp.zeros((labels.shape[0], 3), dtype=dtype)
+        .at[molecule_indices]
+        .add(jnp.where(active[:, None], masses[:, None] * old_unwrapped, 0.0))
+    )
+    centers = weighted_position / molecule_mass[:, None]
+    center_fractional = cell.fractional_with_vectors(centers, old_vectors)
+    proposed_centers = cell.cartesian_with_vectors(center_fractional, new_vectors)
+    displacement = proposed_centers[molecule_indices] - centers[molecule_indices]
+    proposed_unwrapped = jnp.where(
+        active[:, None],
+        old_unwrapped + displacement,
+        old_unwrapped,
+    )
     proposed_positions, proposed_images = cell.wrap_with_vectors(
         proposed_unwrapped, new_vectors
     )

--- a/phydrax/atomistic/_coarse_graining.py
+++ b/phydrax/atomistic/_coarse_graining.py
@@ -229,17 +229,16 @@ class PreparedMolecularCoarseMap(StrictModule, NonTrainableState):
                 cell.vectors.astype(position.dtype),
             )
         elif cell is not None:
-            unwrapped = jnp.zeros_like(position)
-            for bead in range(self.coarse_system.capacity):
-                anchor = position[self.anchor_indices[bead]]
-                relative = cell.minimum_image(position - anchor)
-                selected = self.member_mask[bead]
-                unwrapped = jnp.where(selected[:, None], anchor + relative, unwrapped)
-                distances = jnp.sqrt(jnp.sum(relative * relative, axis=-1))
-                local_margin = jnp.min(
-                    jnp.where(selected, cell.unique_image_radius - distances, jnp.inf)
-                )
-                margin = jnp.minimum(margin, local_margin)
+            active = self.fine_system.active_mask
+            safe_membership = jnp.where(active, self.membership, 0)
+            atom_anchors = self.anchor_indices[safe_membership]
+            anchors = position[atom_anchors]
+            relative = cell.minimum_image(position - anchors)
+            unwrapped = jnp.where(active[:, None], anchors + relative, 0.0)
+            distances = jnp.sqrt(jnp.sum(relative * relative, axis=-1))
+            margin = jnp.min(
+                jnp.where(active, cell.unique_image_radius - distances, jnp.inf)
+            )
         coarse_position = contract("bn,nd->bd", self.center_weights, unwrapped)
         coarse_images = None
         if cell is not None:

--- a/phydrax/atomistic/_force_field.py
+++ b/phydrax/atomistic/_force_field.py
@@ -14,6 +14,7 @@ import jax.scipy.special as jsp
 import numpy as np
 from jaxtyping import Array, ArrayLike
 
+import phydrax.linalg as la
 from phydrax.ein import contract
 
 from .._fingerprint import array_tree_fingerprint, canonical_fingerprint
@@ -1149,8 +1150,11 @@ class SETTLEPlan(StrictModule, NonTrainableState):
             groups.ndim != 2
             or groups.shape[1] != 3
             or not np.issubdtype(groups.dtype, np.integer)
+            or np.any(groups < 0)
         ):
-            raise TypeError("water_groups must have shape (N,3) integer indices.")
+            raise TypeError("water_groups must have shape (N,3) nonnegative indices.")
+        if np.unique(groups).size != groups.size:
+            raise ValueError("SETTLE water groups must be atom-disjoint.")
         oh, hh, tol = (
             float(oxygen_hydrogen_distance),
             float(hydrogen_hydrogen_distance),
@@ -1211,17 +1215,28 @@ class PreparedSETTLE(StrictModule, NonTrainableState):
     def project(self, positions: ArrayLike, momenta: ArrayLike, /) -> SETTLEProjection:
         q = jnp.asarray(positions)
         p = jnp.asarray(momenta, dtype=q.dtype)
-        result_q = q
-        result_p = p
-        maximum_position = jnp.zeros((), dtype=q.dtype)
-        maximum_velocity = jnp.zeros((), dtype=q.dtype)
-        success = jnp.asarray(True)
-        for group in np.asarray(self.plan.water_groups):
-            index = jnp.asarray(group, dtype=jnp.int32)
-            water = result_q[index]
-            masses = self.system.plan.masses[index]
-            total_mass = jnp.sum(masses)
-            center = jnp.sum(masses[:, None] * water, axis=0) / total_mass
+        groups = self.plan.water_groups
+        if groups.shape[0] == 0:
+            zero = jnp.zeros((), dtype=q.dtype)
+            return SETTLEProjection(
+                q,
+                p,
+                zero,
+                zero,
+                jnp.all(jnp.isfinite(q)) & jnp.all(jnp.isfinite(p)),
+            )
+        masses = self.system.plan.masses[groups]
+        inverse_masses = self.system.inverse_masses[groups]
+        water_positions = q[groups]
+        water_momenta = p[groups]
+        pair_left = jnp.asarray((0, 0, 1), dtype=jnp.int32)
+        pair_right = jnp.asarray((1, 2, 2), dtype=jnp.int32)
+        pair_index = jnp.arange(3, dtype=jnp.int32)
+        solve_plan = la.SmallLinearSolvePlan(3)
+
+        def project_water(water, water_p, water_masses, inverse_mass):
+            total_mass = jnp.sum(water_masses)
+            center = jnp.sum(water_masses[:, None] * water, axis=0) / total_mass
             midpoint = 0.5 * (water[1] + water[2])
             x_raw = midpoint - water[0]
             y_raw = water[1] - water[2]
@@ -1229,11 +1244,8 @@ class PreparedSETTLE(StrictModule, NonTrainableState):
             y_norm = jnp.sqrt(jnp.sum(y_raw**2))
             x_axis = x_raw / jnp.where(x_norm > 0.0, x_norm, 1.0)
             y_axis = y_raw - jnp.sum(y_raw * x_axis) * x_axis
-            y_axis = y_axis / jnp.where(
-                jnp.sqrt(jnp.sum(y_axis**2)) > 0.0,
-                jnp.sqrt(jnp.sum(y_axis**2)),
-                1.0,
-            )
+            y_axis_norm = jnp.sqrt(jnp.sum(y_axis**2))
+            y_axis = y_axis / jnp.where(y_axis_norm > 0.0, y_axis_norm, 1.0)
             half_hh = 0.5 * self.plan.hydrogen_hydrogen_distance
             along = jnp.sqrt(self.plan.oxygen_hydrogen_distance**2 - half_hh**2)
             reference = jnp.stack(
@@ -1243,76 +1255,89 @@ class PreparedSETTLE(StrictModule, NonTrainableState):
                     along * x_axis - half_hh * y_axis,
                 )
             )
-            reference_center = jnp.sum(masses[:, None] * reference, axis=0) / total_mass
-            projected = center + reference - reference_center
-            result_q = result_q.at[index].set(projected)
-            inverse_mass = self.system.inverse_masses[index]
-            water_p = result_p[index]
-            pairs = ((0, 1), (0, 2), (1, 2))
-            directions = jnp.stack(
-                tuple(projected[left] - projected[right] for left, right in pairs)
+            reference_center = (
+                jnp.sum(water_masses[:, None] * reference, axis=0) / total_mass
             )
-            jacobian = jnp.zeros((3, 3, 3), dtype=q.dtype)
-            for pair_index, (left, right) in enumerate(pairs):
-                jacobian = jacobian.at[pair_index, left].set(directions[pair_index])
-                jacobian = jacobian.at[pair_index, right].set(-directions[pair_index])
+            projected = center + reference - reference_center
+            directions = projected[pair_left] - projected[pair_right]
+            jacobian = (
+                jnp.zeros((3, 3, 3), dtype=q.dtype)
+                .at[pair_index, pair_left]
+                .set(directions)
+                .at[pair_index, pair_right]
+                .set(-directions)
+            )
             gram = contract("api,p,bpi->ab", jacobian, inverse_mass, jacobian)
-            determinant = jnp.sum(gram[0] * jnp.cross(gram[1], gram[2]))
-            inverse_gram = jnp.stack(
-                (
-                    jnp.cross(gram[1], gram[2]),
-                    jnp.cross(gram[2], gram[0]),
-                    jnp.cross(gram[0], gram[1]),
-                ),
-                axis=1,
-            ) / jnp.where(jnp.abs(determinant) > 0.0, determinant, 1.0)
+            inverse_gram = la.inverse_small_linear(solve_plan, gram)
             velocity = water_p * inverse_mass[:, None]
             residual = contract("api,pi->a", jacobian, velocity)
-            multipliers = -contract("ab,b->a", inverse_gram, residual)
-            water_p = water_p + contract("a,api->pi", multipliers, jacobian)
-            momentum_nonsingular = jnp.abs(determinant) > jnp.finfo(q.dtype).tiny
-            result_p = result_p.at[index].set(water_p)
-            oh1 = jnp.sqrt(jnp.sum((projected[0] - projected[1]) ** 2))
-            oh2 = jnp.sqrt(jnp.sum((projected[0] - projected[2]) ** 2))
-            hh = jnp.sqrt(jnp.sum((projected[1] - projected[2]) ** 2))
-            position_residual = jnp.max(
+            multipliers = -contract("ab,b->a", inverse_gram.value, residual)
+            projected_momenta = water_p + contract(
+                "a,api->pi",
+                multipliers,
+                jacobian,
+            )
+            distances = jnp.sqrt(
+                jnp.sum(
+                    (projected[pair_left] - projected[pair_right]) ** 2,
+                    axis=-1,
+                )
+            )
+            targets = jnp.asarray(
+                (
+                    self.plan.oxygen_hydrogen_distance,
+                    self.plan.oxygen_hydrogen_distance,
+                    self.plan.hydrogen_hydrogen_distance,
+                ),
+                dtype=q.dtype,
+            )
+            position_residual = jnp.max(jnp.abs(distances - targets))
+            relative_velocity = (
+                projected_momenta[pair_left] * inverse_mass[pair_left, None]
+                - projected_momenta[pair_right] * inverse_mass[pair_right, None]
+            )
+            velocity_residual = jnp.max(
                 jnp.abs(
-                    jnp.asarray(
-                        [
-                            oh1 - self.plan.oxygen_hydrogen_distance,
-                            oh2 - self.plan.oxygen_hydrogen_distance,
-                            hh - self.plan.hydrogen_hydrogen_distance,
-                        ]
+                    jnp.sum(
+                        (projected[pair_left] - projected[pair_right])
+                        * relative_velocity,
+                        axis=-1,
                     )
                 )
             )
-            velocity_residual = jnp.zeros((), dtype=q.dtype)
-            for left, right in pairs:
-                displacement = projected[left] - projected[right]
-                relative_velocity = (
-                    water_p[left] * inverse_mass[left]
-                    - water_p[right] * inverse_mass[right]
-                )
-                velocity_residual = jnp.maximum(
-                    velocity_residual,
-                    jnp.abs(jnp.sum(displacement * relative_velocity)),
-                )
-            maximum_position = jnp.maximum(maximum_position, position_residual)
-            maximum_velocity = jnp.maximum(maximum_velocity, velocity_residual)
-            success = (
-                success
-                & (x_norm > 0.0)
+            successful = (
+                (x_norm > 0.0)
                 & (y_norm > 0.0)
-                & momentum_nonsingular
+                & inverse_gram.successful
                 & (position_residual <= self.plan.tolerance)
                 & (velocity_residual <= self.plan.tolerance)
             )
+            return (
+                projected,
+                projected_momenta,
+                position_residual,
+                velocity_residual,
+                successful,
+            )
+
+        projected, projected_momenta, position_residual, velocity_residual, success = (
+            jax.vmap(project_water)(
+                water_positions,
+                water_momenta,
+                masses,
+                inverse_masses,
+            )
+        )
+        result_q = q.at[groups.reshape((-1,))].set(projected.reshape((-1, 3)))
+        result_p = p.at[groups.reshape((-1,))].set(projected_momenta.reshape((-1, 3)))
         return SETTLEProjection(
             result_q,
             result_p,
-            maximum_position,
-            maximum_velocity,
-            success & jnp.all(jnp.isfinite(result_q)),
+            jnp.max(position_residual, initial=0.0),
+            jnp.max(velocity_residual, initial=0.0),
+            jnp.all(success)
+            & jnp.all(jnp.isfinite(result_q))
+            & jnp.all(jnp.isfinite(result_p)),
         )
 
 

--- a/phydrax/atomistic/_graph.py
+++ b/phydrax/atomistic/_graph.py
@@ -78,6 +78,7 @@ class AtomisticGraph(StrictModule, NonTrainableState):
     neighbor_counts: Array
     maximum_neighbor_count: Array
     overflow: Array
+    maximum_neighbors: int = eqx.field(static=True)
     cutoff: float = eqx.field(static=True)
     topology_id: str = eqx.field(static=True)
     execution_id: str = eqx.field(static=True)
@@ -191,6 +192,7 @@ def _assemble_graph(
         neighbor_counts=neighbor_counts,
         maximum_neighbor_count=maximum_neighbor_count,
         overflow=overflow,
+        maximum_neighbors=execution.maximum_neighbors,
         cutoff=float(cutoff),
         topology_id=topology_id,
         execution_id=execution.plan_id,

--- a/phydrax/atomistic/_many_body.py
+++ b/phydrax/atomistic/_many_body.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from enum import StrEnum
 
 import equinox as eqx
+import jax
 import jax.numpy as jnp
 import jax.random as jr
 import numpy as np
@@ -465,7 +466,9 @@ class ManyBodyPotential(AbstractAtomisticEnergyTerm, NonTrainableState):
             local_energy=True,
         )
         self.requirements = AtomisticPotentialRequirements(
-            cutoff=self.cutoff, pair_geometry=True
+            cutoff=self.cutoff,
+            pair_geometry=True,
+            directed_graph=True,
         )
         self.term_id = canonical_fingerprint(
             {
@@ -478,6 +481,80 @@ class ManyBodyPotential(AbstractAtomisticEnergyTerm, NonTrainableState):
 
     def prepare(self, system, /):
         return PreparedManyBodyPotential(self, system)
+
+
+def _many_body_neighbor_slots(context, /):
+    graph = context.graph
+    if graph is None:
+        raise RuntimeError("Many-body potentials require a prepared atomistic graph.")
+    neighbor_capacity = graph.maximum_neighbors
+    atom_capacity = context.positions.shape[0]
+    if neighbor_capacity == 0:
+        return (
+            jnp.empty(
+                (atom_capacity, 0, context.positions.shape[-1]),
+                dtype=context.positions.dtype,
+            ),
+            jnp.empty((atom_capacity, 0), dtype=context.positions.dtype),
+            jnp.empty((atom_capacity, 0), dtype=jnp.int32),
+            jnp.empty((atom_capacity, 0), dtype=bool),
+        )
+    edges = graph.graph
+    senders = edges.senders
+    receivers = edges.receivers
+    valid = edges.edge_mask
+    safe_receivers = jnp.where(valid, receivers, atom_capacity)
+    order = jnp.lexsort((senders, safe_receivers))
+    senders = senders[order]
+    receivers = receivers[order]
+    valid = valid[order]
+    displacement = edges.edges["displacement"][order]
+    distance = edges.edges["distance"][order, 0]
+    route = jnp.arange(senders.shape[0], dtype=jnp.int32)
+    starts = jnp.where(
+        valid & ((route == 0) | (receivers != jnp.roll(receivers, 1))),
+        route,
+        0,
+    )
+    group_start = jax.lax.associative_scan(jnp.maximum, starts)
+    ranks = route - group_start
+    slot_valid = valid & (ranks < neighbor_capacity)
+    safe_center = jnp.where(slot_valid, receivers, 0)
+    safe_rank = jnp.where(slot_valid, ranks, 0)
+    slots = (safe_center, safe_rank)
+    slot_displacement = (
+        jnp.zeros(
+            (atom_capacity, neighbor_capacity, context.positions.shape[-1]),
+            dtype=context.positions.dtype,
+        )
+        .at[slots]
+        .add(jnp.where(slot_valid[:, None], displacement, 0.0))
+    )
+    slot_distance = (
+        jnp.zeros(
+            (atom_capacity, neighbor_capacity),
+            dtype=context.positions.dtype,
+        )
+        .at[slots]
+        .add(jnp.where(slot_valid, distance, 0.0))
+    )
+    slot_neighbors = (
+        jnp.zeros(
+            (atom_capacity, neighbor_capacity),
+            dtype=jnp.int32,
+        )
+        .at[slots]
+        .add(jnp.where(slot_valid, senders, 0))
+    )
+    slot_mask = (
+        jnp.zeros(
+            (atom_capacity, neighbor_capacity),
+            dtype=jnp.int32,
+        )
+        .at[slots]
+        .add(slot_valid.astype(jnp.int32))
+    )
+    return slot_displacement, slot_distance, slot_neighbors, slot_mask > 0
 
 
 class PreparedManyBodyPotential(AbstractPreparedAtomisticEnergyTerm):
@@ -517,20 +594,10 @@ class PreparedManyBodyPotential(AbstractPreparedAtomisticEnergyTerm):
         )
 
     def energy(self, context, /):
-        q = context.positions
-        n = q.shape[0]
-        displacement = q[:, None, :] - q[None, :, :]
-        if context.cell is not None:
-            displacement = context.cell.minimum_image(displacement)
-        identity = jnp.eye(n, dtype=bool)
-        squared_distance = jnp.sum(displacement**2, axis=-1)
-        distance = jnp.sqrt(jnp.where(identity, 1.0, squared_distance))
-        pair_mask = (
-            (~identity)
-            & self.system.active_mask[:, None]
-            & self.system.active_mask[None, :]
-            & (distance < self.plan.cutoff)
+        displacement, distance, neighbors, graph_valid = _many_body_neighbor_slots(
+            context
         )
+        pair_mask = graph_valid & (distance < self.plan.cutoff)
         safe = jnp.where(pair_mask, distance, 1.0)
         p = self.plan.parameters
         if self.plan.kind is ManyBodyKind.EAM:
@@ -539,14 +606,18 @@ class PreparedManyBodyPotential(AbstractPreparedAtomisticEnergyTerm):
                 0.5 * (1.0 + jnp.cos(jnp.pi * safe / self.plan.cutoff)),
                 0.0,
             )
-            density = jnp.sum(cutoff_weight * jnp.exp(-p[0] * (safe - p[1])), axis=1)
+            density = jnp.sum(
+                cutoff_weight * jnp.exp(-p[0] * (safe - p[1])),
+                axis=1,
+            )
             embedding = jnp.where(
                 density > 0.0,
                 -p[2] * jnp.sqrt(jnp.where(density > 0.0, density, 1.0)),
                 0.0,
             )
             pair = 0.5 * jnp.sum(
-                cutoff_weight * p[3] * jnp.exp(-p[4] * (safe - p[1])), axis=1
+                cutoff_weight * p[3] * jnp.exp(-p[4] * (safe - p[1])),
+                axis=1,
             )
             atom = embedding + pair
         elif self.plan.kind is ManyBodyKind.STILLINGER_WEBER:
@@ -571,31 +642,32 @@ class PreparedManyBodyPotential(AbstractPreparedAtomisticEnergyTerm):
                 * (repulsion * ratio**repulsive_power - ratio**attractive_power)
                 * radial_window
             )
-            atom = 0.5 * jnp.sum(jnp.where(pair_mask, directed_pair, 0.0), axis=1)
-            for center in range(n):
-                vectors = -displacement[center]
-                norms = safe[center]
-                cosine = contract("id,jd->ij", vectors, vectors) / (
-                    norms[:, None] * norms[None, :]
-                )
-                triplet_mask = (
-                    pair_mask[center, :, None] & pair_mask[center, None, :] & ~identity
-                )
-                radial = jnp.exp(
-                    angular_range
-                    * sigma
-                    / jnp.where(pair_mask[center], norms - self.plan.cutoff, -1.0)
-                )
-                angular = (
-                    angular_strength
-                    * epsilon
-                    * (cosine - target_cosine) ** 2
-                    * radial[:, None]
-                    * radial[None, :]
-                )
-                atom = atom.at[center].add(
-                    0.5 * jnp.sum(jnp.where(triplet_mask, angular, 0.0))
-                )
+            atom = 0.5 * jnp.sum(
+                jnp.where(pair_mask, directed_pair, 0.0),
+                axis=1,
+            )
+            vectors = -displacement
+            cosine = contract("nkd,nld->nkl", vectors, vectors) / (
+                safe[:, :, None] * safe[:, None, :]
+            )
+            distinct = neighbors[:, :, None] != neighbors[:, None, :]
+            triplet_mask = pair_mask[:, :, None] & pair_mask[:, None, :] & distinct
+            radial = jnp.exp(
+                angular_range
+                * sigma
+                / jnp.where(pair_mask, safe - self.plan.cutoff, -1.0)
+            )
+            angular = (
+                angular_strength
+                * epsilon
+                * (cosine - target_cosine) ** 2
+                * radial[:, :, None]
+                * radial[:, None, :]
+            )
+            atom = atom + 0.5 * jnp.sum(
+                jnp.where(triplet_mask, angular, 0.0),
+                axis=(1, 2),
+            )
         else:
             (
                 repulsive_amplitude,
@@ -622,54 +694,45 @@ class PreparedManyBodyPotential(AbstractPreparedAtomisticEnergyTerm):
                 1.0,
                 jnp.where(distance < outer, transition, 0.0),
             )
-            cutoff_function = jnp.where(
-                (~identity)
-                & self.system.active_mask[:, None]
-                & self.system.active_mask[None, :],
-                cutoff_function,
-                0.0,
-            )
+            cutoff_function = jnp.where(graph_valid, cutoff_function, 0.0)
             repulsive = repulsive_amplitude * jnp.exp(-repulsive_decay * safe)
             attractive = -attractive_amplitude * jnp.exp(-attractive_decay * safe)
-            atom = jnp.zeros((n,), dtype=q.dtype)
-            for center in range(n):
-                vectors = -displacement[center]
-                norms = safe[center]
-                cosine = contract("id,jd->ij", vectors, vectors) / (
-                    norms[:, None] * norms[None, :]
-                )
-                angular = (
-                    1.0
-                    + angular_c**2 / angular_d**2
-                    - angular_c**2 / (angular_d**2 + (angular_h - cosine) ** 2)
-                )
-                for neighbor in range(n):
-                    third_mask = (
-                        (~identity[neighbor])
-                        & (~identity[center])
-                        & (jnp.arange(n) != neighbor)
-                    )
-                    separation = norms[neighbor] - norms
-                    coordination = jnp.sum(
-                        jnp.where(
-                            third_mask,
-                            cutoff_function[center]
-                            * angular[neighbor]
-                            * jnp.exp(
-                                (coordination_decay * separation) ** coordination_power
-                            ),
-                            0.0,
-                        )
-                    )
-                    bond_order = (1.0 + (beta * coordination) ** bond_order_power) ** (
-                        -1.0 / (2.0 * bond_order_power)
-                    )
-                    directed = cutoff_function[center, neighbor] * (
-                        repulsive[center, neighbor]
-                        + bond_order * attractive[center, neighbor]
-                    )
-                    atom = atom.at[center].add(0.5 * directed)
-        success = jnp.all(jnp.isfinite(atom)) & jnp.all(~pair_mask | (distance > 0.0))
+            vectors = -displacement
+            cosine = contract("nkd,nld->nkl", vectors, vectors) / (
+                safe[:, :, None] * safe[:, None, :]
+            )
+            angular = (
+                1.0
+                + angular_c**2 / angular_d**2
+                - angular_c**2 / (angular_d**2 + (angular_h - cosine) ** 2)
+            )
+            separation = safe[:, :, None] - safe[:, None, :]
+            third_mask = (
+                graph_valid[:, :, None]
+                & graph_valid[:, None, :]
+                & (neighbors[:, :, None] != neighbors[:, None, :])
+            )
+            coordination = jnp.sum(
+                jnp.where(
+                    third_mask,
+                    cutoff_function[:, None, :]
+                    * angular
+                    * jnp.exp((coordination_decay * separation) ** coordination_power),
+                    0.0,
+                ),
+                axis=-1,
+            )
+            bond_order = (1.0 + (beta * coordination) ** bond_order_power) ** (
+                -1.0 / (2.0 * bond_order_power)
+            )
+            directed = cutoff_function * (repulsive + bond_order * attractive)
+            atom = 0.5 * jnp.sum(jnp.where(graph_valid, directed, 0.0), axis=-1)
+        atom = jnp.where(self.system.active_mask, atom, 0.0)
+        success = (
+            context.neighborhood_successful
+            & jnp.all(jnp.isfinite(atom))
+            & jnp.all(~pair_mask | (distance > 0.0))
+        )
         return AtomisticTermEvaluation(jnp.sum(atom), atom, success)
 
 

--- a/phydrax/atomistic/_ring_polymer.py
+++ b/phydrax/atomistic/_ring_polymer.py
@@ -139,24 +139,21 @@ class PreparedRingPolymerDynamics(StrictModule):
         )
 
     def _physical(self, positions: Array, /) -> tuple[Array, Array, Array]:
-        energies = []
-        forces = []
-        successes = []
-        for bead in range(self.plan.bead_count):
-            neighborhood = self.neighborhood.build(positions[bead])
+        def evaluate_bead(bead_positions):
+            neighborhood = self.neighborhood.build(bead_positions)
             evaluation = self.potential.evaluate(
-                positions[bead],
+                bead_positions,
                 neighborhood,
                 species=self.potential.system.plan.atom_type_ids,
             )
-            energies.append(evaluation.energy)
-            forces.append(evaluation.forces)
-            successes.append(evaluation.successful & neighborhood.successful)
-        return (
-            jnp.stack(tuple(energies)),
-            jnp.stack(tuple(forces)),
-            jnp.all(jnp.stack(tuple(successes))),
-        )
+            return (
+                evaluation.energy,
+                evaluation.forces,
+                evaluation.successful & neighborhood.successful,
+            )
+
+        energies, forces, successes = eqx.filter_vmap(evaluate_bead)(positions)
+        return energies, forces, jnp.all(successes)
 
     def _spring(self, positions: Array, /) -> tuple[Array, Array]:
         previous = jnp.roll(positions, 1, axis=0)

--- a/phydrax/control/__init__.py
+++ b/phydrax/control/__init__.py
@@ -25,13 +25,6 @@ from ._advanced_collocation import (
     StochasticDirectCollocationEvidence,
     StochasticDirectTranscription,
 )
-from ._batched_trajectory import (
-    ILQRPlan,
-    plan_ilqr,
-    prepare_ilqr,
-    PreparedILQR,
-    solve_prepared_ilqr,
-)
 from ._candidate_search import (
     ControlCandidateSearchResult,
     search_control_candidates,
@@ -247,6 +240,13 @@ from ._parameterization import (
     BSplineControlRefinement,
     PiecewiseConstantControlParameterization,
     PiecewiseLinearControlParameterization,
+)
+from ._prepared_ilqr import (
+    ILQRPlan,
+    plan_ilqr,
+    prepare_ilqr,
+    PreparedILQR,
+    solve_prepared_ilqr,
 )
 from ._problem import ControlProblem
 from ._qp_compiler import (

--- a/phydrax/control/_conic_control.py
+++ b/phydrax/control/_conic_control.py
@@ -19,6 +19,7 @@ from ..optim import (
     ConvexSolvePolicy,
     NonnegativeCone,
     ProductCone,
+    QuadraticProgram,
     SecondOrderCone,
     solve_conic_program,
     ZeroCone,
@@ -220,7 +221,9 @@ def compile_linear_conic_control(
     """Compile affine dynamics, polyhedra, native bounds, and exact SOC constraints."""
 
     quadratic = compile_linear_quadratic_control(problem, cost_tolerance=cost_tolerance)
-    qp = quadratic.quadratic_program
+    qp = quadratic.program
+    if not isinstance(qp, QuadraticProgram):
+        raise RuntimeError("Linear conic control requires dense base QP compilation.")
     stages = tuple(stage_constraints)
     terminals = tuple(terminal_constraints)
     if any(not isinstance(value, StageSecondOrderConstraint) for value in stages):

--- a/phydrax/control/_ilqr.py
+++ b/phydrax/control/_ilqr.py
@@ -14,7 +14,6 @@ from typing import Any, TypeAlias
 import equinox as eqx
 import jax
 import jax.numpy as jnp
-import jax.scipy.linalg as jsp_linalg
 import numpy as np
 from jaxtyping import Array, ArrayLike
 
@@ -22,18 +21,10 @@ import phydrax.ein as ein
 
 from .._strict import StrictModule
 from ..dynamics import DiscreteStepContext, StateLayout, TimeGrid
-from ..dynamics._system import DiscreteTransitionEvidence
-from ._constraints import evaluate_sampled_feasibility
-from ._cost import evaluate_sampled_cost
 from ._dynamics import DifferentialControlDynamics, DiscreteControlDynamics
 from ._parameterization import AbstractControlParameterization
 from ._problem import _identifier, ControlProblem
-from ._trajectory import (
-    CONTROL_DYNAMICS_FAILED,
-    CONTROL_SUCCESS,
-    ControlResult,
-    ControlTrajectory,
-)
+from ._trajectory import ControlResult, ControlTrajectory
 
 
 DifferentialFlowStep: TypeAlias = Callable[[Array, Array, Array, Array, Any], ArrayLike]
@@ -337,20 +328,6 @@ class _LocalModel(StrictModule):
     control_gradient: Array
 
 
-class _BackwardPass(StrictModule):
-    feedforward: Array
-    feedback: Array
-    linear_reduction: Array
-    quadratic_reduction: Array
-    minimum_curvature: Array
-    positive_definite: Array
-    failed_step: Array
-
-
-def _host_bool(value: ArrayLike, /) -> bool:
-    return bool(np.asarray(value))
-
-
 def _validate_solver_options(
     *,
     max_iterations: int,
@@ -442,22 +419,21 @@ def _trajectory_cost(
     controls: Array,
     /,
 ) -> tuple[Array, Array]:
-    running_terms: list[Array] = []
-    for step in range(problem.time_grid.num_steps):
+    def running_term(time: Array, duration: Array, state: Array, control: Array):
         if problem.running_cost is None:
             value = jnp.asarray(0.0, dtype=states.dtype)
         else:
-            value = jnp.asarray(
-                problem.running_cost(
-                    problem.time_grid.times[step],
-                    states[step],
-                    controls[step],
-                    problem.args,
-                )
-            )
+            value = jnp.asarray(problem.running_cost(time, state, control, problem.args))
             if value.shape != ():
                 raise ValueError("RunningCost must return a scalar during iLQR.")
-        running_terms.append(problem.time_grid.durations[step] * value)
+        return duration * value
+
+    running = jax.vmap(running_term)(
+        problem.time_grid.times[:-1],
+        problem.time_grid.durations,
+        states[:-1],
+        controls,
+    )
     if problem.terminal_cost is None:
         terminal = jnp.asarray(0.0, dtype=states.dtype)
     else:
@@ -466,7 +442,6 @@ def _trajectory_cost(
         )
         if terminal.shape != ():
             raise ValueError("TerminalCost must return a scalar during iLQR.")
-    running = jnp.stack(running_terms)
     total = jnp.sum(running) + terminal
     valid = jnp.all(jnp.isfinite(running)) & jnp.isfinite(terminal) & jnp.isfinite(total)
     return total, valid
@@ -507,218 +482,6 @@ def _evaluate_ilqr_flow(
     )
 
 
-def _open_loop_rollout(
-    problem: ControlProblem,
-    controls: Array,
-    flow: ILQRFlow | None,
-    /,
-) -> tuple[
-    Array,
-    Array,
-    Array,
-    Array,
-    Array,
-    DiscreteTransitionEvidence | None,
-]:
-    states: list[Array] = [problem.initial_state]
-    valid: list[Array] = [jnp.all(jnp.isfinite(problem.initial_state))]
-    candidates: list[Array] = []
-    accepted: list[Array] = []
-    transition_attempted: list[Array] = []
-    transition_successful: list[Array] = []
-    transition_status: list[Array] = []
-    failed_step = -1
-    active = _host_bool(valid[0])
-    for step in range(problem.time_grid.num_steps):
-        attempted = False
-        control_finite = _host_bool(jnp.all(jnp.isfinite(controls[step])))
-        if active and control_finite:
-            attempted = True
-            candidate, next_state, successful, backend_status = _evaluate_ilqr_flow(
-                problem,
-                flow,
-                step,
-                states[-1],
-                controls[step],
-            )
-            if tuple(next_state.shape) != problem.state_shape:
-                raise ValueError(
-                    "The selected iLQR flow must return exactly dynamics state_shape."
-                )
-            next_valid = successful & jnp.all(jnp.isfinite(next_state))
-            active = _host_bool(next_valid)
-            if not active:
-                failed_step = step
-        else:
-            if active:
-                failed_step = step
-            active = False
-            candidate = jnp.full(
-                problem.state_shape, jnp.nan, dtype=problem.initial_state.dtype
-            )
-            next_state = jnp.full(
-                problem.state_shape, jnp.nan, dtype=problem.initial_state.dtype
-            )
-            successful = jnp.asarray(False)
-            backend_status = jnp.asarray(0, dtype=jnp.int32)
-            next_valid = jnp.asarray(False)
-        candidates.append(candidate)
-        accepted.append(next_state)
-        transition_attempted.append(jnp.asarray(attempted))
-        transition_successful.append(jnp.asarray(attempted) & successful)
-        transition_status.append(backend_status)
-        states.append(next_state)
-        valid.append(next_valid)
-    state_array = jnp.stack(states)
-    valid_array = jnp.stack(valid)
-    if _host_bool(jnp.all(valid_array)):
-        objective, cost_valid = _trajectory_cost(problem, state_array, controls)
-    else:
-        objective = jnp.asarray(jnp.inf, dtype=state_array.real.dtype)
-        cost_valid = jnp.asarray(False)
-    if not _host_bool(cost_valid):
-        objective = jnp.asarray(jnp.inf, dtype=state_array.real.dtype)
-    evidence = (
-        DiscreteTransitionEvidence(
-            jnp.stack(candidates),
-            jnp.stack(accepted),
-            jnp.stack(transition_attempted),
-            jnp.stack(transition_successful),
-            jnp.stack(transition_status),
-        )
-        if isinstance(problem.dynamics, DiscreteControlDynamics)
-        else None
-    )
-    return (
-        state_array,
-        controls,
-        valid_array,
-        objective,
-        jnp.asarray(failed_step, dtype=jnp.int32),
-        evidence,
-    )
-
-
-def _feedback_rollout(
-    problem: ControlProblem,
-    nominal_states: Array,
-    nominal_controls: Array,
-    feedforward: Array,
-    feedback: Array,
-    step_size: float,
-    flow: ILQRFlow | None,
-    /,
-) -> tuple[
-    Array,
-    Array,
-    Array,
-    Array,
-    Array,
-    DiscreteTransitionEvidence | None,
-]:
-    state_layout = problem.dynamics.system.state_layout
-    geometry = state_layout.geometry
-    state_size = state_layout.local_size
-    control_size = int(np.prod(problem.control_shape))
-    states: list[Array] = [problem.initial_state]
-    controls: list[Array] = []
-    valid: list[Array] = [jnp.all(jnp.isfinite(problem.initial_state))]
-    candidates: list[Array] = []
-    accepted: list[Array] = []
-    transition_attempted: list[Array] = []
-    transition_successful: list[Array] = []
-    transition_status: list[Array] = []
-    failed_step = -1
-    active = _host_bool(valid[0])
-    for step in range(problem.time_grid.num_steps):
-        attempted = False
-        if active:
-            state_delta = jnp.asarray(
-                geometry.inverse_retract(nominal_states[step], states[-1])
-            ).reshape((state_size,))
-            control = (
-                nominal_controls[step].reshape((control_size,))
-                + step_size * feedforward[step]
-                + feedback[step] @ state_delta
-            ).reshape(problem.control_shape)
-            control_finite = _host_bool(jnp.all(jnp.isfinite(control)))
-            if control_finite:
-                attempted = True
-                candidate, next_state, successful, backend_status = _evaluate_ilqr_flow(
-                    problem,
-                    flow,
-                    step,
-                    states[-1],
-                    control,
-                )
-                if tuple(next_state.shape) != problem.state_shape:
-                    raise ValueError(
-                        "The selected iLQR flow must return exactly dynamics state_shape."
-                    )
-                next_valid = successful & jnp.all(jnp.isfinite(next_state))
-            else:
-                candidate = jnp.full(
-                    problem.state_shape, jnp.nan, dtype=nominal_states.dtype
-                )
-                next_state = jnp.full(
-                    problem.state_shape, jnp.nan, dtype=nominal_states.dtype
-                )
-                successful = jnp.asarray(False)
-                backend_status = jnp.asarray(0, dtype=jnp.int32)
-                next_valid = jnp.asarray(False)
-            active = _host_bool(next_valid)
-            if not active:
-                failed_step = step
-        else:
-            control = jnp.full(
-                problem.control_shape, jnp.nan, dtype=nominal_controls.dtype
-            )
-            candidate = jnp.full(problem.state_shape, jnp.nan, dtype=nominal_states.dtype)
-            next_state = jnp.full(
-                problem.state_shape, jnp.nan, dtype=nominal_states.dtype
-            )
-            successful = jnp.asarray(False)
-            backend_status = jnp.asarray(0, dtype=jnp.int32)
-            next_valid = jnp.asarray(False)
-        controls.append(control)
-        candidates.append(candidate)
-        accepted.append(next_state)
-        transition_attempted.append(jnp.asarray(attempted))
-        transition_successful.append(jnp.asarray(attempted) & successful)
-        transition_status.append(backend_status)
-        states.append(next_state)
-        valid.append(next_valid)
-    state_array = jnp.stack(states)
-    control_array = jnp.stack(controls)
-    valid_array = jnp.stack(valid)
-    if _host_bool(jnp.all(valid_array)):
-        objective, cost_valid = _trajectory_cost(problem, state_array, control_array)
-    else:
-        objective = jnp.asarray(jnp.inf, dtype=state_array.real.dtype)
-        cost_valid = jnp.asarray(False)
-    if not _host_bool(cost_valid):
-        objective = jnp.asarray(jnp.inf, dtype=state_array.real.dtype)
-    evidence = (
-        DiscreteTransitionEvidence(
-            jnp.stack(candidates),
-            jnp.stack(accepted),
-            jnp.stack(transition_attempted),
-            jnp.stack(transition_successful),
-            jnp.stack(transition_status),
-        )
-        if isinstance(problem.dynamics, DiscreteControlDynamics)
-        else None
-    )
-    return (
-        state_array,
-        control_array,
-        valid_array,
-        objective,
-        jnp.asarray(failed_step, dtype=jnp.int32),
-        evidence,
-    )
-
-
 def _local_model(
     problem: ControlProblem,
     states: Array,
@@ -730,31 +493,21 @@ def _local_model(
     geometry = state_layout.geometry
     state_size = state_layout.local_size
     control_size = int(np.prod(problem.control_shape))
-    total_size = state_size + control_size
-    dynamics_state: list[Array] = []
-    dynamics_control: list[Array] = []
-    running_state_gradient: list[Array] = []
-    running_control_gradient: list[Array] = []
-    running_state_hessian: list[Array] = []
-    running_control_hessian: list[Array] = []
-    running_control_state_hessian: list[Array] = []
-
-    for step in range(problem.time_grid.num_steps):
-        time = problem.time_grid.times[step]
-        anchor = states[step]
-        nominal_next = states[step + 1]
-        nominal = jnp.concatenate(
-            (
-                jnp.zeros((state_size,), dtype=states.dtype),
-                controls[step].reshape((control_size,)),
-            )
+    local_template = jnp.asarray(geometry.inverse_retract(states[0], states[0]))
+    if local_template.size != state_size:
+        raise ValueError(
+            "iLQR geometry local coordinates must match state_layout.local_size."
         )
-        local_template = jnp.asarray(geometry.inverse_retract(anchor, anchor))
-        if local_template.size != state_size:
-            raise ValueError(
-                "iLQR geometry local coordinates must match state_layout.local_size."
-            )
-        local_shape = local_template.shape
+    local_shape = local_template.shape
+    basis_state = jnp.zeros((state_size,), dtype=states.dtype)
+
+    def stage_model(
+        step: Array,
+        anchor: Array,
+        nominal_next: Array,
+        nominal_control: Array,
+    ):
+        nominal = jnp.concatenate((basis_state, nominal_control.reshape((control_size,))))
 
         def flattened_flow(joint: Array) -> Array:
             state = jnp.asarray(
@@ -777,13 +530,7 @@ def _local_model(
                 jnp.full_like(next_error, jnp.nan),
             )
 
-        basis = jnp.eye(total_size, dtype=nominal.dtype)
-        columns = jax.vmap(
-            lambda tangent: jax.jvp(flattened_flow, (nominal,), (tangent,))[1]
-        )(basis)
-        jacobian = jnp.swapaxes(columns, 0, 1)
-        dynamics_state.append(jacobian[:, :state_size])
-        dynamics_control.append(jacobian[:, state_size:])
+        jacobian = jax.jacfwd(flattened_flow)(nominal)
 
         def stage_cost(joint: Array) -> Array:
             if problem.running_cost is None:
@@ -792,19 +539,44 @@ def _local_model(
                 geometry.retract(anchor, joint[:state_size].reshape(local_shape))
             )
             control = joint[state_size:].reshape(problem.control_shape)
-            value = jnp.asarray(problem.running_cost(time, state, control, problem.args))
+            value = jnp.asarray(
+                problem.running_cost(
+                    problem.time_grid.times[step],
+                    state,
+                    control,
+                    problem.args,
+                )
+            )
             if value.shape != ():
                 raise ValueError("RunningCost must return a scalar during iLQR.")
             return problem.time_grid.durations[step] * value
 
-        gradient = jax.grad(stage_cost)(nominal)
-        hessian = jax.hessian(stage_cost)(nominal)
+        gradient, hessian = jax.jacfwd(jax.value_and_grad(stage_cost))(nominal)
         hessian = 0.5 * (hessian + hessian.T)
-        running_state_gradient.append(gradient[:state_size])
-        running_control_gradient.append(gradient[state_size:])
-        running_state_hessian.append(hessian[:state_size, :state_size])
-        running_control_hessian.append(hessian[state_size:, state_size:])
-        running_control_state_hessian.append(hessian[state_size:, :state_size])
+        return (
+            jacobian[:, :state_size],
+            jacobian[:, state_size:],
+            gradient[:state_size],
+            gradient[state_size:],
+            hessian[:state_size, :state_size],
+            hessian[state_size:, state_size:],
+            hessian[state_size:, :state_size],
+        )
+
+    (
+        dynamics_state,
+        dynamics_control,
+        running_state_gradient,
+        running_control_gradient,
+        running_state_hessian,
+        running_control_hessian,
+        running_control_state_hessian,
+    ) = jax.vmap(stage_model)(
+        jnp.arange(problem.time_grid.num_steps, dtype=jnp.int32),
+        states[:-1],
+        states[1:],
+        controls,
+    )
 
     terminal_anchor = states[-1]
     terminal_local = jnp.zeros((state_size,), dtype=states.dtype)
@@ -832,108 +604,42 @@ def _local_model(
             raise ValueError("TerminalCost must return a scalar during iLQR.")
         return value
 
-    terminal_gradient = jax.grad(terminal_cost)(terminal_local)
-    terminal_hessian = jax.hessian(terminal_cost)(terminal_local)
+    terminal_gradient, terminal_hessian = jax.jacfwd(jax.value_and_grad(terminal_cost))(
+        terminal_local
+    )
     terminal_hessian = 0.5 * (terminal_hessian + terminal_hessian.T)
-    a = jnp.stack(dynamics_state)
-    b = jnp.stack(dynamics_control)
-    lx = jnp.stack(running_state_gradient)
-    lu = jnp.stack(running_control_gradient)
 
-    costate = terminal_gradient
-    control_gradient: list[Array] = [
-        jnp.zeros_like(lu[0]) for _ in range(problem.time_grid.num_steps)
-    ]
-    for step in range(problem.time_grid.num_steps - 1, -1, -1):
-        control_gradient[step] = lu[step] + b[step].T @ costate
-        costate = lx[step] + a[step].T @ costate
+    def adjoint_step(costate: Array, inputs: tuple[Array, Array, Array, Array]):
+        dynamics_state_step, dynamics_control_step, state_gradient, control_gradient = (
+            inputs
+        )
+        reduced_control_gradient = control_gradient + dynamics_control_step.T @ costate
+        next_costate = state_gradient + dynamics_state_step.T @ costate
+        return next_costate, reduced_control_gradient
+
+    _, reverse_control_gradient = jax.lax.scan(
+        adjoint_step,
+        terminal_gradient,
+        (
+            dynamics_state[::-1],
+            dynamics_control[::-1],
+            running_state_gradient[::-1],
+            running_control_gradient[::-1],
+        ),
+    )
 
     return _LocalModel(
-        dynamics_state=a,
-        dynamics_control=b,
-        running_state_gradient=lx,
-        running_control_gradient=lu,
-        running_state_hessian=jnp.stack(running_state_hessian),
-        running_control_hessian=jnp.stack(running_control_hessian),
-        running_control_state_hessian=jnp.stack(running_control_state_hessian),
+        dynamics_state=dynamics_state,
+        dynamics_control=dynamics_control,
+        running_state_gradient=running_state_gradient,
+        running_control_gradient=running_control_gradient,
+        running_state_hessian=running_state_hessian,
+        running_control_hessian=running_control_hessian,
+        running_control_state_hessian=running_control_state_hessian,
         terminal_gradient=terminal_gradient,
         terminal_hessian=terminal_hessian,
-        control_gradient=jnp.stack(control_gradient),
+        control_gradient=reverse_control_gradient[::-1],
     )
-
-
-def _backward_pass(model: _LocalModel, regularization: float, /) -> _BackwardPass:
-    num_steps = int(model.dynamics_state.shape[0])
-    control_size = int(model.dynamics_control.shape[-1])
-    state_size = int(model.dynamics_state.shape[-1])
-    value_gradient = model.terminal_gradient
-    value_hessian = model.terminal_hessian
-    feedforward = [
-        jnp.zeros((control_size,), dtype=value_gradient.dtype) for _ in range(num_steps)
-    ]
-    feedback = [
-        jnp.zeros((control_size, state_size), dtype=value_gradient.dtype)
-        for _ in range(num_steps)
-    ]
-    linear_reduction = jnp.asarray(0.0, dtype=value_gradient.dtype)
-    quadratic_reduction = jnp.asarray(0.0, dtype=value_gradient.dtype)
-    minimum_curvature = jnp.asarray(jnp.inf, dtype=value_gradient.real.dtype)
-    failed_step = -1
-    positive_definite = True
-    identity = jnp.eye(control_size, dtype=value_hessian.dtype)
-
-    for step in range(num_steps - 1, -1, -1):
-        a = model.dynamics_state[step]
-        b = model.dynamics_control[step]
-        qx = model.running_state_gradient[step] + a.T @ value_gradient
-        qu = model.running_control_gradient[step] + b.T @ value_gradient
-        qxx = model.running_state_hessian[step] + a.T @ value_hessian @ a
-        quu = model.running_control_hessian[step] + b.T @ value_hessian @ b
-        qux = model.running_control_state_hessian[step] + b.T @ value_hessian @ a
-        qxx = 0.5 * (qxx + qxx.T)
-        regularized_quu = 0.5 * (quu + quu.T) + regularization * identity
-        curvature = jnp.min(jnp.linalg.eigvalsh(regularized_quu))
-        minimum_curvature = jnp.minimum(minimum_curvature, curvature)
-        if not _host_bool(jnp.isfinite(curvature) & (curvature > 0.0)):
-            positive_definite = False
-            failed_step = step
-            break
-        factor = jnp.linalg.cholesky(regularized_quu)
-        solved_gradient = jsp_linalg.solve_triangular(
-            factor.T,
-            jsp_linalg.solve_triangular(factor, qu, lower=True),
-            lower=False,
-        )
-        solved_cross = jsp_linalg.solve_triangular(
-            factor.T,
-            jsp_linalg.solve_triangular(factor, qux, lower=True),
-            lower=False,
-        )
-        k = -solved_gradient
-        gain = -solved_cross
-        feedforward[step] = k
-        feedback[step] = gain
-        linear_reduction = linear_reduction + qu @ k
-        quadratic_reduction = quadratic_reduction + 0.5 * k @ regularized_quu @ k
-        value_gradient = qx + gain.T @ qu + qux.T @ k + gain.T @ regularized_quu @ k
-        value_hessian = (
-            qxx + gain.T @ qux + qux.T @ gain + gain.T @ regularized_quu @ gain
-        )
-        value_hessian = 0.5 * (value_hessian + value_hessian.T)
-
-    return _BackwardPass(
-        feedforward=jnp.stack(feedforward),
-        feedback=jnp.stack(feedback),
-        linear_reduction=linear_reduction,
-        quadratic_reduction=quadratic_reduction,
-        minimum_curvature=minimum_curvature,
-        positive_definite=jnp.asarray(positive_definite),
-        failed_step=jnp.asarray(failed_step, dtype=jnp.int32),
-    )
-
-
-def _history(values: list[Array], dtype: Any, /) -> Array:
-    return jnp.stack(values) if values else jnp.empty((0,), dtype=dtype)
 
 
 def solve_ilqr(
@@ -953,56 +659,15 @@ def solve_ilqr(
     policy_id: str | None = None,
     result_id: str | None = None,
 ) -> ILQRResult:
-    """Solve one homogeneous finite-horizon case batch by iterative LQR.
+    """Solve a finite-horizon case batch through the prepared iLQR kernel."""
+    from ._prepared_ilqr import (
+        _compiled_solve_prepared_ilqr,
+        plan_ilqr,
+        prepare_ilqr,
+    )
 
-    Nonempty case axes route through the prepared fixed-capacity JAX kernel.
-    Unbatched calls retain the established convenience implementation.
-    """
-    if not isinstance(problem, ControlProblem):
-        raise TypeError("solve_ilqr problem must be a ControlProblem.")
-    if problem.case_shape:
-        from ._batched_trajectory import (
-            plan_ilqr,
-            prepare_ilqr,
-            solve_prepared_ilqr,
-        )
-
-        plan = plan_ilqr(
-            problem,
-            max_iterations=max_iterations,
-            regularization=regularization,
-            gradient_tolerance=gradient_tolerance,
-            cost_tolerance=cost_tolerance,
-            line_search_steps=line_search_steps,
-            line_search_decay=line_search_decay,
-            initial_step_size=initial_step_size,
-            armijo=armijo,
-        )
-        prepared = prepare_ilqr(
-            plan,
-            problem,
-            initial_controls,
-            differential_flow=differential_flow,
-        )
-        return solve_prepared_ilqr(
-            prepared,
-            policy_id=policy_id,
-            result_id=result_id,
-        )
-    if problem.path_constraints or problem.terminal_constraints:
-        raise ValueError(
-            "solve_ilqr is unconstrained; constrained ControlProblems are unsupported."
-        )
-    (
-        max_iterations_,
-        regularization_,
-        gradient_tolerance_,
-        cost_tolerance_,
-        line_search_steps_,
-        line_search_decay_,
-        initial_step_size_,
-        armijo_,
-    ) = _validate_solver_options(
+    plan = plan_ilqr(
+        problem,
         max_iterations=max_iterations,
         regularization=regularization,
         gradient_tolerance=gradient_tolerance,
@@ -1012,222 +677,43 @@ def solve_ilqr(
         initial_step_size=initial_step_size,
         armijo=armijo,
     )
-    controls = jnp.asarray(initial_controls)
-    expected_controls = (problem.time_grid.num_steps,) + problem.control_shape
-    if tuple(controls.shape) != expected_controls:
-        raise ValueError(
-            f"initial_controls must have shape {expected_controls}; got {controls.shape}."
-        )
-    if not jnp.issubdtype(controls.dtype, jnp.inexact):
-        controls = controls.astype(float)
-    flow, discretization_id, backend_id = _flow_map(problem, differential_flow)
-    state_layout = problem.dynamics.system.state_layout
-    if (
-        not state_layout.geometry.supports_exact_inverse
-        or not state_layout.geometry.supports_exact_differential
-    ):
-        raise ValueError(
-            "iLQR requires exact inverse-retraction and retraction-differential geometry."
-        )
-    (
-        states,
-        controls,
-        valid,
-        objective,
-        failed_step,
-        transition_evidence,
-    ) = _open_loop_rollout(problem, controls, flow)
-
-    objective_history: list[Array] = [objective]
-    gradient_history: list[Array] = []
-    curvature_history: list[Array] = []
-    step_history: list[Array] = []
-    expected_history: list[Array] = []
-    actual_history: list[Array] = []
-    evaluations_history: list[Array] = []
-    accepted_iterations = 0
-    status = ILQRStatus.MAX_ITERATIONS
-    final_feedback = jnp.zeros(
+    prepared = prepare_ilqr(
+        plan,
+        problem,
+        initial_controls,
+        differential_flow=differential_flow,
+    )
+    result = _compiled_solve_prepared_ilqr(
+        prepared,
+        policy_id=policy_id,
+        result_id=result_id,
+    )
+    if problem.case_shape:
+        return result
+    attempted = int(jax.device_get(result.diagnostics.iterations))
+    accepted = int(jax.device_get(result.diagnostics.accepted_iterations))
+    diagnostics = eqx.tree_at(
+        lambda value: (
+            value.objective_history,
+            value.gradient_norm_history,
+            value.regularized_minimum_curvature_history,
+            value.step_size_history,
+            value.expected_reduction_history,
+            value.actual_reduction_history,
+            value.line_search_evaluations_history,
+        ),
+        result.diagnostics,
         (
-            problem.time_grid.num_steps,
-            int(np.prod(problem.control_shape)),
-            state_layout.local_size,
+            result.diagnostics.objective_history[: accepted + 1],
+            result.diagnostics.gradient_norm_history[:attempted],
+            result.diagnostics.regularized_minimum_curvature_history[:attempted],
+            result.diagnostics.step_size_history[:attempted],
+            result.diagnostics.expected_reduction_history[:attempted],
+            result.diagnostics.actual_reduction_history[:attempted],
+            result.diagnostics.line_search_evaluations_history[:attempted],
         ),
-        dtype=controls.dtype,
     )
-
-    if not _host_bool(jnp.all(valid) & jnp.isfinite(objective)):
-        status = ILQRStatus.INITIAL_ROLLOUT_FAILED
-    else:
-        for _ in range(max_iterations_):
-            model = _local_model(problem, states, controls, flow)
-            gradient_norm = jnp.linalg.norm(model.control_gradient.reshape((-1,)))
-            backward = _backward_pass(model, regularization_)
-            gradient_history.append(gradient_norm)
-            curvature_history.append(backward.minimum_curvature)
-            if not _host_bool(backward.positive_definite):
-                status = ILQRStatus.BACKWARD_PASS_NOT_POSITIVE_DEFINITE
-                failed_step = backward.failed_step
-                step_history.append(jnp.asarray(0.0, dtype=objective.dtype))
-                expected_history.append(jnp.asarray(jnp.nan, dtype=objective.dtype))
-                actual_history.append(jnp.asarray(jnp.nan, dtype=objective.dtype))
-                evaluations_history.append(jnp.asarray(0, dtype=jnp.int32))
-                break
-            final_feedback = backward.feedback
-            if _host_bool(gradient_norm <= gradient_tolerance_):
-                status = ILQRStatus.SUCCESS
-                step_history.append(jnp.asarray(0.0, dtype=objective.dtype))
-                expected_history.append(jnp.asarray(0.0, dtype=objective.dtype))
-                actual_history.append(jnp.asarray(0.0, dtype=objective.dtype))
-                evaluations_history.append(jnp.asarray(0, dtype=jnp.int32))
-                break
-
-            accepted = False
-            last_expected = jnp.asarray(jnp.nan, dtype=objective.dtype)
-            last_actual = jnp.asarray(jnp.nan, dtype=objective.dtype)
-            candidate_failed_step = jnp.asarray(-1, dtype=jnp.int32)
-            for search in range(line_search_steps_):
-                step_size = initial_step_size_ * line_search_decay_**search
-                (
-                    candidate_states,
-                    candidate_controls,
-                    candidate_valid,
-                    candidate_cost,
-                    candidate_failure,
-                    candidate_evidence,
-                ) = _feedback_rollout(
-                    problem,
-                    states,
-                    controls,
-                    backward.feedforward,
-                    backward.feedback,
-                    step_size,
-                    flow,
-                )
-                expected_reduction = -(
-                    step_size * backward.linear_reduction
-                    + step_size**2 * backward.quadratic_reduction
-                )
-                actual_reduction = objective - candidate_cost
-                last_expected = expected_reduction
-                last_actual = actual_reduction
-                if int(np.asarray(candidate_failure)) >= 0:
-                    candidate_failed_step = candidate_failure
-                acceptable = (
-                    jnp.all(candidate_valid)
-                    & jnp.isfinite(candidate_cost)
-                    & jnp.isfinite(expected_reduction)
-                    & (expected_reduction > 0.0)
-                    & (actual_reduction > 0.0)
-                    & (actual_reduction >= armijo_ * expected_reduction)
-                )
-                if _host_bool(acceptable):
-                    previous_objective = objective
-                    states = candidate_states
-                    controls = candidate_controls
-                    valid = candidate_valid
-                    objective = candidate_cost
-                    transition_evidence = candidate_evidence
-                    objective_history.append(objective)
-                    step_history.append(jnp.asarray(step_size, dtype=objective.dtype))
-                    expected_history.append(expected_reduction)
-                    actual_history.append(actual_reduction)
-                    evaluations_history.append(jnp.asarray(search + 1, dtype=jnp.int32))
-                    accepted_iterations += 1
-                    accepted = True
-                    if _host_bool(
-                        actual_reduction
-                        <= cost_tolerance_
-                        * jnp.maximum(jnp.asarray(1.0), jnp.abs(previous_objective))
-                    ):
-                        status = ILQRStatus.SUCCESS
-                    break
-            if not accepted:
-                status = ILQRStatus.LINE_SEARCH_FAILED
-                failed_step = candidate_failed_step
-                step_history.append(jnp.asarray(0.0, dtype=objective.dtype))
-                expected_history.append(last_expected)
-                actual_history.append(last_actual)
-                evaluations_history.append(
-                    jnp.asarray(line_search_steps_, dtype=jnp.int32)
-                )
-                break
-            if status == ILQRStatus.SUCCESS:
-                break
-
-    policy_name = f"ilqr-policy:{problem.problem_id}" if policy_id is None else policy_id
-    policy = ILQRPolicy(
-        problem.time_grid,
-        states,
-        controls,
-        final_feedback,
-        state_layout=state_layout,
-        control_shape=problem.control_shape,
-        policy_id=policy_name,
-    )
-    trajectory_status = jnp.asarray(
-        CONTROL_SUCCESS if _host_bool(jnp.all(valid)) else CONTROL_DYNAMICS_FAILED,
-        dtype=jnp.int32,
-    )
-    trajectory_backend_status = (
-        transition_evidence.first_failure_status
-        if transition_evidence is not None
-        else trajectory_status
-    )
-    trajectory = ControlTrajectory(
-        time_grid=problem.time_grid,
-        states=states,
-        controls=controls,
-        valid=valid,
-        status=trajectory_status,
-        backend_status=trajectory_backend_status,
-        transition_evidence=transition_evidence,
-        case_shape=(),
-        state_shape=problem.state_shape,
-        control_shape=problem.control_shape,
-        problem_id=problem.problem_id,
-        dynamics_id=problem.dynamics.dynamics_id,
-        control_id=policy.parameterization_id,
-        backend_id=backend_id,
-        method_id="iterative-lqr:explicit-flow-map-jvp",
-        discretization_id=discretization_id,
-        approximation_id=policy.approximation_id,
-    )
-    sampled_loss = evaluate_sampled_cost(problem, trajectory)
-    feasibility = evaluate_sampled_feasibility(problem, trajectory)
-    control_result = ControlResult(
-        trajectory=trajectory,
-        parameters=controls,
-        sampled_loss=sampled_loss,
-        feasibility=feasibility,
-        result_id=(
-            f"ilqr-result:{problem.problem_id}" if result_id is None else result_id
-        ),
-        method_id=trajectory.method_id,
-    )
-    diagnostics = ILQRDiagnostics(
-        objective_history=_history(objective_history, objective.dtype),
-        gradient_norm_history=_history(gradient_history, objective.dtype),
-        regularized_minimum_curvature_history=_history(
-            curvature_history, objective.dtype
-        ),
-        step_size_history=_history(step_history, objective.dtype),
-        expected_reduction_history=_history(expected_history, objective.dtype),
-        actual_reduction_history=_history(actual_history, objective.dtype),
-        line_search_evaluations_history=_history(evaluations_history, jnp.int32),
-        regularization=jnp.asarray(regularization_, dtype=objective.dtype),
-        status=jnp.asarray(int(status), dtype=jnp.int32),
-        iterations=jnp.asarray(len(gradient_history), dtype=jnp.int32),
-        accepted_iterations=jnp.asarray(accepted_iterations, dtype=jnp.int32),
-        failed_step=failed_step,
-        converged=jnp.asarray(status == ILQRStatus.SUCCESS),
-        method_id="iterative-lqr:regularized-backward+backtracking",
-    )
-    return ILQRResult(
-        control_result=control_result,
-        policy=policy,
-        diagnostics=diagnostics,
-    )
+    return eqx.tree_at(lambda value: value.diagnostics, result, diagnostics)
 
 
 __all__ = [

--- a/phydrax/control/_mpc.py
+++ b/phydrax/control/_mpc.py
@@ -18,6 +18,7 @@ import phydrax.ein as ein
 from .._strict import StrictModule
 from ..dynamics import TimeGrid
 from ..optim._programming import (
+    ClarabelInteriorPoint,
     ConvexProgramResult,
     ConvexProgramStatus,
     ConvexSolvePolicy,
@@ -26,6 +27,7 @@ from ..optim._programming import (
 from ._parameterization import PiecewiseConstantControlParameterization
 from ._problem import _identifier
 from ._qp_compiler import (
+    LinearControlCompilationPolicy,
     LinearControlQPSolution,
     LinearQuadraticControlProblem,
     prepare_linear_quadratic_control,
@@ -109,6 +111,7 @@ class RecedingHorizonMPC(StrictModule):
     prediction_horizon: int = eqx.field(static=True)
     terminal_policy: MPCTerminalPolicy = eqx.field(static=True)
     qp_policy: ConvexSolvePolicy
+    compilation_policy: LinearControlCompilationPolicy = eqx.field(static=True)
     warm_start_policy: MPCWarmStartPolicy | None
     cost_tolerance: float = eqx.field(static=True)
     controller_id: str = eqx.field(static=True)
@@ -120,6 +123,7 @@ class RecedingHorizonMPC(StrictModule):
         *,
         prediction_horizon: int,
         terminal_policy: MPCTerminalPolicy,
+        compilation_policy: LinearControlCompilationPolicy | None = None,
         cost_tolerance: float = 1e-10,
         policy: ConvexSolvePolicy | None = None,
         warm_start_policy: MPCWarmStartPolicy | None = None,
@@ -139,18 +143,37 @@ class RecedingHorizonMPC(StrictModule):
         self.specification = specification
         self.prediction_horizon = prediction_horizon
         self.terminal_policy = terminal_policy
-        policy = ConvexSolvePolicy() if policy is None else policy
-        if not isinstance(policy, ConvexSolvePolicy):
+        selected_compilation = (
+            LinearControlCompilationPolicy()
+            if compilation_policy is None
+            else compilation_policy
+        )
+        if not isinstance(selected_compilation, LinearControlCompilationPolicy):
+            raise TypeError(
+                "compilation_policy must be a LinearControlCompilationPolicy or None."
+            )
+        selected_policy = (
+            ConvexSolvePolicy(ClarabelInteriorPoint())
+            if policy is None and selected_compilation.representation == "sparse"
+            else ConvexSolvePolicy()
+            if policy is None
+            else policy
+        )
+        if not isinstance(selected_policy, ConvexSolvePolicy):
             raise TypeError("policy must be a ConvexSolvePolicy or None.")
         if warm_start_policy is not None and not isinstance(
             warm_start_policy, MPCWarmStartPolicy
         ):
             raise TypeError("warm_start_policy must be an MPCWarmStartPolicy or None.")
-        if warm_start_policy is not None and not policy.method.capabilities.warm_start:
+        if (
+            warm_start_policy is not None
+            and not selected_policy.method.capabilities.warm_start
+        ):
             raise ValueError(
-                f"Method {policy.method.method_id!r} does not support MPC warm starts."
+                f"Method {selected_policy.method.method_id!r} does not support MPC warm starts."
             )
-        self.qp_policy = policy
+        self.compilation_policy = selected_compilation
+        self.qp_policy = selected_policy
         self.warm_start_policy = warm_start_policy
         self.cost_tolerance = float(cost_tolerance)
         self.controller_id = _identifier(controller_id, "controller_id")
@@ -200,12 +223,14 @@ class RecedingHorizonMPC(StrictModule):
                     prepared_by_topology[topology],
                     local_problem,
                     cost_tolerance=self.cost_tolerance,
+                    compilation_policy=self.compilation_policy,
                 )
             else:
                 prepared = prepare_linear_quadratic_control(
                     local_problem,
                     policy=self.qp_policy,
                     cost_tolerance=self.cost_tolerance,
+                    compilation_policy=self.compilation_policy,
                 )
             prepared_by_topology[topology] = prepared
             convex_warm = (
@@ -385,7 +410,7 @@ class RecedingHorizonMPC(StrictModule):
             jnp.stack(tuple(states), axis=-2),
             controls,
         )
-        qp = compilation.quadratic_program
+        qp = compilation.program
         margin = jnp.asarray(policy.interior_margin, dtype=dtype)
         lower_finite = jnp.isfinite(qp.lower_bounds)
         upper_finite = jnp.isfinite(qp.upper_bounds)

--- a/phydrax/control/_prepared_ilqr.py
+++ b/phydrax/control/_prepared_ilqr.py
@@ -512,8 +512,7 @@ def _backward(model, regularization):
             + ein.contract("ji,jk,kl->il", gain, regularized, gain)
         )
         next_hessian = 0.5 * (next_hessian + jnp.swapaxes(next_hessian, -1, -2))
-        diagonal = jnp.real(jnp.diagonal(factorization.factors[0]))
-        minimum = jnp.min(diagonal * diagonal)
+        minimum = jnp.min(jnp.linalg.eigvalsh(regularized))
         next_carry = (
             jnp.where(usable, next_gradient, value_gradient),
             jnp.where(usable, next_hessian, value_hessian),
@@ -581,6 +580,7 @@ def _solve_case(prepared: PreparedILQR, initial_state: Array, initial_controls: 
     )
     iterations = plan.maximum_iterations
     history_shape = (iterations,)
+    objective_history = jnp.full((iterations + 1,), jnp.nan, dtype=objective.dtype)
     zeros = jnp.zeros(history_shape, dtype=objective.dtype)
     nan_history = jnp.full(history_shape, jnp.nan, dtype=objective.dtype)
     initial_active = jnp.all(valid) & jnp.isfinite(objective)
@@ -607,7 +607,7 @@ def _solve_case(prepared: PreparedILQR, initial_state: Array, initial_controls: 
         failed_step,
         jnp.asarray(0, dtype=jnp.int32),
         jnp.asarray(0, dtype=jnp.int32),
-        nan_history.at[0].set(objective),
+        objective_history.at[0].set(objective),
         nan_history,
         nan_history,
         zeros,
@@ -799,7 +799,7 @@ def _solve_case(prepared: PreparedILQR, initial_state: Array, initial_controls: 
                 next_failed,
                 iteration_count + 1,
                 accepted_count + found.astype(jnp.int32),
-                objective_history.at[index].set(next_objective),
+                objective_history.at[index + 1].set(next_objective),
                 gradient_history.at[index].set(gradient_norm),
                 curvature_history.at[index].set(curvature),
                 step_history.at[index].set(step_size),
@@ -923,6 +923,9 @@ def solve_prepared_ilqr(
         "iterative-lqr:prepared-fixed-capacity",
     )
     return ILQRResult(control_result, policy, diagnostics)
+
+
+_compiled_solve_prepared_ilqr = eqx.filter_jit(solve_prepared_ilqr)
 
 
 __all__ = [

--- a/phydrax/control/_qp_compiler.py
+++ b/phydrax/control/_qp_compiler.py
@@ -17,16 +17,22 @@ from jaxtyping import Array, ArrayLike
 from .._bounds import Bounds
 from .._strict import StrictModule
 from ..dynamics import TimeGrid
+from ..linalg import OperatorProperties
 from ..optim._programming import (
+    ClarabelInteriorPoint,
+    ConicProgram,
     ConvexProgramResult,
     ConvexProgramStatus,
     ConvexSolvePolicy,
     ConvexWarmStart,
+    NonnegativeCone,
     prepare_convex_program,
     PreparedConvexProgram,
+    ProductCone,
     QuadraticProgram,
     refresh_convex_program,
     solve_convex_program,
+    ZeroCone,
 )
 from ..sparse import EdgeRelation, SparseLinearMap
 from ._parameterization import PiecewiseConstantControlParameterization
@@ -770,95 +776,423 @@ class LinearControlConstraintLayout(StrictModule):
         self.num_inequalities = inequality_cursor
 
 
-def _sparse_map_from_mask(matrix: Array, mask: np.ndarray, /) -> SparseLinearMap:
-    rows, columns = np.nonzero(mask)
-    relation = EdgeRelation(
-        jnp.asarray(columns, dtype=jnp.int32),
-        jnp.asarray(rows, dtype=jnp.int32),
-        source_size=mask.shape[1],
-        target_size=mask.shape[0],
+def _block_route_indices(rows: slice, columns: slice, /) -> tuple[np.ndarray, np.ndarray]:
+    row_indices = np.arange(rows.start, rows.stop, dtype=np.int32)
+    column_indices = np.arange(columns.start, columns.stop, dtype=np.int32)
+    return (
+        np.repeat(row_indices, column_indices.size),
+        np.tile(column_indices, row_indices.size),
     )
-    coefficients = matrix[..., rows, columns]
-    return SparseLinearMap(relation, coefficients)
 
 
-def _control_sparse_operators(
-    specification: LinearQuadraticControlProblem,
-    decision: LinearControlDecisionLayout,
-    constraints: LinearControlConstraintLayout,
-    quadratic: Array,
-    equality: Array,
-    inequality: Array,
+def _append_sparse_block(
+    row_routes: list[np.ndarray],
+    column_routes: list[np.ndarray],
+    coefficient_blocks: list[Array],
+    rows: slice,
+    columns: slice,
+    values: Array,
     /,
-) -> tuple[SparseLinearMap, SparseLinearMap, SparseLinearMap]:
-    variables = decision.num_variables
-    quadratic_mask = np.zeros((variables, variables), dtype=bool)
-    for stage in range(specification.horizon):
-        state = decision.state_slice(stage)
-        control = decision.control_slice(stage)
-        quadratic_mask[state, state] = True
-        quadratic_mask[control, control] = True
-        quadratic_mask[state, control] = True
-        quadratic_mask[control, state] = True
-    terminal = decision.state_slice(specification.horizon)
-    quadratic_mask[terminal, terminal] = True
+) -> None:
+    row_indices, column_indices = _block_route_indices(rows, columns)
+    row_routes.append(row_indices)
+    column_routes.append(column_indices)
+    coefficient_blocks.append(values.reshape(values.shape[:-2] + (-1,)))
 
-    equality_mask = np.zeros((constraints.num_equalities, variables), dtype=bool)
-    initial = constraints.initial_condition_slice
-    for index in range(specification.state_size):
-        equality_mask[
-            initial.start + index, decision.initial_state_slice.start + index
-        ] = True
+
+def _sparse_linear_map(
+    row_routes: list[np.ndarray],
+    column_routes: list[np.ndarray],
+    coefficient_blocks: list[Array],
+    /,
+    *,
+    source_size: int,
+    target_size: int,
+    properties: OperatorProperties | None = None,
+    operator_id: str,
+) -> SparseLinearMap:
+    rows = np.concatenate(row_routes) if row_routes else np.empty((0,), dtype=np.int32)
+    columns = (
+        np.concatenate(column_routes) if column_routes else np.empty((0,), dtype=np.int32)
+    )
+    relation = EdgeRelation(
+        jnp.asarray(columns),
+        jnp.asarray(rows),
+        source_size=source_size,
+        target_size=target_size,
+    )
+    coefficients = (
+        jnp.concatenate(tuple(coefficient_blocks), axis=-1)
+        if coefficient_blocks
+        else jnp.empty((0,))
+    )
+    return SparseLinearMap(
+        relation,
+        coefficients,
+        properties=properties,
+        operator_id=operator_id,
+    )
+
+
+def _control_bounds(
+    specification: LinearQuadraticControlProblem,
+    layout: LinearControlDecisionLayout,
+    /,
+) -> Bounds:
+    batch = specification.case_shape
+    dtype = specification.dynamics_matrices.dtype
+    state_shape = batch + (
+        specification.horizon + 1,
+        specification.state_size,
+    )
+    control_shape = batch + (
+        specification.horizon,
+        specification.control_size,
+    )
+    state_lower = (
+        jnp.full(state_shape, -jnp.inf, dtype=dtype)
+        if specification.state_lower_bounds is None
+        else specification.state_lower_bounds
+    )
+    state_upper = (
+        jnp.full(state_shape, jnp.inf, dtype=dtype)
+        if specification.state_upper_bounds is None
+        else specification.state_upper_bounds
+    )
+    control_lower = (
+        jnp.full(control_shape, -jnp.inf, dtype=dtype)
+        if specification.control_lower_bounds is None
+        else specification.control_lower_bounds
+    )
+    control_upper = (
+        jnp.full(control_shape, jnp.inf, dtype=dtype)
+        if specification.control_upper_bounds is None
+        else specification.control_upper_bounds
+    )
+    return Bounds(
+        jnp.concatenate(
+            (
+                state_lower.reshape(batch + (layout.all_states_slice.stop,)),
+                control_lower.reshape(
+                    batch + (specification.horizon * specification.control_size,)
+                ),
+            ),
+            axis=-1,
+        ),
+        jnp.concatenate(
+            (
+                state_upper.reshape(batch + (layout.all_states_slice.stop,)),
+                control_upper.reshape(
+                    batch + (specification.horizon * specification.control_size,)
+                ),
+            ),
+            axis=-1,
+        ),
+    )
+
+
+def _compile_sparse_control_program(
+    specification: LinearQuadraticControlProblem,
+    layout: LinearControlDecisionLayout,
+    constraints: LinearControlConstraintLayout,
+    bound_layout: LinearControlBoundLayout,
+    state_costs: Array,
+    state_control_cross: Array,
+    control_costs: Array,
+    terminal_state_cost: Array,
+    /,
+) -> LinearControlQPCompilation:
+    batch = specification.case_shape
+    dtype = specification.dynamics_matrices.dtype
+    quadratic_rows: list[np.ndarray] = []
+    quadratic_columns: list[np.ndarray] = []
+    quadratic_values: list[Array] = []
+    for stage in range(specification.horizon):
+        state = layout.state_slice(stage)
+        control = layout.control_slice(stage)
+        cross = state_control_cross[..., stage, :, :]
+        _append_sparse_block(
+            quadratic_rows,
+            quadratic_columns,
+            quadratic_values,
+            state,
+            state,
+            state_costs[..., stage, :, :],
+        )
+        _append_sparse_block(
+            quadratic_rows,
+            quadratic_columns,
+            quadratic_values,
+            control,
+            control,
+            control_costs[..., stage, :, :],
+        )
+        _append_sparse_block(
+            quadratic_rows,
+            quadratic_columns,
+            quadratic_values,
+            state,
+            control,
+            cross,
+        )
+        _append_sparse_block(
+            quadratic_rows,
+            quadratic_columns,
+            quadratic_values,
+            control,
+            state,
+            jnp.swapaxes(cross, -1, -2),
+        )
+    terminal_state = layout.state_slice(specification.horizon)
+    _append_sparse_block(
+        quadratic_rows,
+        quadratic_columns,
+        quadratic_values,
+        terminal_state,
+        terminal_state,
+        terminal_state_cost,
+    )
+    quadratic = _sparse_linear_map(
+        quadratic_rows,
+        quadratic_columns,
+        quadratic_values,
+        source_size=layout.num_variables,
+        target_size=layout.num_variables,
+        properties=OperatorProperties(
+            self_adjoint=True,
+            positive_semidefinite=True,
+            evidence={
+                "self_adjoint": "construction",
+                "positive_semidefinite": "verified",
+            },
+        ),
+        operator_id=f"{specification.problem_id}:sparse-quadratic",
+    )
+
+    state_linear = jnp.concatenate(
+        (
+            specification.state_linear,
+            specification.terminal_linear[..., None, :],
+        ),
+        axis=-2,
+    )
+    linear = jnp.concatenate(
+        (
+            state_linear.reshape(batch + (-1,)),
+            specification.control_linear.reshape(batch + (-1,)),
+        ),
+        axis=-1,
+    )
+
+    constraint_rows: list[np.ndarray] = []
+    constraint_columns: list[np.ndarray] = []
+    constraint_values: list[Array] = []
+    equality_rhs: list[Array] = [specification.initial_state]
+    identity_state = jnp.broadcast_to(
+        jnp.eye(specification.state_size, dtype=dtype),
+        batch + (specification.state_size, specification.state_size),
+    )
+    _append_sparse_block(
+        constraint_rows,
+        constraint_columns,
+        constraint_values,
+        constraints.initial_condition_slice,
+        layout.initial_state_slice,
+        identity_state,
+    )
     for stage, rows in enumerate(constraints.dynamics_slices):
-        previous = decision.state_slice(stage)
-        following = decision.state_slice(stage + 1)
-        control = decision.control_slice(stage)
-        equality_mask[rows, previous] = True
-        equality_mask[rows, control] = True
-        for index in range(specification.state_size):
-            equality_mask[rows.start + index, following.start + index] = True
+        previous = layout.state_slice(stage)
+        following = layout.state_slice(stage + 1)
+        control = layout.control_slice(stage)
+        _append_sparse_block(
+            constraint_rows,
+            constraint_columns,
+            constraint_values,
+            rows,
+            following,
+            identity_state,
+        )
+        _append_sparse_block(
+            constraint_rows,
+            constraint_columns,
+            constraint_values,
+            rows,
+            previous,
+            -specification.dynamics_matrices[..., stage, :, :],
+        )
+        _append_sparse_block(
+            constraint_rows,
+            constraint_columns,
+            constraint_values,
+            rows,
+            control,
+            -specification.control_matrices[..., stage, :, :],
+        )
+        equality_rhs.append(specification.dynamics_bias[..., stage, :])
         if specification.num_stage_equalities:
             stage_rows = constraints.stage_equality_slices[stage]
-            equality_mask[stage_rows, previous] = True
-            equality_mask[stage_rows, control] = True
+            _append_sparse_block(
+                constraint_rows,
+                constraint_columns,
+                constraint_values,
+                stage_rows,
+                previous,
+                _required_array(
+                    specification.stage_equality_state_matrix,
+                    "stage equality state matrix",
+                )[..., stage, :, :],
+            )
+            _append_sparse_block(
+                constraint_rows,
+                constraint_columns,
+                constraint_values,
+                stage_rows,
+                control,
+                _required_array(
+                    specification.stage_equality_control_matrix,
+                    "stage equality control matrix",
+                )[..., stage, :, :],
+            )
+            equality_rhs.append(
+                _required_array(
+                    specification.stage_equality_rhs,
+                    "stage equality right-hand side",
+                )[..., stage, :]
+            )
     if constraints.terminal_equality_slice is not None:
-        equality_mask[constraints.terminal_equality_slice, terminal] = True
+        _append_sparse_block(
+            constraint_rows,
+            constraint_columns,
+            constraint_values,
+            constraints.terminal_equality_slice,
+            terminal_state,
+            _required_array(
+                specification.terminal_equality_matrix,
+                "terminal equality matrix",
+            ),
+        )
+        equality_rhs.append(
+            _required_array(
+                specification.terminal_equality_rhs,
+                "terminal equality right-hand side",
+            )
+        )
 
-    inequality_mask = np.zeros((constraints.num_inequalities, variables), dtype=bool)
+    inequality_rhs: list[Array] = []
+    row_offset = constraints.num_equalities
     for stage, rows in enumerate(constraints.stage_inequality_slices):
-        inequality_mask[rows, decision.state_slice(stage)] = True
-        inequality_mask[rows, decision.control_slice(stage)] = True
+        shifted_rows = slice(rows.start + row_offset, rows.stop + row_offset)
+        _append_sparse_block(
+            constraint_rows,
+            constraint_columns,
+            constraint_values,
+            shifted_rows,
+            layout.state_slice(stage),
+            _required_array(
+                specification.stage_inequality_state_matrix,
+                "stage inequality state matrix",
+            )[..., stage, :, :],
+        )
+        _append_sparse_block(
+            constraint_rows,
+            constraint_columns,
+            constraint_values,
+            shifted_rows,
+            layout.control_slice(stage),
+            _required_array(
+                specification.stage_inequality_control_matrix,
+                "stage inequality control matrix",
+            )[..., stage, :, :],
+        )
+        inequality_rhs.append(
+            _required_array(
+                specification.stage_inequality_rhs,
+                "stage inequality right-hand side",
+            )[..., stage, :]
+        )
     if constraints.terminal_inequality_slice is not None:
-        inequality_mask[constraints.terminal_inequality_slice, terminal] = True
-    return (
-        _sparse_map_from_mask(quadratic, quadratic_mask),
-        _sparse_map_from_mask(equality, equality_mask),
-        _sparse_map_from_mask(inequality, inequality_mask),
+        terminal_rows = constraints.terminal_inequality_slice
+        shifted_rows = slice(
+            terminal_rows.start + row_offset,
+            terminal_rows.stop + row_offset,
+        )
+        _append_sparse_block(
+            constraint_rows,
+            constraint_columns,
+            constraint_values,
+            shifted_rows,
+            terminal_state,
+            _required_array(
+                specification.terminal_inequality_matrix,
+                "terminal inequality matrix",
+            ),
+        )
+        inequality_rhs.append(
+            _required_array(
+                specification.terminal_inequality_rhs,
+                "terminal inequality right-hand side",
+            )
+        )
+
+    equality_rhs_value = jnp.concatenate(tuple(equality_rhs), axis=-1)
+    inequality_rhs_value = (
+        jnp.concatenate(tuple(inequality_rhs), axis=-1)
+        if inequality_rhs
+        else jnp.empty(batch + (0,), dtype=dtype)
+    )
+    constraint_rhs = jnp.concatenate(
+        (equality_rhs_value, inequality_rhs_value),
+        axis=-1,
+    )
+    constraint_operator = _sparse_linear_map(
+        constraint_rows,
+        constraint_columns,
+        constraint_values,
+        source_size=layout.num_variables,
+        target_size=constraints.num_equalities + constraints.num_inequalities,
+        operator_id=f"{specification.problem_id}:sparse-constraints",
+    )
+    program = ConicProgram(
+        quadratic,
+        linear,
+        constraint_operator,
+        constraint_rhs,
+        ProductCone(
+            (
+                ZeroCone(constraints.num_equalities),
+                NonnegativeCone(constraints.num_inequalities),
+            )
+        ),
+        bounds=_control_bounds(specification, layout),
+        problem_id=f"{specification.problem_id}:qp",
+        convexity_evidence="verified",
+    )
+    objective_constant = (
+        jnp.sum(specification.stage_constants, axis=-1) + specification.terminal_constant
+    )
+    return LinearControlQPCompilation(
+        program=program,
+        decision_layout=layout,
+        constraint_layout=constraints,
+        bound_layout=bound_layout,
+        specification=specification,
+        objective_constant=objective_constant,
+        representation="sparse",
+        compiler_id="control:qp-compiler:linear-multiple-shooting",
     )
 
 
 class LinearControlQPCompilation(StrictModule):
-    """A canonical QP together with lossless control/constraint provenance."""
+    """A canonical dense or sparse QP with control/constraint provenance."""
 
-    quadratic_program: QuadraticProgram
+    program: QuadraticProgram | ConicProgram
     decision_layout: LinearControlDecisionLayout
     constraint_layout: LinearControlConstraintLayout
     bound_layout: LinearControlBoundLayout
-    sparse_quadratic: SparseLinearMap | None
-    sparse_equality: SparseLinearMap | None
-    sparse_inequality: SparseLinearMap | None
     specification: LinearQuadraticControlProblem
     objective_constant: Array
     compiler_id: str = eqx.field(static=True)
     representation: ControlQPRepresentation = eqx.field(static=True)
-
-    @property
-    def qp(self) -> QuadraticProgram:
-        return self.quadratic_program
-
-    @property
-    def layout(self) -> LinearControlDecisionLayout:
-        return self.decision_layout
 
     def decode(self, primal: ArrayLike, /) -> tuple[Array, Array]:
         return self.decision_layout.decode(primal)
@@ -880,7 +1214,7 @@ class PreparedLinearControlQP(StrictModule):
             raise TypeError("compilation must be a LinearControlQPCompilation.")
         if not isinstance(prepared, PreparedConvexProgram):
             raise TypeError("prepared must be a PreparedConvexProgram.")
-        if prepared.program is not compilation.quadratic_program:
+        if prepared.program is not compilation.program:
             raise ValueError("Prepared program must be bound to the compilation QP.")
         self.compilation = compilation
         self.prepared = prepared
@@ -977,6 +1311,17 @@ def compile_linear_quadratic_control(
         "terminal_state_cost",
         tolerance,
     )
+    if selected_compilation.representation == "sparse":
+        return _compile_sparse_control_program(
+            specification,
+            layout,
+            constraints,
+            bound_layout,
+            state_costs,
+            state_control_cross,
+            control_costs,
+            terminal_state_cost,
+        )
     quadratic = jnp.zeros(
         batch + (layout.num_variables, layout.num_variables), dtype=dtype
     )
@@ -1141,29 +1486,14 @@ def compile_linear_quadratic_control(
     objective_constant = (
         jnp.sum(specification.stage_constants, axis=-1) + specification.terminal_constant
     )
-    sparse_quadratic = None
-    sparse_equality = None
-    sparse_inequality = None
-    if selected_compilation.representation == "sparse":
-        sparse_quadratic, sparse_equality, sparse_inequality = _control_sparse_operators(
-            specification,
-            layout,
-            constraints,
-            quadratic,
-            equality_matrix,
-            inequality_matrix,
-        )
     return LinearControlQPCompilation(
-        quadratic_program=qp,
+        program=qp,
         decision_layout=layout,
         constraint_layout=constraints,
         bound_layout=bound_layout,
-        sparse_quadratic=sparse_quadratic,
-        sparse_equality=sparse_equality,
-        sparse_inequality=sparse_inequality,
         specification=specification,
         objective_constant=objective_constant,
-        representation=selected_compilation.representation,
+        representation="dense",
         compiler_id="control:qp-compiler:linear-multiple-shooting",
     )
 
@@ -1183,7 +1513,10 @@ def prepare_linear_quadratic_control(
         cost_tolerance=cost_tolerance,
         compilation_policy=compilation_policy,
     )
-    prepared = prepare_convex_program(compilation.quadratic_program, policy)
+    selected_policy = policy
+    if compilation.representation == "sparse" and selected_policy is None:
+        selected_policy = ConvexSolvePolicy(ClarabelInteriorPoint())
+    prepared = prepare_convex_program(compilation.program, selected_policy)
     return PreparedLinearControlQP(compilation, prepared)
 
 
@@ -1211,7 +1544,7 @@ def refresh_linear_quadratic_control(
     )
     refreshed = refresh_convex_program(
         prepared.prepared,
-        compilation.quadratic_program,
+        compilation.program,
     )
     return PreparedLinearControlQP(compilation, refreshed)
 
@@ -1228,10 +1561,10 @@ def decode_linear_control_solution(
         raise TypeError("compilation must be a LinearControlQPCompilation.")
     if not isinstance(result, ConvexProgramResult):
         raise TypeError("result must be a ConvexProgramResult.")
-    qp = compilation.quadratic_program
-    if result.batch_shape != qp.batch_shape:
+    program = compilation.program
+    if result.batch_shape != program.batch_shape:
         raise ValueError("QP result batch shape does not match the compilation.")
-    if int(result.primal.shape[-1]) != qp.num_variables:
+    if int(result.primal.shape[-1]) != program.num_variables:
         raise ValueError("QP result primal dimension does not match the compilation.")
     specification = compilation.specification
     states, controls = compilation.decode(result.primal)

--- a/phydrax/discretization/_simplicial_locator.py
+++ b/phydrax/discretization/_simplicial_locator.py
@@ -7,11 +7,14 @@ from __future__ import annotations
 from enum import IntEnum
 
 import equinox as eqx
+import jax
 import jax.numpy as jnp
+import numpy as np
 from jaxtyping import Array, ArrayLike
 
 from phydrax.ein import contract
 
+from .._bvh import build_packed_bvh, PackedBVH, point_select_leaf_items
 from .._fingerprint import array_tree_fingerprint, canonical_fingerprint
 from .._strict import StrictModule
 from .._trainable import NonTrainableState
@@ -104,6 +107,7 @@ class PreparedSimplicialCellLocator(StrictModule, NonTrainableState):
     coordinates: Array
     cells: Array
     centroids: Array
+    bvh: PackedBVH
     policy: SimplicialLocationPolicy
     locator_id: str = eqx.field(static=True)
 
@@ -124,11 +128,20 @@ class PreparedSimplicialCellLocator(StrictModule, NonTrainableState):
         if values.shape != (cell_map.coordinate_count, cell_map.ambient_dimension):
             raise ValueError("Locator coordinates do not match the prepared cell map.")
         cells = cell_map.coordinate_dofs
+        cell_vertices = np.asarray(values)[np.asarray(cells)]
+        bvh = build_packed_bvh(
+            np.min(cell_vertices, axis=1),
+            np.max(cell_vertices, axis=1),
+            np.mean(cell_vertices, axis=1),
+            leaf_size=min(16, cell_map.cell_count),
+            dtype=values.dtype,
+        )
         centroids = jnp.mean(values[cells], axis=1)
         self.cell_map = cell_map
         self.coordinates = values
         self.cells = cells
         self.centroids = centroids
+        self.bvh = bvh
         self.policy = policy
         self.locator_id = canonical_fingerprint(
             {
@@ -157,10 +170,12 @@ class PreparedSimplicialCellLocator(StrictModule, NonTrainableState):
             raise ValueError("Locator points have incompatible ambient dimension.")
         point_count = values.shape[0]
         candidate_capacity = min(self.policy.maximum_candidates, self.cell_count)
-        distances = jnp.sum(
-            (values[:, None, :] - self.centroids[None, :, :]) ** 2, axis=-1
+        candidates, candidate_valid, search_complete = point_select_leaf_items(
+            values,
+            bvh=self.bvh,
+            maximum_candidates=candidate_capacity,
+            tolerance=self.policy.reference_tolerance,
         )
-        candidates = jnp.argsort(distances, axis=1)[:, :candidate_capacity]
         reference_dimension = self.dimension
         centroid_seed = jnp.full(
             (reference_dimension,), 1.0 / (reference_dimension + 1), dtype=values.dtype
@@ -178,20 +193,27 @@ class PreparedSimplicialCellLocator(StrictModule, NonTrainableState):
         flat_cells = jnp.broadcast_to(
             candidates[:, :, None], (point_count, candidate_capacity, seed_count)
         ).reshape((-1,))
+        flat_candidate_valid = jnp.broadcast_to(
+            candidate_valid[:, :, None],
+            (point_count, candidate_capacity, seed_count),
+        ).reshape((-1,))
         targets = jnp.broadcast_to(
             values[:, None, None, :],
             (point_count, candidate_capacity, seed_count, values.shape[1]),
         ).reshape((-1, values.shape[1]))
         converged = jnp.zeros((flat_cells.size,), dtype=bool)
         first_iteration = jnp.zeros((flat_cells.size,), dtype=jnp.int32)
-        residual_norm = jnp.full((flat_cells.size,), jnp.inf, dtype=values.dtype)
-        condition = jnp.full((flat_cells.size,), jnp.inf, dtype=values.dtype)
         reference_flat = reference.reshape((-1, reference_dimension))
         ever_valid_geometry = jnp.zeros_like(converged)
-        for iteration in range(self.policy.maximum_iterations):
+
+        def newton_step(iteration, carry):
+            current_reference, current_converged, first, ever_valid = carry
             evaluation = self.cell_map.evaluate(
-                self.coordinates, flat_cells, reference_flat
+                self.coordinates,
+                flat_cells,
+                current_reference,
             )
+            geometry_valid = evaluation.valid & flat_candidate_valid
             residual = evaluation.physical_points - targets
             residual_norm = jnp.sqrt(jnp.sum(residual**2, axis=-1))
             delta = contract("qrd,qd->qr", evaluation.inverse_jacobian, residual)
@@ -200,24 +222,50 @@ class PreparedSimplicialCellLocator(StrictModule, NonTrainableState):
                 1.0,
                 self.policy.trust_radius / jnp.maximum(delta_norm, 1.0e-30),
             )
-            candidate_reference = reference_flat - scale[:, None] * delta
+            candidate_reference = current_reference - scale[:, None] * delta
             newly = (
-                (~converged)
-                & evaluation.valid
+                (~current_converged)
+                & geometry_valid
                 & (residual_norm <= self.policy.residual_tolerance)
             )
-            first_iteration = jnp.where(newly, iteration + 1, first_iteration)
-            converged = converged | newly
-            reference_flat = jnp.where(
-                converged[:, None], reference_flat, candidate_reference
+            first = jnp.where(newly, iteration + 1, first)
+            current_converged = current_converged | newly
+            current_reference = jnp.where(
+                current_converged[:, None],
+                current_reference,
+                candidate_reference,
             )
-            ever_valid_geometry = ever_valid_geometry | evaluation.valid
+            return (
+                current_reference,
+                current_converged,
+                first,
+                ever_valid | geometry_valid,
+            )
+
+        (
+            reference_flat,
+            converged,
+            first_iteration,
+            ever_valid_geometry,
+        ) = jax.lax.fori_loop(
+            0,
+            self.policy.maximum_iterations,
+            newton_step,
+            (
+                reference_flat,
+                converged,
+                first_iteration,
+                ever_valid_geometry,
+            ),
+        )
         evaluation = self.cell_map.evaluate(self.coordinates, flat_cells, reference_flat)
         residual_norm = jnp.sqrt(
             jnp.sum((evaluation.physical_points - targets) ** 2, axis=-1)
         )
-        final_converged = evaluation.valid & (
-            residual_norm <= self.policy.residual_tolerance
+        final_converged = (
+            evaluation.valid
+            & flat_candidate_valid
+            & (residual_norm <= self.policy.residual_tolerance)
         )
         first_iteration = jnp.where(
             (~converged) & final_converged,
@@ -225,14 +273,16 @@ class PreparedSimplicialCellLocator(StrictModule, NonTrainableState):
             first_iteration,
         )
         converged = converged | final_converged
-        ever_valid_geometry = ever_valid_geometry | evaluation.valid
+        ever_valid_geometry = ever_valid_geometry | (
+            evaluation.valid & flat_candidate_valid
+        )
         jacobian_norm = jnp.sqrt(jnp.sum(evaluation.jacobian**2, axis=(-2, -1)))
         inverse_norm = jnp.sqrt(jnp.sum(evaluation.inverse_jacobian**2, axis=(-2, -1)))
         condition = jacobian_norm * inverse_norm
         inside_reference = jnp.all(
             reference_flat >= -self.policy.reference_tolerance, axis=-1
         ) & (jnp.sum(reference_flat, axis=-1) <= 1.0 + self.policy.reference_tolerance)
-        accepted = converged & evaluation.valid & inside_reference
+        accepted = converged & evaluation.valid & flat_candidate_valid & inside_reference
         accepted = accepted.reshape((point_count, candidate_capacity, seed_count))
         reference_all = reference_flat.reshape(
             (point_count, candidate_capacity, seed_count, reference_dimension)
@@ -249,7 +299,7 @@ class PreparedSimplicialCellLocator(StrictModule, NonTrainableState):
         candidate_choice = flat_choice // seed_count
         seed_choice = flat_choice % seed_count
         rows = jnp.arange(point_count)
-        inside = jnp.any(accepted, axis=(1, 2))
+        inside = jnp.any(accepted, axis=(1, 2)) & search_complete
         cell_ids = jnp.where(inside, candidates[rows, candidate_choice], -1)
         reference_result = reference_all[rows, candidate_choice, seed_choice]
         residual_result = residual_all[rows, candidate_choice, seed_choice]
@@ -261,20 +311,24 @@ class PreparedSimplicialCellLocator(StrictModule, NonTrainableState):
         )
         converged_valid = converged.reshape(
             (point_count, candidate_capacity, seed_count)
-        ) & evaluation.valid.reshape((point_count, candidate_capacity, seed_count))
+        ) & (evaluation.valid & flat_candidate_valid).reshape(
+            (point_count, candidate_capacity, seed_count)
+        )
         any_valid_geometry = jnp.any(
             ever_valid_geometry.reshape((point_count, candidate_capacity, seed_count)),
             axis=(1, 2),
         )
-        outside_domain = (~inside) & jnp.any(converged_valid, axis=(1, 2))
-        finite = jnp.all(jnp.isfinite(values), axis=-1)
-        candidate_exhausted = (
+        has_candidates = jnp.any(candidate_valid, axis=1)
+        outside_domain = (
             (~inside)
-            & ~outside_domain
-            & any_valid_geometry
-            & (candidate_capacity < self.cell_count)
+            & search_complete
+            & ((~has_candidates) | jnp.any(converged_valid, axis=(1, 2)))
         )
-        degenerate = (~inside) & ~any_valid_geometry & finite
+        finite = jnp.all(jnp.isfinite(values), axis=-1)
+        candidate_exhausted = (~inside) & ~search_complete
+        degenerate = (
+            (~inside) & has_candidates & ~any_valid_geometry & finite & search_complete
+        )
         status = jnp.where(
             ~finite,
             int(CellLocationStatus.NONFINITE),

--- a/phydrax/discretization/amr/_fd_runtime.py
+++ b/phydrax/discretization/amr/_fd_runtime.py
@@ -387,52 +387,60 @@ class AMRMigrationPlan(StrictModule, NonTrainableState):
         if self.source_to_target.shape != (state.plan.maximum_blocks,):
             raise ValueError("AMR migration route count must match source capacity.")
         active_source = state.metadata.active & (self.source_to_target >= 0)
-        block_ids = jnp.full(
-            (self.target_capacity,),
-            -1,
-            dtype=state.metadata.block_ids.dtype,
+        safe_target = jnp.clip(
+            self.source_to_target,
+            0,
+            self.target_capacity - 1,
         )
-        parent_ids = jnp.full(
-            (self.target_capacity,),
-            -1,
-            dtype=state.metadata.parent_ids.dtype,
+        active_count = (
+            jnp.zeros((self.target_capacity,), dtype=jnp.int32)
+            .at[safe_target]
+            .add(active_source.astype(jnp.int32))
         )
-        logical = jnp.zeros(
-            (self.target_capacity, state.metadata.logical_indices.shape[1]),
-            dtype=state.metadata.logical_indices.dtype,
+        active = active_count > 0
+        block_payload = (
+            jnp.zeros((self.target_capacity,), dtype=state.metadata.block_ids.dtype)
+            .at[safe_target]
+            .add(jnp.where(active_source, state.metadata.block_ids + 1, 0))
         )
-        values = jnp.zeros(
-            (self.target_capacity,) + state.values.shape[1:],
-            dtype=state.values.dtype,
+        parent_payload = (
+            jnp.zeros((self.target_capacity,), dtype=state.metadata.parent_ids.dtype)
+            .at[safe_target]
+            .add(jnp.where(active_source, state.metadata.parent_ids + 1, 0))
         )
-        active = jnp.zeros((self.target_capacity,), dtype=bool)
+        logical = (
+            jnp.zeros(
+                (self.target_capacity, state.metadata.logical_indices.shape[1]),
+                dtype=state.metadata.logical_indices.dtype,
+            )
+            .at[safe_target]
+            .add(
+                jnp.where(
+                    active_source[:, None],
+                    state.metadata.logical_indices,
+                    0,
+                )
+            )
+        )
         safe_values = state.safe_values()
-        for source_slot in range(state.plan.maximum_blocks):
-            valid = active_source[source_slot]
-            target = jnp.clip(
-                self.source_to_target[source_slot],
-                0,
-                self.target_capacity - 1,
+        values = (
+            jnp.zeros(
+                (self.target_capacity,) + state.values.shape[1:],
+                dtype=state.values.dtype,
             )
-            active = active.at[target].set(active[target] | valid)
-            block_ids = block_ids.at[target].set(
-                jnp.where(valid, state.metadata.block_ids[source_slot], block_ids[target])
-            )
-            parent_ids = parent_ids.at[target].set(
+            .at[safe_target]
+            .add(
                 jnp.where(
-                    valid, state.metadata.parent_ids[source_slot], parent_ids[target]
+                    active_source.reshape(
+                        active_source.shape + (1,) * (state.values.ndim - 1)
+                    ),
+                    safe_values,
+                    0,
                 )
             )
-            logical = logical.at[target].set(
-                jnp.where(
-                    valid,
-                    state.metadata.logical_indices[source_slot],
-                    logical[target],
-                )
-            )
-            values = values.at[target].set(
-                jnp.where(valid, safe_values[source_slot], values[target])
-            )
+        )
+        block_ids = jnp.where(active, block_payload - 1, -1)
+        parent_ids = jnp.where(active, parent_payload - 1, -1)
         return AMRMigrationResult(
             active=active,
             block_ids=block_ids,

--- a/phydrax/discretization/fem/_distributed.py
+++ b/phydrax/discretization/fem/_distributed.py
@@ -739,13 +739,15 @@ class FiniteElementFacetOwnershipPlan(StrictModule, NonTrainableState):
             (self.cell_count,) + values.shape[1:],
             dtype=values.dtype,
         )
-        for offset in range(self.facet_cells.shape[0]):
+
+        def route(offset, current):
             facet = self.reduction_order[offset]
             left = self.facet_cells[facet, 0]
             right = self.facet_cells[facet, 1]
-            result = result.at[left].add(values[facet])
-            result = result.at[right].add(-values[facet])
-        return result
+            current = current.at[left].add(values[facet])
+            return current.at[right].add(-values[facet])
+
+        return jax.lax.fori_loop(0, self.facet_cells.shape[0], route, result)
 
     def route_partition(self, part: int, facet_values: ArrayLike, /) -> Array:
         values = jnp.asarray(facet_values)

--- a/phydrax/discretization/fem/_hp.py
+++ b/phydrax/discretization/fem/_hp.py
@@ -636,13 +636,14 @@ class FiniteElementHPTransferPlan(StrictModule, NonTrainableState):
         ).reshape((matrices.shape[0], matrices.shape[1]) + (1,) * (values.ndim - 2))
         route_mask = self.valid.reshape(self.valid.shape + (1,) * (mapped.ndim - 1))
         mapped = jnp.where(route_mask & target_mask, mapped, 0.0)
-        result = jnp.zeros(
-            (self.target_capacity, matrices.shape[1]) + values.shape[2:],
-            dtype=mapped.dtype,
+        return (
+            jnp.zeros(
+                (self.target_capacity, matrices.shape[1]) + values.shape[2:],
+                dtype=mapped.dtype,
+            )
+            .at[safe_target]
+            .add(mapped)
         )
-        for route in range(matrices.shape[0]):
-            result = result.at[safe_target[route]].add(mapped[route])
-        return result
 
     def _reverse(self, matrices: Array, target_values: ArrayLike, /) -> Array:
         values = jnp.asarray(target_values)
@@ -664,13 +665,14 @@ class FiniteElementHPTransferPlan(StrictModule, NonTrainableState):
         ).reshape((matrices.shape[0], matrices.shape[1]) + (1,) * (values.ndim - 2))
         route_mask = self.valid.reshape(self.valid.shape + (1,) * (mapped.ndim - 1))
         mapped = jnp.where(route_mask & source_mask, mapped, 0.0)
-        result = jnp.zeros(
-            (self.source_capacity, matrices.shape[1]) + values.shape[2:],
-            dtype=mapped.dtype,
+        return (
+            jnp.zeros(
+                (self.source_capacity, matrices.shape[1]) + values.shape[2:],
+                dtype=mapped.dtype,
+            )
+            .at[safe_source]
+            .add(mapped)
         )
-        for route in range(matrices.shape[0]):
-            result = result.at[safe_source[route]].add(mapped[route])
-        return result
 
     def apply_primal(self, source_values: ArrayLike, /) -> Array:
         return self._forward(self.primal, source_values)

--- a/phydrax/discretization/fem/_spectral_hp_completion.py
+++ b/phydrax/discretization/fem/_spectral_hp_completion.py
@@ -1329,18 +1329,32 @@ class UnfittedAggregationPlan(StrictModule, NonTrainableState):
             if candidates.size == 0:
                 raise ValueError("Small cut cells require one aggregation neighbour.")
             target[cell] = int(candidates[np.argmax(fractions[candidates])])
+        for cell in np.flatnonzero(valid):
+            root = int(target[cell])
+            visited = {int(cell)}
+            while valid[root]:
+                if root in visited:
+                    raise ValueError("Cut-cell aggregation targets contain a cycle.")
+                visited.add(root)
+                root = int(target[root])
+            target[cell] = root
         self.target_cells = jnp.asarray(target)
         self.valid = jnp.asarray(valid)
 
     def aggregate(self, content: ArrayLike, /) -> Array:
         value = jnp.asarray(content)
-        result = value
-        for cell in range(self.target_cells.size):
-            if bool(self.valid[cell]):
-                target = int(self.target_cells[cell])
-                result = result.at[target].add(result[cell])
-                result = result.at[cell].set(0.0)
-        return result
+        trailing = (1,) * (value.ndim - 1)
+        moved = jnp.where(
+            self.valid.reshape(self.valid.shape + trailing),
+            value,
+            0.0,
+        )
+        retained = jnp.where(
+            self.valid.reshape(self.valid.shape + trailing),
+            0.0,
+            value,
+        )
+        return retained.at[self.target_cells].add(moved)
 
 
 class ConservativeMovingInterfaceTransfer(StrictModule, NonTrainableState):

--- a/phydrax/discretization/finite_volume/_distributed.py
+++ b/phydrax/discretization/finite_volume/_distributed.py
@@ -22,6 +22,17 @@ from ..._trainable import NonTrainableState
 from ._dynamics import PreparedFiniteVolumeDynamics
 
 
+@eqx.filter_jit
+def _distributed_residual(
+    dynamics: PreparedFiniteVolumeDynamics,
+    time: Array,
+    state: Array,
+    args: Any,
+    /,
+) -> Array:
+    return dynamics(time, state, args)
+
+
 class FiniteVolumeHaloRoute(StrictModule, NonTrainableState):
     axis: int = eqx.field(static=True)
     side: str = eqx.field(static=True)
@@ -258,13 +269,7 @@ class PreparedFiniteVolumeDecomposition(StrictModule, NonTrainableState):
             self.periodic_halo(state, axis) for axis in range(len(self.plan.global_shape))
         )
 
-    def compile_residual(
-        self,
-        dynamics: PreparedFiniteVolumeDynamics,
-        time: ArrayLike,
-        args: Any = None,
-        /,
-    ) -> Callable[[Array], Array]:
+    def _validate_dynamics(self, dynamics: PreparedFiniteVolumeDynamics, /) -> None:
         if not isinstance(dynamics, PreparedFiniteVolumeDynamics):
             raise TypeError("dynamics must be PreparedFiniteVolumeDynamics.")
         if dynamics.discretization.cell_shape != self.plan.global_shape:
@@ -286,6 +291,15 @@ class PreparedFiniteVolumeDecomposition(StrictModule, NonTrainableState):
             raise ValueError(
                 "Distributed FV dynamics and decomposition periodicity differ."
             )
+
+    def compile_residual(
+        self,
+        dynamics: PreparedFiniteVolumeDynamics,
+        time: ArrayLike,
+        args: Any = None,
+        /,
+    ) -> Callable[[Array], Array]:
+        self._validate_dynamics(dynamics)
         return jax.jit(
             lambda value: dynamics(jnp.asarray(time), value, args),
             in_shardings=self.cell_sharding,
@@ -300,7 +314,8 @@ class PreparedFiniteVolumeDecomposition(StrictModule, NonTrainableState):
         args: Any = None,
         /,
     ) -> Array:
-        return self.compile_residual(dynamics, time, args)(state)
+        self._validate_dynamics(dynamics)
+        return _distributed_residual(dynamics, jnp.asarray(time), state, args)
 
 
 __all__ = [

--- a/phydrax/discretization/finite_volume/_mac_distributed.py
+++ b/phydrax/discretization/finite_volume/_mac_distributed.py
@@ -23,6 +23,33 @@ from ._incompressible import FaceVelocity, PreparedMACOperators
 from ._mac_momentum import PreparedMACMomentumOperators
 
 
+@eqx.filter_jit
+def _mac_convection(
+    operators: PreparedMACMomentumOperators,
+    velocity: FaceVelocity,
+    /,
+) -> FaceVelocity:
+    return operators.convection(velocity)
+
+
+@eqx.filter_jit
+def _mac_laplacian(
+    operators: PreparedMACMomentumOperators,
+    velocity: FaceVelocity,
+    /,
+) -> FaceVelocity:
+    return operators.laplacian(velocity)
+
+
+@eqx.filter_jit
+def _mac_homogeneous_laplacian(
+    operators: PreparedMACMomentumOperators,
+    velocity: FaceVelocity,
+    /,
+) -> FaceVelocity:
+    return operators.homogeneous_laplacian(velocity)
+
+
 MACDistributedPlanState: TypeAlias = Literal[
     "ready", "unsupported-topology", "unavailable-process-topology"
 ]
@@ -1008,12 +1035,7 @@ class PreparedMACDistributedTopology(StrictModule, NonTrainableState):
         values = self._validate_velocity_sharding(velocity)
         if self.momentum_operators is None:
             raise RuntimeError("No PreparedMACMomentumOperators were bound at prepare().")
-        action = jax.jit(
-            self.momentum_operators.convection,
-            in_shardings=(self.plan.face_shardings,),
-            out_shardings=self.plan.face_shardings,
-        )
-        return action(values)
+        return _mac_convection(self.momentum_operators, values)
 
     def face_laplacian(
         self,
@@ -1026,17 +1048,8 @@ class PreparedMACDistributedTopology(StrictModule, NonTrainableState):
         values = self._validate_velocity_sharding(velocity)
         if self.momentum_operators is None:
             raise RuntimeError("No PreparedMACMomentumOperators were bound at prepare().")
-        method = (
-            self.momentum_operators.homogeneous_laplacian
-            if homogeneous
-            else self.momentum_operators.laplacian
-        )
-        action = jax.jit(
-            method,
-            in_shardings=(self.plan.face_shardings,),
-            out_shardings=self.plan.face_shardings,
-        )
-        return action(values)
+        operation = _mac_homogeneous_laplacian if homogeneous else _mac_laplacian
+        return operation(self.momentum_operators, values)
 
     def momentum_rate(
         self,

--- a/phydrax/discretization/flip/_interface_geometry.py
+++ b/phydrax/discretization/flip/_interface_geometry.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import equinox as eqx
 import jax.numpy as jnp
+import numpy as np
 from jaxtyping import Array, ArrayLike
 
 from ..._fingerprint import canonical_fingerprint
@@ -43,6 +44,7 @@ class ParticleLevelSetPlan(StrictModule, NonTrainableState):
     narrow_band_cells: int = eqx.field(static=True)
     minimum_ghost_fraction: float = eqx.field(static=True)
     points: Array
+    stencil_offsets: Array
     spacing: tuple[float, ...] = eqx.field(static=True)
     plan_id: str = eqx.field(static=True)
 
@@ -68,11 +70,23 @@ class ParticleLevelSetPlan(StrictModule, NonTrainableState):
         spacing = tuple(
             float(jnp.min(axis.interval_widths)) for axis in grid.structured_axes
         )
+        maximum_spacing = max(spacing)
+        support = radius + band * maximum_spacing
+        reach = tuple(int(np.ceil(support / value)) + 1 for value in spacing)
+        offset_axes = tuple(
+            np.arange(-extent, extent + 1, dtype=np.int32) for extent in reach
+        )
+        offset_mesh = np.meshgrid(*offset_axes, indexing="ij")
+        stencil_offsets = np.stack(
+            tuple(value.reshape((-1,)) for value in offset_mesh),
+            axis=-1,
+        )
         self.grid = grid
         self.particle_radius = radius
         self.narrow_band_cells = band
         self.minimum_ghost_fraction = minimum
         self.points = points
+        self.stencil_offsets = jnp.asarray(stencil_offsets)
         self.spacing = spacing
         self.plan_id = canonical_fingerprint(
             {
@@ -80,6 +94,7 @@ class ParticleLevelSetPlan(StrictModule, NonTrainableState):
                 "grid": grid.prepared_id,
                 "radius": radius,
                 "band": band,
+                "stencil_reach": list(reach),
                 "minimum_ghost_fraction": minimum,
             }
         )
@@ -93,25 +108,43 @@ class ParticleLevelSetPlan(StrictModule, NonTrainableState):
             raise ValueError("Particle level-set positions have incompatible dimension.")
         if active.shape != (particles.shape[0],):
             raise ValueError("Particle level-set activity must preserve capacity.")
-        delta = self.points[:, None, :] - particles[None, :, :]
+        shape = self.grid.cells().shape
+        maximum_spacing = max(self.spacing)
+        band_width = self.narrow_band_cells * maximum_spacing
+        candidate_indices = []
+        candidate_coordinates = []
+        route_valid = active[:, None]
         for axis, structured_axis in enumerate(self.grid.structured_axes):
+            coordinates = structured_axis.coordinates("interval").astype(particles.dtype)
+            base = jnp.searchsorted(coordinates, particles[:, axis], side="left")
+            indices = base[:, None] + self.stencil_offsets[None, :, axis]
+            if structured_axis.periodic:
+                indices = jnp.mod(indices, shape[axis])
+            else:
+                route_valid = route_valid & ((indices >= 0) & (indices < shape[axis]))
+                indices = jnp.clip(indices, 0, shape[axis] - 1)
+            coordinate = coordinates[indices]
+            delta = coordinate - particles[:, None, axis]
             if structured_axis.periodic:
                 length = structured_axis.bounds[1] - structured_axis.bounds[0]
-                delta = delta.at[..., axis].set(
-                    delta[..., axis] - length * jnp.round(delta[..., axis] / length)
-                )
+                delta = delta - length * jnp.round(delta / length)
+            candidate_indices.append(indices)
+            candidate_coordinates.append(delta)
+        delta = jnp.stack(tuple(candidate_coordinates), axis=-1)
         distance = jnp.sqrt(jnp.sum(delta * delta, axis=-1)) - self.particle_radius
-        phi_flat = jnp.min(jnp.where(active[None, :], distance, jnp.inf), axis=1)
-        empty = ~jnp.any(active)
-        maximum_spacing = max(self.spacing)
-        phi_flat = jnp.where(
-            empty,
-            self.narrow_band_cells * maximum_spacing,
-            phi_flat,
+        route_valid = route_valid & (distance <= band_width)
+        strides = tuple(int(np.prod(shape[axis + 1 :])) for axis in range(len(shape)))
+        flat_indices = sum(
+            indices * stride
+            for indices, stride in zip(candidate_indices, strides, strict=True)
         )
-        shape = self.grid.cells().shape
+        phi_flat = jnp.full((int(np.prod(shape)),), band_width, dtype=particles.dtype)
+        phi_flat = phi_flat.at[flat_indices.reshape((-1,))].min(
+            jnp.where(route_valid, distance, band_width).reshape((-1,))
+        )
+        empty = ~jnp.any(active)
+        phi_flat = jnp.where(empty, band_width, phi_flat)
         phi = phi_flat.reshape(shape)
-        band_width = self.narrow_band_cells * maximum_spacing
         valid_band = jnp.abs(phi) <= band_width
         liquid = phi <= 0.0
         cell_fraction = jnp.clip(0.5 - phi / (2.0 * maximum_spacing), 0.0, 1.0)

--- a/phydrax/discretization/flip/_reseed.py
+++ b/phydrax/discretization/flip/_reseed.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import equinox as eqx
+import jax
 import jax.numpy as jnp
 from jaxtyping import Array, ArrayLike
 
@@ -104,76 +105,180 @@ class FLIPReseedingPlan(StrictModule, NonTrainableState):
         incarnation = population.incarnation
         ever = population.ever_occupied
         retired = population.retired
-        inserted = jnp.zeros_like(active)
-        merged = jnp.zeros_like(active)
-        event_count = jnp.asarray(0, dtype=jnp.int32)
-        for cell in range(self.cell_count):
-            members = active & (cells == cell)
-            count = jnp.sum(members, dtype=jnp.int32)
-            member_indices = jnp.nonzero(members, size=active.size, fill_value=-1)[0]
-            receiver = jnp.maximum(member_indices[0], 0)
-            excess = jnp.maximum(count - self.target_per_cell, 0)
-            for local in range(1, self.maximum_per_cell + 1):
-                slot = jnp.maximum(member_indices[local], 0)
-                use = (
-                    (local <= excess)
-                    & (member_indices[local] >= 0)
-                    & (event_count < self.maximum_events)
-                )
-                combined_mass = mass[receiver] + mass[slot]
-                combined_velocity = (
-                    mass[receiver] * velocity[receiver] + mass[slot] * velocity[slot]
-                ) / jnp.maximum(combined_mass, 1.0e-30)
-                combined_position = (
-                    mass[receiver] * position[receiver] + mass[slot] * position[slot]
-                ) / jnp.maximum(combined_mass, 1.0e-30)
-                mass = mass.at[receiver].set(
-                    jnp.where(use, combined_mass, mass[receiver])
-                )
-                velocity = velocity.at[receiver].set(
-                    jnp.where(use, combined_velocity, velocity[receiver])
-                )
-                position = position.at[receiver].set(
-                    jnp.where(use, combined_position, position[receiver])
-                )
-                active = active.at[slot].set(jnp.where(use, False, active[slot]))
-                mass = mass.at[slot].set(jnp.where(use, 0.0, mass[slot]))
-                velocity = velocity.at[slot].set(
-                    jnp.where(use, jnp.zeros_like(velocity[slot]), velocity[slot])
-                )
-                merged = merged.at[slot].set(use)
-                event_count = event_count + use.astype(jnp.int32)
-            deficit = jnp.maximum(self.target_per_cell - count, 0)
-            free_indices = jnp.nonzero(
-                ~active & ~retired, size=active.size, fill_value=-1
-            )[0]
-            donor_mass = jnp.where(count > 0, mass[receiver], 0.0)
-            split_mass = donor_mass / jnp.maximum(deficit + 1, 1)
-            for local in range(self.target_per_cell):
-                slot = jnp.maximum(free_indices[local], 0)
-                use = (
-                    (local < deficit)
-                    & (count > 0)
-                    & (free_indices[local] >= 0)
-                    & (event_count < self.maximum_events)
-                )
-                mass = mass.at[receiver].set(
-                    jnp.where(use, mass[receiver] - split_mass, mass[receiver])
-                )
-                active = active.at[slot].set(jnp.where(use, True, active[slot]))
-                mass = mass.at[slot].set(jnp.where(use, split_mass, mass[slot]))
-                position = position.at[slot].set(
-                    jnp.where(use, centers[cell], position[slot])
-                )
-                velocity = velocity.at[slot].set(
-                    jnp.where(use, velocity[receiver], velocity[slot])
-                )
-                incarnation = incarnation.at[slot].set(
-                    jnp.where(use, incarnation[slot] + 1, incarnation[slot])
-                )
-                ever = ever.at[slot].set(jnp.where(use, True, ever[slot]))
-                inserted = inserted.at[slot].set(use)
-                event_count = event_count + use.astype(jnp.int32)
+        particle_count = active.shape[0]
+        particle_indices = jnp.arange(particle_count, dtype=jnp.int32)
+        valid_cell = active & (cells >= 0) & (cells < self.cell_count)
+        safe_cells = jnp.where(valid_cell, cells, 0)
+        counts = (
+            jnp.zeros((self.cell_count,), dtype=jnp.int32)
+            .at[safe_cells]
+            .add(valid_cell.astype(jnp.int32))
+        )
+        order = jnp.lexsort(
+            (
+                particle_indices,
+                jnp.where(valid_cell, cells, self.cell_count),
+            )
+        )
+        sorted_particles = particle_indices[order]
+        offsets = jnp.cumsum(counts) - counts
+        receiver_positions = jnp.minimum(offsets, particle_count - 1)
+        receivers = sorted_particles[receiver_positions]
+        receiver_valid = counts > 0
+        safe_receivers = jnp.where(receiver_valid, receivers, 0)
+
+        merge_local = jnp.arange(1, self.maximum_per_cell + 1, dtype=jnp.int32)
+        merge_positions = jnp.minimum(
+            offsets[:, None] + merge_local[None, :],
+            particle_count - 1,
+        )
+        merge_slots = sorted_particles[merge_positions]
+        excess = jnp.maximum(counts - self.target_per_cell, 0)
+        merge_requested = (merge_local[None, :] <= excess[:, None]) & (
+            merge_local[None, :] < counts[:, None]
+        )
+        merge_rank = jnp.cumsum(merge_requested.reshape((-1,)), dtype=jnp.int32) - 1
+        merge_use = merge_requested & (
+            merge_rank.reshape(merge_requested.shape) < self.maximum_events
+        )
+        merge_slot_mask = (
+            jnp.zeros((particle_count,), dtype=jnp.int32)
+            .at[merge_slots.reshape((-1,))]
+            .add(merge_use.reshape((-1,)).astype(jnp.int32))
+            > 0
+        )
+        merged_mass = jnp.sum(
+            jnp.where(merge_use, mass[merge_slots], 0.0),
+            axis=-1,
+        )
+        merged_momentum = jnp.sum(
+            jnp.where(
+                merge_use[..., None],
+                mass[merge_slots, None] * velocity[merge_slots],
+                0.0,
+            ),
+            axis=1,
+        )
+        merged_position_moment = jnp.sum(
+            jnp.where(
+                merge_use[..., None],
+                mass[merge_slots, None] * position[merge_slots],
+                0.0,
+            ),
+            axis=1,
+        )
+        receiver_mass = mass[safe_receivers]
+        combined_mass = receiver_mass + merged_mass
+        combined_velocity = (
+            receiver_mass[:, None] * velocity[safe_receivers] + merged_momentum
+        ) / jnp.maximum(combined_mass[:, None], 1.0e-30)
+        combined_position = (
+            receiver_mass[:, None] * position[safe_receivers] + merged_position_moment
+        ) / jnp.maximum(combined_mass[:, None], 1.0e-30)
+        mass = mass.at[safe_receivers].add(
+            jnp.where(receiver_valid, combined_mass - receiver_mass, 0.0)
+        )
+        velocity = velocity.at[safe_receivers].add(
+            jnp.where(
+                receiver_valid[:, None],
+                combined_velocity - velocity[safe_receivers],
+                0.0,
+            )
+        )
+        position = position.at[safe_receivers].add(
+            jnp.where(
+                receiver_valid[:, None],
+                combined_position - position[safe_receivers],
+                0.0,
+            )
+        )
+        active = active & ~merge_slot_mask
+        mass = jnp.where(merge_slot_mask, 0.0, mass)
+        velocity = jnp.where(merge_slot_mask[:, None], 0.0, velocity)
+
+        free_mask = ~active & ~retired
+        free_count = jnp.sum(free_mask, dtype=jnp.int32)
+        free_indices = jnp.nonzero(
+            free_mask,
+            size=particle_count,
+            fill_value=0,
+        )[0]
+        deficit = jnp.maximum(self.target_per_cell - counts, 0)
+        split_local = jnp.arange(self.target_per_cell, dtype=jnp.int32)
+        split_requested = (split_local[None, :] < deficit[:, None]) & receiver_valid[
+            :, None
+        ]
+        merge_events = jnp.sum(merge_requested, dtype=jnp.int32)
+        remaining_events = jnp.maximum(self.maximum_events - merge_events, 0)
+        split_rank = jnp.cumsum(split_requested.reshape((-1,)), dtype=jnp.int32) - 1
+        split_rank = split_rank.reshape(split_requested.shape)
+        split_use = (
+            split_requested & (split_rank < remaining_events) & (split_rank < free_count)
+        )
+        safe_free_rank = jnp.clip(split_rank, 0, particle_count - 1)
+        split_slots = free_indices[safe_free_rank]
+        donor_mass = jnp.where(receiver_valid, mass[safe_receivers], 0.0)
+        split_mass = donor_mass / jnp.maximum(deficit + 1, 1)
+        split_slot_mask = (
+            jnp.zeros((particle_count,), dtype=jnp.int32)
+            .at[split_slots.reshape((-1,))]
+            .add(split_use.reshape((-1,)).astype(jnp.int32))
+            > 0
+        )
+        split_mass_payload = (
+            jnp.zeros((particle_count,), dtype=mass.dtype)
+            .at[split_slots.reshape((-1,))]
+            .add(
+                jnp.where(
+                    split_use,
+                    split_mass[:, None],
+                    0.0,
+                ).reshape((-1,))
+            )
+        )
+        split_position_payload = (
+            jnp.zeros_like(position)
+            .at[split_slots.reshape((-1,))]
+            .add(
+                jnp.where(
+                    split_use[..., None],
+                    centers[:, None, :],
+                    0.0,
+                ).reshape((-1, position.shape[-1]))
+            )
+        )
+        split_velocity_payload = (
+            jnp.zeros_like(velocity)
+            .at[split_slots.reshape((-1,))]
+            .add(
+                jnp.where(
+                    split_use[..., None],
+                    velocity[safe_receivers, None, :],
+                    0.0,
+                ).reshape((-1, velocity.shape[-1]))
+            )
+        )
+        splits_per_cell = jnp.sum(split_use, axis=-1, dtype=jnp.int32)
+        mass = mass.at[safe_receivers].add(
+            jnp.where(receiver_valid, -splits_per_cell * split_mass, 0.0)
+        )
+        active = active | split_slot_mask
+        mass = jnp.where(split_slot_mask, split_mass_payload, mass)
+        position = jnp.where(
+            split_slot_mask[:, None],
+            split_position_payload,
+            position,
+        )
+        velocity = jnp.where(
+            split_slot_mask[:, None],
+            split_velocity_payload,
+            velocity,
+        )
+        incarnation = incarnation + split_slot_mask.astype(incarnation.dtype)
+        ever = ever | split_slot_mask
+        inserted = split_slot_mask
+        merged = merge_slot_mask
+        required_events = merge_events + jnp.sum(split_requested, dtype=jnp.int32)
         candidate_population = ParticlePopulationState(
             active, mass, incarnation, ever, retired
         )
@@ -196,7 +301,9 @@ class FLIPReseedingPlan(StrictModule, NonTrainableState):
             momentum_defect
             <= tolerance * jnp.maximum(1.0, jnp.sqrt(jnp.sum(initial_momentum**2)))
         )
-        capacity_available = event_count <= self.maximum_events
+        capacity_available = (required_events <= self.maximum_events) & (
+            jnp.sum(split_requested, dtype=jnp.int32) <= free_count
+        )
         successful = finite & conservative & capacity_available
         accepted_population = jax_tree_where(successful, candidate_population, population)
         accepted_particles = jax_tree_where(successful, candidate_particles, particles)
@@ -218,7 +325,6 @@ class FLIPReseedingPlan(StrictModule, NonTrainableState):
 
 
 def jax_tree_where(predicate, candidate, current):
-    import jax
 
     return jax.tree.map(
         lambda proposed, old: jnp.where(predicate, proposed, old), candidate, current

--- a/phydrax/discretization/lattice_boltzmann/_fused.py
+++ b/phydrax/discretization/lattice_boltzmann/_fused.py
@@ -98,22 +98,10 @@ class FusedLatticeBoltzmannExecutionPlan(StrictModule, NonTrainableState):
             else None
         )
 
-        def fused_kernel(populations, size, runtime_args, initial_time):
-            return _realize_lattice_boltzmann(
-                self.reference.step,
-                self.reference.velocity_set,
-                populations,
-                step_count=step_count,
-                step_size=size,
-                args=runtime_args,
-                t0=initial_time,
-                plan_id=self.plan_id,
-                step_id=self.reference.step_id,
-                execution_kind="fused",
-            )
-
-        candidate = eqx.filter_jit(fused_kernel)(
+        candidate = _compiled_fused_lattice_boltzmann(
+            self,
             initial_populations,
+            step_count,
             step_size,
             args,
             t0,
@@ -127,6 +115,32 @@ class FusedLatticeBoltzmannExecutionPlan(StrictModule, NonTrainableState):
             atol=atol,
         )
         return with_lattice_boltzmann_equivalence(candidate, evidence)
+
+
+def _fused_lattice_boltzmann(
+    plan: FusedLatticeBoltzmannExecutionPlan,
+    initial_populations: Array,
+    step_count: int,
+    step_size: Any,
+    args: Any,
+    t0: Any,
+    /,
+) -> LatticeBoltzmannRealizationResult:
+    return _realize_lattice_boltzmann(
+        plan.reference.step,
+        plan.reference.velocity_set,
+        initial_populations,
+        step_count=step_count,
+        step_size=step_size,
+        args=args,
+        t0=t0,
+        plan_id=plan.plan_id,
+        step_id=plan.reference.step_id,
+        execution_kind="fused",
+    )
+
+
+_compiled_fused_lattice_boltzmann = eqx.filter_jit(_fused_lattice_boltzmann)
 
 
 __all__ = [

--- a/phydrax/discretization/lattice_boltzmann/_immersed.py
+++ b/phydrax/discretization/lattice_boltzmann/_immersed.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import equinox as eqx
+import jax
 import jax.numpy as jnp
 import numpy as np
 from jaxtyping import Array, ArrayLike
@@ -61,6 +62,7 @@ class ImmersedBoundaryForcingPlan(StrictModule, NonTrainableState):
     iteration_count: int = eqx.field(static=True)
     kernel_radius: float = eqx.field(static=True)
     convergence_tolerance: float = eqx.field(static=True)
+    stencil_offsets: Array
     plan_id: str = eqx.field(static=True)
 
     def __init__(
@@ -83,10 +85,21 @@ class ImmersedBoundaryForcingPlan(StrictModule, NonTrainableState):
             raise ValueError("kernel_radius must be finite and greater than one.")
         if not np.isfinite(tolerance) or tolerance <= 0.0:
             raise ValueError("convergence_tolerance must be finite and positive.")
+        reach = int(np.ceil(radius))
+        offset_axes = tuple(
+            np.arange(-reach, reach + 1, dtype=np.int32)
+            for _ in range(discretization.velocity_set.dimension)
+        )
+        offset_mesh = np.meshgrid(*offset_axes, indexing="ij")
+        stencil_offsets = np.stack(
+            tuple(value.reshape((-1,)) for value in offset_mesh),
+            axis=-1,
+        )
         self.discretization = discretization
         self.iteration_count = iterations
         self.kernel_radius = radius
         self.convergence_tolerance = tolerance
+        self.stencil_offsets = jnp.asarray(stencil_offsets)
         self.plan_id = canonical_fingerprint(
             {
                 "kind": "immersed-boundary-lattice-boltzmann-forcing",
@@ -102,20 +115,41 @@ class ImmersedBoundaryForcingPlan(StrictModule, NonTrainableState):
         marker_positions: Array,
         fluid_mask: Array,
         /,
-    ) -> tuple[Array, Array]:
-        coordinates = self.discretization.grid.points.astype(marker_positions.dtype)
-        difference = coordinates[:, None, :] - marker_positions[None, :, :]
+    ) -> tuple[Array, Array, Array]:
+        grid = self.discretization.grid
+        grid_shape = grid.shape
         cell_size = jnp.asarray(
-            self.discretization.cell_size, dtype=marker_positions.dtype
+            self.discretization.cell_size,
+            dtype=marker_positions.dtype,
         )
-        for axis, periodic in enumerate(self.discretization.periodic):
+        indices_by_axis = []
+        scaled_components = []
+        valid = jnp.ones(
+            (marker_positions.shape[0], self.stencil_offsets.shape[0]),
+            dtype=bool,
+        )
+        for axis, (grid_axis, periodic) in enumerate(
+            zip(grid.structured_axes, self.discretization.periodic, strict=True)
+        ):
+            coordinates = grid_axis.coordinates("interval").astype(marker_positions.dtype)
+            base = jnp.searchsorted(
+                coordinates,
+                marker_positions[:, axis],
+                side="left",
+            )
+            indices = base[:, None] + self.stencil_offsets[None, :, axis]
             if periodic:
-                length = cell_size * self.discretization.grid.shape[axis]
-                component = difference[..., axis]
-                difference = difference.at[..., axis].set(
-                    component - jnp.round(component / length) * length
-                )
-        scaled = jnp.abs(difference / cell_size)
+                indices = jnp.mod(indices, grid_shape[axis])
+            else:
+                valid = valid & ((indices >= 0) & (indices < grid_shape[axis]))
+                indices = jnp.clip(indices, 0, grid_shape[axis] - 1)
+            difference = coordinates[indices] - marker_positions[:, None, axis]
+            if periodic:
+                length = cell_size * grid_shape[axis]
+                difference = difference - jnp.round(difference / length) * length
+            indices_by_axis.append(indices)
+            scaled_components.append(jnp.abs(difference / cell_size))
+        scaled = jnp.stack(tuple(scaled_components), axis=-1)
         kernel = jnp.where(
             scaled < self.kernel_radius,
             0.5
@@ -123,15 +157,25 @@ class ImmersedBoundaryForcingPlan(StrictModule, NonTrainableState):
             * (1.0 + jnp.cos(jnp.pi * scaled / self.kernel_radius)),
             0.0,
         )
-        raw = jnp.prod(kernel, axis=-1) * fluid_mask.reshape((-1, 1))
-        partition = jnp.sum(raw, axis=0)
+        strides = tuple(
+            int(np.prod(grid_shape[axis + 1 :])) for axis in range(len(grid_shape))
+        )
+        flat_indices = sum(
+            indices * stride
+            for indices, stride in zip(indices_by_axis, strides, strict=True)
+        )
+        flat_mask = fluid_mask.reshape((-1,))
+        valid = valid & flat_mask[flat_indices]
+        raw = jnp.where(valid, jnp.prod(kernel, axis=-1), 0.0)
+        partition = jnp.sum(raw, axis=-1)
         partition = eqx.error_if(
             partition,
             jnp.any(partition <= 0.0),
             "Every immersed marker must overlap at least one active fluid cell.",
         )
-        weights = raw / partition[None, :]
-        return weights, jnp.max(jnp.abs(jnp.sum(weights, axis=0) - 1.0))
+        weights = raw / partition[:, None]
+        residual = jnp.max(jnp.abs(jnp.sum(weights, axis=-1) - 1.0))
+        return flat_indices, weights, residual
 
     def apply(
         self,
@@ -217,35 +261,75 @@ class ImmersedBoundaryForcingPlan(StrictModule, NonTrainableState):
             "marker_measures must be finite and positive.",
         )
 
-        weights, partition_residual = self._weights(positions, mask)
+        route_indices, weights, partition_residual = self._weights(positions, mask)
         flat_velocity = velocity.reshape((-1, dimension))
         flat_density = rho.reshape((-1,))
-        marker_density = ein.contract("nm,n->m", weights, flat_density)
+        marker_density = jnp.sum(
+            weights * flat_density[route_indices],
+            axis=-1,
+        )
         cell_measure = jnp.asarray(
             self.discretization.cell_size**dimension, dtype=velocity.dtype
         )
-        force_density = jnp.zeros_like(flat_velocity)
-        marker_force = jnp.zeros_like(target)
-        marker_acceleration = jnp.zeros_like(target)
-        corrected_velocity = flat_velocity
-        for _ in range(self.iteration_count):
-            interpolated = ein.contract("nm,nd->md", weights, corrected_velocity)
-            marker_acceleration = (target - interpolated) / dt
-            increment = marker_density[:, None] * measures[:, None] * marker_acceleration
-            marker_force = marker_force + increment
-            spread = ein.contract("nm,md->nd", weights, increment) / cell_measure
-            force_density = force_density + spread
-            corrected_velocity = corrected_velocity + dt * spread / jnp.maximum(
-                flat_density[:, None], jnp.finfo(velocity.dtype).tiny
+        initial_carry = (
+            jnp.zeros_like(flat_velocity),
+            jnp.zeros_like(target),
+            jnp.zeros_like(target),
+            flat_velocity,
+        )
+
+        def forcing_step(_, carry):
+            force_density_, marker_force_, _, corrected_velocity_ = carry
+            interpolated_ = jnp.sum(
+                weights[..., None] * corrected_velocity_[route_indices],
+                axis=1,
+            )
+            marker_acceleration_ = (target - interpolated_) / dt
+            increment = marker_density[:, None] * measures[:, None] * marker_acceleration_
+            marker_force_ = marker_force_ + increment
+            spread = (
+                jnp.zeros_like(flat_velocity)
+                .at[route_indices.reshape((-1,))]
+                .add(
+                    (weights[..., None] * increment[:, None, :]).reshape((-1, dimension))
+                )
+                / cell_measure
+            )
+            force_density_ = force_density_ + spread
+            corrected_velocity_ = corrected_velocity_ + dt * spread / jnp.maximum(
+                flat_density[:, None],
+                jnp.finfo(velocity.dtype).tiny,
+            )
+            return (
+                force_density_,
+                marker_force_,
+                marker_acceleration_,
+                corrected_velocity_,
             )
 
-        interpolated = ein.contract("nm,nd->md", weights, corrected_velocity)
+        (
+            force_density,
+            marker_force,
+            marker_acceleration,
+            corrected_velocity,
+        ) = jax.lax.fori_loop(
+            0,
+            self.iteration_count,
+            forcing_step,
+            initial_carry,
+        )
+
+        interpolated = jnp.sum(
+            weights[..., None] * corrected_velocity[route_indices],
+            axis=1,
+        )
         velocity_residual = interpolated - target
         maximum_residual = jnp.max(jnp.abs(velocity_residual))
         body_count = centers.shape[0]
-        membership = indices[:, None] == jnp.arange(body_count)[None, :]
-        body_force = -ein.contract(
-            "mb,md->bd", membership.astype(velocity.dtype), marker_force
+        body_force = (
+            jnp.zeros((body_count, dimension), dtype=velocity.dtype)
+            .at[indices]
+            .add(-marker_force)
         )
         radius = positions - centers[indices]
         if dimension == 2:
@@ -266,12 +350,17 @@ class ImmersedBoundaryForcingPlan(StrictModule, NonTrainableState):
                 ),
                 axis=-1,
             )
-        body_torque = ein.contract(
-            "mb,ma->ba", membership.astype(velocity.dtype), marker_torque
+        body_torque = (
+            jnp.zeros(
+                (body_count, marker_torque.shape[-1]),
+                dtype=velocity.dtype,
+            )
+            .at[indices]
+            .add(marker_torque)
         )
         marker_work = -ein.contract("md,md->m", marker_force, target)
-        body_work = ein.contract(
-            "mb,m->b", membership.astype(velocity.dtype), marker_work
+        body_work = (
+            jnp.zeros((body_count,), dtype=velocity.dtype).at[indices].add(marker_work)
         )
         grid_force = jnp.sum(force_density, axis=0) * cell_measure
         force_balance = grid_force + jnp.sum(body_force, axis=0)

--- a/phydrax/discretization/particle/_reduced_dynamics.py
+++ b/phydrax/discretization/particle/_reduced_dynamics.py
@@ -125,17 +125,11 @@ class ReducedSemiImplicitVelocityEulerStepPolicy(StrictModule):
         if not math.isfinite(maximum) or maximum <= 0.0:
             raise ValueError("maximum_step_size must be finite and positive.")
         if not math.isfinite(absolute) or absolute < 0.0:
-            raise ValueError(
-                "absolute_energy_tolerance must be finite and non-negative."
-            )
+            raise ValueError("absolute_energy_tolerance must be finite and non-negative.")
         if not math.isfinite(relative) or relative < 0.0:
-            raise ValueError(
-                "relative_energy_tolerance must be finite and non-negative."
-            )
+            raise ValueError("relative_energy_tolerance must be finite and non-negative.")
         if not math.isfinite(residual) or residual < 0.0:
-            raise ValueError(
-                "inverse_forward_tolerance must be finite and non-negative."
-            )
+            raise ValueError("inverse_forward_tolerance must be finite and non-negative.")
         self.maximum_step_size = maximum
         self.absolute_energy_tolerance = absolute
         self.relative_energy_tolerance = relative
@@ -178,7 +172,9 @@ def _require_articulation(
 def _configuration(
     articulation: PreparedReducedArticulation, value: ArrayLike, /
 ) -> Array:
-    result = jnp.asarray(value, dtype=articulation.graph.bodies.particles.safe_masses.dtype)
+    result = jnp.asarray(
+        value, dtype=articulation.graph.bodies.particles.safe_masses.dtype
+    )
     if result.shape != (articulation.nq,):
         raise ValueError("configuration must have articulation configuration shape.")
     return result
@@ -191,14 +187,18 @@ def _tangent(
     *,
     name: str,
 ) -> Array:
-    result = jnp.asarray(value, dtype=articulation.graph.bodies.particles.safe_masses.dtype)
+    result = jnp.asarray(
+        value, dtype=articulation.graph.bodies.particles.safe_masses.dtype
+    )
     if result.shape != (articulation.nv,):
         raise ValueError(f"{name} must have articulation velocity shape.")
     return result
 
 
 def _gravity(articulation: PreparedReducedArticulation, value: ArrayLike, /) -> Array:
-    result = jnp.asarray(value, dtype=articulation.graph.bodies.particles.safe_masses.dtype)
+    result = jnp.asarray(
+        value, dtype=articulation.graph.bodies.particles.safe_masses.dtype
+    )
     if result.shape != (3,):
         raise ValueError("gravity must be one explicit three-vector acceleration.")
     return result
@@ -323,9 +323,7 @@ def _edge_geometry(
     )
     displacement = position[child] - position[parent]
     edge_count = articulation.child_indices.shape[0]
-    identity = jnp.broadcast_to(
-        jnp.eye(6, dtype=position.dtype), (edge_count, 6, 6)
-    )
+    identity = jnp.broadcast_to(jnp.eye(6, dtype=position.dtype), (edge_count, 6, 6))
     motion_transform = identity.at[:, :3, 3:].set(-_skew(displacement))
 
     hinge = articulation.joint_kinds == int(RigidJointKind.HINGE)
@@ -375,9 +373,7 @@ def _external_power(
     )
     generalized_power = jnp.vdot(external_effort, velocity).real
     residual = body_power - generalized_power
-    scale = jnp.maximum(
-        jnp.maximum(jnp.abs(body_power), jnp.abs(generalized_power)), 1.0
-    )
+    scale = jnp.maximum(jnp.maximum(jnp.abs(body_power), jnp.abs(generalized_power)), 1.0)
     return body_power, generalized_power, residual / scale
 
 
@@ -396,9 +392,7 @@ def reduced_energy(
     gravity_ = _gravity(articulation, gravity)
     kinematics = articulation.forward_kinematics(q, v)
     selected = articulation.body_indices
-    mass, world_inertia = _world_body_inertia(
-        articulation, kinematics.body_transforms
-    )
+    mass, world_inertia = _world_body_inertia(articulation, kinematics.body_transforms)
     linear = kinematics.bodies.velocity[selected]
     angular = kinematics.bodies.angular_velocity[selected]
     mass_ = mass[selected]
@@ -447,9 +441,7 @@ def _dense_mass_matrix_reference(
     selected = articulation.body_indices
     linear = jacobian[selected, :3, :]
     angular = jacobian[selected, 3:, :]
-    matrix = contract(
-        "bai,b,baj->ij", linear, mass[selected], linear
-    ) + contract(
+    matrix = contract("bai,b,baj->ij", linear, mass[selected], linear) + contract(
         "bai,bac,bcj->ij", angular, world_inertia[selected], angular
     )
     return matrix
@@ -465,9 +457,7 @@ def reduced_mass_matrix(
     articulation = _require_articulation(articulation)
     q = _configuration(articulation, configuration)
     raw_matrix = _dense_mass_matrix_reference(articulation, q)
-    symmetry_residual = jnp.max(
-        jnp.abs(raw_matrix - raw_matrix.T), initial=0.0
-    )
+    symmetry_residual = jnp.max(jnp.abs(raw_matrix - raw_matrix.T), initial=0.0)
     matrix = 0.5 * (raw_matrix + raw_matrix.T)
     finite = jnp.all(jnp.isfinite(matrix))
     if articulation.nv == 0:
@@ -528,9 +518,7 @@ def _rnea_effort(
         child,
     ) = _edge_geometry(articulation, configuration)
     body_velocity = articulation.body_velocity_action(configuration, velocity)
-    convective = _convective_body_acceleration(
-        articulation, configuration, velocity
-    )
+    convective = _convective_body_acceleration(articulation, configuration, velocity)
     body_acceleration = convective + articulation.body_velocity_action(
         configuration, acceleration
     )
@@ -544,15 +532,25 @@ def _rnea_effort(
         ),
         axis=-1,
     )
-    edge_effort = jnp.zeros((child.shape[0],), dtype=configuration.dtype)
-    for edge in range(child.shape[0] - 1, -1, -1):
-        child_force = body_force[child[edge]]
-        edge_effort = edge_effort.at[edge].set(
+
+    def reverse_edge(index, carry):
+        body_force_, edge_effort_ = carry
+        edge = child.shape[0] - 1 - index
+        child_force = body_force_[child[edge]]
+        edge_effort_ = edge_effort_.at[edge].set(
             jnp.vdot(motion_subspace[edge], child_force).real
         )
-        body_force = body_force.at[parent[edge]].add(
+        body_force_ = body_force_.at[parent[edge]].add(
             motion_transform[edge].T @ child_force
         )
+        return body_force_, edge_effort_
+
+    _, edge_effort = jax.lax.fori_loop(
+        0,
+        child.shape[0],
+        reverse_edge,
+        (body_force, jnp.zeros((child.shape[0],), dtype=configuration.dtype)),
+    )
     return edge_effort[articulation.dof_joint_indices]
 
 
@@ -634,9 +632,7 @@ def reduced_inverse_dynamics(
         articulation, q, v, load, external_effort
     )
     candidate = mass_effort + bias_effort + gravity_effort - external_effort
-    direct = (
-        _rnea_effort(articulation, q, v, a, gravity_) - external_effort
-    )
+    direct = _rnea_effort(articulation, q, v, a, gravity_) - external_effort
     decomposition_scale = jnp.maximum(
         jnp.maximum(
             jnp.max(jnp.abs(candidate), initial=0.0),
@@ -645,8 +641,7 @@ def reduced_inverse_dynamics(
         1.0,
     )
     decomposition_residual = (
-        jnp.max(jnp.abs(candidate - direct), initial=0.0)
-        / decomposition_scale
+        jnp.max(jnp.abs(candidate - direct), initial=0.0) / decomposition_scale
     )
     input_finite = (
         jnp.all(jnp.isfinite(q))
@@ -709,9 +704,7 @@ def _aba_acceleration(
         child,
     ) = _edge_geometry(articulation, configuration)
     body_velocity = articulation.body_velocity_action(configuration, velocity)
-    convective = _convective_body_acceleration(
-        articulation, configuration, velocity
-    )
+    convective = _convective_body_acceleration(articulation, configuration, velocity)
     mass, world_inertia = _world_body_inertia(articulation, transforms)
     capacity = articulation.graph.bodies.capacity
     spatial_inertia = jnp.zeros((capacity, 6, 6), dtype=configuration.dtype)
@@ -723,8 +716,7 @@ def _aba_acceleration(
     bias_force = jnp.concatenate(
         (
             -external_load.force - mass[:, None] * gravity[None, :],
-            jnp.cross(body_velocity[:, 3:], angular_momentum)
-            - external_load.torque,
+            jnp.cross(body_velocity[:, 3:], angular_momentum) - external_load.torque,
         ),
         axis=-1,
     )
@@ -733,9 +725,7 @@ def _aba_acceleration(
     )
     edge_count = child.shape[0]
     edge_effort = jnp.zeros((edge_count,), dtype=configuration.dtype)
-    edge_effort = edge_effort.at[articulation.dof_joint_indices].set(
-        generalized_effort
-    )
+    edge_effort = edge_effort.at[articulation.dof_joint_indices].set(generalized_effort)
     articulated_inertia = spatial_inertia
     articulated_bias = bias_force
     projected_inertia = jnp.zeros((edge_count, 6), dtype=configuration.dtype)
@@ -746,16 +736,25 @@ def _aba_acceleration(
     positive = jnp.asarray(True)
     pivot_tolerance = jnp.finfo(configuration.dtype).tiny
 
-    for edge in range(edge_count - 1, -1, -1):
+    def reverse_edge(index, carry):
+        (
+            articulated_inertia_,
+            articulated_bias_,
+            projected_inertia_,
+            scalar_inertia_,
+            scalar_effort_,
+            inverse_scalar_,
+            minimum_inertia_,
+            positive_,
+        ) = carry
+        edge = edge_count - 1 - index
         child_index = child[edge]
         parent_index = parent[edge]
-        inertia_child = articulated_inertia[child_index]
-        bias_child = articulated_bias[child_index]
+        inertia_child = articulated_inertia_[child_index]
+        bias_child = articulated_bias_[child_index]
         projected = inertia_child @ motion_subspace[edge]
         pivot = jnp.vdot(motion_subspace[edge], projected).real
-        effort = edge_effort[edge] - jnp.vdot(
-            motion_subspace[edge], bias_child
-        ).real
+        effort = edge_effort[edge] - jnp.vdot(motion_subspace[edge], bias_child).real
         safe_pivot = jnp.where(
             moving[edge] & (jnp.abs(pivot) > pivot_tolerance), pivot, 1.0
         )
@@ -766,41 +765,84 @@ def _aba_acceleration(
             + reduced_inertia @ edge_convective[edge]
             + projected * (inverse * effort)
         )
-        articulated_inertia = articulated_inertia.at[parent_index].add(
-            motion_transform[edge].T
-            @ reduced_inertia
-            @ motion_transform[edge]
+        articulated_inertia_ = articulated_inertia_.at[parent_index].add(
+            motion_transform[edge].T @ reduced_inertia @ motion_transform[edge]
         )
-        articulated_bias = articulated_bias.at[parent_index].add(
+        articulated_bias_ = articulated_bias_.at[parent_index].add(
             motion_transform[edge].T @ reduced_bias
         )
-        projected_inertia = projected_inertia.at[edge].set(projected)
-        scalar_inertia = scalar_inertia.at[edge].set(pivot)
-        scalar_effort = scalar_effort.at[edge].set(effort)
-        inverse_scalar = inverse_scalar.at[edge].set(inverse)
-        minimum_inertia = jnp.where(
-            moving[edge], jnp.minimum(minimum_inertia, pivot), minimum_inertia
+        projected_inertia_ = projected_inertia_.at[edge].set(projected)
+        scalar_inertia_ = scalar_inertia_.at[edge].set(pivot)
+        scalar_effort_ = scalar_effort_.at[edge].set(effort)
+        inverse_scalar_ = inverse_scalar_.at[edge].set(inverse)
+        minimum_inertia_ = jnp.where(
+            moving[edge],
+            jnp.minimum(minimum_inertia_, pivot),
+            minimum_inertia_,
         )
-        positive = positive & (
+        positive_ = positive_ & (
             ~moving[edge] | (jnp.isfinite(pivot) & (pivot > pivot_tolerance))
         )
+        return (
+            articulated_inertia_,
+            articulated_bias_,
+            projected_inertia_,
+            scalar_inertia_,
+            scalar_effort_,
+            inverse_scalar_,
+            minimum_inertia_,
+            positive_,
+        )
 
-    body_acceleration = jnp.zeros((capacity, 6), dtype=configuration.dtype)
-    edge_acceleration = jnp.zeros((edge_count,), dtype=configuration.dtype)
-    for edge in range(edge_count):
+    (
+        articulated_inertia,
+        articulated_bias,
+        projected_inertia,
+        scalar_inertia,
+        scalar_effort,
+        inverse_scalar,
+        minimum_inertia,
+        positive,
+    ) = jax.lax.fori_loop(
+        0,
+        edge_count,
+        reverse_edge,
+        (
+            articulated_inertia,
+            articulated_bias,
+            projected_inertia,
+            scalar_inertia,
+            scalar_effort,
+            inverse_scalar,
+            minimum_inertia,
+            positive,
+        ),
+    )
+
+    def forward_edge(edge, carry):
+        body_acceleration_, edge_acceleration_ = carry
         base = (
-            motion_transform[edge] @ body_acceleration[parent[edge]]
+            motion_transform[edge] @ body_acceleration_[parent[edge]]
             + edge_convective[edge]
         )
         acceleration = inverse_scalar[edge] * (
             scalar_effort[edge] - jnp.vdot(projected_inertia[edge], base).real
         )
         child_acceleration = base + motion_subspace[edge] * acceleration
-        body_acceleration = body_acceleration.at[child[edge]].set(child_acceleration)
-        edge_acceleration = edge_acceleration.at[edge].set(acceleration)
-    generalized_acceleration = edge_acceleration[
-        articulation.dof_joint_indices
-    ]
+        body_acceleration_ = body_acceleration_.at[child[edge]].set(child_acceleration)
+        edge_acceleration_ = edge_acceleration_.at[edge].set(acceleration)
+        return body_acceleration_, edge_acceleration_
+
+    _, edge_acceleration = jax.lax.fori_loop(
+        0,
+        edge_count,
+        forward_edge,
+        (
+            jnp.zeros((capacity, 6), dtype=configuration.dtype),
+            jnp.zeros((edge_count,), dtype=configuration.dtype),
+        ),
+    )
+    generalized_acceleration = edge_acceleration[articulation.dof_joint_indices]
     return generalized_acceleration, minimum_inertia, positive
 
 
@@ -822,9 +864,7 @@ def reduced_forward_dynamics(
         raise ValueError("residual_tolerance must be finite and non-negative.")
     q = _configuration(articulation, configuration)
     v = _tangent(articulation, velocity, name="velocity")
-    effort = _tangent(
-        articulation, generalized_effort, name="generalized_effort"
-    )
+    effort = _tangent(articulation, generalized_effort, name="generalized_effort")
     gravity_ = _gravity(articulation, gravity)
     load = _body_load(articulation, external_load)
     candidate, minimum_inertia, inertia_positive = _aba_acceleration(
@@ -906,9 +946,7 @@ def _dense_reduced_forward_dynamics_reference(
     articulation = _require_articulation(articulation)
     q = _configuration(articulation, configuration)
     v = _tangent(articulation, velocity, name="velocity")
-    effort = _tangent(
-        articulation, generalized_effort, name="generalized_effort"
-    )
+    effort = _tangent(articulation, generalized_effort, name="generalized_effort")
     gravity_ = _gravity(articulation, gravity)
     load = _body_load(articulation, external_load)
     mass = reduced_mass_matrix(articulation, q)
@@ -921,9 +959,7 @@ def _dense_reduced_forward_dynamics_reference(
             problem_id=f"{articulation.prepared_id}:dense-reduced-dynamics-reference",
         ),
         rhs,
-        policy=LinearSolvePolicy(
-            DenseCholesky(), failure=FailurePolicy("status")
-        ),
+        policy=LinearSolvePolicy(DenseCholesky(), failure=FailurePolicy("status")),
     )
     candidate = solved.value
     inverse = reduced_inverse_dynamics(
@@ -1002,18 +1038,14 @@ def reduced_semi_implicit_velocity_euler_step(
     articulation = _require_articulation(articulation)
     if not isinstance(state, ReducedArticulationState):
         raise TypeError("state must be ReducedArticulationState.")
-    policy_ = (
-        ReducedSemiImplicitVelocityEulerStepPolicy() if policy is None else policy
-    )
+    policy_ = ReducedSemiImplicitVelocityEulerStepPolicy() if policy is None else policy
     if not isinstance(policy_, ReducedSemiImplicitVelocityEulerStepPolicy):
         raise TypeError(
             "policy must be ReducedSemiImplicitVelocityEulerStepPolicy or None."
         )
     q = _configuration(articulation, state.configuration)
     v = _tangent(articulation, state.velocity, name="state.velocity")
-    effort = _tangent(
-        articulation, generalized_effort, name="generalized_effort"
-    )
+    effort = _tangent(articulation, generalized_effort, name="generalized_effort")
     gravity_ = _gravity(articulation, gravity)
     load = _body_load(articulation, external_load)
     dt = jnp.asarray(step_size, dtype=q.dtype).reshape(())
@@ -1030,17 +1062,13 @@ def reduced_semi_implicit_velocity_euler_step(
     candidate_configuration = articulation.integrate_configuration(
         q, candidate_velocity, dt
     )
-    candidate = ReducedArticulationState(
-        candidate_configuration, candidate_velocity
-    )
+    candidate = ReducedArticulationState(candidate_configuration, candidate_velocity)
     initial_energy = reduced_energy(articulation, q, v, gravity_)
     candidate_energy = reduced_energy(
         articulation, candidate_configuration, candidate_velocity, gravity_
     )
     external_effort, _ = articulation.body_load_pullback(q, load, candidate_velocity)
-    applied_work = dt * jnp.vdot(
-        effort + external_effort, candidate_velocity
-    ).real
+    applied_work = dt * jnp.vdot(effort + external_effort, candidate_velocity).real
     energy_defect = candidate_energy.total - initial_energy.total - applied_work
     energy_scale = jnp.maximum(
         jnp.maximum(
@@ -1069,12 +1097,7 @@ def reduced_semi_implicit_velocity_euler_step(
         & jnp.isfinite(applied_work)
         & jnp.isfinite(energy_defect)
     )
-    successful = (
-        dynamics.successful
-        & step_size_within_bound
-        & finite
-        & energy_accepted
-    )
+    successful = dynamics.successful & step_size_within_bound & finite & energy_accepted
     accepted = ReducedArticulationState(
         jnp.where(successful, candidate.configuration, q),
         jnp.where(successful, candidate.velocity, v),

--- a/phydrax/discretization/splatting/_mesh.py
+++ b/phydrax/discretization/splatting/_mesh.py
@@ -14,10 +14,12 @@ from jaxtyping import Array, ArrayLike
 
 import phydrax.ein as ein
 
+from ..._bvh import build_packed_bvh, point_select_leaf_items
 from ..._fingerprint import canonical_fingerprint
 from ..._interpolation import apply_gather_stencil, GatherStencil
 from ..._strict import StrictModule
 from ..._trainable import NonTrainableState
+from ...geometry.simplicial import AffineSimplexMap
 from .._cell_mesh import CellMesh
 from .._measure import DiscreteMeasure
 from ..particle._population import ParticlePopulationState
@@ -123,6 +125,7 @@ class SimplicialBarycentricSplatAssignment(StrictModule, NonTrainableState):
     boundary: MeshSplatBoundaryPolicy = eqx.field(static=True)
     geometry_ad: MeshSplatGeometryAD = eqx.field(static=True)
     tie_tolerance: float = eqx.field(static=True)
+    maximum_candidates: int = eqx.field(static=True)
     assignment_id: str = eqx.field(static=True)
 
     def __init__(
@@ -131,6 +134,7 @@ class SimplicialBarycentricSplatAssignment(StrictModule, NonTrainableState):
         boundary: MeshSplatBoundaryPolicy = "reject",
         geometry_ad: MeshSplatGeometryAD = "piecewise",
         tie_tolerance: float = 1.0e-10,
+        maximum_candidates: int = 64,
     ):
         if boundary not in ("reject", "drop"):
             raise ValueError("boundary must be 'reject' or 'drop'.")
@@ -139,15 +143,20 @@ class SimplicialBarycentricSplatAssignment(StrictModule, NonTrainableState):
         tolerance = float(tie_tolerance)
         if not np.isfinite(tolerance) or tolerance < 0.0:
             raise ValueError("tie_tolerance must be finite and nonnegative.")
+        candidates = int(maximum_candidates)
+        if candidates <= 0:
+            raise ValueError("maximum_candidates must be positive.")
         self.boundary = boundary
         self.geometry_ad = geometry_ad
         self.tie_tolerance = tolerance
+        self.maximum_candidates = candidates
         self.assignment_id = canonical_fingerprint(
             {
                 "kind": "simplicial-barycentric-splat",
                 "boundary": boundary,
                 "geometry_ad": geometry_ad,
                 "tie_tolerance": tolerance,
+                "maximum_candidates": candidates,
             }
         )
 
@@ -197,51 +206,58 @@ class SimplicialBarycentricSplatAssignment(StrictModule, NonTrainableState):
         order = np.argsort(cell_ids, kind="stable")
         cells = cells[order]
         cell_ids = cell_ids[order]
-        width = target.mesh.topological_dimension + 1
-        particle_count = positions.shape[0]
-        route_indices = np.zeros((particle_count, width), dtype=np.int32)
-        selected_origins = np.zeros((particle_count, target.mesh.ambient_dimension))
-        selected_inverse = np.zeros(
-            (
-                particle_count,
-                target.mesh.topological_dimension,
-                target.mesh.ambient_dimension,
-            )
+        simplices = AffineSimplexMap(jnp.asarray(coordinates[cells]))
+        if not bool(jnp.all(simplices.evidence.successful)):
+            raise ValueError("Barycentric splatting requires nondegenerate simplices.")
+        cell_vertices = coordinates[cells]
+        bvh = build_packed_bvh(
+            np.min(cell_vertices, axis=1),
+            np.max(cell_vertices, axis=1),
+            np.mean(cell_vertices, axis=1),
+            leaf_size=min(16, cells.shape[0]),
+            dtype=simplices.vertices.dtype,
         )
-        supported = np.zeros((particle_count,), dtype=bool)
-        tie_margin = np.full((particle_count,), np.inf)
-        query_count = np.zeros((particle_count,), dtype=np.int32)
-        tolerance = self.tie_tolerance
-        for particle in range(particle_count):
-            if not active_host[particle]:
-                continue
-            candidates: list[tuple[int, float, np.ndarray, np.ndarray]] = []
-            for cell_index, vertices in enumerate(cells):
-                simplex = coordinates[vertices]
-                jacobian = (simplex[1:] - simplex[0]).T
-                gram = jacobian.T @ jacobian
-                if not np.all(np.isfinite(gram)) or np.linalg.det(gram) <= 0.0:
-                    continue
-                inverse = np.linalg.solve(gram, jacobian.T)
-                reduced = inverse @ (positions[particle] - simplex[0])
-                barycentric = np.concatenate(([1.0 - np.sum(reduced)], reduced))
-                margin = float(np.min(barycentric))
-                if margin >= -tolerance:
-                    candidates.append((cell_index, margin, barycentric, inverse))
-            query_count[particle] = len(candidates)
-            if not candidates:
-                continue
-            candidates.sort(key=lambda item: int(cell_ids[item[0]]))
-            chosen = candidates[0]
-            route_indices[particle] = cells[chosen[0]]
-            selected_origins[particle] = coordinates[cells[chosen[0], 0]]
-            selected_inverse[particle] = chosen[3]
-            supported[particle] = True
-            if len(candidates) > 1:
-                tie_margin[particle] = min(candidate[1] for candidate in candidates)
-            else:
-                tie_margin[particle] = chosen[1]
-
+        candidate_cells, candidate_valid, search_complete = point_select_leaf_items(
+            jnp.asarray(positions),
+            bvh=bvh,
+            maximum_candidates=min(self.maximum_candidates, cells.shape[0]),
+            tolerance=self.tie_tolerance,
+        )
+        candidate_points = jnp.broadcast_to(
+            jnp.asarray(positions)[:, None, :],
+            candidate_cells.shape + (target.mesh.ambient_dimension,),
+        )
+        barycentric = simplices.barycentric_at(candidate_points, candidate_cells)
+        contained = (
+            candidate_valid
+            & simplices.contains_at(
+                candidate_points,
+                candidate_cells,
+                tolerance=self.tie_tolerance,
+            )
+            & jnp.asarray(active_host)[:, None]
+        )
+        safe_candidates = jnp.where(contained, candidate_cells, cells.shape[0])
+        selected = jnp.min(safe_candidates, axis=-1)
+        supported = (selected < cells.shape[0]) & search_complete
+        selected = jnp.minimum(selected, cells.shape[0] - 1)
+        margins = jnp.min(barycentric, axis=-1)
+        tie_margin = jnp.min(
+            jnp.where(contained, margins, jnp.inf),
+            axis=-1,
+        )
+        query_count = jnp.sum(contained, axis=-1, dtype=jnp.int32)
+        query_count = jnp.where(
+            search_complete,
+            query_count,
+            self.maximum_candidates + 1,
+        )
+        route_indices = cells[np.asarray(selected)]
+        selected_origins = np.asarray(simplices.origin)[np.asarray(selected)]
+        selected_inverse = np.asarray(simplices.dual)[np.asarray(selected)]
+        supported = np.asarray(supported)
+        tie_margin = np.asarray(tie_margin)
+        query_count = np.asarray(query_count)
         return PreparedMeshParticleGridSplat(
             target=target,
             stable_source_ids=jnp.asarray(source_ids),
@@ -496,7 +512,7 @@ class PreparedMeshParticleGridSplat(StrictModule, NonTrainableState):
             valid = active_[:, None] & supported[:, None]
             raw_sum = jnp.sum(jnp.where(valid, weights, 0.0), axis=-1)
             normalization = jnp.ones_like(raw_sum)
-            overflow = jnp.zeros_like(active_)
+            overflow = self.prepared_query_count > self.route_width
             derivative_valid = (~active_) | (
                 supported & (tolerance > self.prepared_tie_margin.dtype.type(0))
             )

--- a/phydrax/dynamics/analysis/_periodic.py
+++ b/phydrax/dynamics/analysis/_periodic.py
@@ -845,16 +845,20 @@ def floquet_spectrum(
                 f"Full Floquet dimension {dimension} exceeds "
                 f"max_full_dimension={full_limit}."
             )
-        columns = []
-        action_valid = True
-        for column in range(dimension):
-            basis = jnp.zeros((dimension,), dtype=orbit.nodes.dtype).at[column].set(1.0)
+
+        def apply_column(basis):
             action = monodromy_action(
-                orbit, basis.reshape(orbit.problem.state_layout.shape), args=args
+                orbit,
+                basis.reshape(orbit.problem.state_layout.shape),
+                args=args,
             )
-            columns.append(action.tangent.reshape((-1,)))
-            action_valid = action_valid and bool(action.valid)
-        monodromy = jnp.stack(tuple(columns), axis=-1)
+            return action.tangent.reshape((-1,)), action.valid
+
+        columns, column_valid = jax.vmap(apply_column)(
+            jnp.eye(dimension, dtype=orbit.nodes.dtype)
+        )
+        monodromy = jnp.swapaxes(columns, 0, 1)
+        action_valid = bool(jnp.all(column_valid))
         eigen_result = general_eigensolve(
             GeneralEigenproblem(
                 DenseLinearOperator(monodromy),

--- a/phydrax/finance/exposure/_collateral.py
+++ b/phydrax/finance/exposure/_collateral.py
@@ -432,21 +432,18 @@ def evolve_collateral(
     )
     current = jnp.broadcast_to(initial, (path_count,))
     pending = jnp.zeros((path_count, time_count), dtype=values.dtype)
-    balances = jnp.zeros_like(values)
-    calls = jnp.zeros_like(values)
-    settlements = jnp.zeros_like(values)
     unsettled = jnp.zeros((path_count,), dtype=values.dtype)
 
-    for index in range(time_count):
-        if index > 0:
-            duration = nodes[index] - nodes[index - 1]
-            current = current * jnp.exp(agreement.remuneration_rate * duration)
-        settled = pending[:, index]
-        current = current + settled
-        settlements = settlements.at[:, index].set(jnp.where(valid, settled, 0.0))
-        outstanding = jnp.sum(pending[:, index + 1 :], axis=-1)
+    def collateral_step(carry, index):
+        current_, pending_, outstanding_, unsettled_ = carry
+        previous = jnp.maximum(index - 1, 0)
+        duration = jnp.where(index > 0, nodes[index] - nodes[previous], 0.0)
+        current_ = current_ * jnp.exp(agreement.remuneration_rate * duration)
+        settled = pending_[:, index]
+        current_ = current_ + settled
+        outstanding_ = outstanding_ - settled
         target = collateral_target(agreement, values[:, index])
-        requested = target - current - outstanding - unsettled
+        requested = target - current_ - outstanding_ - unsettled_
         requested = jnp.where(
             jnp.abs(requested) >= agreement.minimum_transfer_amount,
             requested,
@@ -457,14 +454,36 @@ def evolve_collateral(
         settles_on_grid = prepared.settles_on_grid[index]
         settles_immediately = settles_on_grid & (settlement_index == index)
         immediate = jnp.where(settles_immediately, requested, 0.0)
-        deferred = jnp.where(settles_on_grid & ~settles_immediately, requested, 0.0)
-        calls = calls.at[:, index].set(requested)
-        current = current + immediate
-        settlements = settlements.at[:, index].add(immediate)
-        pending = pending.at[:, settlement_index].add(deferred)
-        unsettled = unsettled + jnp.where(settles_on_grid, 0.0, requested)
-        balances = balances.at[:, index].set(jnp.where(valid, current, 0.0))
+        deferred = jnp.where(
+            settles_on_grid & ~settles_immediately,
+            requested,
+            0.0,
+        )
+        current_ = current_ + immediate
+        settlement = jnp.where(valid, settled + immediate, 0.0)
+        pending_ = pending_.at[:, settlement_index].add(deferred)
+        outstanding_ = outstanding_ + deferred
+        unsettled_ = unsettled_ + jnp.where(settles_on_grid, 0.0, requested)
+        balance = jnp.where(valid, current_, 0.0)
+        return (
+            current_,
+            pending_,
+            outstanding_,
+            unsettled_,
+        ), (balance, requested, settlement)
 
+    (current, pending, _, unsettled), outputs = jax.lax.scan(
+        collateral_step,
+        (
+            current,
+            pending,
+            jnp.zeros((path_count,), dtype=values.dtype),
+            unsettled,
+        ),
+        jnp.arange(time_count, dtype=jnp.int32),
+    )
+    del pending
+    balances, calls, settlements = (jnp.swapaxes(output, 0, 1) for output in outputs)
     state = CollateralState(
         jnp.where(valid, current, 0.0),
         jnp.where(valid, unsettled, 0.0),

--- a/phydrax/geometry/simplicial/_affine.py
+++ b/phydrax/geometry/simplicial/_affine.py
@@ -144,6 +144,71 @@ class AffineSimplexMap(StrictModule, NonTrainableState):
             axis=-1,
         )
 
+    @property
+    def simplex_count(self) -> int:
+        """Number of simplices on the indexed collection axis."""
+        if self.vertices.ndim < 3:
+            raise ValueError("Indexed simplex operations require a simplex collection.")
+        return int(self.vertices.shape[-3])
+
+    def _indices(self, simplex_indices: ArrayLike, /) -> Array:
+        indices = jnp.asarray(simplex_indices)
+        if not jnp.issubdtype(indices.dtype, jnp.integer):
+            raise TypeError("simplex_indices must have an integer dtype.")
+        indices = indices.astype(jnp.int32)
+        return eqx.error_if(
+            indices,
+            jnp.any((indices < 0) | (indices >= self.simplex_count)),
+            "simplex_indices contain an out-of-range simplex.",
+        )
+
+    def barycentric_at(
+        self,
+        points: ArrayLike,
+        simplex_indices: ArrayLike,
+        /,
+    ) -> Array:
+        """Map points through selected simplices without dense broadcasting."""
+        value = jnp.asarray(points, dtype=self.vertices.dtype)
+        if value.shape[-1:] != (self.ambient_dimension,):
+            raise ValueError(
+                f"points must end in ambient dimension {self.ambient_dimension}."
+            )
+        indices = self._indices(simplex_indices)
+        origin = jnp.take(self.origin, indices, axis=-2)
+        dual = jnp.take(self.dual, indices, axis=-3)
+        local = ein.contract("...ia,...a->...i", dual, value - origin)
+        return jnp.concatenate(
+            (1.0 - jnp.sum(local, axis=-1, keepdims=True), local),
+            axis=-1,
+        )
+
+    def contains_at(
+        self,
+        points: ArrayLike,
+        simplex_indices: ArrayLike,
+        /,
+        *,
+        tolerance: ArrayLike | None = None,
+    ) -> Array:
+        """Return containment for selected point-simplex pairs."""
+        indices = self._indices(simplex_indices)
+        coordinates = self.barycentric_at(points, indices)
+        resolved = (
+            64.0 * jnp.finfo(jnp.real(coordinates).dtype).eps
+            if tolerance is None
+            else jnp.asarray(tolerance, dtype=jnp.real(coordinates).dtype)
+        )
+        if jnp.asarray(resolved).shape != ():
+            raise ValueError("tolerance must be scalar or None.")
+        successful = jnp.take(self.evidence.successful, indices, axis=-1)
+        return (
+            jnp.all(jnp.isfinite(coordinates), axis=-1)
+            & jnp.all(coordinates >= -resolved, axis=-1)
+            & jnp.all(coordinates <= 1.0 + resolved, axis=-1)
+            & successful
+        )
+
     def contains(
         self,
         points: ArrayLike,
@@ -180,6 +245,20 @@ class AffineSimplexMap(StrictModule, NonTrainableState):
         if values.shape[-1:] != (self.intrinsic_dimension + 1,):
             raise ValueError("nodal_values must end in the simplex vertex count.")
         return ein.contract("...v,...va->...a", values, self.barycentric_gradients)
+
+    def physical_gradient_at(
+        self,
+        nodal_values: ArrayLike,
+        simplex_indices: ArrayLike,
+        /,
+    ) -> Array:
+        """Return gradients for fields on selected simplices."""
+        values = jnp.asarray(nodal_values)
+        if values.shape[-1:] != (self.intrinsic_dimension + 1,):
+            raise ValueError("nodal_values must end in the simplex vertex count.")
+        indices = self._indices(simplex_indices)
+        gradients = jnp.take(self.barycentric_gradients, indices, axis=-3)
+        return ein.contract("...v,...va->...a", values, gradients)
 
 
 __all__ = ["AffineSimplexEvidence", "AffineSimplexMap"]

--- a/phydrax/imaging/tomography/_core.py
+++ b/phydrax/imaging/tomography/_core.py
@@ -14,11 +14,14 @@ import jax.numpy as jnp
 import numpy as np
 from jaxtyping import Array, ArrayLike
 
+from phydrax import ein
+from phydrax._bvh import build_packed_bvh, ray_select_leaf_items
 from phydrax._interpolation import linear_interpolate
 
 from ..._fingerprint import array_tree_fingerprint, canonical_fingerprint
 from ..._strict import StrictModule
 from ..._trainable import NonTrainableState
+from ...geometry.simplicial import AffineSimplexMap
 from ...measurement import MeasurementAsset, RaySampleSupport
 
 
@@ -232,12 +235,20 @@ class TetrahedralXRayTransformPlan(StrictModule, NonTrainableState):
     cell_indices: Array
     segment_lengths: Array
     segment_valid: Array
+    route_complete: Array
     projection_shape: tuple[int, ...] = eqx.field(static=True)
     cell_count: int = eqx.field(static=True)
+    maximum_segments_per_ray: int = eqx.field(static=True)
     operator_id: str = eqx.field(static=True)
 
     def __init__(
-        self, support: ProjectionSupport, vertices: ArrayLike, tetrahedra: ArrayLike, /
+        self,
+        support: ProjectionSupport,
+        vertices: ArrayLike,
+        tetrahedra: ArrayLike,
+        /,
+        *,
+        maximum_segments_per_ray: int = 64,
     ):
         vertices_ = np.asarray(vertices, dtype=float)
         cells_ = np.asarray(tetrahedra, dtype=np.int32)
@@ -246,61 +257,115 @@ class TetrahedralXRayTransformPlan(StrictModule, NonTrainableState):
             or vertices_.shape[1] != 3
             or cells_.ndim != 2
             or cells_.shape[1] != 4
+            or cells_.shape[0] < 1
+            or np.any(cells_ < 0)
+            or np.any(cells_ >= vertices_.shape[0])
         ):
-            raise ValueError("vertices and tetrahedra require shapes (V,3) and (C,4).")
-        cells = vertices_[cells_]
-        inverse = np.linalg.inv(
-            np.stack(
-                (
-                    cells[:, 1] - cells[:, 0],
-                    cells[:, 2] - cells[:, 0],
-                    cells[:, 3] - cells[:, 0],
-                ),
-                axis=-1,
+            raise ValueError(
+                "vertices and tetrahedra require shapes (V,3) and nonempty (C,4) "
+                "with valid vertex indices."
             )
+        requested_capacity = int(maximum_segments_per_ray)
+        if requested_capacity <= 0:
+            raise ValueError("maximum_segments_per_ray must be positive.")
+        capacity = min(requested_capacity, cells_.shape[0])
+        cell_vertices = vertices_[cells_]
+        simplex = AffineSimplexMap(jnp.asarray(cell_vertices))
+        if not bool(jnp.all(simplex.evidence.successful)):
+            raise ValueError("Tetrahedral X-ray geometry contains degenerate cells.")
+        bvh = build_packed_bvh(
+            np.min(cell_vertices, axis=1),
+            np.max(cell_vertices, axis=1),
+            np.mean(cell_vertices, axis=1),
+            leaf_size=min(4, cells_.shape[0]),
+            dtype=simplex.vertices.dtype,
         )
-        origins = np.asarray(support.rays.origins)
-        directions = np.asarray(support.rays.directions)
-        near = np.asarray(support.rays.near)
-        far = np.asarray(support.rays.far)
-        indices = np.tile(
-            np.arange(cells_.shape[0], dtype=np.int32), (origins.shape[0], 1)
+        origins = jnp.asarray(support.rays.origins, dtype=simplex.vertices.dtype)
+        directions = jnp.asarray(support.rays.directions, dtype=origins.dtype)
+        near = jnp.asarray(support.rays.near, dtype=origins.dtype)
+        far = jnp.asarray(support.rays.far, dtype=origins.dtype)
+        active = jnp.asarray(support.rays.active_mask, dtype=bool)
+        candidate_capacity = min(cells_.shape[0], max(capacity, 4 * capacity))
+        candidates, candidate_valid, search_complete = ray_select_leaf_items(
+            origins,
+            directions,
+            bvh=bvh,
+            maximum_candidates=candidate_capacity,
+            minimum_parameter=near,
+            maximum_parameter=far,
         )
-        lengths = np.zeros(indices.shape)
-        valid = np.zeros(indices.shape, dtype=bool)
-        for ray, (origin, direction) in enumerate(zip(origins, directions, strict=True)):
-            for cell in range(cells_.shape[0]):
-                base = inverse[cell] @ (origin - cells[cell, 0])
-                slope = inverse[cell] @ direction
-                coefficients = np.concatenate((np.asarray((1.0 - np.sum(base),)), base))
-                derivatives = np.concatenate((np.asarray((-np.sum(slope),)), slope))
-                lower, upper = float(near[ray]), float(far[ray])
-                for coefficient, derivative in zip(
-                    coefficients, derivatives, strict=True
-                ):
-                    if abs(derivative) <= np.finfo(float).eps:
-                        if coefficient < 0.0:
-                            lower, upper = 1.0, 0.0
-                            break
-                    elif derivative > 0.0:
-                        lower = max(lower, -coefficient / derivative)
-                    else:
-                        upper = min(upper, -coefficient / derivative)
-                if upper > max(lower, 0.0):
-                    lengths[ray, cell] = upper - max(lower, 0.0)
-                    valid[ray, cell] = True
-        self.cell_indices = jnp.asarray(indices)
-        self.segment_lengths = jnp.asarray(lengths)
-        self.segment_valid = jnp.asarray(valid)
+        candidate_origins = simplex.origin[candidates]
+        candidate_dual = simplex.dual[candidates]
+        relative = origins[:, None, :] - candidate_origins
+        base = ein.contract("...ia,...a->...i", candidate_dual, relative)
+        slope = ein.contract(
+            "...ia,...a->...i",
+            candidate_dual,
+            directions[:, None, :],
+        )
+        coefficients = jnp.concatenate(
+            (1.0 - jnp.sum(base, axis=-1, keepdims=True), base),
+            axis=-1,
+        )
+        derivatives = jnp.concatenate(
+            (-jnp.sum(slope, axis=-1, keepdims=True), slope),
+            axis=-1,
+        )
+        epsilon = jnp.finfo(origins.dtype).eps
+        parallel = jnp.abs(derivatives) <= epsilon
+        excluded = jnp.any(parallel & (coefficients < 0.0), axis=-1)
+        safe_derivatives = jnp.where(parallel, 1.0, derivatives)
+        crossings = -coefficients / safe_derivatives
+        lower = jnp.maximum(
+            near[:, None],
+            jnp.max(
+                jnp.where(derivatives > epsilon, crossings, -jnp.inf),
+                axis=-1,
+            ),
+        )
+        lower = jnp.maximum(lower, 0.0)
+        upper = jnp.minimum(
+            far[:, None],
+            jnp.min(
+                jnp.where(derivatives < -epsilon, crossings, jnp.inf),
+                axis=-1,
+            ),
+        )
+        intersects = candidate_valid & active[:, None] & ~excluded & (upper > lower)
+        intersection_count = jnp.sum(intersects, axis=-1, dtype=jnp.int32)
+        complete = search_complete & (intersection_count <= capacity)
+        if not bool(jnp.all(complete | ~active)):
+            raise ValueError(
+                "maximum_segments_per_ray is insufficient for the tetrahedral routes."
+            )
+        stable_cells = jnp.where(intersects, candidates, cells_.shape[0])
+        _, selected_slots = jax.lax.top_k(-stable_cells, capacity)
+        selected_cells = jnp.take_along_axis(candidates, selected_slots, axis=-1)
+        selected_lower = jnp.take_along_axis(lower, selected_slots, axis=-1)
+        selected_upper = jnp.take_along_axis(upper, selected_slots, axis=-1)
+        selected_valid = (
+            jnp.arange(capacity, dtype=jnp.int32)[None, :] < intersection_count[:, None]
+        )
+        lengths = jnp.where(
+            selected_valid,
+            selected_upper - selected_lower,
+            0.0,
+        )
+        self.cell_indices = selected_cells
+        self.segment_lengths = lengths
+        self.segment_valid = selected_valid
+        self.route_complete = complete
         self.projection_shape = support.projection_shape
         self.cell_count = cells_.shape[0]
+        self.maximum_segments_per_ray = capacity
         self.operator_id = canonical_fingerprint(
             {
                 "kind": "tetrahedral-xray-transform",
                 "support": support.support_id,
                 "vertices": array_tree_fingerprint(vertices_),
                 "cells": array_tree_fingerprint(cells_),
-                "routes": array_tree_fingerprint((lengths, valid)),
+                "maximum_segments_per_ray": capacity,
+                "routes": array_tree_fingerprint((lengths, selected_valid)),
             }
         )
 
@@ -310,7 +375,9 @@ class TetrahedralXRayTransformPlan(StrictModule, NonTrainableState):
             raise ValueError("attenuation must contain one value per tetrahedron.")
         return jnp.sum(
             jnp.where(
-                self.segment_valid, values[self.cell_indices] * self.segment_lengths, 0.0
+                self.segment_valid,
+                values[self.cell_indices] * self.segment_lengths,
+                0.0,
             ),
             axis=-1,
         ).reshape(self.projection_shape)

--- a/phydrax/linalg/_distributed_line.py
+++ b/phydrax/linalg/_distributed_line.py
@@ -994,36 +994,44 @@ def _block_pcr(
         upper,
         rhs,
     )
+    indices = jnp.arange(count, dtype=jnp.int32)
     while stride < count:
-        next_lower = jnp.zeros_like(current_lower)
-        next_diagonal = current_diagonal
-        next_upper = jnp.zeros_like(current_upper)
-        next_rhs = current_rhs
-        for index in range(count):
-            if index - stride >= 0:
-                inverse, _ = _inverse_2x2(current_diagonal[index - stride], tolerance)
-                alpha = -contract("ij,jk->ik", current_lower[index], inverse)
-                next_diagonal = next_diagonal.at[index].add(
-                    contract("ij,jk->ik", alpha, current_upper[index - stride])
-                )
-                next_rhs = next_rhs.at[:, index, :].add(
-                    contract("ij,bj->bi", alpha, current_rhs[:, index - stride, :])
-                )
-                next_lower = next_lower.at[index].set(
-                    contract("ij,jk->ik", alpha, current_lower[index - stride])
-                )
-            if index + stride < count:
-                inverse, _ = _inverse_2x2(current_diagonal[index + stride], tolerance)
-                beta = -contract("ij,jk->ik", current_upper[index], inverse)
-                next_diagonal = next_diagonal.at[index].add(
-                    contract("ij,jk->ik", beta, current_lower[index + stride])
-                )
-                next_rhs = next_rhs.at[:, index, :].add(
-                    contract("ij,bj->bi", beta, current_rhs[:, index + stride, :])
-                )
-                next_upper = next_upper.at[index].set(
-                    contract("ij,jk->ik", beta, current_upper[index + stride])
-                )
+        left_valid = indices >= stride
+        right_valid = indices + stride < count
+        left_indices = jnp.maximum(indices - stride, 0)
+        right_indices = jnp.minimum(indices + stride, count - 1)
+        left_inverse, _ = _inverse_2x2(
+            current_diagonal[left_indices],
+            tolerance,
+        )
+        right_inverse, _ = _inverse_2x2(
+            current_diagonal[right_indices],
+            tolerance,
+        )
+        alpha = -contract("pij,pjk->pik", current_lower, left_inverse)
+        beta = -contract("pij,pjk->pik", current_upper, right_inverse)
+        alpha = jnp.where(left_valid[:, None, None], alpha, 0.0)
+        beta = jnp.where(right_valid[:, None, None], beta, 0.0)
+        next_diagonal = (
+            current_diagonal
+            + contract("pij,pjk->pik", alpha, current_upper[left_indices])
+            + contract("pij,pjk->pik", beta, current_lower[right_indices])
+        )
+        next_rhs = (
+            current_rhs
+            + contract("pij,bpj->bpi", alpha, current_rhs[:, left_indices, :])
+            + contract("pij,bpj->bpi", beta, current_rhs[:, right_indices, :])
+        )
+        next_lower = jnp.where(
+            left_valid[:, None, None],
+            contract("pij,pjk->pik", alpha, current_lower[left_indices]),
+            0.0,
+        )
+        next_upper = jnp.where(
+            right_valid[:, None, None],
+            contract("pij,pjk->pik", beta, current_upper[right_indices]),
+            0.0,
+        )
         current_lower, current_diagonal, current_upper, current_rhs = (
             next_lower,
             next_diagonal,

--- a/phydrax/linalg/backends/_native_block_krylov.py
+++ b/phydrax/linalg/backends/_native_block_krylov.py
@@ -493,9 +493,8 @@ def _block_cg_raw(
     breakdown = jnp.zeros((rhs_count,), dtype=bool)
     last_executed_iteration = jnp.asarray(0, dtype=jnp.int32)
 
-    for index in range(max_steps):
-
-        def execute(operand):
+    def iteration_body(index, operand):
+        def execute(selected):
             (
                 correction_,
                 residual_,
@@ -508,7 +507,7 @@ def _block_cg_raw(
                 breakdown_,
                 last_executed_iteration_,
                 observed_,
-            ) = operand
+            ) = selected
             action_direction = action(direction_)
             curvature = _hermitian_gram(
                 block_gram,
@@ -576,24 +575,34 @@ def _block_cg_raw(
                 next_iteration,
             )
 
-        operand = (
-            correction,
-            residual,
-            direction,
-            gram,
-            value,
-            converged,
-            iterations,
-            matvec_count,
-            breakdown,
-            last_executed_iteration,
-            iteration_state,
-        )
         should_execute = (
-            (~jnp.all(converged | breakdown))
+            (~jnp.all(operand[5] | operand[8]))
             & jnp.any(active)
-            & ~_iteration_stop(iteration_state)
+            & ~_iteration_stop(operand[10])
         )
+        return jax.lax.cond(
+            should_execute,
+            execute,
+            lambda selected: selected,
+            operand,
+        )
+
+    (
+        correction,
+        residual,
+        direction,
+        gram,
+        value,
+        converged,
+        iterations,
+        matvec_count,
+        breakdown,
+        last_executed_iteration,
+        iteration_state,
+    ) = jax.lax.fori_loop(
+        0,
+        max_steps,
+        iteration_body,
         (
             correction,
             residual,
@@ -606,7 +615,8 @@ def _block_cg_raw(
             breakdown,
             last_executed_iteration,
             iteration_state,
-        ) = jax.lax.cond(should_execute, execute, lambda selected: selected, operand)
+        ),
+    )
     return (
         value,
         iterations,

--- a/phydrax/ml/inspection/_inspection.py
+++ b/phydrax/ml/inspection/_inspection.py
@@ -196,12 +196,14 @@ def individual_conditional_expectation(
     common_dtype = jnp.result_type(x.dtype, values.dtype)
     x = x.astype(common_dtype)
     values = values.astype(common_dtype)
-    predictions = []
-    for grid_index in range(values.shape[0]):
-        modified = x.at[..., jnp.asarray(indices_tuple)].set(values[grid_index])
+    grid_indices = jnp.arange(values.shape[0], dtype=jnp.uint32)
+
+    def evaluate_grid(grid_index, grid_values):
+        modified = x.at[..., jnp.asarray(indices_tuple)].set(grid_values)
         member_key = None if key is None else jr.fold_in(key, grid_index)
-        predictions.append(jnp.asarray(model(modified, key=member_key)))
-    ice = jnp.stack(tuple(predictions), axis=0)
+        return jnp.asarray(model(modified, key=member_key))
+
+    ice = jax.vmap(evaluate_grid)(grid_indices, values)
     sample_axis = 1 + len(case_shape)
     output_rank = ice.ndim - (sample_axis + 1)
     expanded_weight = weights[None, ...].reshape(
@@ -285,20 +287,26 @@ def permutation_importance(
     sample_axis = len(batch.case_shape)
     baseline_prediction = jnp.asarray(model(x, key=jr.fold_in(key, 0)))
     baseline = jnp.asarray(scorer(batch, baseline_prediction))
-    repeat_scores = []
-    for repeat in range(int(repeats)):
-        feature_scores = []
-        for feature in range(batch.feature_count):
-            stream = 1 + repeat * batch.feature_count + feature
-            permutation = jr.permutation(jr.fold_in(key, stream), batch.sample_count)
-            column = jnp.take(x[..., feature], permutation, axis=sample_axis)
-            permuted = x.at[..., feature].set(column)
-            prediction = jnp.asarray(
-                model(permuted, key=jr.fold_in(key, 100000 + stream))
-            )
-            feature_scores.append(jnp.asarray(scorer(batch, prediction)))
-        repeat_scores.append(jnp.stack(tuple(feature_scores), axis=0))
-    permuted_scores = jnp.stack(tuple(repeat_scores), axis=0)
+    evaluation_count = int(repeats) * batch.feature_count
+    streams = jnp.arange(evaluation_count, dtype=jnp.int32)
+
+    def evaluate_permutation(flat_index):
+        repeat = flat_index // batch.feature_count
+        feature = flat_index % batch.feature_count
+        stream = 1 + repeat * batch.feature_count + feature
+        permutation = jr.permutation(
+            jr.fold_in(key, stream),
+            batch.sample_count,
+        )
+        column = jnp.take(x[..., feature], permutation, axis=sample_axis)
+        permuted = x.at[..., feature].set(column)
+        prediction = jnp.asarray(model(permuted, key=jr.fold_in(key, 100000 + stream)))
+        return jnp.asarray(scorer(batch, prediction))
+
+    permuted_scores = jax.lax.map(
+        evaluate_permutation,
+        streams,
+    ).reshape((int(repeats), batch.feature_count) + baseline.shape)
     baseline_expanded = baseline.reshape((1, 1) + baseline.shape)
     return PermutationImportanceResult(
         baseline,

--- a/phydrax/ml/metrics/_classification.py
+++ b/phydrax/ml/metrics/_classification.py
@@ -807,9 +807,12 @@ def roc_auc_score(
         weight = weight[order]
         positive = weight * (labels == 1)
         negative = weight * (labels == 0)
-        comparison = scores[:, None] - scores[None, :]
-        credit = (comparison > 0.0).astype(weight.dtype) + 0.5 * (comparison == 0.0)
-        numerator = jnp.sum(positive[:, None] * negative[None, :] * credit)
+        tie_start = (jnp.arange(scores.shape[0]) == 0) | (scores != jnp.roll(scores, 1))
+        groups = jnp.cumsum(tie_start.astype(jnp.int32)) - 1
+        group_negative = jnp.zeros_like(negative).at[groups].add(negative)
+        negative_before = jnp.cumsum(group_negative) - group_negative
+        credit = negative_before[groups] + 0.5 * group_negative[groups]
+        numerator = jnp.sum(positive * credit)
         positive_mass = jnp.sum(positive)
         negative_mass = jnp.sum(negative)
         return numerator / jnp.where(

--- a/phydrax/ml/tree/_hard.py
+++ b/phydrax/ml/tree/_hard.py
@@ -462,82 +462,105 @@ def _build_tree(
                         )
                     )
 
-            for candidate, kind, categories, category_mask in candidates:
-                if kind == 1:
-                    ordinary_left = present & jnp.any(
-                        category_mask[None, :] & (values[:, None] == categories[None, :]),
-                        axis=-1,
+            if not candidates:
+                continue
+            candidate_values = jnp.stack(tuple(item[0] for item in candidates))
+            candidate_kinds = jnp.asarray(
+                tuple(item[1] for item in candidates),
+                dtype=jnp.int32,
+            )
+            candidate_categories = jnp.stack(tuple(item[2] for item in candidates))
+            candidate_category_masks = jnp.stack(tuple(item[3] for item in candidates))
+            categorical_left = present[None, :] & jnp.any(
+                candidate_category_masks[:, None, :]
+                & (values[None, :, None] == candidate_categories[:, None, :]),
+                axis=-1,
+            )
+            ordered_left = present[None, :] & (
+                values[None, :] <= candidate_values[:, None]
+            )
+            ordinary_left = jnp.where(
+                candidate_kinds[:, None] == 1,
+                categorical_left,
+                ordered_left,
+            )
+            candidate_indices = jnp.repeat(
+                jnp.arange(candidate_values.shape[0], dtype=jnp.int32),
+                2,
+            )
+            defaults = jnp.tile(jnp.asarray((False, True)), candidate_values.shape[0])
+            ordinary = ordinary_left[candidate_indices]
+            missing = node_samples & ~present
+            left_masks = node_samples[None, :] & (
+                ordinary | (missing[None, :] & defaults[:, None])
+            )
+            right_masks = node_samples[None, :] & ~(
+                ordinary | (missing[None, :] & defaults[:, None])
+            )
+            if newton:
+                assert gradient is not None and hessian is not None
+                left_value, left_metric, left_cover, left_count = jax.vmap(
+                    lambda mask: _newton_stats(
+                        gradient,
+                        hessian,
+                        mask,
+                        l2_regularization=l2_regularization,
+                        l1_regularization=l1_regularization,
+                        max_delta_step=max_delta_step,
                     )
-                    candidate_valid = jnp.any(category_mask)
-                else:
-                    ordinary_left = present & (values <= candidate)
-                    candidate_valid = jnp.isfinite(candidate)
-                missing = node_samples & ~present
-                for default_left in (False, True):
-                    left_mask = node_samples & (ordinary_left | (missing & default_left))
-                    right_mask = node_samples & ~(
-                        ordinary_left | (missing & default_left)
+                )(left_masks)
+                right_value, right_metric, right_cover, right_count = jax.vmap(
+                    lambda mask: _newton_stats(
+                        gradient,
+                        hessian,
+                        mask,
+                        l2_regularization=l2_regularization,
+                        l1_regularization=l1_regularization,
+                        max_delta_step=max_delta_step,
                     )
-                    if newton:
-                        assert gradient is not None and hessian is not None
-                        left_value, left_metric, left_cover, left_count = _newton_stats(
-                            gradient,
-                            hessian,
-                            left_mask,
-                            l2_regularization=l2_regularization,
-                            l1_regularization=l1_regularization,
-                            max_delta_step=max_delta_step,
-                        )
-                        right_value, right_metric, right_cover, right_count = (
-                            _newton_stats(
-                                gradient,
-                                hessian,
-                                right_mask,
-                                l2_regularization=l2_regularization,
-                                l1_regularization=l1_regularization,
-                                max_delta_step=max_delta_step,
-                            )
-                        )
-                        gain = left_metric + right_metric - parent_metric - gamma
-                    else:
-                        assert y is not None
-                        left_value, left_metric, left_cover, left_count = _cart_stats(
-                            y, weight, left_mask
-                        )
-                        right_value, right_metric, right_cover, right_count = _cart_stats(
-                            y, weight, right_mask
-                        )
-                        gain = parent_metric - left_metric - right_metric - gamma
-                    if monotonic_enabled:
-                        left_value = jnp.clip(left_value, lower_bound, upper_bound)
-                        right_value = jnp.clip(right_value, lower_bound, upper_bound)
-                    valid = (
-                        candidate_valid
-                        & (left_count >= min_samples_leaf)
-                        & (right_count >= min_samples_leaf)
-                        & (left_cover >= min_weight_leaf)
-                        & (right_cover >= min_weight_leaf)
-                        & jnp.isfinite(gain)
-                    )
-                    monotonic = (
-                        0 if not monotonic_constraints else monotonic_constraints[feature]
-                    )
-                    if monotonic != 0:
-                        ordering = left_value[0] <= right_value[0]
-                        valid = valid & (ordering if monotonic > 0 else ~ordering)
-                    improve = valid & (gain > best_gain)
-                    if _as_bool(improve):
-                        best_gain = gain
-                        best_feature = feature
-                        best_threshold = candidate
-                        best_default_left = default_left
-                        best_kind = kind
-                        best_categories = categories
-                        best_category_mask = category_mask
-                        best_left_mask = left_mask
-                        best_right_mask = right_mask
-                        best_left_value = left_value
-                        best_right_value = right_value
+                )(right_masks)
+                gain = left_metric + right_metric - parent_metric - gamma
+            else:
+                assert y is not None
+                left_value, left_metric, left_cover, left_count = jax.vmap(
+                    lambda mask: _cart_stats(y, weight, mask)
+                )(left_masks)
+                right_value, right_metric, right_cover, right_count = jax.vmap(
+                    lambda mask: _cart_stats(y, weight, mask)
+                )(right_masks)
+                gain = parent_metric - left_metric - right_metric - gamma
+            if monotonic_enabled:
+                left_value = jnp.clip(left_value, lower_bound, upper_bound)
+                right_value = jnp.clip(right_value, lower_bound, upper_bound)
+            candidate_valid = jnp.isfinite(candidate_values)[candidate_indices]
+            valid = (
+                candidate_valid
+                & (left_count >= min_samples_leaf)
+                & (right_count >= min_samples_leaf)
+                & (left_cover >= min_weight_leaf)
+                & (right_cover >= min_weight_leaf)
+                & jnp.isfinite(gain)
+            )
+            monotonic = 0 if not monotonic_constraints else monotonic_constraints[feature]
+            if monotonic != 0:
+                ordering = left_value[:, 0] <= right_value[:, 0]
+                valid = valid & (ordering if monotonic > 0 else ~ordering)
+            scores = jnp.where(valid, gain, -jnp.inf)
+            local_index = jnp.argmax(scores)
+            local_gain = scores[local_index]
+            if _as_bool(local_gain > best_gain):
+                selected_candidate = candidate_indices[local_index]
+                best_gain = local_gain
+                best_feature = feature
+                best_threshold = candidate_values[selected_candidate]
+                best_default_left = defaults[local_index]
+                best_kind = candidate_kinds[selected_candidate]
+                best_categories = candidate_categories[selected_candidate]
+                best_category_mask = candidate_category_masks[selected_candidate]
+                best_left_mask = left_masks[local_index]
+                best_right_mask = right_masks[local_index]
+                best_left_value = left_value[local_index]
+                best_right_value = right_value[local_index]
 
         if best_feature < 0 or _as_float(best_gain) <= min_gain:
             continue

--- a/phydrax/operators/integral/vortex/_panels2d.py
+++ b/phydrax/operators/integral/vortex/_panels2d.py
@@ -114,6 +114,35 @@ class RigidPanelMotion2D(StrictModule):
         return geometry, surface_velocity
 
 
+def _constant_panel_velocity_kernel(
+    targets: Array,
+    geometry: FlowPanelGeometry2D,
+    /,
+    *,
+    kind: str,
+) -> Array:
+    relative = targets[:, None, :] - geometry.start[None, :, :]
+    x = jnp.sum(relative * geometry.tangent[None, :, :], axis=-1)
+    y = jnp.sum(relative * geometry.normal[None, :, :], axis=-1)
+    x2 = x - geometry.length[None, :]
+    tiny = jnp.finfo(targets.dtype).tiny
+    r1 = jnp.maximum(x * x + y * y, tiny)
+    r2 = jnp.maximum(x2 * x2 + y * y, tiny)
+    theta = jnp.arctan2(y, x2) - jnp.arctan2(y, x)
+    tangent_component = 0.25 / math.pi * jnp.log(r1 / r2)
+    normal_component = 0.5 / math.pi * theta
+    source_velocity = (
+        tangent_component[..., None] * geometry.tangent[None, :, :]
+        + normal_component[..., None] * geometry.normal[None, :, :]
+    )
+    if kind == "source":
+        return source_velocity
+    return jnp.stack(
+        (-source_velocity[..., 1], source_velocity[..., 0]),
+        axis=-1,
+    )
+
+
 def constant_panel_velocity_2d(
     targets: ArrayLike,
     geometry: FlowPanelGeometry2D,
@@ -130,24 +159,10 @@ def constant_panel_velocity_2d(
         raise ValueError("Panel targets/strengths have invalid shapes.")
     if kind not in ("source", "vortex"):
         raise ValueError("kind must be 'source' or 'vortex'.")
-    relative = target[:, None, :] - geometry.start[None, :, :]
-    x = jnp.sum(relative * geometry.tangent[None, :, :], axis=-1)
-    y = jnp.sum(relative * geometry.normal[None, :, :], axis=-1)
-    x2 = x - geometry.length[None, :]
-    tiny = jnp.finfo(target.dtype).tiny
-    r1 = jnp.maximum(x * x + y * y, tiny)
-    r2 = jnp.maximum(x2 * x2 + y * y, tiny)
-    theta = jnp.arctan2(y, x2) - jnp.arctan2(y, x)
-    tangent_component = 0.25 / math.pi * jnp.log(r1 / r2)
-    normal_component = 0.5 / math.pi * theta
-    source_velocity = (
-        tangent_component[..., None] * geometry.tangent[None, :, :]
-        + normal_component[..., None] * geometry.normal[None, :, :]
-    )
-    panel_velocity = (
-        source_velocity
-        if kind == "source"
-        else jnp.stack((-source_velocity[..., 1], source_velocity[..., 0]), axis=-1)
+    panel_velocity = _constant_panel_velocity_kernel(
+        target,
+        geometry,
+        kind=kind,
     )
     return jnp.sum(values[None, :, None] * panel_velocity, axis=1)
 
@@ -155,13 +170,11 @@ def constant_panel_velocity_2d(
 def panel_influence_matrix_2d(
     geometry: FlowPanelGeometry2D, /, *, kind: str = "vortex"
 ) -> tuple[Array, Array]:
-    unit_columns = []
-    for panel in range(int(geometry.length.size)):
-        strength = jnp.zeros_like(geometry.length).at[panel].set(1.0)
-        unit_columns.append(
-            constant_panel_velocity_2d(geometry.control, geometry, strength, kind=kind)
-        )
-    velocity = jnp.stack(tuple(unit_columns), axis=1)
+    velocity = _constant_panel_velocity_kernel(
+        geometry.control,
+        geometry,
+        kind=kind,
+    )
     normal = jnp.sum(velocity * geometry.normal[:, None, :], axis=-1)
     tangential = jnp.sum(velocity * geometry.tangent[:, None, :], axis=-1)
     if kind == "vortex":

--- a/phydrax/operators/integral/vortex/_panels3d_complete.py
+++ b/phydrax/operators/integral/vortex/_panels3d_complete.py
@@ -146,13 +146,9 @@ class NativePanelFieldPlan3D(StrictModule):
     ) -> tuple[Array, Array]:
         offset = offset_fraction * jnp.sqrt(self.geometry.area)
         targets = self.geometry.control_point + offset[:, None] * self.geometry.normal
-        columns_velocity, columns_potential = [], []
-        for panel in range(self.geometry.panel_count):
-            density = (
-                jnp.zeros((self.geometry.panel_count,), dtype=targets.dtype)
-                .at[panel]
-                .set(1.0)
-            )
+        densities = jnp.eye(self.geometry.panel_count, dtype=targets.dtype)
+
+        def evaluate_column(density):
             evaluation = self.evaluate(
                 targets,
                 density,
@@ -160,11 +156,10 @@ class NativePanelFieldPlan3D(StrictModule):
                 target_side="exterior",
                 accuracy_clearance=0.0,
             )
-            columns_velocity.append(evaluation.velocity)
-            columns_potential.append(evaluation.potential)
-        velocity = jnp.stack(tuple(columns_velocity), axis=1)
-        potential = jnp.stack(tuple(columns_potential), axis=1)
-        return velocity, potential
+            return evaluation.velocity, evaluation.potential
+
+        velocity, potential = jax.vmap(evaluate_column)(densities)
+        return jnp.swapaxes(velocity, 0, 1), jnp.swapaxes(potential, 0, 1)
 
 
 __all__ = ["NativePanelFieldPlan3D", "NativePanelGeometry3D", "PanelFieldEvaluation3D"]

--- a/phydrax/operators/quantum/_nonmarkovianity.py
+++ b/phydrax/operators/quantum/_nonmarkovianity.py
@@ -56,16 +56,10 @@ class DynamicalMapSeriesPhysicality(StrictModule):
 
 def _choi_evidence(superoperator: Array, dimension: int, /) -> tuple[Array, Array]:
     size = int(dimension)
-    choi = jnp.zeros((size, size, size, size), dtype=superoperator.dtype)
-    for row in range(size):
-        for column in range(size):
-            basis = (
-                jnp.zeros((size, size), dtype=superoperator.dtype)
-                .at[row, column]
-                .set(1.0)
-            )
-            output = (superoperator @ basis.reshape(-1)).reshape((size, size))
-            choi = choi.at[row, :, column, :].set(output)
+    choi = jnp.transpose(
+        superoperator.reshape((size, size, size, size)),
+        (2, 0, 3, 1),
+    )
     flat = choi.reshape((size * size, size * size))
     hermiticity_residual = jnp.max(jnp.abs(flat - jnp.conj(flat.T)))
     hermitian = 0.5 * flat + 0.5 * jnp.conj(flat.T)

--- a/phydrax/optics/geometric/_graded_index.py
+++ b/phydrax/optics/geometric/_graded_index.py
@@ -16,6 +16,7 @@ import jax.numpy as jnp
 import numpy as np
 from jaxtyping import Array, ArrayLike
 
+from ..._bvh import build_packed_bvh, PackedBVH, point_select_leaf_items
 from ..._fingerprint import array_tree_fingerprint, canonical_fingerprint
 from ..._physical import SpatialCoordinateContract
 from ..._strict import StrictModule
@@ -192,6 +193,8 @@ class TetrahedralRefractiveIndexField(AbstractRefractiveIndexField, NonTrainable
     inverse_edges: Array
     value_gradients: Array
     simplex: AffineSimplexMap
+    bvh: PackedBVH
+    maximum_candidates: int = eqx.field(static=True)
 
     def __init__(
         self,
@@ -202,6 +205,7 @@ class TetrahedralRefractiveIndexField(AbstractRefractiveIndexField, NonTrainable
         /,
         *,
         field_id: str,
+        maximum_candidates: int = 64,
     ):
         vertices_host = np.asarray(vertices, dtype=float)
         tetrahedra_host = np.asarray(tetrahedra, dtype=np.int32)
@@ -233,6 +237,18 @@ class TetrahedralRefractiveIndexField(AbstractRefractiveIndexField, NonTrainable
         simplex = AffineSimplexMap(cells)
         if not bool(jnp.all(simplex.evidence.successful)):
             raise ValueError("Tetrahedral refractive field contains degenerate cells.")
+        candidate_capacity = int(maximum_candidates)
+        if candidate_capacity <= 0:
+            raise ValueError("maximum_candidates must be positive.")
+        cell_bounds_min = np.min(cells, axis=1)
+        cell_bounds_max = np.max(cells, axis=1)
+        bvh = build_packed_bvh(
+            cell_bounds_min,
+            cell_bounds_max,
+            np.mean(cells, axis=1),
+            leaf_size=min(16, cells.shape[0]),
+            dtype=simplex.vertices.dtype,
+        )
         nodal_values = jnp.asarray(values_host[tetrahedra_host])
         gradients = simplex.physical_gradient(nodal_values)
         self.vertices = jnp.asarray(vertices_host)
@@ -242,6 +258,8 @@ class TetrahedralRefractiveIndexField(AbstractRefractiveIndexField, NonTrainable
         self.inverse_edges = simplex.dual
         self.value_gradients = gradients
         self.simplex = simplex
+        self.bvh = bvh
+        self.maximum_candidates = candidate_capacity
         self.coordinate_contract = coordinate_contract
         self.field_id = canonical_fingerprint(
             {
@@ -250,6 +268,7 @@ class TetrahedralRefractiveIndexField(AbstractRefractiveIndexField, NonTrainable
                 "vertices": array_tree_fingerprint(vertices_host),
                 "tetrahedra": array_tree_fingerprint(tetrahedra_host),
                 "values": array_tree_fingerprint(values_host),
+                "maximum_candidates": candidate_capacity,
                 "coordinates": coordinate_contract.spatial_id,
             }
         )
@@ -257,20 +276,36 @@ class TetrahedralRefractiveIndexField(AbstractRefractiveIndexField, NonTrainable
     def sample(self, points: Array, /) -> tuple[Array, Array, Array, Array]:
         points_ = jnp.asarray(points, dtype=self.vertices.dtype)
         flat = points_.reshape((-1, 3))
-        barycentric = self.simplex.barycentric(flat[:, None, :])
-        tolerance = 64.0 * jnp.finfo(points_.dtype).eps
-        contained = self.simplex.contains(
-            flat[:, None, :],
-            tolerance=tolerance,
+        candidates, candidate_valid, complete = point_select_leaf_items(
+            flat,
+            bvh=self.bvh,
+            maximum_candidates=self.maximum_candidates,
         )
-        valid = jnp.any(contained, axis=1)
-        cell = jnp.argmax(contained, axis=1)
-        safe_barycentric = barycentric[jnp.arange(flat.shape[0]), cell]
+        candidate_points = jnp.broadcast_to(
+            flat[:, None, :],
+            candidates.shape + (3,),
+        )
+        tolerance = 64.0 * jnp.finfo(points_.dtype).eps
+        contained = (
+            self.simplex.contains_at(
+                candidate_points,
+                candidates,
+                tolerance=tolerance,
+            )
+            & candidate_valid
+        )
+        safe_cells = jnp.where(contained, candidates, self.simplex.simplex_count)
+        cell = jnp.min(safe_cells, axis=-1)
+        located = cell < self.simplex.simplex_count
+        cell = jnp.minimum(cell, self.simplex.simplex_count - 1)
+        barycentric = self.simplex.barycentric_at(flat, cell)
         values = jnp.sum(
-            safe_barycentric * self.vertex_values[self.tetrahedra[cell]], axis=-1
+            barycentric * self.vertex_values[self.tetrahedra[cell]],
+            axis=-1,
         )
         gradients = self.value_gradients[cell]
         hessians = jnp.zeros((flat.shape[0], 3, 3), dtype=points_.dtype)
+        valid = located & complete
         shape = points_.shape[:-1]
         return (
             values.reshape(shape),

--- a/phydrax/optim/_differential_evolution.py
+++ b/phydrax/optim/_differential_evolution.py
@@ -284,7 +284,7 @@ def _reflect_unit_box(population: Array, /) -> Array:
 
 
 def _ranks_and_crowding(objectives: Array, valid: Array, /) -> tuple[Array, Array]:
-    count, objective_count = objectives.shape
+    count = objectives.shape[0]
     dominance = dominance_matrix(objectives, valid)
     ranks = jnp.full((count,), count, dtype=jnp.int32)
     remaining = valid
@@ -297,25 +297,45 @@ def _ranks_and_crowding(objectives: Array, valid: Array, /) -> tuple[Array, Arra
         return ranks_, remaining_ & ~front
 
     ranks, _ = jax.lax.fori_loop(0, count, assign, (ranks, remaining))
-    crowding = jnp.zeros((count,), dtype=objectives.dtype)
-    for rank in range(count):
-        front = valid & (ranks == rank)
-        front_count = jnp.sum(front, dtype=jnp.int32)
-        for objective in range(objective_count):
-            values = objectives[:, objective]
-            order = jnp.argsort(jnp.where(front, values, jnp.inf), stable=True)
-            ordered_valid = front[order]
-            ordered = values[order]
-            position = jnp.arange(count)
-            previous = ordered[jnp.maximum(position - 1, 0)]
-            following = ordered[jnp.minimum(position + 1, count - 1)]
-            finite_values = jnp.where(front, values, jnp.nan)
-            span = jnp.nanmax(finite_values) - jnp.nanmin(finite_values)
-            contribution = jnp.where(span > 0.0, (following - previous) / span, 0.0)
-            boundary = (position == 0) | (position == front_count - 1)
-            contribution = jnp.where(ordered_valid & boundary, jnp.inf, contribution)
-            contribution = jnp.where(ordered_valid, contribution, 0.0)
-            crowding = crowding.at[order].add(contribution)
+    indices = jnp.arange(count, dtype=jnp.int32)
+
+    def objective_crowding(values):
+        safe_values = jnp.where(valid, values, jnp.inf)
+        order = jnp.lexsort((indices, safe_values, ranks))
+        ordered_ranks = ranks[order]
+        ordered_values = safe_values[order]
+        position = jnp.arange(count, dtype=jnp.int32)
+        previous_position = jnp.maximum(position - 1, 0)
+        following_position = jnp.minimum(position + 1, count - 1)
+        previous_rank = ordered_ranks[previous_position]
+        following_rank = ordered_ranks[following_position]
+        boundary = (
+            (position == 0)
+            | (position == count - 1)
+            | (previous_rank != ordered_ranks)
+            | (following_rank != ordered_ranks)
+        )
+        minimum = (
+            jnp.full((count + 1,), jnp.inf, dtype=values.dtype)
+            .at[ranks]
+            .min(jnp.where(valid, values, jnp.inf))
+        )
+        maximum = (
+            jnp.full((count + 1,), -jnp.inf, dtype=values.dtype)
+            .at[ranks]
+            .max(jnp.where(valid, values, -jnp.inf))
+        )
+        span = maximum[ordered_ranks] - minimum[ordered_ranks]
+        contribution = jnp.where(
+            (~boundary) & valid[order] & (span > 0.0),
+            (ordered_values[following_position] - ordered_values[previous_position])
+            / span,
+            0.0,
+        )
+        contribution = jnp.where(boundary & valid[order], jnp.inf, contribution)
+        return jnp.zeros((count,), dtype=values.dtype).at[order].set(contribution)
+
+    crowding = jnp.sum(jax.vmap(objective_crowding)(objectives.T), axis=0)
     return ranks, crowding
 
 
@@ -399,6 +419,38 @@ def _categorical_mutant(space, population, a, b, c, key):
     return population[a].at[:, columns].set(selected)
 
 
+def _sample_distinct_donors(key: Array, population_size: int, /) -> Array:
+    targets = jnp.arange(population_size, dtype=jnp.int32)
+    first_key, second_key, third_key = jr.split(key, 3)
+    first_raw = jr.randint(
+        first_key,
+        (population_size,),
+        0,
+        population_size - 1,
+    )
+    first = first_raw + (first_raw >= targets)
+    lower = jnp.minimum(targets, first)
+    upper = jnp.maximum(targets, first)
+    second_raw = jr.randint(
+        second_key,
+        (population_size,),
+        0,
+        population_size - 2,
+    )
+    second = second_raw + (second_raw >= lower)
+    second = second + (second >= upper)
+    excluded = jnp.sort(jnp.stack((targets, first, second), axis=-1), axis=-1)
+    third = jr.randint(
+        third_key,
+        (population_size,),
+        0,
+        population_size - 3,
+    )
+    for slot in range(3):
+        third = third + (third >= excluded[:, slot])
+    return jnp.stack((first, second, third), axis=-1)
+
+
 @eqx.filter_jit
 def _run_differential_evolution(
     objective, validity, space, search, initial_population, key
@@ -450,11 +502,10 @@ def _run_differential_evolution(
         mutation_key, rounding_key, categorical_key, crossover_key = jr.split(
             generation_key, 4
         )
-        scores = jr.uniform(
-            mutation_key, (search.population_size, search.population_size)
+        donors = _sample_distinct_donors(
+            mutation_key,
+            search.population_size,
         )
-        scores = jnp.where(jnp.eye(search.population_size, dtype=bool), jnp.inf, scores)
-        donors = jnp.argsort(scores, axis=-1)[:, :3]
         a, b, c = donors[:, 0], donors[:, 1], donors[:, 2]
         if search.strategy == "best1bin":
             safe = jnp.where(valid_, objectives_[:, 0], jnp.inf)

--- a/phydrax/optim/_graph_least_squares.py
+++ b/phydrax/optim/_graph_least_squares.py
@@ -74,6 +74,22 @@ class ResidualGraphSolveEvidence(StrictModule):
     linear_iterations: Array
 
 
+class _ResidualGraphIterationState(StrictModule):
+    parameters: PyTree[Any]
+    model: ResidualGraphLinearization
+    damping: Array
+    status: Array
+    iterations: Array
+    accepted: Array
+    rejected: Array
+    linear_solves: Array
+    linear_iterations: Array
+    residual_evaluations: Array
+    jacobian_evaluations: Array
+    step_norm: Array
+    ratio: Array
+
+
 def _variable_layout(graph: ResidualGraphProblem, parameters: PyTree[Any], /):
     values = graph.parameter_values(parameters)
     spaces = {}
@@ -353,92 +369,207 @@ def solve_residual_graph(
     damping_ = float(initial_damping)
     if not isfinite(damping_) or damping_ <= 0.0:
         raise ValueError("initial_damping must be finite and positive.")
-    parameters = initial_parameters
     prepared: PreparedResidualGraph = prepare_residual_graph(
         graph,
-        parameters,
+        initial_parameters,
         args=args,
     )
     route = plan_least_squares_route(prepared, policy=route_policy)
     schur = prepare_schur_plan(prepared) if route.route == "schur" else None
-    _, spaces, slices, dimension = _variable_layout(graph, parameters)
-    model = linearize_residual_graph(graph, parameters, args)
+    _, spaces, slices, dimension = _variable_layout(graph, initial_parameters)
+    model = linearize_residual_graph(graph, initial_parameters, args)
     initial_optimality = jnp.linalg.norm(model.gradient, ord=jnp.inf)
-    damping = jnp.asarray(damping_, dtype=model.objective.dtype)
-    status = int(OptimizationStatus.ITERATING)
-    iterations = accepted = rejected = linear_solves = linear_iterations = 0
-    residual_evaluations = jacobian_evaluations = 1
-    step_norm = 0.0
-    ratio = jnp.asarray(jnp.nan, dtype=model.objective.dtype)
-    while status == int(OptimizationStatus.ITERATING):
-        optimality = jnp.linalg.norm(model.gradient, ord=jnp.inf)
-        if not bool(model.finite):
-            status = int(OptimizationStatus.NONFINITE_EVALUATION)
-            break
-        if float(optimality) <= float(
-            termination_.optimality_threshold(initial_optimality)
-        ):
-            status = int(OptimizationStatus.SUCCESS)
-            break
-        if iterations >= termination_.maximum_steps:
-            status = int(OptimizationStatus.MAXIMUM_STEPS_REACHED)
-            break
-        if (
-            termination_.maximum_evaluations is not None
-            and residual_evaluations >= termination_.maximum_evaluations
-        ):
-            status = int(OptimizationStatus.MAXIMUM_EVALUATIONS_REACHED)
-            break
-        matrix = model.curvature + damping * jnp.eye(
-            dimension,
-            dtype=model.curvature.dtype,
+    dtype = model.objective.dtype
+    state = _ResidualGraphIterationState(
+        parameters=initial_parameters,
+        model=model,
+        damping=jnp.asarray(damping_, dtype=dtype),
+        status=jnp.asarray(int(OptimizationStatus.ITERATING), dtype=jnp.int32),
+        iterations=jnp.asarray(0, dtype=jnp.int32),
+        accepted=jnp.asarray(0, dtype=jnp.int32),
+        rejected=jnp.asarray(0, dtype=jnp.int32),
+        linear_solves=jnp.asarray(0, dtype=jnp.int32),
+        linear_iterations=jnp.asarray(0, dtype=jnp.int32),
+        residual_evaluations=jnp.asarray(1, dtype=jnp.int32),
+        jacobian_evaluations=jnp.asarray(1, dtype=jnp.int32),
+        step_norm=jnp.asarray(0.0, dtype=dtype),
+        ratio=jnp.asarray(jnp.nan, dtype=dtype),
+    )
+    evaluation_limit = (
+        termination_.maximum_steps + 1
+        if termination_.maximum_evaluations is None
+        else termination_.maximum_evaluations
+    )
+    optimality_threshold = termination_.optimality_threshold(initial_optimality)
+
+    def select_tree(predicate, candidate, current):
+        return jax.tree_util.tree_map(
+            lambda new, old: jnp.where(predicate, new, old) if eqx.is_array(new) else old,
+            candidate,
+            current,
         )
-        step, route_iterations, usable = _solve_route(
-            matrix,
-            model.gradient,
-            route,
-            schur,
-        )
-        linear_solves += 1
-        linear_iterations += int(route_iterations)
-        if not bool(usable):
-            status = int(OptimizationStatus.LINEAR_SOLVE_FAILED)
-            break
-        tangent_steps = _tangent_steps(
-            graph,
-            parameters,
-            step,
-            spaces,
-            slices,
-        )
-        candidate = graph.retract(parameters, tangent_steps)
-        candidate_model = linearize_residual_graph(graph, candidate, args)
-        residual_evaluations += 1
-        jacobian_evaluations += 1
-        predicted = -jnp.real(jnp.vdot(model.gradient, step)) - 0.5 * jnp.real(
-            jnp.vdot(step, model.curvature @ step)
-        )
-        actual = model.objective - candidate_model.objective
-        ratio = actual / jnp.maximum(predicted, 1e-30)
-        accept = bool(
-            candidate_model.finite & (predicted > 0.0) & (actual > 0.0) & (ratio >= 1e-4)
-        )
-        step_norm = float(jnp.linalg.norm(step))
-        iterations += 1
-        if accept:
-            parameters = candidate
-            model = candidate_model
-            accepted += 1
-            damping = jnp.maximum(1e-12, 0.25 * damping)
-            if step_norm <= float(
-                termination_.step_threshold(_graph_parameter_norm(graph, parameters))
-            ):
-                status = int(OptimizationStatus.STAGNATION)
-        else:
-            rejected += 1
-            damping = jnp.minimum(1e12, 4.0 * damping)
-            if float(damping) >= 1e12:
-                status = int(OptimizationStatus.TRUST_REGION_FAILED)
+
+    def iteration(_, current):
+        optimality = jnp.linalg.norm(current.model.gradient, ord=jnp.inf)
+        entry_status = jnp.where(
+            ~current.model.finite,
+            int(OptimizationStatus.NONFINITE_EVALUATION),
+            jnp.where(
+                optimality <= optimality_threshold,
+                int(OptimizationStatus.SUCCESS),
+                jnp.where(
+                    current.residual_evaluations >= evaluation_limit,
+                    int(OptimizationStatus.MAXIMUM_EVALUATIONS_REACHED),
+                    current.status,
+                ),
+            ),
+        ).astype(jnp.int32)
+        current = eqx.tree_at(lambda value: value.status, current, entry_status)
+        active = entry_status == int(OptimizationStatus.ITERATING)
+
+        def attempt(value):
+            matrix = value.model.curvature + value.damping * jnp.eye(
+                dimension,
+                dtype=value.model.curvature.dtype,
+            )
+            step, route_iterations, usable = _solve_route(
+                matrix,
+                value.model.gradient,
+                route,
+                schur,
+            )
+
+            def failed_linear_solve(operand):
+                return eqx.tree_at(
+                    lambda item: (
+                        item.status,
+                        item.linear_solves,
+                        item.linear_iterations,
+                    ),
+                    operand,
+                    (
+                        jnp.asarray(
+                            int(OptimizationStatus.LINEAR_SOLVE_FAILED),
+                            dtype=jnp.int32,
+                        ),
+                        operand.linear_solves + 1,
+                        operand.linear_iterations + route_iterations,
+                    ),
+                )
+
+            def evaluate_candidate(operand):
+                tangent_steps = _tangent_steps(
+                    graph,
+                    operand.parameters,
+                    step,
+                    spaces,
+                    slices,
+                )
+                candidate_parameters = graph.retract(
+                    operand.parameters,
+                    tangent_steps,
+                )
+                candidate_model = linearize_residual_graph(
+                    graph,
+                    candidate_parameters,
+                    args,
+                )
+                predicted = -jnp.real(
+                    jnp.vdot(operand.model.gradient, step)
+                ) - 0.5 * jnp.real(jnp.vdot(step, operand.model.curvature @ step))
+                actual = operand.model.objective - candidate_model.objective
+                ratio = actual / jnp.maximum(predicted, 1e-30)
+                accept = (
+                    candidate_model.finite
+                    & (predicted > 0.0)
+                    & (actual > 0.0)
+                    & (ratio >= 1e-4)
+                )
+                parameters = select_tree(
+                    accept,
+                    candidate_parameters,
+                    operand.parameters,
+                )
+                selected_model = select_tree(
+                    accept,
+                    candidate_model,
+                    operand.model,
+                )
+                damping = jnp.where(
+                    accept,
+                    jnp.maximum(1e-12, 0.25 * operand.damping),
+                    jnp.minimum(1e12, 4.0 * operand.damping),
+                )
+                step_norm = jnp.linalg.norm(step)
+                stagnated = accept & (
+                    step_norm
+                    <= termination_.step_threshold(
+                        _graph_parameter_norm(graph, parameters)
+                    )
+                )
+                trust_failed = ~accept & (damping >= 1e12)
+                status = jnp.where(
+                    stagnated,
+                    int(OptimizationStatus.STAGNATION),
+                    jnp.where(
+                        trust_failed,
+                        int(OptimizationStatus.TRUST_REGION_FAILED),
+                        int(OptimizationStatus.ITERATING),
+                    ),
+                ).astype(jnp.int32)
+                return _ResidualGraphIterationState(
+                    parameters=parameters,
+                    model=selected_model,
+                    damping=damping,
+                    status=status,
+                    iterations=operand.iterations + 1,
+                    accepted=operand.accepted + accept.astype(jnp.int32),
+                    rejected=operand.rejected + (~accept).astype(jnp.int32),
+                    linear_solves=operand.linear_solves + 1,
+                    linear_iterations=(operand.linear_iterations + route_iterations),
+                    residual_evaluations=operand.residual_evaluations + 1,
+                    jacobian_evaluations=operand.jacobian_evaluations + 1,
+                    step_norm=step_norm,
+                    ratio=ratio,
+                )
+
+            return jax.lax.cond(
+                usable,
+                evaluate_candidate,
+                failed_linear_solve,
+                value,
+            )
+
+        return jax.lax.cond(active, attempt, lambda value: value, current)
+
+    state = jax.lax.fori_loop(
+        0,
+        termination_.maximum_steps,
+        iteration,
+        state,
+    )
+    state = eqx.tree_at(
+        lambda value: value.status,
+        state,
+        jnp.where(
+            state.status == int(OptimizationStatus.ITERATING),
+            int(OptimizationStatus.MAXIMUM_STEPS_REACHED),
+            state.status,
+        ).astype(jnp.int32),
+    )
+    parameters = state.parameters
+    model = state.model
+    damping = state.damping
+    status = state.status
+    iterations = state.iterations
+    accepted = state.accepted
+    rejected = state.rejected
+    linear_solves = state.linear_solves
+    linear_iterations = state.linear_iterations
+    residual_evaluations = state.residual_evaluations
+    jacobian_evaluations = state.jacobian_evaluations
+    step_norm = state.step_norm
+    ratio = state.ratio
     physical = factor_graph_certificate(
         graph,
         parameters,
@@ -488,7 +619,7 @@ def solve_residual_graph(
         initial_optimality_norm=initial_optimality,
         final_optimality_norm=certificate.optimality_norm,
         final_step_norm=step_norm,
-        accepted_step_size=1.0 if accepted else 0.0,
+        accepted_step_size=jnp.where(accepted > 0, 1.0, 0.0),
         damping=damping,
         reduction_ratio=ratio,
         primal_feasibility=feasibility,
@@ -504,7 +635,7 @@ def solve_residual_graph(
             f"route={route.route};plan={route.plan_id};"
             f"schur={'' if schur is None else schur.plan_id};"
             f"clipped-blocks={int(model.clipped_curvature_blocks)};"
-            f"internal-status={status}"
+            f"internal-status={int(status)}"
         ),
     )
     return LeastSquaresResult(

--- a/phydrax/optim/_structured_ipm.py
+++ b/phydrax/optim/_structured_ipm.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from typing import Any
 
 import equinox as eqx
+import jax
 import jax.numpy as jnp
 import numpy as np
 from jaxtyping import Array, ArrayLike
@@ -209,7 +210,7 @@ def _residuals(prepared, plan, state):
     dual = jnp.maximum(dual, _maximum(jnp.minimum(state.upper_bound_multipliers, 0.0)))
     dual = jnp.maximum(dual, _maximum(jnp.minimum(state.lower_slack_multipliers, 0.0)))
     dual = jnp.maximum(dual, _maximum(jnp.minimum(state.upper_slack_multipliers, 0.0)))
-    complementarity_norm = max(_maximum(value) for value in complementarity)
+    complementarity_norm = jnp.max(jnp.stack(tuple(map(_maximum, complementarity))))
     norm = jnp.maximum(primal, jnp.maximum(dual, complementarity_norm))
     return (
         evaluation,
@@ -471,7 +472,7 @@ def _step_fraction(state, prepared, plan, direction, fraction):
         _fraction(state.lower_slack_multipliers, dvl, lower_s_finite, fraction),
         _fraction(state.upper_slack_multipliers, dvu, upper_s_finite, fraction),
     )
-    return min(values)
+    return jnp.min(jnp.stack(values))
 
 
 def _candidate(state, direction, rate):
@@ -524,11 +525,12 @@ def advance_sparse_structured_ipm(
     sufficient_decrease,
     maximum_line_search_steps,
     regularization,
+    assume_active=False,
 ):
     residuals = _residuals(prepared, plan, state)
     current_norm = residuals[-1]
     threshold = termination.absolute_optimality
-    if float(current_norm) <= float(threshold):
+    if not assume_active and float(current_norm) <= float(threshold):
         return eqx.tree_at(
             lambda value: value.status,
             state,
@@ -639,56 +641,77 @@ def advance_sparse_structured_ipm(
         direction,
         fraction_to_boundary,
     )
-    accepted = False
-    candidate = state
-    candidate_norm = current_norm
-    for _ in range(maximum_line_search_steps):
-        trial = _candidate(state, direction, rate)
+
+    def line_search_step(_, carry):
+        accepted_, candidate_, candidate_norm_, rate_ = carry
+        trial = _candidate(state, direction, rate_)
         trial_norm = _residuals(prepared, plan, trial)[-1]
-        finite = all(
-            bool(jnp.all(jnp.isfinite(value)))
-            for value in (
-                trial.primal,
-                trial.slack,
-                trial.lower_bound_multipliers,
-                trial.upper_bound_multipliers,
-                trial.lower_slack_multipliers,
-                trial.upper_slack_multipliers,
+        finite = jnp.all(
+            jnp.stack(
+                tuple(
+                    jnp.all(jnp.isfinite(value))
+                    for value in (
+                        trial.primal,
+                        trial.slack,
+                        trial.lower_bound_multipliers,
+                        trial.upper_bound_multipliers,
+                        trial.lower_slack_multipliers,
+                        trial.upper_slack_multipliers,
+                    )
+                )
             )
         )
-        if finite and float(trial_norm) <= float(
-            (1.0 - sufficient_decrease * rate) * current_norm
-        ):
-            candidate = trial
-            candidate_norm = trial_norm
-            accepted = True
-            break
-        rate *= 0.5
+        acceptable = finite & (
+            trial_norm <= (1.0 - sufficient_decrease * rate_) * current_norm
+        )
+        select = ~accepted_ & acceptable
+        selected_candidate = jax.tree_util.tree_map(
+            lambda new, old: jnp.where(select, new, old),
+            trial,
+            candidate_,
+        )
+        return (
+            accepted_ | acceptable,
+            selected_candidate,
+            jnp.where(select, trial_norm, candidate_norm_),
+            jnp.where(accepted_ | acceptable, rate_, 0.5 * rate_),
+        )
+
+    accepted, candidate, candidate_norm, rate = jax.lax.fori_loop(
+        0,
+        maximum_line_search_steps,
+        line_search_step,
+        (
+            jnp.asarray(False),
+            state,
+            current_norm,
+            rate,
+        ),
+    )
     if isinstance(linear_policy.method, SparseLDLT):
         release_linear(linear)
-    if not accepted:
-        return eqx.tree_at(
-            lambda value: (
-                value.iteration,
-                value.status,
-                value.rejected_steps,
-                value.hessian_evaluations,
-                value.kkt_assemblies,
-                value.factorizations,
-                value.right_hand_side_solves,
-            ),
-            state,
-            (
-                state.iteration + 1,
-                jnp.asarray(int(OptimizationStatus.RESTORATION_FAILED), dtype=jnp.int32),
-                state.rejected_steps + 1,
-                state.hessian_evaluations + 1,
-                state.kkt_assemblies + 1,
-                state.factorizations + 1,
-                state.right_hand_side_solves + 2,
-            ),
-        )
-    candidate = eqx.tree_at(
+    rejected_state = eqx.tree_at(
+        lambda value: (
+            value.iteration,
+            value.status,
+            value.rejected_steps,
+            value.hessian_evaluations,
+            value.kkt_assemblies,
+            value.factorizations,
+            value.right_hand_side_solves,
+        ),
+        state,
+        (
+            state.iteration + 1,
+            jnp.asarray(int(OptimizationStatus.RESTORATION_FAILED), dtype=jnp.int32),
+            state.rejected_steps + 1,
+            state.hessian_evaluations + 1,
+            state.kkt_assemblies + 1,
+            state.factorizations + 1,
+            state.right_hand_side_solves + 2,
+        ),
+    )
+    accepted_state = eqx.tree_at(
         lambda value: (
             value.barrier,
             value.iteration,
@@ -702,6 +725,7 @@ def advance_sparse_structured_ipm(
             value.kkt_assemblies,
             value.factorizations,
             value.right_hand_side_solves,
+            value.status,
         ),
         candidate,
         (
@@ -717,14 +741,19 @@ def advance_sparse_structured_ipm(
             state.kkt_assemblies + 1,
             state.factorizations + 1,
             state.right_hand_side_solves + 2,
+            jnp.where(
+                candidate_norm <= threshold,
+                int(OptimizationStatus.SUCCESS),
+                int(OptimizationStatus.ITERATING),
+            ).astype(jnp.int32),
         ),
     )
-    status = jnp.where(
-        candidate_norm <= threshold,
-        int(OptimizationStatus.SUCCESS),
-        int(OptimizationStatus.ITERATING),
-    ).astype(jnp.int32)
-    return eqx.tree_at(lambda value: value.status, candidate, status)
+    return jax.lax.cond(
+        accepted,
+        lambda _: accepted_state,
+        lambda _: rejected_state,
+        operand=None,
+    )
 
 
 def finalize_sparse_structured_ipm(
@@ -886,27 +915,59 @@ def solve_sparse_structured_ipm(
         warm_start,
     )
     initial_norm = _residuals(prepared, plan, state)[-1]
-    while (
-        int(state.status) == int(OptimizationStatus.ITERATING)
-        and int(state.iteration) < termination.maximum_steps
-    ):
-        state = advance_sparse_structured_ipm(
-            prepared,
-            plan,
+    if isinstance(linear_policy.method, SparseLDLT):
+        while (
+            int(state.status) == int(OptimizationStatus.ITERATING)
+            and int(state.iteration) < termination.maximum_steps
+        ):
+            state = advance_sparse_structured_ipm(
+                prepared,
+                plan,
+                state,
+                termination,
+                linear_policy,
+                fraction_to_boundary=fraction_to_boundary,
+                sufficient_decrease=sufficient_decrease,
+                maximum_line_search_steps=maximum_line_search_steps,
+                regularization=regularization,
+            )
+    else:
+
+        def iteration(_, current):
+            active = current.status == int(OptimizationStatus.ITERATING)
+            candidate = advance_sparse_structured_ipm(
+                prepared,
+                plan,
+                current,
+                termination,
+                linear_policy,
+                fraction_to_boundary=fraction_to_boundary,
+                sufficient_decrease=sufficient_decrease,
+                maximum_line_search_steps=maximum_line_search_steps,
+                regularization=regularization,
+                assume_active=True,
+            )
+            return jax.tree_util.tree_map(
+                lambda new, old: jnp.where(active, new, old),
+                candidate,
+                current,
+            )
+
+        state = jax.lax.fori_loop(
+            0,
+            termination.maximum_steps,
+            iteration,
             state,
-            termination,
-            linear_policy,
-            fraction_to_boundary=fraction_to_boundary,
-            sufficient_decrease=sufficient_decrease,
-            maximum_line_search_steps=maximum_line_search_steps,
-            regularization=regularization,
         )
-    if int(state.status) == int(OptimizationStatus.ITERATING):
-        state = eqx.tree_at(
-            lambda value: value.status,
-            state,
-            jnp.asarray(int(OptimizationStatus.MAXIMUM_STEPS_REACHED), dtype=jnp.int32),
-        )
+    state = eqx.tree_at(
+        lambda value: value.status,
+        state,
+        jnp.where(
+            state.status == int(OptimizationStatus.ITERATING),
+            int(OptimizationStatus.MAXIMUM_STEPS_REACHED),
+            state.status,
+        ).astype(jnp.int32),
+    )
     return finalize_sparse_structured_ipm(
         prepared,
         plan,

--- a/phydrax/pgm/_belief_propagation.py
+++ b/phydrax/pgm/_belief_propagation.py
@@ -728,6 +728,100 @@ def _factor_update(
     return output, all_feasible
 
 
+def _factor_group_message(
+    prepared: PreparedBeliefPropagation,
+    variable_to_factor: Array,
+    group_index: int,
+    position: int,
+    /,
+) -> tuple[Array, Array]:
+    sum_product = isinstance(prepared.method, SumProductBeliefPropagation)
+    table = prepared.precision.accumulation(prepared.factor_tables[group_index])
+    layout = prepared.message_layout[group_index]
+    arity = len(layout)
+    incoming = [
+        variable_to_factor[start:stop].reshape((count, cardinality))
+        for start, stop, count, cardinality in layout
+    ]
+    group = prepared.graph.factor_groups[group_index]
+    outputs = None
+    if isinstance(group, EnumeratedFactorGroup):
+        outputs = enumerated_factor_messages(
+            group,
+            table,
+            tuple(incoming),
+            factor_group_cardinality_signature(prepared.graph, group_index),
+            mode="sum" if sum_product else "max",
+        )
+    elif isinstance(group, IsingFactorGroup):
+        outputs = ising_factor_messages(
+            group,
+            tuple(incoming),
+            mode="sum" if sum_product else "max",
+        )
+    elif isinstance(group, LogicalFactorGroup):
+        outputs = logical_factor_messages(
+            group,
+            tuple(incoming),
+            mode="sum" if sum_product else "max",
+        )
+    elif isinstance(group, BinaryCardinalityFactorGroup):
+        outputs = cardinality_factor_messages(
+            group,
+            tuple(incoming),
+            mode="sum" if sum_product else "max",
+        )
+    if outputs is not None:
+        values = outputs[position]
+        return values.reshape((-1,)), jnp.all(jnp.any(jnp.isfinite(values), axis=-1))
+
+    joint = table
+    for other, values in enumerate(incoming):
+        if other != position:
+            joint = joint + _broadcast_message(values, other, arity)
+    axes = tuple(axis for axis in range(1, arity + 1) if axis != position + 1)
+    reduced = (
+        jsp.special.logsumexp(joint, axis=axes)
+        if sum_product and axes
+        else jnp.max(joint, axis=axes)
+        if axes
+        else joint
+    )
+    maxima = jnp.max(reduced, axis=-1, keepdims=True)
+    feasible = jnp.isfinite(maxima)
+    return jnp.where(feasible, reduced - maxima, -jnp.inf).reshape((-1,)), jnp.all(
+        feasible
+    )
+
+
+def _relax_message_segment(
+    prepared: PreparedBeliefPropagation,
+    current: Array,
+    candidate: Array,
+    count: int,
+    cardinality: int,
+    /,
+) -> Array:
+    relaxation = prepared.method.relaxation
+    if relaxation == 1.0:
+        return candidate
+    if isinstance(prepared.method, SumProductBeliefPropagation):
+        mixed = jnp.logaddexp(
+            jnp.log1p(-relaxation) + current,
+            jnp.log(relaxation) + candidate,
+        )
+    else:
+        both = jnp.isfinite(current) & jnp.isfinite(candidate)
+        mixed = jnp.where(
+            both,
+            current + relaxation * (candidate - current),
+            candidate,
+        )
+    values = mixed.reshape((count, cardinality))
+    maxima = jnp.max(values, axis=-1, keepdims=True)
+    return jnp.where(jnp.isfinite(maxima), values - maxima, -jnp.inf).reshape((-1,))
+
+
 def _normalize_flat_messages(
     prepared: PreparedBeliefPropagation,
     messages: Array,
@@ -987,19 +1081,25 @@ def _asynchronous_bp_step(
     original = messages
     feasible = jnp.asarray(True)
     finite = jnp.asarray(True)
-    for layout in prepared.message_layout:
-        for start, stop, _count, _cardinality in layout:
+    for group_index, layout in enumerate(prepared.message_layout):
+        for position, (start, stop, count, cardinality) in enumerate(layout):
             variable_to_factor = _variable_to_factor(prepared, messages, evidence)
-            candidate, candidate_feasible = _factor_update(
+            candidate, candidate_feasible = _factor_group_message(
                 prepared,
                 variable_to_factor,
+                group_index,
+                position,
             )
-            relaxed = _relax_messages(prepared, messages, candidate)
-            messages = messages.at[start:stop].set(relaxed[start:stop])
+            relaxed = _relax_message_segment(
+                prepared,
+                messages[start:stop],
+                candidate,
+                count,
+                cardinality,
+            )
+            messages = messages.at[start:stop].set(relaxed)
             feasible = feasible & candidate_feasible
-            finite = finite & ~jnp.any(
-                jnp.isnan(relaxed[start:stop]) | jnp.isposinf(relaxed[start:stop])
-            )
+            finite = finite & ~jnp.any(jnp.isnan(relaxed) | jnp.isposinf(relaxed))
     residual, support_changed = _message_residual(original, messages)
     return messages, residual, support_changed, feasible, finite
 

--- a/phydrax/solver/_functional_update_kernel.py
+++ b/phydrax/solver/_functional_update_kernel.py
@@ -32,22 +32,67 @@ def _tree_finite(tree: Any, /) -> Array:
     return jnp.all(jnp.stack(values)) if values else jnp.asarray(True)
 
 
+def _functional_update(
+    solver: FunctionalSolver,
+    optimizer: Optimizer,
+    subspace: ParameterSubspace,
+    parameters: Any,
+    optimizer_state: Any,
+    key: Key[Array, ""],
+    step: Array,
+    /,
+):
+    def loss_fn(values):
+        functions = subspace.reconstruct(values)
+        bound_solver = eqx.tree_at(
+            lambda value: value.functions,
+            solver,
+            functions,
+        )
+        return bound_solver.loss(key=key, step=step)
+
+    loss, gradient = eqx.filter_value_and_grad(loss_fn)(parameters)
+    updates, candidate_optimizer_state = optimizer.update(
+        gradient,
+        optimizer_state,
+        parameters,
+    )
+    candidate = optax.apply_updates(parameters, updates)
+    finite = jnp.isfinite(loss) & _tree_finite(candidate)
+    accepted_parameters = jax.tree_util.tree_map(
+        lambda new, old: jnp.where(finite, new, old) if eqx.is_array(new) else old,
+        candidate,
+        parameters,
+    )
+    accepted_state = jax.tree_util.tree_map(
+        lambda new, old: jnp.where(finite, new, old) if eqx.is_array(new) else old,
+        candidate_optimizer_state,
+        optimizer_state,
+    )
+    return accepted_parameters, accepted_state, loss, finite
+
+
+_compiled_functional_update = eqx.filter_jit(_functional_update)
+
+
 class FunctionalUpdateState(StrictModule):
     """Canonical functions and backend state after accepted parameter updates."""
 
     functions: frozendict[str, DomainFunction]
     optimizer_state: Any
-    step: int
+    step: Array
 
     def __init__(
         self,
         functions: Mapping[str, DomainFunction],
         optimizer_state: Any,
-        step: int = 0,
+        step: Any = 0,
     ):
-        step_ = int(step)
-        if step_ < 0:
+        if isinstance(step, int) and step < 0:
             raise ValueError("step must be non-negative.")
+        step_ = jnp.asarray(step, dtype=jnp.int32)
+        if step_.shape != ():
+            raise ValueError("step must be a scalar.")
         self.functions = frozendict(functions)
         self.optimizer_state = optimizer_state
         self.step = step_
@@ -138,50 +183,21 @@ class FunctionalUpdateKernel(StrictModule):
         )
         selected = subspace.initial
 
-        def update(parameters, optimizer_state):
-            def loss_fn(values):
-                functions = subspace.reconstruct(values)
-                solver = eqx.tree_at(
-                    lambda value: value.functions,
-                    self.solver,
-                    functions,
-                )
-                return solver.loss(key=key, step=state.step)
-
-            loss, gradient = eqx.filter_value_and_grad(loss_fn)(parameters)
-            updates, candidate_optimizer_state = self.optimizer.update(
-                gradient,
-                optimizer_state,
-                parameters,
-            )
-            candidate = optax.apply_updates(parameters, updates)
-            finite = jnp.isfinite(loss) & _tree_finite(candidate)
-            accepted_parameters = jax.tree_util.tree_map(
-                lambda new, old: (
-                    jnp.where(finite, new, old) if eqx.is_array(new) else old
-                ),
-                candidate,
-                parameters,
-            )
-            accepted_state = jax.tree_util.tree_map(
-                lambda new, old: (
-                    jnp.where(finite, new, old) if eqx.is_array(new) else old
-                ),
-                candidate_optimizer_state,
-                optimizer_state,
-            )
-            return accepted_parameters, accepted_state, loss, finite
-
-        update_fn = eqx.filter_jit(update) if self.jit else update
+        update_fn = _compiled_functional_update if self.jit else _functional_update
         parameters, optimizer_state, loss, accepted = update_fn(
+            self.solver,
+            self.optimizer,
+            subspace,
             selected,
             state.optimizer_state,
+            key,
+            state.step,
         )
         functions = subspace.reconstruct(parameters)
         next_state = FunctionalUpdateState(
             functions,
             optimizer_state,
-            state.step + int(bool(jax.device_get(accepted))),
+            state.step + accepted.astype(jnp.int32),
         )
         return next_state, FunctionalUpdateEvidence(loss, accepted)
 

--- a/phydrax/solver/_helmholtz3d.py
+++ b/phydrax/solver/_helmholtz3d.py
@@ -111,9 +111,9 @@ def _trace_matrices_3d(
         start = panel_id * panelization.nodes_per_panel
         stop = start + panelization.nodes_per_panel
         for target_index in range(start, stop):
-            single_values = []
-            double_values = []
-            for source_index in range(start, stop):
+            source_indices = jnp.arange(start, stop, dtype=jnp.int32)
+
+            def evaluate_source(source_index):
                 density = jnp.zeros_like(zero_density).at[source_index].set(1.0 + 0.0j)
                 single_estimate = evaluate_single_layer_self_triangle_3d(
                     single_base.with_density(density),
@@ -127,24 +127,41 @@ def _trace_matrices_3d(
                     panelization.references[target_index],
                     quadrature,
                 )
-                single_values.append(single_estimate.value)
-                double_values.append(double_estimate.value)
-                status.extend((single_estimate.status, double_estimate.status))
-                errors.extend(
-                    (
-                        jnp.inf
-                        if single_estimate.error_estimate is None
-                        else single_estimate.error_estimate,
-                        jnp.inf
-                        if double_estimate.error_estimate is None
-                        else double_estimate.error_estimate,
-                    )
+                single_error = (
+                    jnp.inf
+                    if single_estimate.error_estimate is None
+                    else single_estimate.error_estimate
                 )
-                evaluations.extend(
-                    (single_estimate.num_evaluations, double_estimate.num_evaluations)
+                double_error = (
+                    jnp.inf
+                    if double_estimate.error_estimate is None
+                    else double_estimate.error_estimate
                 )
-            single = single.at[target_index, start:stop].set(jnp.stack(single_values))
-            double = double.at[target_index, start:stop].set(jnp.stack(double_values))
+                return (
+                    single_estimate.value,
+                    double_estimate.value,
+                    jnp.stack((single_estimate.status, double_estimate.status)),
+                    jnp.stack((single_error, double_error)),
+                    jnp.stack(
+                        (
+                            single_estimate.num_evaluations,
+                            double_estimate.num_evaluations,
+                        )
+                    ),
+                )
+
+            (
+                single_values,
+                double_values,
+                local_status,
+                local_errors,
+                local_evaluations,
+            ) = jax.vmap(evaluate_source)(source_indices)
+            status.append(local_status.reshape((-1,)))
+            errors.append(local_errors.reshape((-1,)))
+            evaluations.append(local_evaluations.reshape((-1,)))
+            single = single.at[target_index, start:stop].set(single_values)
+            double = double.at[target_index, start:stop].set(double_values)
     report = BoundaryOperatorAssemblyReport(
         panelization=panelization,
         kernel_id=kernel.kernel_id,
@@ -154,9 +171,9 @@ def _trace_matrices_3d(
             f"max_intervals={quadrature.max_intervals}"
         ),
         trace_policy="3d-exterior-brakhage-werner-single-and-double-duffy",
-        block_status=jnp.stack(status),
-        block_errors=jnp.stack(errors),
-        block_evaluations=jnp.stack(evaluations),
+        block_status=jnp.concatenate(tuple(status)),
+        block_errors=jnp.concatenate(tuple(errors)),
+        block_evaluations=jnp.concatenate(tuple(evaluations)),
     )
     if not bool(report.accuracy_supported):
         raise ValueError("3D Helmholtz singular assembly failed its quadrature contract.")
@@ -186,7 +203,11 @@ def solve_exterior_helmholtz_dirichlet_3d(
     if not jnp.isfinite(coupling) or coupling <= 0.0:
         raise ValueError("eta must be finite and positive.")
     single, double, report = _trace_matrices_3d(panelization, kernel, quadrature)
-    trace = double + 0.5 * jnp.eye(panelization.node_count, dtype=double.dtype) - 1j * coupling * single
+    trace = (
+        double
+        + 0.5 * jnp.eye(panelization.node_count, dtype=double.dtype)
+        - 1j * coupling * single
+    )
     problem = LinearSystem(
         DenseLinearOperator(trace),
         problem_id="exterior-helmholtz-dirichlet-brakhage-werner-3d",

--- a/phydrax/solver/_memory_kernel.py
+++ b/phydrax/solver/_memory_kernel.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from collections.abc import Callable
 
 import equinox as eqx
+import jax
 import jax.numpy as jnp
 from jaxtyping import Array, ArrayLike
 
@@ -371,6 +372,40 @@ class DynamicalMapPhysicality(StrictModule):
         return self.finite_map
 
 
+def _memory_kernel_states(
+    problem: MemoryKernelMasterEquation,
+    initial_density: Array,
+    step: Array,
+    count: int,
+    temporal: TemporalPrecisionPolicy,
+    integration: IntegrationPrecisionPolicy,
+    /,
+) -> Array:
+    states = [initial_density]
+    horizon_steps = int(problem.kernel.memory_horizon / float(step))
+    for current in range(count):
+        time = step * current
+        density = states[-1]
+        lower = max(0, current - horizon_steps)
+        memory = integration.accumulation(jnp.zeros_like(density))
+        if current > lower:
+            for past in range(lower, current + 1):
+                lag = time - step * past
+                weight = 0.5 if past in (lower, current) else 1.0
+                contribution = integration.evaluation(problem.kernel(lag, states[past]))
+                memory = memory + weight * integration.accumulation(contribution)
+        local = temporal.stage(problem.local_generator(time, density))
+        convolution = temporal.stage(integration.output(step * memory))
+        derivative = temporal.residual(local + convolution)
+        states.append(
+            jnp.asarray(
+                density + step * temporal.accumulation(derivative),
+                dtype=density.dtype,
+            )
+        )
+    return jnp.stack(states)
+
+
 def solve_memory_kernel(
     problem: MemoryKernelMasterEquation,
     /,
@@ -416,30 +451,14 @@ def solve_memory_kernel(
     horizon = float(problem.kernel.memory_horizon)
     if 0.0 < horizon < float(step):
         raise ValueError("memory_horizon must be zero or at least one integration step.")
-    states = [problem.initial_density]
-    for current in range(count):
-        time = step * current
-        density = states[-1]
-        lower = max(
-            0,
-            current - int(problem.kernel.memory_horizon / float(step)),
-        )
-        memory = integration_.accumulation(jnp.zeros_like(density))
-        if current > lower:
-            for past in range(lower, current + 1):
-                lag = time - step * past
-                weight = 0.5 if past in (lower, current) else 1.0
-                contribution = integration_.evaluation(problem.kernel(lag, states[past]))
-                memory = memory + weight * integration_.accumulation(contribution)
-        local = temporal_.stage(problem.local_generator(time, density))
-        convolution = temporal_.stage(integration_.output(step * memory))
-        derivative = temporal_.residual(local + convolution)
-        candidate = jnp.asarray(
-            density + step * temporal_.accumulation(derivative),
-            dtype=density.dtype,
-        )
-        states.append(candidate)
-    values = jnp.stack(states)
+    values = _memory_kernel_states(
+        problem,
+        problem.initial_density,
+        step,
+        count,
+        temporal_,
+        integration_,
+    )
     return OpenSystemHistorySolution(
         values,
         step * jnp.arange(count + 1),
@@ -552,32 +571,27 @@ def certify_memory_kernel_map(
 ) -> MemoryKernelMapCertification:
     """Reconstruct and certify the discrete dynamical map on matrix units."""
     dimension = problem.kernel.dimension
-    columns = []
-    for row in range(dimension):
-        for column in range(dimension):
-            basis = (
-                jnp.zeros(
-                    (dimension, dimension),
-                    dtype=problem.initial_density.dtype,
-                )
-                .at[row, column]
-                .set(1.0)
-            )
-            basis_problem = MemoryKernelMasterEquation(
-                problem.local_generator,
-                problem.kernel,
-                basis,
-                geometry_precision=problem.geometry_precision,
-                hermitian_precision=problem.hermitian_precision,
-                problem_id=f"{problem.problem_id}:basis-{row}-{column}",
-            )
-            solution = solve_memory_kernel(
-                basis_problem,
-                step_size=step_size,
-                steps=steps,
-            )
-            columns.append(solution.states.reshape((int(steps) + 1, -1)))
-    superoperators = jnp.stack(columns, axis=-1)
+    basis = jnp.eye(
+        dimension * dimension,
+        dtype=problem.initial_density.dtype,
+    ).reshape((dimension * dimension, dimension, dimension))
+    step = jnp.asarray(step_size, dtype=problem.initial_density.real.dtype).reshape(())
+    count = int(steps)
+    if count <= 0 or float(step) <= 0.0 or not bool(jnp.isfinite(step)):
+        raise ValueError("steps and step_size must be finite and positive.")
+    temporal = TemporalPrecisionPolicy()
+    integration = IntegrationPrecisionPolicy()
+    columns = jax.vmap(
+        lambda initial_density: _memory_kernel_states(
+            problem,
+            initial_density,
+            step,
+            count,
+            temporal,
+            integration,
+        ).reshape((count + 1, -1))
+    )(basis)
+    superoperators = jnp.moveaxis(columns, 0, -1)
     certifications = tuple(
         DynamicalMapPhysicality(
             superoperator,

--- a/phydrax/solver/_particle_conversion.py
+++ b/phydrax/solver/_particle_conversion.py
@@ -29,10 +29,10 @@ from ..equations._particle_conversion import (
     PreparedParticleConversionDynamics,
 )
 from ..linalg import (
+    BandedLinearOperator,
     DenseLinearOperator,
     LinearSystem,
     solve,
-    TridiagonalLinearOperator,
 )
 from ._differential import DifferentialProblem
 from ._rosenbrock import solve_rosenbrock
@@ -414,25 +414,25 @@ def _implicit_transport_step(prepared, state, material, boundary, step_size):
         face_conductivity * metrics.face_measures[:, 1:-1] / metrics.center_distances
     )
     heat_boundary = boundary.heat_transfer_coefficient * metrics.surface_measure
-    temperatures = []
-    linear_successful = jnp.asarray(True)
-    for particle in range(prepared.particle_count):
-        capacity = thermo.heat_capacity[particle]
-        conductance = heat_conductance[particle]
-        diagonal = capacity / step_size
-        diagonal = diagonal.at[:-1].add(conductance)
-        diagonal = diagonal.at[1:].add(conductance)
-        diagonal = diagonal.at[-1].add(heat_boundary[particle])
-        off = -conductance
-        right = capacity / step_size * thermo.temperature[particle]
-        right = right.at[-1].add(
-            heat_boundary[particle] * boundary.temperature[particle]
-            + boundary.prescribed_heat_rate[particle]
-        )
-        result = solve(LinearSystem(TridiagonalLinearOperator(off, diagonal, off)), right)
-        temperatures.append(result.value)
-        linear_successful = linear_successful & result.successful
-    temperature = jnp.stack(temperatures)
+    capacity = thermo.heat_capacity
+    conductance = heat_conductance
+    diagonal = capacity / step_size
+    diagonal = diagonal.at[..., :-1].add(conductance)
+    diagonal = diagonal.at[..., 1:].add(conductance)
+    diagonal = diagonal.at[..., -1].add(heat_boundary)
+    off = -conductance
+    right = capacity / step_size * thermo.temperature
+    right = right.at[..., -1].add(
+        heat_boundary * boundary.temperature + boundary.prescribed_heat_rate
+    )
+    heat_operator = BandedLinearOperator(
+        _tridiagonal_bands(off, diagonal, off),
+        lower_bandwidth=1,
+        upper_bandwidth=1,
+    )
+    heat_result = solve(LinearSystem(heat_operator), right)
+    temperature = heat_result.value
+    linear_successful = jnp.all(heat_result.successful)
     energy = state.internal_energy + thermo.heat_capacity * (
         temperature - thermo.temperature
     )
@@ -449,33 +449,40 @@ def _implicit_transport_step(prepared, state, material, boundary, step_size):
         * metrics.face_measures[:, 1:-1, None]
         / metrics.center_distances[:, :, None]
     )
-    species = jnp.zeros_like(state.species_amount)
-    for particle in range(prepared.particle_count):
-        for species_index in range(prepared.species_count):
-            face = conductance[particle, :, species_index]
-            volume = metrics.cell_measures[particle]
-            boundary_conductance = (
-                boundary.mass_transfer_coefficient[particle, species_index]
-                * metrics.surface_measure[particle]
-            )
-            diagonal = jnp.ones((prepared.cell_capacity,), dtype=energy.dtype) / step_size
-            diagonal = diagonal.at[:-1].add(face / volume[:-1])
-            diagonal = diagonal.at[1:].add(face / volume[1:])
-            diagonal = diagonal.at[-1].add(boundary_conductance / volume[-1])
-            lower = -face / volume[:-1]
-            upper = -face / volume[1:]
-            right = state.species_amount[particle, :, species_index] / step_size
-            right = right.at[-1].add(
-                boundary_conductance
-                * boundary.species_concentration[particle, species_index]
-                + boundary.prescribed_species_rate[particle, species_index]
-            )
-            result = solve(
-                LinearSystem(TridiagonalLinearOperator(lower, diagonal, upper)),
-                right,
-            )
-            species = species.at[particle, :, species_index].set(result.value)
-            linear_successful = linear_successful & result.successful
+    volume = metrics.cell_measures[:, None, :]
+    face = jnp.swapaxes(conductance, 1, 2)
+    boundary_conductance = (
+        boundary.mass_transfer_coefficient * metrics.surface_measure[:, None]
+    )
+    diagonal = (
+        jnp.ones(
+            (
+                prepared.particle_count,
+                prepared.species_count,
+                prepared.cell_capacity,
+            ),
+            dtype=energy.dtype,
+        )
+        / step_size
+    )
+    diagonal = diagonal.at[..., :-1].add(face / volume[..., :-1])
+    diagonal = diagonal.at[..., 1:].add(face / volume[..., 1:])
+    diagonal = diagonal.at[..., -1].add(boundary_conductance / volume[..., -1])
+    lower = -face / volume[..., :-1]
+    upper = -face / volume[..., 1:]
+    right = jnp.swapaxes(state.species_amount, 1, 2) / step_size
+    right = right.at[..., -1].add(
+        boundary_conductance * boundary.species_concentration
+        + boundary.prescribed_species_rate
+    )
+    species_operator = BandedLinearOperator(
+        _tridiagonal_bands(lower, diagonal, upper),
+        lower_bandwidth=1,
+        upper_bandwidth=1,
+    )
+    species_result = solve(LinearSystem(species_operator), right)
+    species = jnp.swapaxes(species_result.value, 1, 2)
+    linear_successful = linear_successful & jnp.all(species_result.successful)
     candidate = eqx.tree_at(
         lambda value: (value.internal_energy, value.species_amount),
         state,
@@ -520,40 +527,39 @@ def _implicit_unstructured_transport_step(
     heat_conductance = (
         face_conductivity * metrics.face_measures / metrics.center_distances
     )
-    temperature_values = []
-    linear_successful = jnp.asarray(True)
-    for particle in range(prepared.particle_count):
-        capacity = thermo.heat_capacity[particle]
-        matrix = jnp.diag(capacity / step_size)
-        face = jnp.where(interior[particle], heat_conductance[particle], 0.0)
-        matrix = matrix.at[owner, owner].add(face)
-        matrix = matrix.at[safe_neighbour, safe_neighbour].add(face)
-        matrix = matrix.at[owner, safe_neighbour].add(-face)
-        matrix = matrix.at[safe_neighbour, owner].add(-face)
-        boundary_face = metrics.boundary_faces & metrics.active_faces[particle]
-        boundary_conductance = jnp.where(
+    capacity = thermo.heat_capacity
+    matrix = (
+        jnp.eye(prepared.cell_capacity, dtype=capacity.dtype)[None, :, :]
+        * (capacity / step_size)[:, None, :]
+    )
+    face = jnp.where(interior, heat_conductance, 0.0)
+    matrix = matrix.at[..., owner, owner].add(face)
+    matrix = matrix.at[..., safe_neighbour, safe_neighbour].add(face)
+    matrix = matrix.at[..., owner, safe_neighbour].add(-face)
+    matrix = matrix.at[..., safe_neighbour, owner].add(-face)
+    boundary_face = metrics.boundary_faces[None, :] & metrics.active_faces
+    boundary_conductance = jnp.where(
+        boundary_face,
+        boundary.heat_transfer_coefficient[:, None] * metrics.face_measures,
+        0.0,
+    )
+    matrix = matrix.at[..., owner, owner].add(boundary_conductance)
+    area_fraction = metrics.face_measures / jnp.maximum(
+        metrics.surface_measure[:, None],
+        1.0e-30,
+    )
+    right = capacity / step_size * thermo.temperature
+    right = right.at[..., owner].add(
+        boundary_conductance * boundary.temperature[:, None]
+        + jnp.where(
             boundary_face,
-            boundary.heat_transfer_coefficient[particle]
-            * metrics.face_measures[particle],
+            boundary.prescribed_heat_rate[:, None] * area_fraction,
             0.0,
         )
-        matrix = matrix.at[owner, owner].add(boundary_conductance)
-        area_fraction = metrics.face_measures[particle] / jnp.maximum(
-            metrics.surface_measure[particle], 1.0e-30
-        )
-        right = capacity / step_size * thermo.temperature[particle]
-        right = right.at[owner].add(
-            boundary_conductance * boundary.temperature[particle]
-            + jnp.where(
-                boundary_face,
-                boundary.prescribed_heat_rate[particle] * area_fraction,
-                0.0,
-            )
-        )
-        result = solve(LinearSystem(DenseLinearOperator(matrix)), right)
-        temperature_values.append(result.value)
-        linear_successful = linear_successful & result.successful
-    temperature = jnp.stack(temperature_values)
+    )
+    heat_result = solve(LinearSystem(DenseLinearOperator(matrix)), right)
+    temperature = heat_result.value
+    linear_successful = jnp.all(heat_result.successful)
     energy = state.internal_energy + thermo.heat_capacity * (
         temperature - thermo.temperature
     )
@@ -570,47 +576,55 @@ def _implicit_unstructured_transport_step(
         * metrics.face_measures[:, :, None]
         / metrics.center_distances[:, :, None]
     )
-    species = jnp.zeros_like(state.species_amount)
-    for particle in range(prepared.particle_count):
-        volume = metrics.cell_measures[particle]
-        boundary_face = metrics.boundary_faces & metrics.active_faces[particle]
-        area_fraction = metrics.face_measures[particle] / jnp.maximum(
-            metrics.surface_measure[particle], 1.0e-30
+    volume = metrics.cell_measures[:, None, :]
+    boundary_face = (
+        metrics.boundary_faces[None, None, :] & metrics.active_faces[:, None, :]
+    )
+    area_fraction = metrics.face_measures / jnp.maximum(
+        metrics.surface_measure[:, None],
+        1.0e-30,
+    )
+    face = jnp.where(
+        interior[:, None, :],
+        jnp.swapaxes(species_conductance, 1, 2),
+        0.0,
+    )
+    matrix = jnp.broadcast_to(
+        jnp.eye(prepared.cell_capacity, dtype=state.species_amount.dtype) / step_size,
+        (
+            prepared.particle_count,
+            prepared.species_count,
+            prepared.cell_capacity,
+            prepared.cell_capacity,
+        ),
+    )
+    matrix = matrix.at[..., owner, owner].add(face / volume[..., owner])
+    matrix = matrix.at[..., safe_neighbour, safe_neighbour].add(
+        face / volume[..., safe_neighbour]
+    )
+    matrix = matrix.at[..., owner, safe_neighbour].add(-face / volume[..., owner])
+    matrix = matrix.at[..., safe_neighbour, owner].add(
+        -face / volume[..., safe_neighbour]
+    )
+    boundary_conductance = jnp.where(
+        boundary_face,
+        boundary.mass_transfer_coefficient[:, :, None]
+        * metrics.face_measures[:, None, :],
+        0.0,
+    )
+    matrix = matrix.at[..., owner, owner].add(boundary_conductance / volume[..., owner])
+    right = jnp.swapaxes(state.species_amount, 1, 2) / step_size
+    right = right.at[..., owner].add(
+        boundary_conductance * boundary.species_concentration[:, :, None]
+        + jnp.where(
+            boundary_face,
+            boundary.prescribed_species_rate[:, :, None] * area_fraction[:, None, :],
+            0.0,
         )
-        for species_index in range(prepared.species_count):
-            face = jnp.where(
-                interior[particle],
-                species_conductance[particle, :, species_index],
-                0.0,
-            )
-            matrix = jnp.eye(prepared.cell_capacity, dtype=energy.dtype) / step_size
-            matrix = matrix.at[owner, owner].add(face / volume[owner])
-            matrix = matrix.at[safe_neighbour, safe_neighbour].add(
-                face / volume[safe_neighbour]
-            )
-            matrix = matrix.at[owner, safe_neighbour].add(-face / volume[owner])
-            matrix = matrix.at[safe_neighbour, owner].add(-face / volume[safe_neighbour])
-            boundary_conductance = jnp.where(
-                boundary_face,
-                boundary.mass_transfer_coefficient[particle, species_index]
-                * metrics.face_measures[particle],
-                0.0,
-            )
-            matrix = matrix.at[owner, owner].add(boundary_conductance / volume[owner])
-            right = state.species_amount[particle, :, species_index] / step_size
-            right = right.at[owner].add(
-                boundary_conductance
-                * boundary.species_concentration[particle, species_index]
-                + jnp.where(
-                    boundary_face,
-                    boundary.prescribed_species_rate[particle, species_index]
-                    * area_fraction,
-                    0.0,
-                )
-            )
-            result = solve(LinearSystem(DenseLinearOperator(matrix)), right)
-            species = species.at[particle, :, species_index].set(result.value)
-            linear_successful = linear_successful & result.successful
+    )
+    species_result = solve(LinearSystem(DenseLinearOperator(matrix)), right)
+    species = jnp.swapaxes(species_result.value, 1, 2)
+    linear_successful = linear_successful & jnp.all(species_result.successful)
     candidate = eqx.tree_at(
         lambda value: (value.internal_energy, value.species_amount),
         state,
@@ -723,6 +737,16 @@ def _update_ledger(previous, candidate, sources):
         previous.ledger.accepted_steps + jnp.asarray(1, dtype=jnp.int32),
     )
     return ParticleConversionState(candidate.batches, ledger, candidate.state_id)
+
+
+def _tridiagonal_bands(lower, diagonal, upper):
+    bands = jnp.zeros(
+        diagonal.shape[:-1] + (3, diagonal.shape[-1]),
+        dtype=diagonal.dtype,
+    )
+    bands = bands.at[..., 1, :].set(diagonal)
+    bands = bands.at[..., 2, :-1].set(lower)
+    return bands.at[..., 0, 1:].set(upper)
 
 
 def _harmonic_mean(left, right):

--- a/phydrax/special/_continuation.py
+++ b/phydrax/special/_continuation.py
@@ -65,10 +65,13 @@ def _jv_series_direct(order: Array, argument: Array, /) -> Array:
     v, z = jnp.broadcast_arrays(order, argument)
     half = 0.5 * z
     term = jnp.exp(v * jnp.log(half) - _loggamma_lanczos(v + 1.0))
-    total = term
-    for index in range(1, 96):
-        term = term * (-(half * half)) / (index * (v + index))
-        total = total + term
+
+    def accumulate(index, state):
+        current, total_ = state
+        current = current * (-(half * half)) / (index * (v + index))
+        return current, total_ + current
+
+    _, total = jax.lax.fori_loop(1, 96, accumulate, (term, term))
     return total
 
 
@@ -113,12 +116,19 @@ def _negative_integer_jv_order_derivative(order: Array, argument: Array, /) -> A
     term = parity * jnp.exp(
         n * log_half - _loggamma_lanczos(jnp.asarray(n + 1.0, dtype=argument.dtype))
     )
-    late = jnp.zeros_like(argument)
-    harmonic = 0.0
-    for index in range(96):
-        late = late + term * (log_half - harmonic + 0.5772156649015329)
-        term = term * (-(half * half)) / ((index + 1) * (n + index + 1.0))
-        harmonic += 1.0 / (index + 1)
+
+    def accumulate_late(index, state):
+        current, total, harmonic = state
+        total = total + current * (log_half - harmonic + 0.5772156649015329)
+        current = current * (-(half * half)) / ((index + 1) * (n + index + 1.0))
+        return current, total, harmonic + 1.0 / (index + 1)
+
+    _, late, _ = jax.lax.fori_loop(
+        0,
+        96,
+        accumulate_late,
+        (term, jnp.zeros_like(argument), jnp.asarray(0.0)),
+    )
     return early + late
 
 
@@ -146,10 +156,13 @@ def _iv_series(order: Array, argument: Array, /) -> Array:
     v, z = jnp.broadcast_arrays(order, argument)
     half = 0.5 * z
     term = jnp.exp(v * jnp.log(half) - _loggamma_lanczos(v + 1.0))
-    total = term
-    for index in range(1, 96):
-        term = term * (half * half) / (index * (v + index))
-        total = total + term
+
+    def accumulate(index, state):
+        current, total_ = state
+        current = current * (half * half) / (index * (v + index))
+        return current, total_ + current
+
+    _, total = jax.lax.fori_loop(1, 96, accumulate, (term, term))
     return total
 
 

--- a/phydrax/stochastic/_point_process.py
+++ b/phydrax/stochastic/_point_process.py
@@ -265,21 +265,45 @@ def evaluate_hawkes_likelihood(
 
     times = observation.times
     channels = jnp.where(observation.valid, observation.channels, 0)
-    difference = times[:, None] - times[None, :]
-    earlier_index = jnp.tril(jnp.ones(difference.shape, dtype=bool), k=-1)
-    if plan_.tie_policy == "simultaneous":
-        causal = earlier_index & (difference > 0.0)
-    else:
-        causal = earlier_index & (difference >= 0.0)
-    causal = causal & observation.valid[:, None] & observation.valid[None, :]
-    target = jnp.arange(process.channel_count, dtype=jnp.int32)
-    excitation = process.excitation[target[:, None], channels[None, :]]
-    decay = process.decay[target[:, None], channels[None, :]]
-    contribution = excitation[None, :, :] * jnp.exp(
-        -decay[None, :, :] * jnp.maximum(difference[:, None, :], 0.0)
-    )
-    channel_intensity = process.baseline[None, :] + jnp.sum(
-        jnp.where(causal[:, None, :], contribution, 0.0), axis=-1
+    initial_history = jnp.zeros_like(process.excitation)
+    initial_pending = jnp.zeros_like(process.excitation)
+
+    def likelihood_step(carry, inputs):
+        history, pending, previous_time = carry
+        time, channel, valid = inputs
+        elapsed = jnp.maximum(time - previous_time, 0.0)
+        if plan_.tie_policy == "simultaneous":
+            next_group = elapsed > 0.0
+            advanced = (history + pending) * jnp.exp(-process.decay * elapsed)
+            evaluated_history = jnp.where(next_group, advanced, history)
+            pending = jnp.where(next_group, 0.0, pending)
+            intensity = process.baseline + jnp.sum(evaluated_history, axis=-1)
+            increment = (
+                jnp.zeros_like(pending).at[:, channel].set(process.excitation[:, channel])
+            )
+            next_history = evaluated_history
+            next_pending = pending + increment
+        else:
+            evaluated_history = history * jnp.exp(-process.decay * elapsed)
+            intensity = process.baseline + jnp.sum(evaluated_history, axis=-1)
+            increment = (
+                jnp.zeros_like(history).at[:, channel].set(process.excitation[:, channel])
+            )
+            next_history = evaluated_history + increment
+            next_pending = pending
+        return (
+            (
+                jnp.where(valid, next_history, history),
+                jnp.where(valid, next_pending, pending),
+                jnp.where(valid, time, previous_time),
+            ),
+            jnp.where(valid, intensity, process.baseline),
+        )
+
+    _, channel_intensity = jax.lax.scan(
+        likelihood_step,
+        (initial_history, initial_pending, observation.start_time),
+        (times, channels, observation.valid),
     )
     event_intensity = jnp.take_along_axis(channel_intensity, channels[:, None], axis=-1)[
         :, 0

--- a/phydrax/tensor_network/_local_lindblad.py
+++ b/phydrax/tensor_network/_local_lindblad.py
@@ -116,18 +116,10 @@ def prepare_local_lindblad_channel(
         jax.vmap(lambda density: generator(density).reshape(-1))(basis), -1, -2
     )
     superoperator = jsp.linalg.expm(step * generator_matrix)
-    choi = jnp.zeros(
-        (dimension, dimension, dimension, dimension), dtype=superoperator.dtype
+    choi = jnp.transpose(
+        superoperator.reshape((dimension, dimension, dimension, dimension)),
+        (2, 0, 3, 1),
     )
-    for row in range(dimension):
-        for column in range(dimension):
-            matrix = (
-                jnp.zeros((dimension, dimension), dtype=superoperator.dtype)
-                .at[row, column]
-                .set(1.0)
-            )
-            output = (superoperator @ matrix.reshape(-1)).reshape((dimension, dimension))
-            choi = choi.at[row, :, column, :].set(output)
     flat = choi.reshape((size, size))
     hermiticity = jnp.max(jnp.abs(flat - _adjoint(flat)))
     hermitian = 0.5 * flat + 0.5 * _adjoint(flat)

--- a/phydrax/tensor_network/_observables.py
+++ b/phydrax/tensor_network/_observables.py
@@ -108,58 +108,51 @@ def finite_correlation_matrix(
     norm = eqx.error_if(
         norm, ~jnp.isfinite(norm) | (norm <= 0.0), "MPS norm must be finite and positive."
     )
-    one_first = jnp.zeros((state.site_count,), dtype=jnp.result_type(tensors[0], first))
-    one_second = jnp.zeros((state.site_count,), dtype=jnp.result_type(tensors[0], second))
+    left, right = _identity_environments(state)
+    value_dtype = jnp.result_type(tensors[0], first, second)
+    one_first = jnp.zeros((state.site_count,), dtype=value_dtype)
+    one_second = jnp.zeros((state.site_count,), dtype=value_dtype)
     values = jnp.zeros(
         (state.site_count, state.site_count),
         dtype=jnp.result_type(tensors[0], first, second),
     )
-    for row in range(state.site_count):
-        for column in range(state.site_count):
-            environment = jnp.ones((1, 1), dtype=values.dtype)
-            for site, tensor in enumerate(tensors):
-                if site == row == column:
-                    insertion = first @ second
-                elif site == row:
-                    insertion = first
-                elif site == column:
-                    insertion = second
-                else:
-                    insertion = jnp.eye(dimension, dtype=values.dtype)
-                environment = ein.contract(
-                    "ab,api,pq,bqj->ij",
-                    environment,
-                    jnp.conj(tensor),
-                    insertion,
-                    tensor,
-                )
-            values = values.at[row, column].set(environment.reshape(()) / norm)
-    for site in range(state.site_count):
-        environment_first = jnp.ones((1, 1), dtype=values.dtype)
-        environment_second = jnp.ones((1, 1), dtype=values.dtype)
-        for index, tensor in enumerate(tensors):
-            insertion_first = (
-                first if index == site else jnp.eye(dimension, dtype=values.dtype)
+    identity = jnp.eye(dimension, dtype=value_dtype)
+
+    def insert(environment, tensor, local_operator):
+        return ein.contract(
+            "ab,api,pq,bqj->ij",
+            environment,
+            jnp.conj(tensor),
+            local_operator,
+            tensor,
+        )
+
+    def close(environment, terminal):
+        return ein.contract("ab,ab->", environment, terminal)
+
+    for row, tensor in enumerate(tensors):
+        first_environment = insert(left[row], tensor, first)
+        second_environment = insert(left[row], tensor, second)
+        one_first = one_first.at[row].set(close(first_environment, right[row + 1]) / norm)
+        one_second = one_second.at[row].set(
+            close(second_environment, right[row + 1]) / norm
+        )
+        diagonal = insert(left[row], tensor, first @ second)
+        values = values.at[row, row].set(close(diagonal, right[row + 1]) / norm)
+        running_first = first_environment
+        running_second = second_environment
+        for column in range(row + 1, state.site_count):
+            column_tensor = tensors[column]
+            first_then_second = insert(running_first, column_tensor, second)
+            second_then_first = insert(running_second, column_tensor, first)
+            values = values.at[row, column].set(
+                close(first_then_second, right[column + 1]) / norm
             )
-            insertion_second = (
-                second if index == site else jnp.eye(dimension, dtype=values.dtype)
+            values = values.at[column, row].set(
+                close(second_then_first, right[column + 1]) / norm
             )
-            environment_first = ein.contract(
-                "ab,api,pq,bqj->ij",
-                environment_first,
-                jnp.conj(tensor),
-                insertion_first,
-                tensor,
-            )
-            environment_second = ein.contract(
-                "ab,api,pq,bqj->ij",
-                environment_second,
-                jnp.conj(tensor),
-                insertion_second,
-                tensor,
-            )
-        one_first = one_first.at[site].set(environment_first.reshape(()) / norm)
-        one_second = one_second.at[site].set(environment_second.reshape(()) / norm)
+            running_first = insert(running_first, column_tensor, identity)
+            running_second = insert(running_second, column_tensor, identity)
     connected = values - one_first[:, None] * one_second[None, :]
     valid = jnp.all(jnp.isfinite(values)) & jnp.all(jnp.isfinite(connected))
     return FiniteCorrelationResult(

--- a/phydrax/uq/_dropout_predictive.py
+++ b/phydrax/uq/_dropout_predictive.py
@@ -344,18 +344,29 @@ def sample_mc_dropout_predictive(
     address = SampleAddress(
         "uq.mc-dropout", "function-draw", target=draw_dim, role="dropout"
     )
-    values: list[Array] = []
-    template: cx.Field | None = None
-    for start in range(0, draws, chunk):
-        for draw in range(start, min(start + chunk, draws)):
-            field = function(points, key=derive_key(key, address, draw), **kwargs)
-            if template is None:
-                template = field
-            elif field.dims != template.dims or field.data.shape != template.data.shape:
-                raise ValueError("MC-dropout draws changed field geometry.")
-            values.append(jnp.asarray(field.data))
-    assert template is not None
-    stacked = jnp.stack(values, axis=0)
+    template = function(points, key=derive_key(key, address, 0), **kwargs)
+    draw_indices = jnp.arange(draws, dtype=jnp.uint32)
+    keys = jax.vmap(lambda draw: derive_key(key, address, draw))(draw_indices)
+    chunk_count = (draws + chunk - 1) // chunk
+    padded_count = chunk_count * chunk
+    padding = padded_count - draws
+    keys = jnp.concatenate(
+        (
+            keys,
+            jnp.broadcast_to(keys[-1], (padding,) + keys.shape[1:]),
+        ),
+        axis=0,
+    )
+
+    def evaluate_batch(batch_keys):
+        return jax.vmap(
+            lambda draw_key: jnp.asarray(function(points, key=draw_key, **kwargs).data)
+        )(batch_keys)
+
+    stacked = jax.lax.map(
+        evaluate_batch,
+        keys.reshape((chunk_count, chunk) + keys.shape[1:]),
+    ).reshape((padded_count,) + template.data.shape)[:draws]
     finite = jnp.all(jnp.isfinite(stacked).reshape((draws, -1)), axis=1)
     if valid_policy == "raise" and not bool(jnp.all(finite)):
         raise FloatingPointError("MC-dropout produced a nonfinite whole-function draw.")

--- a/phydrax/uq/_ensemble_filter.py
+++ b/phydrax/uq/_ensemble_filter.py
@@ -182,15 +182,21 @@ def initialize_ensemble_filter(
     )
     case_shape = problem.observations.case_shape
     draws = []
+    member_indices = jnp.arange(count, dtype=jnp.int32)
     for case_index, case_id in enumerate(problem.observations.case_ids):
-        case_draws = []
-        for member in range(count):
+
+        def draw_member(member):
             member_key = state_space_key(
-                key, "ensemble-filter-prior", case_id, 0, member=member
+                key,
+                "ensemble-filter-prior",
+                case_id,
+                0,
+                member=member,
             )
             complete_draw = problem.model.prior.sample(member_key)
-            case_draws.append(_case_value(complete_draw, case_index, case_shape))
-        draws.append(jnp.stack(case_draws, axis=0))
+            return _case_value(complete_draw, case_index, case_shape)
+
+        draws.append(jax.vmap(draw_member)(member_indices))
     ensemble = jnp.stack(draws, axis=0).reshape(
         case_shape + (count,) + problem.model.state_shape
     )
@@ -230,42 +236,40 @@ def _forecast(
     active_flat = active.reshape((case_count,))
     cases = []
     valid_cases = []
+    member_indices = jnp.arange(count, dtype=jnp.int32)
+    state_valid = state.valid.reshape((-1,))
     for case_index, case_id in enumerate(problem.observations.case_ids):
         context = problem.step_context(case_index, state.step_index)
-        members = []
-        member_validity = []
-        for member in range(count):
-            if bool(active_flat[case_index]) and bool(
-                state.valid.reshape((-1,))[case_index]
-            ):
-                member_key = state_space_key(
-                    state.root_key,
-                    "ensemble-filter-transition",
-                    case_id,
-                    state.step_index,
-                    member=member,
-                )
-                sample = problem.model.transition.sample(
-                    member_key,
-                    previous[case_index, member],
-                    starts[case_index],
-                    ends[case_index],
-                    context,
-                )
-                sample_valid = jnp.all(sample.valid) & jnp.all(sample.status == 0)
-                members.append(
-                    jnp.where(
-                        sample_valid,
-                        sample.values,
-                        previous[case_index, member],
-                    )
-                )
-                member_validity.append(sample_valid)
-            else:
-                members.append(previous[case_index, member])
-                member_validity.append(jnp.asarray(True))
-        cases.append(jnp.stack(members, axis=0))
-        valid_cases.append(jnp.stack(member_validity, axis=0))
+        case_active = active_flat[case_index] & state_valid[case_index]
+
+        def forecast_member(member, previous_member):
+            member_key = state_space_key(
+                state.root_key,
+                "ensemble-filter-transition",
+                case_id,
+                state.step_index,
+                member=member,
+            )
+            sample = problem.model.transition.sample(
+                member_key,
+                previous_member,
+                starts[case_index],
+                ends[case_index],
+                context,
+            )
+            sample_valid = jnp.all(sample.valid) & jnp.all(sample.status == 0)
+            accepted = case_active & sample_valid
+            return (
+                jnp.where(accepted, sample.values, previous_member),
+                jnp.where(case_active, sample_valid, True),
+            )
+
+        members, member_validity = jax.vmap(forecast_member)(
+            member_indices,
+            previous[case_index],
+        )
+        cases.append(members)
+        valid_cases.append(member_validity)
     return (
         jnp.stack(cases, axis=0).reshape(
             case_shape + (count,) + problem.model.state_shape
@@ -295,18 +299,13 @@ def _etkf_case(
     forecast_mean = jnp.mean(forecast_flat, axis=0)
     state_anomalies = (forecast_flat - forecast_mean[None, :]) * inflation
     inflated_forecast = forecast_mean[None, :] + state_anomalies
-    observations = []
-    for member in range(count):
-        observations.append(
-            problem.model.observation.location(
-                inflated_forecast[member].reshape(problem.model.state_shape),
-                time,
-                context,
-            )
+    forecast_observations = jax.vmap(
+        lambda member: problem.model.observation.location(
+            member.reshape(problem.model.state_shape),
+            time,
+            context,
         )
-    forecast_observations = jnp.stack(observations, axis=0).reshape(
-        (count, observation_size)
-    )
+    )(inflated_forecast).reshape((count, observation_size))
     observation_mean = jnp.mean(forecast_observations, axis=0)
     observation_anomalies = forecast_observations - observation_mean[None, :]
     mask_flat = jnp.asarray(mask, dtype=bool).reshape((observation_size,))

--- a/phydrax/uq/_particle.py
+++ b/phydrax/uq/_particle.py
@@ -921,6 +921,19 @@ def bootstrap_particle_filter(
     return result
 
 
+def _segment_logsumexp(values: Array, labels: Array, segment_count: int, /) -> Array:
+    maximum = (
+        jnp.full((segment_count,), -jnp.inf, dtype=values.dtype).at[labels].max(values)
+    )
+    shifted = jnp.where(
+        jnp.isfinite(values),
+        jnp.exp(values - maximum[labels]),
+        0.0,
+    )
+    total = jnp.zeros((segment_count,), dtype=values.dtype).at[labels].add(shifted)
+    return jnp.where(total > 0.0, maximum + jnp.log(total), -jnp.inf)
+
+
 def full_particle_smoother(
     result: ParticleFilterResult,
     /,
@@ -938,40 +951,82 @@ def full_particle_smoother(
     ancestors = result.ancestor_indices.reshape((case_count, num_steps, count))
     active = result.step_valid.reshape((case_count, num_steps))
     filter_valid = result.valid.reshape((case_count, num_steps)) & active
-    smoothed_weights = jnp.full_like(filter_weights, -jnp.inf)
-    lineages = jnp.broadcast_to(
-        jnp.arange(count, dtype=jnp.int32), (case_count, num_steps, count)
+    particle_ids = jnp.arange(count, dtype=jnp.int32)
+    step_ids = jnp.arange(num_steps, dtype=jnp.int32)
+
+    def smooth_case(case_weights, case_ancestors, case_active, case_filter_valid):
+        active_count = jnp.sum(case_active, dtype=jnp.int32)
+        terminal = jnp.maximum(active_count - 1, 0)
+        case_valid = (active_count > 0) & jnp.all(
+            jnp.where(step_ids < active_count, case_filter_valid, True)
+        )
+        terminal_weights = case_weights[terminal]
+        smoothed = jnp.full_like(case_weights, -jnp.inf)
+        lineages = jnp.broadcast_to(particle_ids, (num_steps, count))
+        horizons = step_ids
+        valid = jnp.zeros((num_steps,), dtype=bool)
+
+        def reverse_step(offset, carry):
+            lineage, weights_, lineages_, horizons_, valid_ = carry
+            active_step = offset < active_count
+            step = jnp.maximum(terminal - offset, 0)
+
+            def update(values):
+                (
+                    current_lineage,
+                    current_weights,
+                    current_lineages,
+                    current_horizons,
+                    current_valid,
+                ) = values
+                current_lineage = jax.lax.cond(
+                    offset > 0,
+                    lambda item: case_ancestors[step + 1, item],
+                    lambda item: item,
+                    current_lineage,
+                )
+                grouped = _segment_logsumexp(
+                    terminal_weights,
+                    _stop_indices(current_lineage),
+                    count,
+                )
+                normalized, _, weights_valid = normalize_log_weights(grouped)
+                path_valid = case_valid & weights_valid
+                current_weights = current_weights.at[step].set(
+                    jnp.where(path_valid, normalized, -jnp.inf)
+                )
+                current_lineages = current_lineages.at[step].set(current_lineage)
+                current_horizons = current_horizons.at[step].set(terminal)
+                current_valid = current_valid.at[step].set(path_valid)
+                return (
+                    current_lineage,
+                    current_weights,
+                    current_lineages,
+                    current_horizons,
+                    current_valid,
+                )
+
+            return jax.lax.cond(
+                active_step,
+                update,
+                lambda values: values,
+                (lineage, weights_, lineages_, horizons_, valid_),
+            )
+
+        _, smoothed, lineages, horizons, valid = jax.lax.fori_loop(
+            0,
+            num_steps,
+            reverse_step,
+            (particle_ids, smoothed, lineages, horizons, valid),
+        )
+        return smoothed, lineages, horizons, valid
+
+    smoothed_weights, lineages, horizons, smoother_valid = jax.vmap(smooth_case)(
+        filter_weights,
+        ancestors,
+        active,
+        filter_valid,
     )
-    horizons = jnp.arange(num_steps, dtype=jnp.int32)[None, :].repeat(case_count, axis=0)
-    smoother_valid = jnp.zeros((case_count, num_steps), dtype=bool)
-    for case_index in range(case_count):
-        active_count = int(np.sum(np.asarray(jax.device_get(active[case_index]))))
-        if active_count == 0:
-            continue
-        terminal = active_count - 1
-        case_valid = bool(jnp.all(filter_valid[case_index, : terminal + 1]))
-        terminal_weights = filter_weights[case_index, terminal]
-        for target in range(active_count):
-            lineage = jnp.arange(count, dtype=jnp.int32)
-            for step in range(terminal, target, -1):
-                lineage = ancestors[case_index, step, lineage]
-            lineage = _stop_indices(lineage)
-            grouped = jax.scipy.special.logsumexp(
-                jnp.where(
-                    lineage[None, :] == jnp.arange(count, dtype=jnp.int32)[:, None],
-                    terminal_weights[None, :],
-                    -jnp.inf,
-                ),
-                axis=-1,
-            )
-            normalized, _, weights_valid = normalize_log_weights(grouped)
-            path_valid = case_valid and bool(weights_valid)
-            smoothed_weights = smoothed_weights.at[case_index, target].set(
-                jnp.where(path_valid, normalized, -jnp.inf)
-            )
-            lineages = lineages.at[case_index, target].set(lineage)
-            horizons = horizons.at[case_index, target].set(terminal)
-            smoother_valid = smoother_valid.at[case_index, target].set(path_valid)
     means = jnp.sum(
         jnp.exp(smoothed_weights)[..., *(None for _ in state_shape)] * particles,
         axis=2,
@@ -1030,73 +1085,164 @@ def particle_backward_smoother(
     times = result.times.reshape((case_count, num_steps))
     active = result.step_valid.reshape((case_count, num_steps))
     filter_valid = result.valid.reshape((case_count, num_steps)) & active
-    smoothed_weights = jnp.full_like(filter_weights, -jnp.inf)
-    backward = jnp.full(
-        (case_count, max(num_steps - 1, 0), count, count),
-        -jnp.inf,
-        dtype=filter_weights.dtype,
-    )
-    pairs = jnp.full_like(backward, -jnp.inf)
-    smoother_valid = jnp.zeros((case_count, num_steps), dtype=bool)
-    for case_index in range(case_count):
-        active_count = int(np.sum(np.asarray(jax.device_get(active[case_index]))))
-        if active_count == 0:
-            continue
-        terminal = active_count - 1
-        if not bool(jnp.all(filter_valid[case_index, :active_count])):
-            continue
-        terminal_weights, _, terminal_valid = normalize_log_weights(
-            filter_weights[case_index, terminal]
+    step_ids = jnp.arange(num_steps, dtype=jnp.int32)
+    backward_steps = max(num_steps - 1, 0)
+
+    def smooth_case(
+        case_index,
+        case_particles,
+        case_weights,
+        case_times,
+        case_active,
+        case_filter_valid,
+    ):
+        active_count = jnp.sum(case_active, dtype=jnp.int32)
+        terminal = jnp.maximum(active_count - 1, 0)
+        path_valid = (active_count > 0) & jnp.all(
+            jnp.where(step_ids < active_count, case_filter_valid, True)
         )
-        if not bool(terminal_valid):
-            continue
-        smoothed_weights = smoothed_weights.at[case_index, terminal].set(terminal_weights)
-        smoother_valid = smoother_valid.at[case_index, terminal].set(True)
-        for step in range(terminal - 1, -1, -1):
-            density_rows = []
-            for next_index in range(count):
-                density_row = []
-                for previous_index in range(count):
-                    density_row.append(
-                        jnp.asarray(
+        terminal_weights, _, terminal_valid = normalize_log_weights(
+            case_weights[terminal]
+        )
+        running_valid = path_valid & terminal_valid
+        smoothed = (
+            jnp.full_like(case_weights, -jnp.inf)
+            .at[terminal]
+            .set(jnp.where(running_valid, terminal_weights, -jnp.inf))
+        )
+        backward_ = jnp.full(
+            (backward_steps, count, count),
+            -jnp.inf,
+            dtype=case_weights.dtype,
+        )
+        pairs_ = jnp.full_like(backward_, -jnp.inf)
+        valid_ = jnp.zeros((num_steps,), dtype=bool).at[terminal].set(running_valid)
+        degenerate = jnp.asarray(False)
+
+        def reverse_step(offset, carry):
+            (
+                smoothed_value,
+                backward_value,
+                pair_value,
+                valid_value,
+                current_valid,
+                failed,
+            ) = carry
+            step = jnp.maximum(terminal - offset, 0)
+            active_step = (offset < active_count) & current_valid
+
+            def update(values):
+                (
+                    current_smoothed,
+                    current_backward,
+                    current_pairs,
+                    current_step_valid,
+                    _,
+                    current_failed,
+                ) = values
+                previous_particles = case_particles[step]
+                next_particles = case_particles[step + 1]
+                context = result.problem.step_context(case_index, step + 1)
+
+                def density_row(next_particle):
+                    return jax.vmap(
+                        lambda previous_particle: jnp.asarray(
                             transition.log_prob(
-                                particles[case_index, step + 1, next_index],
-                                particles[case_index, step, previous_index],
-                                times[case_index, step],
-                                times[case_index, step + 1],
-                                result.problem.step_context(case_index, step + 1),
+                                next_particle,
+                                previous_particle,
+                                case_times[step],
+                                case_times[step + 1],
+                                context,
                             )
                         ).reshape(())
-                    )
-                density_rows.append(jnp.stack(density_row))
-            density = jnp.stack(density_rows)
-            unnormalized = filter_weights[case_index, step][None, :] + density
-            log_normalizers = jax.scipy.special.logsumexp(unnormalized, axis=-1)
-            row_valid = jnp.isfinite(log_normalizers) & jnp.all(
-                ~jnp.isnan(unnormalized), axis=-1
-            )
-            next_weights = smoothed_weights[case_index, step + 1]
-            required_rows = jnp.isfinite(next_weights)
-            if not bool(jnp.all(row_valid | ~required_rows)):
-                raise RuntimeError(
-                    "Backward particle probabilities degenerated for a physical case."
+                    )(previous_particles)
+
+                density = jax.vmap(density_row)(next_particles)
+                unnormalized = case_weights[step][None, :] + density
+                log_normalizers = jax.scipy.special.logsumexp(
+                    unnormalized,
+                    axis=-1,
                 )
-            backward_step = jnp.where(
-                row_valid[:, None],
-                unnormalized - log_normalizers[:, None],
-                -jnp.inf,
-            )
-            pair_step = next_weights[:, None] + backward_step
-            current = jax.scipy.special.logsumexp(pair_step, axis=0)
-            current, _, current_valid = normalize_log_weights(current)
-            if not bool(current_valid):
-                raise RuntimeError(
-                    "Backward particle marginals degenerated for a physical case."
+                row_valid = jnp.isfinite(log_normalizers) & jnp.all(
+                    ~jnp.isnan(unnormalized),
+                    axis=-1,
                 )
-            backward = backward.at[case_index, step].set(backward_step)
-            pairs = pairs.at[case_index, step].set(pair_step)
-            smoothed_weights = smoothed_weights.at[case_index, step].set(current)
-            smoother_valid = smoother_valid.at[case_index, step].set(True)
+                next_weights = current_smoothed[step + 1]
+                rows_usable = jnp.all(row_valid | ~jnp.isfinite(next_weights))
+                backward_step = jnp.where(
+                    row_valid[:, None],
+                    unnormalized - log_normalizers[:, None],
+                    -jnp.inf,
+                )
+                pair_step = next_weights[:, None] + backward_step
+                current = jax.scipy.special.logsumexp(pair_step, axis=0)
+                current, _, marginal_valid = normalize_log_weights(current)
+                step_valid = rows_usable & marginal_valid
+                current_smoothed = current_smoothed.at[step].set(
+                    jnp.where(step_valid, current, -jnp.inf)
+                )
+                current_backward = current_backward.at[step].set(backward_step)
+                current_pairs = current_pairs.at[step].set(pair_step)
+                current_step_valid = current_step_valid.at[step].set(step_valid)
+                return (
+                    current_smoothed,
+                    current_backward,
+                    current_pairs,
+                    current_step_valid,
+                    step_valid,
+                    current_failed | ~step_valid,
+                )
+
+            return jax.lax.cond(
+                active_step,
+                update,
+                lambda values: values,
+                (
+                    smoothed_value,
+                    backward_value,
+                    pair_value,
+                    valid_value,
+                    current_valid,
+                    failed,
+                ),
+            )
+
+        if num_steps > 1:
+            (
+                smoothed,
+                backward_,
+                pairs_,
+                valid_,
+                _,
+                degenerate,
+            ) = jax.lax.fori_loop(
+                1,
+                num_steps,
+                reverse_step,
+                (
+                    smoothed,
+                    backward_,
+                    pairs_,
+                    valid_,
+                    running_valid,
+                    degenerate,
+                ),
+            )
+        return smoothed, backward_, pairs_, valid_, degenerate
+
+    smoothed_weights, backward, pairs, smoother_valid, degenerate = jax.vmap(smooth_case)(
+        jnp.arange(case_count, dtype=jnp.int32),
+        particles,
+        filter_weights,
+        times,
+        active,
+        filter_valid,
+    )
+    smoothed_weights = eqx.error_if(
+        smoothed_weights,
+        jnp.any(degenerate),
+        "Backward particle probabilities degenerated for a physical case.",
+    )
     means = jnp.sum(
         jnp.exp(smoothed_weights)[..., *(None for _ in state_shape)] * particles,
         axis=2,
@@ -1160,58 +1306,113 @@ def particle_backward_simulation(
         (case_count, max(num_steps - 1, 0), result.num_particles, result.num_particles)
     )
     active = result.step_valid.reshape((case_count, num_steps))
-    paths = np.full((sample_count, case_count, num_steps, state_size), np.nan)
-    particle_indices = np.full((sample_count, case_count, num_steps), -1, dtype=np.int32)
-    sample_valid = np.zeros((sample_count, case_count), dtype=bool)
-    for sample_index in range(sample_count):
-        for case_index, case_id in enumerate(result.case_ids):
-            active_count = int(np.sum(np.asarray(jax.device_get(active[case_index]))))
-            if active_count == 0 or not bool(
-                jnp.all(
-                    smoother.valid.reshape((case_count, num_steps))[
-                        case_index, :active_count
-                    ]
-                )
-            ):
-                continue
-            terminal = active_count - 1
-            terminal_key = state_space_key(
-                key,
-                "particle-backward-simulation",
-                case_id,
-                terminal,
-                member=sample_index,
+    smoother_valid = smoother.valid.reshape((case_count, num_steps))
+    sample_indices = jnp.arange(sample_count, dtype=jnp.int32)
+    case_paths = []
+    case_particle_indices = []
+    case_sample_valid = []
+    for case_index, case_id in enumerate(result.case_ids):
+        active_count = jnp.sum(active[case_index], dtype=jnp.int32)
+        terminal = jnp.maximum(active_count - 1, 0)
+        case_valid = (active_count > 0) & jnp.all(
+            jnp.where(
+                jnp.arange(num_steps, dtype=jnp.int32) < active_count,
+                smoother_valid[case_index],
+                True,
             )
-            particle_index = _sample_terminal_index(
-                terminal_key, weights[case_index, terminal]
+        )
+
+        def sample_path(sample_index):
+            path = jnp.full(
+                (num_steps, state_size),
+                jnp.nan,
+                dtype=particles.dtype,
             )
-            particle_indices[sample_index, case_index, terminal] = particle_index
-            paths[sample_index, case_index, terminal] = np.asarray(
-                particles[case_index, terminal, particle_index]
-            )
-            for step in range(terminal - 1, -1, -1):
-                draw_key = state_space_key(
+            indices = jnp.full((num_steps,), -1, dtype=jnp.int32)
+
+            def initialize(_):
+                terminal_key = state_space_key(
                     key,
                     "particle-backward-simulation",
                     case_id,
-                    step,
+                    terminal,
                     member=sample_index,
                 )
                 particle_index = _sample_terminal_index(
-                    draw_key, backward[case_index, step, particle_index]
+                    terminal_key,
+                    weights[case_index, terminal],
                 )
-                particle_indices[sample_index, case_index, step] = particle_index
-                paths[sample_index, case_index, step] = np.asarray(
-                    particles[case_index, step, particle_index]
+                return (
+                    particle_index,
+                    path.at[terminal].set(
+                        particles[case_index, terminal, particle_index]
+                    ),
+                    indices.at[terminal].set(particle_index),
                 )
-            sample_valid[sample_index, case_index] = True
-    output_paths = jnp.asarray(paths).reshape(
+
+            particle_index, path, indices = jax.lax.cond(
+                case_valid,
+                initialize,
+                lambda _: (jnp.asarray(0, dtype=jnp.int32), path, indices),
+                operand=None,
+            )
+
+            def reverse_step(offset, carry):
+                current_index, current_path, current_indices = carry
+                step = jnp.maximum(terminal - offset, 0)
+                active_step = case_valid & (offset < active_count)
+
+                def update(values):
+                    previous_index, previous_path, previous_indices = values
+                    draw_key = state_space_key(
+                        key,
+                        "particle-backward-simulation",
+                        case_id,
+                        step,
+                        member=sample_index,
+                    )
+                    selected = _sample_terminal_index(
+                        draw_key,
+                        backward[case_index, step, previous_index],
+                    )
+                    return (
+                        selected,
+                        previous_path.at[step].set(particles[case_index, step, selected]),
+                        previous_indices.at[step].set(selected),
+                    )
+
+                return jax.lax.cond(
+                    active_step,
+                    update,
+                    lambda values: values,
+                    (current_index, current_path, current_indices),
+                )
+
+            particle_index, path, indices = jax.lax.fori_loop(
+                1,
+                num_steps,
+                reverse_step,
+                (particle_index, path, indices),
+            )
+            del particle_index
+            return path, indices, case_valid
+
+        sampled_paths, sampled_indices, sampled_valid = jax.vmap(sample_path)(
+            sample_indices
+        )
+        case_paths.append(sampled_paths)
+        case_particle_indices.append(sampled_indices)
+        case_sample_valid.append(sampled_valid)
+    paths = jnp.stack(tuple(case_paths), axis=1)
+    particle_indices = jnp.stack(tuple(case_particle_indices), axis=1)
+    sample_valid = jnp.stack(tuple(case_sample_valid), axis=1)
+    output_paths = paths.reshape(
         samples + result.case_shape + (num_steps,) + result.state_shape
     )
     output_indices = _stop_indices(
-        jnp.asarray(particle_indices).reshape(samples + result.case_shape + (num_steps,))
+        particle_indices.reshape(samples + result.case_shape + (num_steps,))
     )
-    output_valid = jnp.asarray(sample_valid).reshape(samples + result.case_shape)
+    output_valid = sample_valid.reshape(samples + result.case_shape)
     if not samples:
         output_paths = output_paths.reshape(
             result.case_shape + (num_steps,) + result.state_shape
@@ -1465,8 +1666,8 @@ def _sample_terminal_index(
     key: Array,
     log_weights: Array,
     /,
-) -> int:
-    return int(jr.categorical(key, log_weights))
+) -> Array:
+    return jr.categorical(key, log_weights).astype(jnp.int32)
 
 
 def sample_particle_ancestry_paths(

--- a/phydrax/uq/_sgmcmc_advanced.py
+++ b/phydrax/uq/_sgmcmc_advanced.py
@@ -395,6 +395,8 @@ def _sample_advanced(
             )
     if len(states) != chains:
         raise ValueError("Continuation chain count changed.")
+    states = jax.tree.map(lambda *values: jnp.stack(values), *states)
+    chain_indices = jnp.arange(chains, dtype=jnp.uint32)
     address = SampleAddress(
         "uq.sgmcmc", algorithm, target=source.fingerprint, role="transition"
     )
@@ -412,14 +414,19 @@ def _sample_advanced(
         batch = epoch_cache[epoch][batch_index]
         epsilon = schedule(update)
         step_trace.append(epsilon)
-        next_states = []
-        for chain, state in enumerate(states):
-            transition_key = derive_key(key, address, chain, update)
+        transition_keys = jax.vmap(lambda chain: derive_key(key, address, chain, update))(
+            chain_indices
+        )
+
+        def advance_chain(state, transition_key):
             position_tree = unravel(state.position)
             gradient_tree = gradient_fn(position_tree, batch)
             gradient, _ = ravel_pytree(gradient_tree)
-            if bool(jnp.any(~jnp.isfinite(gradient))):
-                raise FloatingPointError("SG-MCMC gradient is nonfinite.")
+            gradient = eqx.error_if(
+                gradient,
+                jnp.any(~jnp.isfinite(gradient)),
+                "SG-MCMC gradient is nonfinite.",
+            )
             if algorithm == "sghmc":
                 assert isinstance(state, SGHMCState)
                 assert friction is not None
@@ -429,14 +436,15 @@ def _sample_advanced(
                     noise_state = noise_state.freeze()
                 b_hat = 0.5 * epsilon * noise_state.diagonal
                 diffusion = friction_vector - b_hat
-                if bool(jnp.any(~jnp.isfinite(diffusion))) or bool(
-                    jnp.any(diffusion < 0.0)
-                ):
-                    raise ValueError(
-                        "SGHMC friction minus estimated gradient noise is not PSD."
-                    )
+                diffusion = eqx.error_if(
+                    diffusion,
+                    jnp.any(~jnp.isfinite(diffusion)) | jnp.any(diffusion < 0.0),
+                    "SGHMC friction minus estimated gradient noise is not PSD.",
+                )
                 random = jr.normal(
-                    transition_key, (dimension,), dtype=state.position.dtype
+                    transition_key,
+                    (dimension,),
+                    dtype=state.position.dtype,
                 )
                 momentum = (
                     state.momentum
@@ -458,20 +466,35 @@ def _sample_advanced(
                 )
                 metric = 1.0 / (geometry.regularization + jnp.sqrt(square_average))
                 random = jr.normal(
-                    transition_key, (dimension,), dtype=state.position.dtype
+                    transition_key,
+                    (dimension,),
+                    dtype=state.position.dtype,
                 )
                 position = (
                     state.position
                     + 0.5 * epsilon * metric * gradient
                     + jnp.sqrt(epsilon * metric) * random
                 )
-                next_state = PSGLDState(position=position, square_average=square_average)
-            if bool(jnp.any(~jnp.isfinite(next_state.position))):
-                raise FloatingPointError("SG-MCMC transition produced nonfinite state.")
-            next_states.append(next_state)
-        states = tuple(next_states)
+                next_state = PSGLDState(
+                    position=position,
+                    square_average=square_average,
+                )
+            return eqx.tree_at(
+                lambda value: value.position,
+                next_state,
+                eqx.error_if(
+                    next_state.position,
+                    jnp.any(~jnp.isfinite(next_state.position)),
+                    "SG-MCMC transition produced nonfinite state.",
+                ),
+            )
+
+        states = eqx.filter_vmap(
+            advance_chain,
+            in_axes=(eqx.if_array(0), 0),
+        )(states, transition_keys)
         if local_update >= burnin and (local_update - burnin + 1) % thinning == 0:
-            retained.append(jnp.stack(tuple(state.position for state in states)))
+            retained.append(states.position)
     flat_samples = jnp.stack(retained, axis=1)
     unconstrained = jax.vmap(jax.vmap(unravel))(flat_samples)
     constrained = problem.parameter_space.constrain(unconstrained)
@@ -482,11 +505,15 @@ def _sample_advanced(
         if algorithm == "sghmc"
         else "rmsprop_psgld_frozen_geometry_correction"
     )
+    final_states = tuple(
+        jax.tree.map(lambda value, index=index: value[index], states)
+        for index in range(chains)
+    )
     return AdvancedSGMCMCResult(
         problem=problem,
         unconstrained_samples=unconstrained,
         samples=constrained,
-        final_states=states,
+        final_states=final_states,
         step_size_trace=jnp.stack(step_trace),
         root_key=jnp.asarray(key),
         final_update=start_update + total_updates,

--- a/phydrax/uq/_state_space_gp.py
+++ b/phydrax/uq/_state_space_gp.py
@@ -467,26 +467,15 @@ def _expanded_state_space(
         (schedule_size, row_capacity, state_size), dtype=drift.dtype
     )
     train_count = int(train_orders.shape[0])
-    for index in range(train_count):
-        temporal_row = _time_observation_row(
-            temporal, int(np.asarray(jax.device_get(train_orders[index])))
-        )
-        row = jnp.kron(spatial_factor[index], temporal_row)
-        time_index = int(np.asarray(jax.device_get(train_gather[index, 0])))
-        row_index = int(np.asarray(jax.device_get(train_gather[index, 1])))
-        observation_matrices = observation_matrices.at[time_index, row_index].set(row)
-    query_rows = []
-    offset = train_count
-    for index in range(int(query_orders.shape[0])):
-        temporal_row = _time_observation_row(
-            temporal, int(np.asarray(jax.device_get(query_orders[index])))
-        )
-        query_rows.append(jnp.kron(spatial_factor[offset + index], temporal_row))
-    query_matrix = (
-        jnp.stack(tuple(query_rows))
-        if query_rows
-        else jnp.zeros((0, state_size), dtype=drift.dtype)
-    )
+    all_orders = jnp.concatenate((train_orders, query_orders))
+    temporal_rows = _time_observation_rows(temporal, all_orders)
+    rows = jax.vmap(jnp.kron)(spatial_factor, temporal_rows)
+    train_indices = np.asarray(jax.device_get(train_gather), dtype=np.int32)
+    observation_matrices = observation_matrices.at[
+        train_indices[:, 0],
+        train_indices[:, 1],
+    ].set(rows[:train_count])
+    query_matrix = rows[train_count:]
     return _ExpandedStateSpace(
         drift,
         stationary,
@@ -499,20 +488,31 @@ def _expanded_state_space(
     )
 
 
-def _time_observation_row(component: _KernelStateSpace, order: int, /) -> Array:
-    if order < 0:
+def _time_observation_rows(component: _KernelStateSpace, orders: Array, /) -> Array:
+    order_values = np.asarray(jax.device_get(orders), dtype=np.int32)
+    if np.any(order_values < 0):
         raise ValueError("Time derivative orders must be nonnegative.")
+    maximum_order = int(np.max(order_values, initial=0))
+    rows = [component.observation_row]
     row = component.observation_row
     tolerance = 256.0 * jnp.finfo(component.drift.dtype).eps
-    for _ in range(order):
+    for _ in range(maximum_order):
         feedthrough = row @ component.process_factor
         host = np.asarray(jax.device_get(feedthrough))
         if not np.all(np.isfinite(host)) or np.max(np.abs(host)) > float(tolerance):
             raise ValueError(
-                "Requested time derivative lacks the required mean-square differentiability certificate."
+                "Requested temporal derivative is not mean-square defined by this kernel."
             )
         row = row @ component.drift
-    return row
+        rows.append(row)
+    return jnp.stack(tuple(rows))[jnp.asarray(order_values)]
+
+
+def _time_observation_row(component: _KernelStateSpace, order: int, /) -> Array:
+    return _time_observation_rows(
+        component,
+        jnp.asarray((order,), dtype=jnp.int32),
+    )[0]
 
 
 def _spatial_factor(
@@ -824,13 +824,14 @@ def fit_state_space_gaussian_process(
         ),
         dtype=values.dtype,
     )
-    for index in range(plan.train_size):
-        time_index = plan.train_gather_indices[index, 0]
-        row_index = plan.train_gather_indices[index, 1]
-        schedule_values = schedule_values.at[time_index, row_index].set(values[index])
-        observation_covariance = observation_covariance.at[
-            time_index, row_index, row_index
-        ].set(noise[index] * noise[index])
+    time_indices = plan.train_gather_indices[:, 0]
+    row_indices = plan.train_gather_indices[:, 1]
+    schedule_values = schedule_values.at[time_indices, row_indices].set(values)
+    observation_covariance = observation_covariance.at[
+        time_indices,
+        row_indices,
+        row_indices,
+    ].set(noise * noise)
     arguments = _StateSpaceGaussianProcessArguments(
         observation_covariance=observation_covariance,
         observation_matrices=plan.observation_matrices,

--- a/tests/unit/atomistic/test_ecosystem_advanced.py
+++ b/tests/unit/atomistic/test_ecosystem_advanced.py
@@ -1039,10 +1039,14 @@ def test_committee_diversity_and_advanced_methods():
         state.kinematics.positions, neighborhood.build(state.kinematics.positions)
     )
     assert bool(wall_evaluation.successful)
+    graph_execution = phx.atomistic.AtomisticGraphExecutionPlan(
+        system.capacity - 1,
+        backend="particle",
+    )
 
     eam = phx.atomistic.AtomisticPotentialProgram(
         [phx.atomistic.EAMPotential([2.0, 1.0, 1.0, 0.5, 2.0], 2.5)]
-    ).prepare(system)
+    ).prepare(system, graph_execution=graph_execution)
     eam_result = eam.evaluate(
         state.kinematics.positions, neighborhood.build(state.kinematics.positions)
     )
@@ -1064,7 +1068,7 @@ def test_committee_diversity_and_advanced_methods():
     for factory, parameters, cutoff in many_body_cases:
         many_body = phx.atomistic.AtomisticPotentialProgram(
             [factory(parameters, cutoff)]
-        ).prepare(system)
+        ).prepare(system, graph_execution=graph_execution)
         evaluation = many_body.evaluate(
             state.kinematics.positions,
             neighborhood.build(state.kinematics.positions),

--- a/tests/unit/control/test_batched_trajectory_optimization.py
+++ b/tests/unit/control/test_batched_trajectory_optimization.py
@@ -4,7 +4,7 @@ import jax.numpy as jnp
 import numpy as np
 
 import phydrax as phx
-from phydrax.control._batched_trajectory import (
+from phydrax.control._prepared_ilqr import (
     plan_ilqr,
     prepare_ilqr,
     solve_prepared_ilqr,
@@ -48,7 +48,7 @@ def test_prepared_ilqr_preserves_two_dimensional_case_axes_and_statuses():
     assert result.trajectory.states.shape == problem.case_shape + (3, 1)
     assert result.policy.feedback.shape == problem.case_shape + (2, 1, 1)
     assert result.diagnostics.status.shape == problem.case_shape
-    assert result.diagnostics.objective_history.shape == problem.case_shape + (8,)
+    assert result.diagnostics.objective_history.shape == problem.case_shape + (9,)
 
 
 def test_prepared_ilqr_uses_six_pose_feedback_coordinates_across_signs():

--- a/tests/unit/control/test_conic_control.py
+++ b/tests/unit/control/test_conic_control.py
@@ -45,7 +45,7 @@ def test_linear_conic_compiler_preserves_soc_block_and_decision_layout():
 
     assert conic.cone.cones[-1].contains(slack, tolerance=1e-12)
     np.testing.assert_allclose(slack, [0.5, -0.25], atol=1e-12)
-    assert compilation.quadratic_compilation.qp.num_user_inequalities == 0
+    assert compilation.quadratic_compilation.program.num_user_inequalities == 0
 
 
 def test_stage_soc_constraint_shape_mismatch_is_rejected():

--- a/tests/unit/control/test_control_qp_mpc.py
+++ b/tests/unit/control/test_control_qp_mpc.py
@@ -128,7 +128,7 @@ def test_decision_and_constraint_layouts_identify_every_compiled_block():
     decision = compilation.decision_layout
     constraints_layout = compilation.constraint_layout
     bound_layout = compilation.bound_layout
-    qp = compilation.quadratic_program
+    qp = compilation.program
 
     assert decision.initial_state_slice == slice(0, 2)
     assert decision.state_stage_slices == (slice(2, 4), slice(4, 6))
@@ -338,7 +338,7 @@ def test_batched_cases_and_failure_statuses_remain_case_explicit():
     )
     compilation = phx.control.compile_linear_quadratic_control(specification)
     solution = phx.control.solve_linear_quadratic_control(specification)
-    assert compilation.quadratic_program.batch_shape == (2,)
+    assert compilation.program.batch_shape == (2,)
     assert solution.states.shape == (2, horizon + 1, 1)
     assert solution.controls.shape == (2, horizon, 1)
     assert solution.valid.shape == (2,)

--- a/tests/unit/control/test_control_sparse_qp.py
+++ b/tests/unit/control/test_control_sparse_qp.py
@@ -41,21 +41,26 @@ def test_structural_sparse_control_operators_match_dense_compilation():
     )
 
     assert sparse.representation == "sparse"
-    assert sparse.sparse_quadratic is not None
-    assert sparse.sparse_equality is not None
-    assert sparse.sparse_inequality is not None
+    assert isinstance(sparse.program, phx.optim.ConicProgram)
+    assert sparse.program.quadratic_is_sparse
+    assert sparse.program.constraint_is_sparse
     np.testing.assert_allclose(
-        sparse.sparse_quadratic.as_dense(), dense.qp.quadratic, atol=1e-12
-    )
-    np.testing.assert_allclose(
-        sparse.sparse_equality.as_dense(), dense.qp.equality_matrix, atol=1e-12
-    )
-    np.testing.assert_allclose(
-        sparse.sparse_inequality.as_dense(),
-        dense.qp.inequality_matrix[..., : dense.qp.num_user_inequalities, :],
+        sparse.program.quadratic.as_dense(),
+        dense.program.quadratic,
         atol=1e-12,
     )
-    assert sparse.qp.num_user_inequalities == 0
+    constraints = sparse.program.constraint_matrix.as_dense()
+    equalities = sparse.constraint_layout.num_equalities
+    np.testing.assert_allclose(
+        constraints[:equalities],
+        dense.program.equality_matrix,
+        atol=1e-12,
+    )
+    np.testing.assert_allclose(
+        constraints[equalities:],
+        dense.program.inequality_matrix[..., : dense.program.num_user_inequalities, :],
+        atol=1e-12,
+    )
     assert sparse.bound_layout.control_lower_slices
 
 
@@ -65,14 +70,12 @@ def test_sparse_control_compilation_preserves_shared_case_batches():
         compilation_policy=phx.control.LinearControlCompilationPolicy("sparse"),
     )
 
-    assert compilation.sparse_quadratic.batch_shape == (2,)
-    assert compilation.sparse_equality.batch_shape == (2,)
-    assert compilation.sparse_quadratic.sparse_storage().batch_shape == (2,)
-    np.testing.assert_allclose(
-        compilation.sparse_quadratic.as_dense(),
-        compilation.qp.quadratic,
-        atol=1e-12,
-    )
+    quadratic = compilation.program.quadratic
+    constraints = compilation.program.constraint_matrix
+    assert quadratic.batch_shape == (2,)
+    assert constraints.batch_shape == (2,)
+    assert quadratic.sparse_storage().batch_shape == (2,)
+    assert constraints.sparse_storage().batch_shape == (2,)
 
 
 def test_sparse_prepared_control_refresh_and_solution_match_dense():

--- a/tests/unit/geometry/simplicial/test_affine.py
+++ b/tests/unit/geometry/simplicial/test_affine.py
@@ -2,6 +2,7 @@
 # Copyright © 2026 PHYDRA, Inc. All rights reserved.
 #
 
+import equinox as eqx
 import jax
 import jax.numpy as jnp
 
@@ -50,3 +51,25 @@ def test_embedded_triangle_and_degenerate_simplex_report_geometry_evidence():
     assert jnp.allclose(barycentric, jnp.asarray((0.5, 0.25, 0.25)))
     assert bool(triangle.contains(jnp.asarray((0.5, 0.75, 1.0))))
     assert not bool(degenerate.evidence.successful)
+
+
+def test_indexed_affine_simplex_operations_select_without_cross_product():
+    vertices = jnp.asarray(
+        (
+            ((0.0, 0.0), (1.0, 0.0), (0.0, 1.0)),
+            ((2.0, 0.0), (3.0, 0.0), (2.0, 1.0)),
+        )
+    )
+    simplices = AffineSimplexMap(vertices)
+    points = jnp.asarray(((0.25, 0.25), (2.5, 0.25)))
+    indices = jnp.asarray((0, 1), dtype=jnp.int32)
+    barycentric = eqx.filter_jit(simplices.barycentric_at)(points, indices)
+    nodal = jnp.asarray(((0.0, 1.0, 2.0), (4.0, 5.0, 6.0)))
+
+    assert barycentric.shape == (2, 3)
+    assert jnp.allclose(barycentric, jnp.asarray(((0.5, 0.25, 0.25), (0.25, 0.5, 0.25))))
+    assert jnp.all(simplices.contains_at(points, indices))
+    assert jnp.allclose(
+        simplices.physical_gradient_at(nodal, indices),
+        jnp.asarray(((1.0, 2.0), (1.0, 2.0))),
+    )


### PR DESCRIPTION
## Summary

This change removes high-impact numerical bottlenecks across Phydrax while preserving fixed-capacity evidence, rollback, deterministic addressing, and explicit resource ownership.

The implementation standardizes four execution choices:

- homogeneous array lanes use `jax.vmap`
- homogeneous stacked Equinox PyTrees use explicit `eqx.filter_vmap` axes
- long recurrences use `lax.scan`/`fori_loop`
- local and sparse interactions use prepared routes, bounded stencils, neighborhoods, or BVHs

## Runtime and control

- Consolidates scalar and case-shaped iLQR on the prepared fixed-capacity kernel and renames its internal owner to `_prepared_ilqr.py`.
- Preserves compact convenience histories for scalar calls while retaining fixed-capacity case histories.
- Batches horizon-local derivatives and lowers adjoint recurrences to device execution.
- Replaces runtime JIT closure creation in functional updates, distributed finite volume, distributed MAC, fused LBM, and coordinate proposal sampling with stable compiled entry points.
- Lowers native structured IPM line searches and residual-graph least-squares iterations to device loops.
- Makes sparse linear-control compilation structurally sparse: sparse compilations now own a sparse `ConicProgram` assembled directly from stage blocks, without retaining a dense QP.
- Adds explicit sparse compilation selection to receding-horizon MPC.

## Geometry and discretization

- Makes `PackedBVH` a transform-safe non-trainable PyTree and adds bounded point and ray candidate traversal.
- Adds indexed affine-simplex barycentric, containment, and physical-gradient operations.
- Routes simplicial location, unstructured splatting, tetrahedral refractive sampling, and tetrahedral X-ray paths through bounded candidates.
- Adds an explicit `maximum_segments_per_ray` resource to tetrahedral tomography.
- Replaces FLIP grid-by-particle level-set materialization and immersed-LBM grid-by-marker materialization with compact local stencils.
- Rewrites FLIP reseeding around sorted cell groups, prefix-ranked events, and bulk updates.
- Consolidates hp, FEM, AMR, facet, and cut-cell transfers into bulk or explicitly ordered device reductions.
- Lowers articulated RNEA and ABA recurrences to device loops.

## Atomistic execution

- Reimplements EAM, Stillinger--Weber, and Tersoff over prepared directed atomistic graphs and bounded neighbor slots.
- Propagates `maximum_neighbors` and graph overflow into many-body validity rather than falling back to dense all-pairs work.
- Batches SETTLE across disjoint water groups.
- Replaces molecular barostat and periodic coarse-map per-group masks with indexed reductions.
- Uses filtered vectorization for homogeneous ring-polymer bead evaluations.
- Batches structured and unstructured particle internal heat/species solves.

## Inference, learning, and optimization

- Rewrites full genealogy smoothing with reverse ancestry composition and segment log-sum-exp.
- Batches FFBSm transition-density evaluation and lowers FFBSm/FFBSi backward recurrences.
- Batches ensemble prior, forecast, and observation operations.
- Makes MC-dropout `draw_batch_size` an actual bounded execution policy while preserving draw identities across chunk sizes.
- Vectorizes state-space GP row construction and schedule binding.
- Uses explicit `eqx.filter_vmap` axes for homogeneous SG-MCMC chain states.
- Removes differential evolution's population-squared donor matrix and repeated per-front sorting.
- Batches hard-tree split-candidate statistics.
- Replaces quadratic ROC-AUC comparison matrices with stable tie-group accumulation.
- Batches ICE and lowers permutation importance through bounded mapping.
- Restricts asynchronous belief-propagation updates to the affected factor group instead of recomputing every factor group for every message segment.

## Linear algebra and scientific operators

- Lowers block-CG iterations to `fori_loop` and vectorizes PCR updates across each line stride.
- Vmaps variable-projection covariance actions and lowers fixed special-function recurrences.
- Reuses the analytic 2-D panel kernel for direct influence assembly and batches 3-D panel and Helmholtz basis evaluation.
- Reuses finite-chain identity environments, reducing complete correlation matrices from cubic to quadratic contraction count.
- Replaces matrix-unit Choi assembly with the exact vectorization reshape/permutation.
- Batches memory-kernel basis propagation.
- Replaces dense Hawkes event-history tensors with a tie-aware exponential recurrence.
- Vectorizes Boltzmann multipole hierarchies, spherical-harmonic synthesis, gravity value/gradient evaluation, flow-control influence columns, and Floquet monodromy actions.
- Replaces quadratic collateral pending-balance work with a single scan and lowers monodomain replay to a fail-closed device loop.

## Contract changes

- `LinearControlQPCompilation.program` is now the canonical dense-or-sparse program owner; the former dense-only field and parallel sparse side fields are removed.
- Sparse linear-control preparation selects a sparse-capable conic method and refreshes the same sparse topology.
- Cutoff many-body programs require an explicit particle `AtomisticGraphExecutionPlan` with a declared neighbor capacity.
- `TetrahedralXRayTransformPlan` exposes `maximum_segments_per_ray` and rejects insufficient capacity.
- `SimplicialBarycentricSplatAssignment` exposes `maximum_candidates`.
- SETTLE water groups are required to be atom-disjoint.
- The internal prepared iLQR module is renamed; public control exports remain canonical.

## Failure and numerical semantics

- Resource overflow remains fail-closed.
- Sparse and bounded routes do not silently densify or drop interactions.
- Stochastic keys are derived from semantic indices before batching, so execution chunking does not alter random identities.
- Declared ordered reductions remain ordered; unordered sparse routes use bulk accumulation.
- Host ownership remains limited to dynamic topology, external providers, and preparation metadata.
