### PR TITLE
Add experimental conflict-free optimizer update alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@
   typed domain records, explicit device stop rules, deterministic host sessions,
   capability-checked terminal/output/step/attempt/inner-iteration granularity, and
   checkpointed host cursors across production and training lifecycles.
+- Added experimental PyTree-native conflict-free optimizer-update alignment
+  with exact small active sets, canonical dual-QP fallback, real/complex cone
+  evidence, and checkpointed gradient--update mismatch statistics across
+  standard-Optax functional and neural-operator training.
 - Added native functional domain decomposition with exact multidimensional,
   nonuniform, and periodic Cartesian topology; mapped-cover evidence; sparse
   partition-of-unity and side-aware broken fields; typed local references; physical

--- a/NOTICE
+++ b/NOTICE
@@ -505,15 +505,19 @@ kernels, cache format, or runtime dependency is copied or redistributed.
 Physics-learning composition design study
 The multi-objective gradient design considered Liu et al., “ConFIG:
 Towards Conflict-free Training of Physics Informed Neural Networks” (2024).
-The progressively refined solve policy considered “Progressively Refined
-Differentiable Physics” (2025). The terminal transport objective considered
-“Physics-Based Flow Matching” (2025). The conservative learned pair exchange
-considered the pairwise momentum construction in “Deep Lagrangian Fluids”
-and related momentum-conserving learned-fluid work. Phydrax independently
-implements these ideas against its native PyTree, measured-field, closure-data,
-Krylov-control, fixed-step, transport, particle-relation, status, evidence, and
-provenance contracts. No upstream source, tests, fixtures, generated data,
-notebooks, model weights, runtime types, or dependencies are copied, translated,
+The applied-update alignment design considered Xiao et al.,
+“Gradient-Update Mismatch: Rethinking Conflict-Free Training of
+Physics-Informed Neural Networks” (2026), arXiv:2609.01558. The progressively
+refined solve policy considered “Progressively Refined Differentiable Physics”
+(2025). The terminal transport objective considered “Physics-Based Flow
+Matching” (2025). The conservative learned pair exchange considered the
+pairwise momentum construction in “Deep Lagrangian Fluids” and related
+momentum-conserving learned-fluid work. Phydrax independently implements these
+ideas against its native PyTree, quadratic-program, measured-field,
+closure-data, Krylov-control, fixed-step, transport, particle-relation,
+checkpoint, status, evidence, and provenance contracts. No upstream source,
+tests, fixtures, generated data, numerical tables, notebooks, model weights,
+runtime types, APIs, executables, or dependencies are copied, translated,
 bundled, linked, imported, or redistributed.
 
 Causal inference and discovery design study

--- a/docs/all-of-phydrax.md
+++ b/docs/all-of-phydrax.md
@@ -2130,9 +2130,12 @@ rollout transitions so model outputs can act inside periodic SSPRK or MAC
 pressure-projected dynamics.
 
 `ConflictFreeGradientPolicy` composes named objective gradients from one
-prepared stochastic realization. `ProgressiveLinearRefinementPolicy` controls a
-training-only native Krylov budget from fixed validation while preserving
-full-fidelity selection. `PhysicsFlowMatchingTerm` adds a differentiably
-unrolled terminal functional to flow matching. Learned particle exchanges use
-the existing pair relation and scatter substrate to guarantee only their
-constructed conservation laws.
+prepared stochastic realization. `ConflictFreeUpdatePolicy` then projects the
+exact standard-Optax proposal onto their simultaneous first-order nonascent
+cone without flattening parameter PyTrees; checkpointed diagnostics distinguish
+component-gradient, constructed-direction, raw-proposal, and applied-direction
+conflicts. `ProgressiveLinearRefinementPolicy` controls a training-only native
+Krylov budget from fixed validation while preserving full-fidelity selection.
+`PhysicsFlowMatchingTerm` adds a differentiably unrolled terminal functional to
+flow matching. Learned particle exchanges use the existing pair relation and
+scatter substrate to guarantee only their constructed conservation laws.

--- a/docs/api/optim.md
+++ b/docs/api/optim.md
@@ -2195,7 +2195,7 @@ optimization-gradient claim.
 
 ::: phydrax.optim.threshold_density
 
-## Multi-objective gradient composition
+## Multi-objective gradient and update geometry
 
 ::: phydrax.optim.ConflictFreeGradientPolicy
 
@@ -2212,3 +2212,36 @@ parameter PyTrees and a small rank-aware objective-space pseudoinverse. It
 records norms, cosine matrix, rank, condition estimate, conflicts, and final
 projections. Rank deficiency is not automatically failure: identical gradients
 remain feasible, while opposite gradients fail their projection check.
+
+Experimental `ConflictFreeUpdatePolicy` applies the same
+simultaneous-nonascent contract to the optimizer proposal rather than assuming
+a stateful transform preserves its input geometry. One-to-three objective
+projections use exact active-set solves; larger problems use the canonical
+Phydrax quadratic-program substrate; the parameter PyTree is never flattened.
+
+---
+
+::: phydrax.optim.ConflictFreeUpdatePolicy
+
+---
+
+::: phydrax.optim.ConflictFreeUpdateStatus
+
+---
+
+::: phydrax.optim.ConflictFreeUpdateResult
+
+---
+
+::: phydrax.optim.ConflictFreeUpdateStatistics
+
+---
+
+::: phydrax.optim.project_conflict_free_direction
+
+The public projector consumes a positive descent proposal. Its optional
+`metric_diagonal` is the positive diagonal of the projection metric; functional
+and operator training currently use the Euclidean metric and do not inspect
+optimizer state. Results distinguish feasible identity, projection, zero
+proposal, no effective objectives, nonfinite input, invalid metric, dual-solve
+failure, and failed post-certification.

--- a/docs/cookbook/operator_learning.md
+++ b/docs/cookbook/operator_learning.md
@@ -1714,6 +1714,41 @@ training_model = fit_result.execution_model
 assert fit_result.completed_steps == 1
 ```
 
+For experimental multiple-objective update alignment, constrain the exact
+optimizer proposal rather than assuming an adaptive transform preserves its
+input direction:
+
+```python
+aligned_fit = phx.nn.operator.training.fit_operator(
+    training_model,
+    split.train,
+    loss_terms=(
+        phx.nn.operator.training.SupervisedOperatorLoss(name="data"),
+        physics_loss,
+    ),
+    include_model_losses=False,
+    gradient_composition=phx.optim.ConflictFreeGradientPolicy(),
+    update_alignment=phx.optim.ConflictFreeUpdatePolicy(),
+    gradient_accumulation=1,
+    epochs=10,
+    batch_size=16,
+)
+```
+
+Gradient composition and update alignment are independent: omit
+`gradient_composition` to retain the ordinary aggregate gradient while still
+projecting the emitted optimizer proposal. Each loss term supplies one active
+cone constraint when its support is positive; zero-support terms are inactive.
+The returned `update_alignment_statistics` and per-step
+`history.train_metrics` distinguish component-gradient, constructed-direction,
+raw-proposal, and applied-direction conflicts and survive exact checkpoint
+resume.
+
+Update alignment currently requires one microstep, explicit loss terms, no
+attached model losses, and no loss scaling. Keep the accumulation example above
+separate. The guarantee is first order on the sampled batch, not a claim that
+every finite update decreases every population objective.
+
 For parameter-efficient transfer, adapt explicit native affine sites and pass
 only their factors to the same production fitting control plane:
 

--- a/docs/guides_functional_training.md
+++ b/docs/guides_functional_training.md
@@ -269,3 +269,48 @@ zero-support objectives remain separately identified.
 Componentized terms, including `PhysicsFlowMatchingTerm`, share one sampled
 payload and expose multiple gradients without duplicating stochastic
 realizations.
+
+## Conflict-free optimizer updates
+
+This experimental update-space contract follows the gradient--update mismatch
+analysis of [Xiao et al. (2026)](https://arxiv.org/abs/2609.01558), implemented
+independently against Phydrax's functional optimizer and evidence boundaries.
+
+`ConflictFreeUpdatePolicy` constrains the direction that the optimizer actually
+applies. For objective gradients `g_i`, a positive descent direction is feasible
+when every real pairing `Re <g_i, d>` is nonnegative. A standard Optax transform
+returns additive updates, so the runtime projects their negation and applies the
+negative aligned direction.
+
+Configure alignment independently or after gradient composition:
+
+```python
+training = phx.solver.FunctionalTrainingPlan(
+    gradient_composition=phx.optim.ConflictFreeGradientPolicy(),
+    update_alignment=phx.optim.ConflictFreeUpdatePolicy(),
+)
+```
+
+The projector returns the original additive Optax update unchanged when it is
+already feasible. Otherwise it solves a loss-dimensional dual problem and
+records gradient, constructed-direction, raw-proposal, and applied-direction
+conflicts; correction norms; active constraints; and KKT residuals. Cumulative
+statistics live in `FunctionalTrainingState.update_alignment_statistics`, so
+checkpoint resume preserves the complete mismatch history.
+
+The cone is built from authored physical objective components on the same
+prepared stochastic realization. Term balancing, causal transforms, and
+pseudo-transient continuation may change the optimizer proposal without changing
+that physical cone. Positive component rescaling cannot change a halfspace sign,
+so balancing and update alignment are complementary rather than substitutes.
+
+Initial training integration requires standard Optax, all terms active, one
+microstep, and no attached model losses. KFAC, Evosax, line-search, iterative,
+mirror, and Riemannian backends fail before training rather than ignoring the
+policy. A zero aligned direction can be a valid local Pareto-stationary result.
+
+The guarantee is first order and realization-local. Curvature can increase a
+component after a finite step, noisy batch gradients need not represent the
+population objective, and splitting or grouping objective components changes
+the cone. Decoupled weight decay is part of the emitted proposal and may be
+partly removed when it conflicts with declared objectives.

--- a/phydrax/nn/operator/training/_fit.py
+++ b/phydrax/nn/operator/training/_fit.py
@@ -42,6 +42,7 @@ from ...._training_objective import (
     _ObjectiveAccumulator,
     _ObjectiveContribution,
 )
+from ...._tree_math import tree_inner, tree_negative, tree_norm, tree_where
 from ....optim import (
     OptimizerStateCompressionPolicy,
     prepare_compressed_optimizer,
@@ -49,6 +50,11 @@ from ....optim import (
 from ....optim._gradient_composition import (
     conflict_free_gradient,
     ConflictFreeGradientPolicy,
+)
+from ....optim._update_alignment import (
+    ConflictFreeUpdatePolicy,
+    ConflictFreeUpdateStatistics,
+    project_conflict_free_direction,
 )
 from ..._loss import model_loss_labels, model_loss_values
 from ...layers._dropout import inference_mode
@@ -190,6 +196,7 @@ class OperatorFitResult:
     resumed_from_step: int
     training_seconds: float
     checkpoint_path: Path | None
+    update_alignment_statistics: ConflictFreeUpdateStatistics | None
     stopped_by_signal: bool = False
     stopped_by_host_control: bool = False
 
@@ -566,6 +573,7 @@ def fit_operator(
     rollout_policy: OperatorRolloutPolicy | None = None,
     include_model_losses: bool = True,
     gradient_composition: ConflictFreeGradientPolicy | None = None,
+    update_alignment: ConflictFreeUpdatePolicy | None = None,
     optimizer: optax.GradientTransformation
     | optax.GradientTransformationExtraArgs
     | None = None,
@@ -618,6 +626,11 @@ def fit_operator(
     Rollout loss terms share one task-bound ``rollout_route`` and one static-
     maximum ``rollout_policy``; future targets remain aliases rather than model
     outputs.
+
+    Experimental ``update_alignment`` projects the exact emitted optimizer
+    proposal against every supported explicit loss term before parameter
+    application. It requires one microstep, excludes attached model losses and
+    loss scaling, and checkpoints cumulative mismatch evidence.
     """
     if not isinstance(model, AbstractOperatorModel):
         raise TypeError("fit_operator requires a PhydraX operator model.")
@@ -710,6 +723,23 @@ def fit_operator(
         if loss_scale_policy is not None:
             raise ValueError(
                 "Operator gradient composition does not yet support dynamic loss scaling."
+            )
+    if update_alignment is not None:
+        if not isinstance(update_alignment, ConflictFreeUpdatePolicy):
+            raise TypeError(
+                "update_alignment must be a ConflictFreeUpdatePolicy or None."
+            )
+        if int(gradient_accumulation) != 1:
+            raise ValueError(
+                "Operator update alignment does not support gradient accumulation."
+            )
+        if include_model_losses:
+            raise ValueError(
+                "Operator update alignment does not yet support attached model losses."
+            )
+        if loss_scale_policy is not None:
+            raise ValueError(
+                "Operator update alignment does not yet support dynamic loss scaling."
             )
     if (
         any(isinstance(term, TargetOperatorConsistencyLoss) for term in specified_terms)
@@ -1056,6 +1086,11 @@ def fit_operator(
     )
     evaluation_model = reconstruct_fit_model(evaluated_parameters, fixed)
     reduction_dtype = jnp.dtype(resolved_dtype.reduction_dtype)
+    update_alignment_statistics = (
+        None
+        if update_alignment is None
+        else ConflictFreeUpdateStatistics.zeros(reduction_dtype)
+    )
     gradient_accumulator = _GradientAccumulationState.empty(
         parameters,
         accumulation_dtype=reduction_dtype,
@@ -1352,7 +1387,7 @@ def fit_operator(
             )
             return scaled, (total_arrays, component_arrays)
 
-        if gradient_composition is None:
+        if gradient_composition is None and update_alignment is None:
             (_, (total_arrays, component_arrays)), gradient = eqx.filter_value_and_grad(
                 objective,
                 has_aux=True,
@@ -1362,6 +1397,8 @@ def fit_operator(
                     gradient,
                     loss_scale_state_,
                 )
+            component_gradients = ()
+            active = jnp.zeros((0,), dtype=bool)
             composition_finite = jnp.asarray(True)
         else:
 
@@ -1396,49 +1433,164 @@ def fit_operator(
                 active_ = jnp.stack(
                     tuple(component.support > 0.0 for component in components)
                 )
-                return values, (total_arrays_, component_arrays_, active_)
+                return (total.numerator, values), (
+                    total_arrays_,
+                    component_arrays_,
+                    active_,
+                )
 
-            component_values, pullback, auxiliary = eqx.filter_vjp(
+            (
+                (total_numerator, component_values),
+                pullback,
+                auxiliary,
+            ) = eqx.filter_vjp(
                 component_objective,
                 current_parameters,
                 has_aux=True,
             )
             total_arrays, component_arrays, active = auxiliary
-            gradients = tuple(
-                pullback(jnp.zeros_like(component_values).at[index].set(1.0))[0]
+            component_gradients = tuple(
+                pullback(
+                    (
+                        jnp.zeros_like(total_numerator),
+                        jnp.zeros_like(component_values).at[index].set(1.0),
+                    )
+                )[0]
                 for index in range(int(component_values.shape[0]))
             )
-            composition = conflict_free_gradient(
-                gradients,
-                active=active,
-                policy=gradient_composition,
-            )
-            gradient = jax.tree.map(
-                lambda leaf: eqx.error_if(
-                    leaf,
-                    ~composition.successful,
-                    "Operator objectives do not admit a conflict-free direction.",
-                ),
-                composition.direction,
-            )
-            composition_finite = composition.successful
-        finite = tree_all_finite((gradient, total_arrays, component_arrays))
+            if gradient_composition is None:
+                gradient = pullback(
+                    (
+                        jnp.ones_like(total_numerator),
+                        jnp.zeros_like(component_values),
+                    )
+                )[0]
+                composition_finite = jnp.asarray(True)
+            else:
+                composition = conflict_free_gradient(
+                    component_gradients,
+                    active=active,
+                    policy=gradient_composition,
+                )
+                gradient = jax.tree.map(
+                    lambda leaf: eqx.error_if(
+                        leaf,
+                        ~composition.successful,
+                        "Operator objectives do not admit a conflict-free direction.",
+                    ),
+                    composition.direction,
+                )
+                composition_finite = composition.successful
+        finite = tree_all_finite(
+            (gradient, total_arrays, component_arrays, component_gradients)
+        )
         finite = finite & composition_finite
         if sharding_policy is not None:
             finite = eqx.filter_shard(finite, sharding_policy.replicated)
-        return total_arrays, component_arrays, gradient, finite
+        return (
+            total_arrays,
+            component_arrays,
+            gradient,
+            component_gradients,
+            active,
+            finite,
+        )
 
-    def update_fn(current_parameters, current_state, gradient):
+    def constructed_direction_conflict(gradients, direction, alignment):
+        direction_norm = tree_norm(direction)
+        effective = alignment.active & ~alignment.stationary
+        safe_norms = jnp.where(
+            effective,
+            alignment.gradient_norms,
+            jnp.ones_like(alignment.gradient_norms),
+        )
+        safe_direction_norm = jnp.where(direction_norm > 0.0, direction_norm, 1.0)
+        cosines = jnp.stack(
+            tuple(
+                tree_inner(gradient, direction)
+                / (safe_norms[index] * safe_direction_norm)
+                for index, gradient in enumerate(gradients)
+            )
+        )
+        count = len(gradients)
+        tolerance = jnp.maximum(
+            jnp.asarray(
+                update_alignment.feasibility_tolerance,
+                dtype=cosines.dtype,
+            ),
+            jnp.asarray(float(8 * count), dtype=cosines.dtype)
+            * jnp.finfo(cosines.dtype).eps,
+        )
+        constructed = jnp.any(effective & (cosines < -tolerance))
+        pairs = (
+            effective[:, None]
+            & effective[None, :]
+            & jnp.tril(
+                jnp.ones_like(alignment.gradient_cosine_matrix, dtype=bool),
+                -1,
+            )
+        )
+        gradient_conflict = jnp.any(
+            pairs & (alignment.gradient_cosine_matrix < -tolerance)
+        )
+        return gradient_conflict, constructed
+
+    def update_fn(
+        current_parameters,
+        current_state,
+        gradient,
+        component_gradients,
+        active,
+    ):
         updates, next_state = optimizer.update(
             gradient,
             current_state,
             current_parameters,
         )
+        alignment_result = None
+        gradient_conflict = None
+        constructed_conflict = None
+        if update_alignment is not None:
+            proposal = tree_negative(updates)
+            alignment_result = project_conflict_free_direction(
+                proposal,
+                component_gradients,
+                active=active,
+                policy=update_alignment,
+            )
+            aligned_updates = tree_negative(alignment_result.direction)
+            updates = tree_where(
+                alignment_result.projected,
+                aligned_updates,
+                updates,
+            )
+            updates = jax.tree.map(
+                lambda leaf: eqx.error_if(
+                    leaf,
+                    ~alignment_result.successful,
+                    "Operator optimizer proposal could not be aligned.",
+                ),
+                updates,
+            )
+            gradient_conflict, constructed_conflict = constructed_direction_conflict(
+                component_gradients,
+                gradient,
+                alignment_result,
+            )
         next_parameters = eqx.apply_updates(current_parameters, updates)
         finite = tree_all_finite((next_parameters, next_state))
+        if alignment_result is not None:
+            finite = finite & alignment_result.successful
         if sharding_policy is not None:
             finite = eqx.filter_shard(finite, sharding_policy.replicated)
-        return next_parameters, next_state, finite
+        return (
+            next_parameters,
+            next_state,
+            finite,
+            alignment_result,
+            gradient_conflict,
+            constructed_conflict,
+        )
 
     run_gradient_fn = eqx.filter_jit(gradient_fn) if jit else gradient_fn
     run_update_fn = eqx.filter_jit(update_fn) if jit else update_fn
@@ -1653,6 +1805,8 @@ def fit_operator(
         ),
         "configuration": {} if configuration is None else dict(configuration),
     }
+    if update_alignment is not None:
+        fit_contract_data["update_alignment"] = update_alignment.policy_id
     if resolved_evaluation_parameters_id is not None:
         fit_contract_data["evaluation_parameters_id"] = resolved_evaluation_parameters_id
     fit_contract = _canonical_json(fit_contract_data)
@@ -1663,7 +1817,18 @@ def fit_operator(
     initial_metrics: dict[str, float]
     if resume_manifest is not None:
         assert checkpoint is not None
-        state_template = (optimizer_state, loss_scale_state, target_state)
+        if resume_manifest["metadata"].get("fit_contract") != fit_contract:
+            raise ValueError("Operator fit checkpoint contract mismatch.")
+        state_template = (
+            (optimizer_state, loss_scale_state, target_state)
+            if update_alignment is None
+            else (
+                optimizer_state,
+                loss_scale_state,
+                target_state,
+                update_alignment_statistics,
+            )
+        )
         restored = load_operator_training_checkpoint(
             checkpoint,
             (model, best_model),
@@ -1673,7 +1838,22 @@ def fit_operator(
         if restored.metadata["fit_contract"] != fit_contract:
             raise ValueError("Operator fit checkpoint contract mismatch.")
         model, best_model = restored.model
-        optimizer_state, loss_scale_state, target_state = restored.optimizer_state
+        if update_alignment is None:
+            optimizer_state, loss_scale_state, target_state = restored.optimizer_state
+        else:
+            (
+                optimizer_state,
+                loss_scale_state,
+                target_state,
+                update_alignment_statistics,
+            ) = restored.optimizer_state
+            if not isinstance(
+                update_alignment_statistics,
+                ConflictFreeUpdateStatistics,
+            ):
+                raise ValueError(
+                    "Operator checkpoint update-alignment statistics are invalid."
+                )
         metadata = restored.metadata
         if metadata.get("update_boundary") is not True:
             raise ValueError(
@@ -1748,10 +1928,20 @@ def fit_operator(
                 TrainingIterationKind.CHECKPOINT,
                 metrics={"step": control.progress.update_step},
             )
+        checkpoint_state = (
+            (optimizer_state, loss_scale_state, target_state)
+            if update_alignment is None
+            else (
+                optimizer_state,
+                loss_scale_state,
+                target_state,
+                update_alignment_statistics,
+            )
+        )
         save_operator_training_checkpoint(
             checkpoint,
             (model, best_model),
-            (optimizer_state, loss_scale_state, target_state),
+            checkpoint_state,
             step=control.progress.update_step,
             key=master_key,
             normalization=resolved_normalization,
@@ -1852,7 +2042,14 @@ def fit_operator(
                     if control.stop_requested or signal_guard.stop_requested:
                         break
                     key = control.key_for(control.progress.microstep, site=0)
-                    total, components, gradient, finite_array = run_gradient_fn(
+                    (
+                        total,
+                        components,
+                        gradient,
+                        component_gradients,
+                        component_active,
+                        finite_array,
+                    ) = run_gradient_fn(
                         parameters,
                         (target_state.target if target_state is not None else parameters),
                         training_batch.batch,
@@ -1950,10 +2147,15 @@ def fit_operator(
                         candidate_parameters,
                         candidate_optimizer_state,
                         candidate_finite_array,
+                        update_alignment_result,
+                        gradient_conflict,
+                        constructed_conflict,
                     ) = run_update_fn(
                         parameters,
                         optimizer_state,
                         averaged_gradient,
+                        component_gradients,
+                        component_active,
                     )
                     if not bool(jax.device_get(candidate_finite_array)):
                         raise FloatingPointError(
@@ -1983,6 +2185,81 @@ def fit_operator(
                             strict=True,
                         )
                     }
+                    if update_alignment_result is not None:
+                        if update_alignment_statistics is None:
+                            raise RuntimeError(
+                                "Operator update-alignment statistics are missing."
+                            )
+                        update_alignment_statistics = update_alignment_statistics.update(
+                            update_alignment_result,
+                            gradient_conflict=gradient_conflict,
+                            constructed_conflict=constructed_conflict,
+                        )
+                        metrics.update(
+                            {
+                                "update_alignment/raw_conflict": float(
+                                    jax.device_get(
+                                        jnp.any(update_alignment_result.raw_conflicts)
+                                    )
+                                ),
+                                "update_alignment/applied_conflict": float(
+                                    jax.device_get(
+                                        jnp.any(update_alignment_result.aligned_conflicts)
+                                    )
+                                ),
+                                "update_alignment/projected": float(
+                                    jax.device_get(update_alignment_result.projected)
+                                ),
+                                "update_alignment/relative_correction": float(
+                                    jax.device_get(
+                                        update_alignment_result.relative_correction
+                                    )
+                                ),
+                                "update_alignment/metric_correction_norm": float(
+                                    jax.device_get(
+                                        update_alignment_result.metric_correction_norm
+                                    )
+                                ),
+                                "update_alignment/active_constraints": float(
+                                    jax.device_get(
+                                        update_alignment_result.active_constraint_count
+                                    )
+                                ),
+                                "update_alignment/pareto_stationary": float(
+                                    jax.device_get(
+                                        update_alignment_result.pareto_stationary
+                                    )
+                                ),
+                                "update_alignment/kkt_residual": float(
+                                    jax.device_get(
+                                        update_alignment_result.kkt_residual_norm
+                                    )
+                                ),
+                                "update_alignment/status": float(
+                                    jax.device_get(update_alignment_result.status)
+                                ),
+                                "update_alignment/gradient_conflict_rate": float(
+                                    jax.device_get(
+                                        update_alignment_statistics.gradient_conflict_rate
+                                    )
+                                ),
+                                "update_alignment/constructed_conflict_rate": float(
+                                    jax.device_get(
+                                        update_alignment_statistics.constructed_conflict_rate
+                                    )
+                                ),
+                                "update_alignment/proposal_conflict_rate": float(
+                                    jax.device_get(
+                                        update_alignment_statistics.proposal_conflict_rate
+                                    )
+                                ),
+                                "update_alignment/applied_conflict_rate": float(
+                                    jax.device_get(
+                                        update_alignment_statistics.applied_conflict_rate
+                                    )
+                                ),
+                            }
+                        )
                     train_steps.append(update_step)
                     train_history.append(metrics)
                     gradient_accumulator = _GradientAccumulationState.empty(
@@ -2137,6 +2414,7 @@ def fit_operator(
         resumed_from_step=resumed_from_step,
         training_seconds=training_seconds,
         checkpoint_path=checkpoint,
+        update_alignment_statistics=update_alignment_statistics,
         stopped_by_signal=stopped_by_signal,
         stopped_by_host_control=control.stop_requested
         and not control.progress.stopped_early,

--- a/phydrax/optim/__init__.py
+++ b/phydrax/optim/__init__.py
@@ -459,6 +459,14 @@ from ._unconstrained import (
     NonlinearConjugateGradient,
     NonlinearConjugateGradientState,
 )
+from ._update_alignment import (
+    ConflictFreeUpdateFailureMode,
+    ConflictFreeUpdatePolicy,
+    ConflictFreeUpdateResult,
+    ConflictFreeUpdateStatistics,
+    ConflictFreeUpdateStatus,
+    project_conflict_free_direction,
+)
 from ._variable_projection import (
     variable_projection,
     VariableProjectionProblem,
@@ -590,6 +598,12 @@ __all__ = [
     "ConflictFreeGradientPolicy",
     "ConflictFreeGradientResult",
     "ConflictFreeGradientStatus",
+    "project_conflict_free_direction",
+    "ConflictFreeUpdateFailureMode",
+    "ConflictFreeUpdatePolicy",
+    "ConflictFreeUpdateResult",
+    "ConflictFreeUpdateStatistics",
+    "ConflictFreeUpdateStatus",
     "DifferentialEvolutionSelection",
     "DifferentialEvolutionSpace",
     "DifferentialEvolutionStatus",

--- a/phydrax/optim/_update_alignment.py
+++ b/phydrax/optim/_update_alignment.py
@@ -1,0 +1,703 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from enum import IntEnum
+from itertools import combinations
+from typing import Any, Literal
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jaxtyping import Array, PyTree
+
+from .._bounds import Bounds
+from .._fingerprint import canonical_fingerprint
+from .._strict import StrictModule
+from .._trainable import NonTrainableState
+from .._tree_math import (
+    tree_allfinite,
+    tree_inner,
+    tree_norm,
+    tree_scale,
+    tree_where,
+    validate_inexact_tree,
+)
+from ..ein import contract
+from ..linalg import FailurePolicy, SmallLinearSolvePlan, solve_small_linear
+from ._programming import (
+    ConvexSolvePolicy,
+    ConvexTermination,
+    QuadraticProgram,
+    solve_quadratic_program,
+)
+
+
+ConflictFreeUpdateFailureMode = Literal["status", "error"]
+
+
+class ConflictFreeUpdateStatus(IntEnum):
+    """Terminal state of one optimizer-direction alignment."""
+
+    PROJECTED = 0
+    ALREADY_FEASIBLE = 1
+    ZERO_PROPOSAL = 2
+    NO_EFFECTIVE_OBJECTIVES = 3
+    NONFINITE = 4
+    INVALID_METRIC = 5
+    DUAL_SOLVE_FAILED = 6
+    POSTCHECK_FAILED = 7
+
+
+class ConflictFreeUpdatePolicy(StrictModule, NonTrainableState):
+    """Experimental contract for conflict-free optimizer-direction projection."""
+
+    dual_solve_policy: ConvexSolvePolicy
+    minimum_norm: float = eqx.field(static=True)
+    feasibility_tolerance: float = eqx.field(static=True)
+    maximum_condition: float = eqx.field(static=True)
+    failure: ConflictFreeUpdateFailureMode = eqx.field(static=True)
+    policy_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        dual_solve_policy: ConvexSolvePolicy | None = None,
+        minimum_norm: float = 1e-12,
+        feasibility_tolerance: float = 1e-10,
+        maximum_condition: float = 1e12,
+        failure: ConflictFreeUpdateFailureMode = "status",
+    ):
+        norm = float(minimum_norm)
+        tolerance = float(feasibility_tolerance)
+        condition = float(maximum_condition)
+        if not np.isfinite(norm) or norm <= 0.0:
+            raise ValueError("minimum_norm must be finite and strictly positive.")
+        if not np.isfinite(tolerance) or tolerance < 0.0:
+            raise ValueError("feasibility_tolerance must be finite and nonnegative.")
+        if not np.isfinite(condition) or condition <= 1.0:
+            raise ValueError("maximum_condition must be finite and greater than one.")
+        if failure not in ("status", "error"):
+            raise ValueError("failure must be 'status' or 'error'.")
+        if dual_solve_policy is None:
+            solver_tolerance = max(tolerance, 1e-10)
+            dual = ConvexSolvePolicy(
+                termination=ConvexTermination(
+                    absolute=solver_tolerance,
+                    relative=0.0,
+                    primal_infeasible=solver_tolerance,
+                    dual_infeasible=solver_tolerance,
+                    maximum_steps=100,
+                ),
+                regularization=0.0,
+                failure=FailurePolicy("status"),
+            )
+        else:
+            dual = dual_solve_policy
+        if not isinstance(dual, ConvexSolvePolicy):
+            raise TypeError("dual_solve_policy must be a ConvexSolvePolicy or None.")
+        if dual.failure.mode != "status":
+            raise ValueError("dual_solve_policy must use status failure handling.")
+        if dual.regularization != 0.0:
+            raise ValueError(
+                "dual_solve_policy must not regularize the exact projection."
+            )
+        self.dual_solve_policy = dual
+        self.minimum_norm = norm
+        self.feasibility_tolerance = tolerance
+        self.maximum_condition = condition
+        self.failure = failure
+        self.policy_id = canonical_fingerprint(
+            {
+                "kind": "conflict-free-update-policy",
+                "dual_solve_policy_id": dual.policy_id,
+                "minimum_norm": norm,
+                "feasibility_tolerance": tolerance,
+                "maximum_condition": condition,
+                "failure": failure,
+            }
+        )
+
+
+class ConflictFreeUpdateResult(StrictModule):
+    """Aligned descent direction and complete local projection evidence."""
+
+    direction: PyTree[Array]
+    gradient_norms: Array
+    gradient_cosine_matrix: Array
+    raw_projections: Array
+    aligned_projections: Array
+    raw_cosines: Array
+    aligned_cosines: Array
+    active: Array
+    stationary: Array
+    raw_conflicts: Array
+    aligned_conflicts: Array
+    multipliers: Array
+    proposal_norm: Array
+    direction_norm: Array
+    correction_norm: Array
+    relative_correction: Array
+    metric_correction_norm: Array
+    active_constraint_count: Array
+    dual_feasibility_violation: Array
+    complementarity_residual: Array
+    kkt_residual_norm: Array
+    projected: Array
+    pareto_stationary: Array
+    successful: Array
+    status: Array
+    solver_method: str = eqx.field(static=True)
+    metric_kind: str = eqx.field(static=True)
+    policy_id: str = eqx.field(static=True)
+
+
+class ConflictFreeUpdateStatistics(StrictModule):
+    """Checkpointable aggregate gradient-update mismatch evidence."""
+
+    steps: Array
+    gradient_conflict_steps: Array
+    constructed_conflict_steps: Array
+    proposal_conflict_steps: Array
+    applied_conflict_steps: Array
+    projected_steps: Array
+    zero_proposal_steps: Array
+    pareto_stationary_steps: Array
+    correction_norm_sum: Array
+    relative_correction_sum: Array
+    metric_correction_norm_sum: Array
+    maximum_kkt_residual: Array
+
+    @classmethod
+    def zeros(cls, dtype: Any = jnp.float32) -> ConflictFreeUpdateStatistics:
+        dtype_ = jnp.dtype(dtype)
+        zero_count = jnp.asarray(0, dtype=jnp.int32)
+        zero_value = jnp.asarray(0.0, dtype=dtype_)
+        return cls(
+            zero_count,
+            zero_count,
+            zero_count,
+            zero_count,
+            zero_count,
+            zero_count,
+            zero_count,
+            zero_count,
+            zero_value,
+            zero_value,
+            zero_value,
+            zero_value,
+        )
+
+    def update(
+        self,
+        result: ConflictFreeUpdateResult,
+        /,
+        *,
+        gradient_conflict: Any,
+        constructed_conflict: Any,
+    ) -> ConflictFreeUpdateStatistics:
+        if not isinstance(result, ConflictFreeUpdateResult):
+            raise TypeError("result must be a ConflictFreeUpdateResult.")
+        integer = jnp.asarray(1, dtype=self.steps.dtype)
+        gradient = jnp.asarray(gradient_conflict, dtype=bool)
+        constructed = jnp.asarray(constructed_conflict, dtype=bool)
+        return ConflictFreeUpdateStatistics(
+            self.steps + integer,
+            self.gradient_conflict_steps + gradient.astype(self.steps.dtype),
+            self.constructed_conflict_steps + constructed.astype(self.steps.dtype),
+            self.proposal_conflict_steps
+            + jnp.any(result.raw_conflicts).astype(self.steps.dtype),
+            self.applied_conflict_steps
+            + jnp.any(result.aligned_conflicts).astype(self.steps.dtype),
+            self.projected_steps + result.projected.astype(self.steps.dtype),
+            self.zero_proposal_steps
+            + (result.status == int(ConflictFreeUpdateStatus.ZERO_PROPOSAL)).astype(
+                self.steps.dtype
+            ),
+            self.pareto_stationary_steps
+            + result.pareto_stationary.astype(self.steps.dtype),
+            self.correction_norm_sum + result.correction_norm,
+            self.relative_correction_sum + result.relative_correction,
+            self.metric_correction_norm_sum + result.metric_correction_norm,
+            jnp.maximum(self.maximum_kkt_residual, result.kkt_residual_norm),
+        )
+
+    def _rate(self, count: Array, /) -> Array:
+        denominator = jnp.maximum(self.steps, 1).astype(self.correction_norm_sum.dtype)
+        return count.astype(self.correction_norm_sum.dtype) / denominator
+
+    @property
+    def gradient_conflict_rate(self) -> Array:
+        return self._rate(self.gradient_conflict_steps)
+
+    @property
+    def constructed_conflict_rate(self) -> Array:
+        return self._rate(self.constructed_conflict_steps)
+
+    @property
+    def proposal_conflict_rate(self) -> Array:
+        return self._rate(self.proposal_conflict_steps)
+
+    @property
+    def applied_conflict_rate(self) -> Array:
+        return self._rate(self.applied_conflict_steps)
+
+    @property
+    def projection_rate(self) -> Array:
+        return self._rate(self.projected_steps)
+
+    @property
+    def mean_correction_norm(self) -> Array:
+        denominator = jnp.maximum(self.steps, 1).astype(self.correction_norm_sum.dtype)
+        return self.correction_norm_sum / denominator
+
+    @property
+    def mean_relative_correction(self) -> Array:
+        denominator = jnp.maximum(self.steps, 1).astype(self.correction_norm_sum.dtype)
+        return self.relative_correction_sum / denominator
+
+    @property
+    def mean_metric_correction_norm(self) -> Array:
+        denominator = jnp.maximum(self.steps, 1).astype(self.correction_norm_sum.dtype)
+        return self.metric_correction_norm_sum / denominator
+
+
+def _validate_congruent(
+    reference: PyTree[Array],
+    values: Sequence[PyTree[Array]],
+    /,
+    *,
+    name: str,
+) -> None:
+    structure = jax.tree.structure(reference)
+    shapes = tuple(leaf.shape for leaf in jax.tree.leaves(reference))
+    if any(jax.tree.structure(value) != structure for value in values):
+        raise ValueError(f"{name} must have congruent PyTree structures.")
+    if any(
+        tuple(leaf.shape for leaf in jax.tree.leaves(value)) != shapes for value in values
+    ):
+        raise ValueError(f"{name} leaves must have congruent shapes.")
+
+
+def _tree_add(left: PyTree[Array], right: PyTree[Array], /) -> PyTree[Array]:
+    return jax.tree.map(lambda x, y: x + y, left, right)
+
+
+def _tree_subtract(left: PyTree[Array], right: PyTree[Array], /) -> PyTree[Array]:
+    return jax.tree.map(lambda x, y: x - y, left, right)
+
+
+def _tree_zeros_like(vector: PyTree[Array], /) -> PyTree[Array]:
+    return jax.tree.map(jnp.zeros_like, vector)
+
+
+def _metric_inverse_apply(
+    vector: PyTree[Array],
+    metric_diagonal: PyTree[Array] | None,
+    /,
+) -> PyTree[Array]:
+    if metric_diagonal is None:
+        return vector
+    return jax.tree.map(lambda value, diagonal: value / diagonal, vector, metric_diagonal)
+
+
+def _metric_norm(
+    vector: PyTree[Array],
+    metric_diagonal: PyTree[Array] | None,
+    /,
+) -> Array:
+    if metric_diagonal is None:
+        return tree_norm(vector)
+    squared = jax.tree.leaves(
+        jax.tree.map(
+            lambda value, diagonal: jnp.real(jnp.vdot(value, diagonal * value)),
+            vector,
+            metric_diagonal,
+        )
+    )
+    total = squared[0]
+    for value in squared[1:]:
+        total = total + value
+    return jnp.sqrt(jnp.maximum(total, 0.0))
+
+
+def _small_active_set_dual(
+    matrix: Array,
+    linear: Array,
+    /,
+    *,
+    tolerance: Array,
+    policy: ConflictFreeUpdatePolicy,
+) -> tuple[Array, Array]:
+    count = int(linear.shape[0])
+    zero = jnp.zeros_like(linear)
+    empty_feasible = jnp.all(linear >= -tolerance)
+    best = zero
+    best_objective = jnp.where(empty_feasible, jnp.asarray(0.0, linear.dtype), jnp.inf)
+    best_valid = empty_feasible
+    for size in range(1, count + 1):
+        plan = SmallLinearSolvePlan(
+            size,
+            singular_tolerance=max(policy.feasibility_tolerance, 1e-12),
+            maximum_condition=policy.maximum_condition,
+        )
+        for subset in combinations(range(count), size):
+            indices = jnp.asarray(subset, dtype=jnp.int32)
+            submatrix = matrix[indices[:, None], indices[None, :]]
+            sublinear = linear[indices]
+            solve = solve_small_linear(plan, submatrix, -sublinear)
+            candidate = zero.at[indices].set(jnp.maximum(solve.value, 0.0))
+            gradient = linear + contract("ij,j->i", matrix, candidate)
+            feasible = (
+                solve.successful
+                & jnp.all(solve.value >= -tolerance)
+                & jnp.all(gradient >= -tolerance)
+                & jnp.all(jnp.isfinite(candidate))
+            )
+            objective = 0.5 * contract(
+                "i,ij,j->", candidate, matrix, candidate
+            ) + contract("i,i->", linear, candidate)
+            select = feasible & (~best_valid | (objective < best_objective))
+            best = jnp.where(select, candidate, best)
+            best_objective = jnp.where(select, objective, best_objective)
+            best_valid = best_valid | feasible
+    return best, best_valid
+
+
+def _dual_solution(
+    matrix: Array,
+    linear: Array,
+    /,
+    *,
+    tolerance: Array,
+    policy: ConflictFreeUpdatePolicy,
+) -> tuple[Array, Array, str]:
+    count = int(linear.shape[0])
+    if count <= 3:
+        value, successful = _small_active_set_dual(
+            matrix,
+            linear,
+            tolerance=tolerance,
+            policy=policy,
+        )
+        return value, successful, "exact-active-set"
+    problem = QuadraticProgram(
+        matrix,
+        linear,
+        bounds=Bounds(0.0, jnp.inf),
+        problem_id="conflict-free-update-dual",
+        convexity_evidence="gradient-gram",
+    )
+    solved = solve_quadratic_program(problem, policy=policy.dual_solve_policy)
+    return solved.primal, solved.successful, solved.method
+
+
+def project_conflict_free_direction(
+    proposal: PyTree[Any],
+    objective_gradients: Sequence[PyTree[Any]],
+    /,
+    *,
+    active: Any | None = None,
+    metric_diagonal: PyTree[Any] | None = None,
+    policy: ConflictFreeUpdatePolicy | None = None,
+) -> ConflictFreeUpdateResult:
+    """Project a positive descent proposal onto every active objective halfspace."""
+
+    proposal_ = validate_inexact_tree(proposal, name="proposal")
+    gradients = tuple(
+        validate_inexact_tree(value, name=f"objective gradient {index}")
+        for index, value in enumerate(objective_gradients)
+    )
+    if not gradients:
+        raise ValueError("At least one objective gradient is required.")
+    _validate_congruent(
+        proposal_,
+        gradients,
+        name="Proposal and objective gradients",
+    )
+    resolved = ConflictFreeUpdatePolicy() if policy is None else policy
+    if not isinstance(resolved, ConflictFreeUpdatePolicy):
+        raise TypeError("policy must be a ConflictFreeUpdatePolicy.")
+    count = len(gradients)
+    active_mask = (
+        jnp.ones((count,), dtype=bool)
+        if active is None
+        else jnp.asarray(active, dtype=bool)
+    )
+    if active_mask.shape != (count,):
+        raise ValueError("active must contain one Boolean per objective gradient.")
+
+    metric: PyTree[Array] | None
+    if metric_diagonal is None:
+        metric = None
+        metric_valid = jnp.asarray(True)
+        metric_kind = "euclidean"
+    else:
+        metric = validate_inexact_tree(
+            metric_diagonal,
+            name="metric diagonal",
+            real=True,
+        )
+        _validate_congruent(proposal_, (metric,), name="Proposal and metric diagonal")
+        metric_checks = tuple(
+            jnp.all(jnp.isfinite(leaf) & (leaf > 0.0)) for leaf in jax.tree.leaves(metric)
+        )
+        metric_valid = metric_checks[0]
+        for check in metric_checks[1:]:
+            metric_valid = metric_valid & check
+        metric = jax.tree.map(
+            lambda leaf: jnp.where(jnp.isfinite(leaf) & (leaf > 0.0), leaf, 1.0),
+            metric,
+        )
+        metric_kind = "diagonal"
+
+    norms = jnp.stack(tuple(tree_norm(value) for value in gradients))
+    gradient_finite = jnp.stack(tuple(tree_allfinite(value) for value in gradients))
+    proposal_finite = tree_allfinite(proposal_)
+    active_input_finite = jnp.all(~active_mask | gradient_finite)
+    data_finite = proposal_finite & active_input_finite
+    stationary = active_mask & gradient_finite & (norms <= resolved.minimum_norm)
+    effective = active_mask & gradient_finite & ~stationary
+    effective_count = jnp.sum(effective.astype(jnp.int32))
+    safe_norms = jnp.where(effective, norms, jnp.ones_like(norms))
+    normalized = tuple(
+        jax.tree.map(
+            lambda leaf, index=index: jnp.where(
+                effective[index],
+                leaf / safe_norms[index],
+                jnp.zeros_like(leaf),
+            ),
+            value,
+        )
+        for index, value in enumerate(gradients)
+    )
+
+    proposal_norm = tree_norm(proposal_)
+    usable_proposal = proposal_finite & (proposal_norm > resolved.minimum_norm)
+    unit_proposal = tree_scale(
+        jnp.where(usable_proposal, 1.0 / proposal_norm, 0.0),
+        proposal_,
+    )
+    raw_cosines = jnp.stack(
+        tuple(tree_inner(value, unit_proposal) for value in normalized)
+    )
+    effective_tolerance = jnp.maximum(
+        jnp.asarray(resolved.feasibility_tolerance, dtype=raw_cosines.dtype),
+        jnp.asarray(float(8 * count), dtype=raw_cosines.dtype)
+        * jnp.finfo(raw_cosines.dtype).eps,
+    )
+    raw_conflicts = effective & (raw_cosines < -effective_tolerance)
+    needs_projection = (
+        data_finite
+        & metric_valid
+        & (effective_count > 0)
+        & usable_proposal
+        & jnp.any(raw_conflicts)
+    )
+
+    cosine_matrix = jnp.stack(
+        tuple(
+            jnp.stack(tuple(tree_inner(left, right) for right in normalized))
+            for left in normalized
+        )
+    )
+    inverse_normalized = tuple(
+        _metric_inverse_apply(value, metric) for value in normalized
+    )
+    gram = (
+        cosine_matrix
+        if metric is None
+        else jnp.stack(
+            tuple(
+                jnp.stack(tuple(tree_inner(left, right) for right in inverse_normalized))
+                for left in normalized
+            )
+        )
+    )
+    inactive = ~effective
+    gram = gram + jnp.diag(inactive.astype(gram.dtype))
+    dual_linear = jnp.where(effective, raw_cosines, 0.0)
+
+    def solve_dual(_: None) -> tuple[Array, Array]:
+        multipliers_, successful_, _ = _dual_solution(
+            gram,
+            dual_linear,
+            tolerance=effective_tolerance,
+            policy=resolved,
+        )
+        return multipliers_, successful_
+
+    def skip_dual(_: None) -> tuple[Array, Array]:
+        return jnp.zeros_like(dual_linear), jnp.asarray(True)
+
+    multipliers, solver_successful = jax.lax.cond(
+        needs_projection,
+        solve_dual,
+        skip_dual,
+        operand=None,
+    )
+    correction_unit = tree_scale(0.0, proposal_)
+    for multiplier, normal in zip(multipliers, inverse_normalized, strict=True):
+        correction_unit = _tree_add(
+            correction_unit,
+            tree_scale(multiplier, normal),
+        )
+    projected_unit = _tree_add(unit_proposal, correction_unit)
+    projected_direction = tree_scale(proposal_norm, projected_unit)
+    attempted_direction = tree_where(needs_projection, projected_direction, proposal_)
+    attempted_norm = tree_norm(attempted_direction)
+    attempted_finite = tree_allfinite(attempted_direction)
+    attempted_unit = tree_scale(
+        jnp.where(attempted_norm > resolved.minimum_norm, 1.0 / attempted_norm, 0.0),
+        attempted_direction,
+    )
+    attempted_cosines = jnp.stack(
+        tuple(tree_inner(value, attempted_unit) for value in normalized)
+    )
+    postcheck = attempted_finite & jnp.all(
+        ~effective | (attempted_cosines >= -effective_tolerance)
+    )
+
+    no_effective = data_finite & metric_valid & (effective_count == 0)
+    zero_proposal = data_finite & metric_valid & (effective_count > 0) & ~usable_proposal
+    already_feasible = (
+        data_finite
+        & metric_valid
+        & (effective_count > 0)
+        & usable_proposal
+        & ~jnp.any(raw_conflicts)
+    )
+    projected_successfully = needs_projection & solver_successful & postcheck
+    successful = no_effective | zero_proposal | already_feasible | projected_successfully
+    zero_direction = _tree_zeros_like(proposal_)
+    direction = tree_where(successful, attempted_direction, zero_direction)
+    if resolved.failure == "error":
+        direction = jax.tree.map(
+            lambda leaf: eqx.error_if(
+                leaf,
+                ~successful,
+                "Optimizer proposal could not be projected onto the objective cone.",
+            ),
+            direction,
+        )
+
+    direction_norm = tree_norm(direction)
+    direction_unit = tree_scale(
+        jnp.where(direction_norm > resolved.minimum_norm, 1.0 / direction_norm, 0.0),
+        direction,
+    )
+    aligned_cosines = jnp.stack(
+        tuple(tree_inner(value, direction_unit) for value in normalized)
+    )
+    raw_dimensional = jnp.stack(
+        tuple(tree_inner(value, proposal_) for value in gradients)
+    )
+    aligned_dimensional = jnp.stack(
+        tuple(tree_inner(value, direction) for value in gradients)
+    )
+    raw_projections = jnp.where(active_mask & gradient_finite, raw_dimensional, 0.0)
+    aligned_projections = jnp.where(
+        active_mask & gradient_finite,
+        aligned_dimensional,
+        0.0,
+    )
+    aligned_conflicts = effective & (aligned_cosines < -effective_tolerance)
+    correction = _tree_subtract(direction, proposal_)
+    correction_norm = tree_norm(correction)
+    relative_correction = correction_norm / jnp.maximum(
+        proposal_norm,
+        jnp.asarray(resolved.minimum_norm, dtype=proposal_norm.dtype),
+    )
+    metric_correction_norm = _metric_norm(correction, metric)
+
+    dual_gradient = dual_linear + contract("ij,j->i", gram, multipliers)
+    multiplier_violation = jnp.max(jnp.maximum(-multipliers, 0.0))
+    gradient_violation = jnp.max(jnp.maximum(-dual_gradient, 0.0))
+    dual_feasibility_violation = jnp.maximum(
+        multiplier_violation,
+        gradient_violation,
+    )
+    complementarity_residual = jnp.abs(contract("i,i->", multipliers, dual_gradient))
+    kkt_residual_norm = jnp.maximum(
+        dual_feasibility_violation,
+        complementarity_residual,
+    )
+    pareto_stationary = (
+        successful & (effective_count > 0) & (direction_norm <= resolved.minimum_norm)
+    )
+    status = jnp.where(
+        ~data_finite,
+        int(ConflictFreeUpdateStatus.NONFINITE),
+        jnp.where(
+            ~metric_valid,
+            int(ConflictFreeUpdateStatus.INVALID_METRIC),
+            jnp.where(
+                no_effective,
+                int(ConflictFreeUpdateStatus.NO_EFFECTIVE_OBJECTIVES),
+                jnp.where(
+                    zero_proposal,
+                    int(ConflictFreeUpdateStatus.ZERO_PROPOSAL),
+                    jnp.where(
+                        already_feasible,
+                        int(ConflictFreeUpdateStatus.ALREADY_FEASIBLE),
+                        jnp.where(
+                            ~solver_successful,
+                            int(ConflictFreeUpdateStatus.DUAL_SOLVE_FAILED),
+                            jnp.where(
+                                ~postcheck,
+                                int(ConflictFreeUpdateStatus.POSTCHECK_FAILED),
+                                int(ConflictFreeUpdateStatus.PROJECTED),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+    solver_method = (
+        "exact-active-set" if count <= 3 else resolved.dual_solve_policy.method.method_id
+    )
+    return ConflictFreeUpdateResult(
+        direction,
+        norms,
+        cosine_matrix,
+        raw_projections,
+        aligned_projections,
+        raw_cosines,
+        aligned_cosines,
+        active_mask,
+        stationary,
+        raw_conflicts,
+        aligned_conflicts,
+        multipliers,
+        proposal_norm,
+        direction_norm,
+        correction_norm,
+        relative_correction,
+        metric_correction_norm,
+        jnp.sum((multipliers > effective_tolerance).astype(jnp.int32)),
+        dual_feasibility_violation,
+        complementarity_residual,
+        kkt_residual_norm,
+        needs_projection & successful,
+        pareto_stationary,
+        successful,
+        status.astype(jnp.int32),
+        solver_method,
+        metric_kind,
+        resolved.policy_id,
+    )
+
+
+__all__ = [
+    "ConflictFreeUpdateFailureMode",
+    "ConflictFreeUpdatePolicy",
+    "ConflictFreeUpdateResult",
+    "ConflictFreeUpdateStatistics",
+    "ConflictFreeUpdateStatus",
+    "project_conflict_free_direction",
+]

--- a/phydrax/solver/_functional_backend.py
+++ b/phydrax/solver/_functional_backend.py
@@ -87,6 +87,10 @@ class _EvosaxBackend:
         config: FunctionalSolveConfig,
         /,
     ) -> "FunctionalSolver":
+        if config.training is not None and config.training.update_alignment is not None:
+            raise ValueError(
+                "Functional update alignment is unsupported by Evosax backends."
+            )
         if config.parameter_paths is not None:
             raise ValueError(
                 "Explicit parameter subspaces are unsupported by Evosax backends."
@@ -118,6 +122,10 @@ class _KFACBackend:
         config: FunctionalSolveConfig,
         /,
     ) -> "FunctionalSolver":
+        if config.training is not None and config.training.update_alignment is not None:
+            raise ValueError(
+                "Functional update alignment is unsupported by KFAC backends."
+            )
         if config.parameter_paths is not None:
             raise ValueError("Explicit parameter subspaces are unsupported by KFAC.")
         from ._kfac_solver import solve_kfac

--- a/phydrax/solver/_functional_checkpoint.py
+++ b/phydrax/solver/_functional_checkpoint.py
@@ -237,6 +237,7 @@ def load_functional_training_checkpoint(
         pseudo_inverse_steps=restored.pseudo_inverse_steps,
         term_multipliers=restored.term_multipliers,
         previous_gradient=restored.previous_gradient,
+        update_alignment_statistics=restored.update_alignment_statistics,
         progress=progress,
         run_id=str(manifest["run_id"]),
         gradient_accumulation=int(manifest["gradient_accumulation"]),

--- a/phydrax/solver/_functional_gradient.py
+++ b/phydrax/solver/_functional_gradient.py
@@ -37,6 +37,7 @@ from .._training_objective import (
     _ObjectiveAccumulator,
     _ObjectiveContribution,
 )
+from .._tree_math import tree_inner, tree_negative, tree_norm, tree_where
 from ..logging import is_enabled as _logging_enabled
 from ..nn.parameters import ParameterSubspace
 from ..nn.parameters._low_rank import validate_low_rank_subspace
@@ -56,6 +57,11 @@ from ..optim._riemannian import (
     AbstractRiemannianOptimizer,
 )
 from ..optim._scalar import ScalarIterativeState
+from ..optim._update_alignment import (
+    ConflictFreeUpdateResult,
+    ConflictFreeUpdateStatistics,
+    project_conflict_free_direction,
+)
 from ._functional_checkpoint import (
     load_functional_training_checkpoint,
     save_functional_training_checkpoint,
@@ -363,6 +369,30 @@ def solve_gradient(
                     "Functional gradient composition does not yet support attached "
                     "model losses."
                 )
+        update_alignment = None if training is None else training.update_alignment
+        if update_alignment is not None:
+            if _opt_standard is None:
+                raise ValueError(
+                    "Functional update alignment requires a standard Optax "
+                    "transformation."
+                )
+            if accumulation_steps != 1:
+                raise ValueError(
+                    "Functional update alignment does not support gradient accumulation."
+                )
+            if train_term_sample_size not in (None, len(self.terms)):
+                raise ValueError(
+                    "Functional update alignment requires every training term."
+                )
+            if not self.terms:
+                raise ValueError(
+                    "Functional update alignment requires at least one objective term."
+                )
+            if model_loss_names:
+                raise ValueError(
+                    "Functional update alignment does not yet support attached "
+                    "model losses."
+                )
         evaluation_term_names = tuple(_term_label(c) for c in self.evaluation_terms)
         term_sample_size = _train_term_sample_size(
             train_term_sample_size,
@@ -399,22 +429,6 @@ def solve_gradient(
                 values = evaluate_prepared_objective(prepared_, functions)
             return values.total, values.flat_values
 
-        def _composition_loss_wrt_params(params_, non_trainable_, prepared_):
-            if isinstance(prepared_, PreparedFunctionalUpdate):
-                surrogate_params, surrogate_non_trainable = surrogate_coordinates(
-                    params_,
-                    non_trainable_,
-                )
-                values = prepared_.surrogate_values(
-                    surrogate_params,
-                    surrogate_non_trainable,
-                )
-                return values.total, values.gradient_values
-            functions = reconstruct_functions(params_, non_trainable_)
-            with _precision_context():
-                values = evaluate_prepared_objective(prepared_, functions)
-            return values.total, values.gradient_values
-
         def _term_values_wrt_params(params_, non_trainable_, prepared_):
             functions = reconstruct_functions(params_, non_trainable_)
             with _precision_context():
@@ -431,36 +445,113 @@ def solve_gradient(
 
         loss_fn = eqx.filter_value_and_grad(_loss_wrt_params, has_aux=True)
 
-        def _composed_loss_and_grad(params_, non_trainable_, prepared_):
+        def _multiobjective_loss_wrt_params(
+            params_,
+            non_trainable_,
+            prepared_,
+        ):
+            if isinstance(prepared_, PreparedFunctionalUpdate):
+                surrogate_params, surrogate_non_trainable = surrogate_coordinates(
+                    params_,
+                    non_trainable_,
+                )
+                values = prepared_.surrogate_values(
+                    surrogate_params,
+                    surrogate_non_trainable,
+                )
+                return values.total, values.flat_values, values.gradient_values
+            functions = reconstruct_functions(params_, non_trainable_)
+            with _precision_context():
+                values = evaluate_prepared_objective(prepared_, functions)
+            return values.total, values.flat_values, values.gradient_values
+
+        def _multiobjective_loss_and_grad(params_, non_trainable_, prepared_):
             outputs, pullback = eqx.filter_vjp(
-                _composition_loss_wrt_params,
+                _multiobjective_loss_wrt_params,
                 params_,
                 non_trainable_,
                 prepared_,
             )
-            loss_value, component_values = outputs
+            loss_value, flat_values, component_values = outputs
             gradients = []
             for index in range(int(component_values.shape[0])):
                 component_cotangent = jnp.zeros_like(component_values).at[index].set(1)
                 gradient, _, _ = pullback(
-                    (jnp.zeros_like(loss_value), component_cotangent)
+                    (
+                        jnp.zeros_like(loss_value),
+                        jnp.zeros_like(flat_values),
+                        component_cotangent,
+                    )
                 )
                 gradients.append(gradient)
+            component_gradients = tuple(gradients)
             if gradient_composition is None:
-                raise RuntimeError("Gradient composition is not configured.")
-            composition = conflict_free_gradient(
-                tuple(gradients),
-                policy=gradient_composition,
+                gradient, _, _ = pullback(
+                    (
+                        jnp.ones_like(loss_value),
+                        jnp.zeros_like(flat_values),
+                        jnp.zeros_like(component_values),
+                    )
+                )
+            else:
+                composition = conflict_free_gradient(
+                    component_gradients,
+                    policy=gradient_composition,
+                )
+                gradient = jax.tree.map(
+                    lambda leaf: eqx.error_if(
+                        leaf,
+                        ~composition.successful,
+                        "Functional objectives do not admit a conflict-free direction.",
+                    ),
+                    composition.direction,
+                )
+            return (loss_value, flat_values), gradient, component_gradients
+
+        def _constructed_direction_conflict(
+            gradients,
+            direction,
+            alignment: ConflictFreeUpdateResult,
+        ):
+            direction_norm = tree_norm(direction)
+            effective = alignment.active & ~alignment.stationary
+            safe_norms = jnp.where(
+                effective,
+                alignment.gradient_norms,
+                jnp.ones_like(alignment.gradient_norms),
             )
-            gradient = jax.tree.map(
-                lambda leaf: eqx.error_if(
-                    leaf,
-                    ~composition.successful,
-                    "Functional objectives do not admit a conflict-free direction.",
+            safe_direction_norm = jnp.where(direction_norm > 0.0, direction_norm, 1.0)
+            cosines = jnp.stack(
+                tuple(
+                    tree_inner(gradient, direction)
+                    / (safe_norms[index] * safe_direction_norm)
+                    for index, gradient in enumerate(gradients)
+                )
+            )
+            count = len(gradients)
+            tolerance = jnp.maximum(
+                jnp.asarray(
+                    update_alignment.feasibility_tolerance,
+                    dtype=cosines.dtype,
                 ),
-                composition.direction,
+                jnp.asarray(float(8 * count), dtype=cosines.dtype)
+                * jnp.finfo(cosines.dtype).eps,
             )
-            return (loss_value, component_values), gradient
+            return jnp.any(effective & (cosines < -tolerance)), tolerance
+
+        def _gradient_conflict(
+            alignment: ConflictFreeUpdateResult,
+            tolerance,
+        ):
+            effective = alignment.active & ~alignment.stationary
+            pairs = (
+                effective[:, None]
+                & effective[None, :]
+                & jnp.tril(
+                    jnp.ones_like(alignment.gradient_cosine_matrix, dtype=bool), -1
+                )
+            )
+            return jnp.any(pairs & (alignment.gradient_cosine_matrix < -tolerance))
 
         is_composite = _opt_composite is not None
         is_least_squares = _opt_least_squares is not None
@@ -548,7 +639,7 @@ def solve_gradient(
                     non_trainable_,
                     prepared_,
                 )
-                return params_, opt_state, loss_val, terms
+                return params_, opt_state, loss_val, terms, None, None, None
 
             if is_least_squares:
                 physical_ = _physical_prepared(prepared_)
@@ -593,7 +684,7 @@ def solve_gradient(
                     non_trainable_,
                     prepared_,
                 )
-                return params_, opt_state, loss_val, terms
+                return params_, opt_state, loss_val, terms, None, None, None
 
             if is_iterative:
                 assert _opt_iterative is not None
@@ -616,7 +707,7 @@ def solve_gradient(
                     non_trainable_,
                     prepared_,
                 )
-                return params_, opt_state, loss_val, terms
+                return params_, opt_state, loss_val, terms, None, None, None
 
             if is_mirror:
                 (loss_val, terms), grads = loss_fn(
@@ -630,7 +721,7 @@ def solve_gradient(
                     opt_state,
                     params_,
                 )
-                return params_, opt_state, loss_val, terms
+                return params_, opt_state, loss_val, terms, None, None, None
 
             if is_riemannian:
                 (loss_val, terms), grads = loss_fn(
@@ -670,7 +761,7 @@ def solve_gradient(
                         opt_state,
                         params_,
                     )
-                return params_, opt_state, loss_val, terms
+                return params_, opt_state, loss_val, terms, None, None, None
 
             if is_linesearch:
                 import jax.tree_util as jtu
@@ -711,24 +802,70 @@ def solve_gradient(
                     non_trainable_,
                     prepared_,
                 )
-                return params_, opt_state, loss_val, term_values
+                return params_, opt_state, loss_val, term_values, None, None, None
 
-            if gradient_composition is None:
+            if gradient_composition is None and update_alignment is None:
                 (loss_val, term_values), grads = loss_fn(
                     params_,
                     non_trainable_,
                     prepared_,
                 )
+                component_gradients = ()
             else:
-                (loss_val, term_values), grads = _composed_loss_and_grad(
+                (
+                    (loss_val, term_values),
+                    grads,
+                    component_gradients,
+                ) = _multiobjective_loss_and_grad(
                     params_,
                     non_trainable_,
                     prepared_,
                 )
             assert _opt_standard is not None
             updates, opt_state = _opt_standard.update(grads, opt_state, params_)
+            alignment_result = None
+            gradient_conflict = None
+            constructed_conflict = None
+            if update_alignment is not None:
+                proposal = tree_negative(updates)
+                alignment_result = project_conflict_free_direction(
+                    proposal,
+                    component_gradients,
+                    policy=update_alignment,
+                )
+                aligned_updates = tree_negative(alignment_result.direction)
+                updates = tree_where(
+                    alignment_result.projected,
+                    aligned_updates,
+                    updates,
+                )
+                updates = jax.tree.map(
+                    lambda leaf: eqx.error_if(
+                        leaf,
+                        ~alignment_result.successful,
+                        "Functional optimizer proposal could not be aligned.",
+                    ),
+                    updates,
+                )
+                constructed_conflict, tolerance = _constructed_direction_conflict(
+                    component_gradients,
+                    grads,
+                    alignment_result,
+                )
+                gradient_conflict = _gradient_conflict(
+                    alignment_result,
+                    tolerance,
+                )
             params_ = eqx.apply_updates(params_, updates)
-            return params_, opt_state, loss_val, term_values
+            return (
+                params_,
+                opt_state,
+                loss_val,
+                term_values,
+                alignment_result,
+                gradient_conflict,
+                constructed_conflict,
+            )
 
         solve_step = (
             eqx.filter_jit(solve_step_terms)
@@ -823,6 +960,11 @@ def solve_gradient(
                         else len(training.term_balance.blocks)
                     ),
                     dtype=float,
+                ),
+                update_alignment_statistics=(
+                    None
+                    if update_alignment is None
+                    else ConflictFreeUpdateStatistics.zeros(accumulation_dtype)
                 ),
                 progress=TrainingProgress(),
                 run_id=training.plan_id,
@@ -955,6 +1097,18 @@ def solve_gradient(
         previous_gradient = (
             None if resume_state is None else resume_state.previous_gradient
         )
+        if update_alignment is None:
+            update_alignment_statistics = None
+        elif resume_state is None:
+            update_alignment_statistics = ConflictFreeUpdateStatistics.zeros(
+                accumulation_dtype
+            )
+        elif resume_state.update_alignment_statistics is None:
+            raise ValueError(
+                "Resumed functional state is missing update-alignment statistics."
+            )
+        else:
+            update_alignment_statistics = resume_state.update_alignment_statistics
 
         def make_training_state(
             current_params,
@@ -977,6 +1131,7 @@ def solve_gradient(
                 pseudo_inverse_steps=pseudo_inverse_steps_,
                 term_multipliers=term_multipliers_,
                 previous_gradient=previous_gradient,
+                update_alignment_statistics=update_alignment_statistics,
                 progress=control.progress,
                 run_id=training.plan_id,
                 gradient_accumulation=accumulation_steps,
@@ -1102,6 +1257,9 @@ def solve_gradient(
             try:
                 iter_start = time.perf_counter()
                 iter_ = jnp.asarray(epoch + 1, dtype=float)
+                update_alignment_result = None
+                gradient_conflict = None
+                constructed_conflict = None
                 if accumulation_steps == 1:
                     subkey = control.split_key()
                     (
@@ -1143,7 +1301,15 @@ def solve_gradient(
                         )
                     pre_update_params = params
                     optimizer_started = time.perf_counter() if profile_adaptive else 0.0
-                    params, opt_state, loss_val, term_values = solve_step(
+                    (
+                        params,
+                        opt_state,
+                        loss_val,
+                        term_values,
+                        update_alignment_result,
+                        gradient_conflict,
+                        constructed_conflict,
+                    ) = solve_step(
                         params,
                         non_trainable,
                         opt_state,
@@ -1178,6 +1344,16 @@ def solve_gradient(
                         if is_linesearch
                         else True
                     )
+                    if update_alignment_result is not None:
+                        if update_alignment_statistics is None:
+                            raise RuntimeError(
+                                "Functional update-alignment statistics are missing."
+                            )
+                        update_alignment_statistics = update_alignment_statistics.update(
+                            update_alignment_result,
+                            gradient_conflict=gradient_conflict,
+                            constructed_conflict=constructed_conflict,
+                        )
                     training_evaluation_multiplier = (
                         1
                         if iterative_step_metrics is None
@@ -1611,6 +1787,70 @@ def solve_gradient(
                                 ),
                             }
                         )
+                    if update_alignment_result is not None:
+                        effective_alignment = (
+                            update_alignment_result.active
+                            & ~update_alignment_result.stationary
+                        )
+                        minimum_raw_cosine = jnp.where(
+                            jnp.any(effective_alignment),
+                            jnp.min(
+                                jnp.where(
+                                    effective_alignment,
+                                    update_alignment_result.raw_cosines,
+                                    jnp.inf,
+                                )
+                            ),
+                            0.0,
+                        )
+                        minimum_aligned_cosine = jnp.where(
+                            jnp.any(effective_alignment),
+                            jnp.min(
+                                jnp.where(
+                                    effective_alignment,
+                                    update_alignment_result.aligned_cosines,
+                                    jnp.inf,
+                                )
+                            ),
+                            0.0,
+                        )
+                        optimizer_metrics.update(
+                            {
+                                "optimizer/update_alignment/raw_conflict": jnp.any(
+                                    update_alignment_result.raw_conflicts
+                                ),
+                                "optimizer/update_alignment/applied_conflict": jnp.any(
+                                    update_alignment_result.aligned_conflicts
+                                ),
+                                "optimizer/update_alignment/projected": (
+                                    update_alignment_result.projected
+                                ),
+                                "optimizer/update_alignment/minimum_raw_cosine": (
+                                    minimum_raw_cosine
+                                ),
+                                "optimizer/update_alignment/minimum_aligned_cosine": (
+                                    minimum_aligned_cosine
+                                ),
+                                "optimizer/update_alignment/relative_correction": (
+                                    update_alignment_result.relative_correction
+                                ),
+                                "optimizer/update_alignment/metric_correction_norm": (
+                                    update_alignment_result.metric_correction_norm
+                                ),
+                                "optimizer/update_alignment/active_constraints": (
+                                    update_alignment_result.active_constraint_count
+                                ),
+                                "optimizer/update_alignment/pareto_stationary": (
+                                    update_alignment_result.pareto_stationary
+                                ),
+                                "optimizer/update_alignment/kkt_residual": (
+                                    update_alignment_result.kkt_residual_norm
+                                ),
+                                "optimizer/update_alignment/status": (
+                                    update_alignment_result.status
+                                ),
+                            }
+                        )
                     loss_f = float(loss_val)
                     best_display = _best_display_value(
                         control.progress.best_value,
@@ -1889,6 +2129,44 @@ def solve_gradient(
                 "gradient_alignment/intra": prepared.intra_gradient_alignment,
                 "gradient_alignment/inter": prepared.inter_gradient_alignment,
             }
+        update_alignment_diagnostics: dict[str, Any] = {}
+        if update_alignment_statistics is not None:
+            update_alignment_diagnostics = {
+                "optimizer/update_alignment/steps": update_alignment_statistics.steps,
+                "optimizer/update_alignment/gradient_conflict_rate": (
+                    update_alignment_statistics.gradient_conflict_rate
+                ),
+                "optimizer/update_alignment/constructed_conflict_rate": (
+                    update_alignment_statistics.constructed_conflict_rate
+                ),
+                "optimizer/update_alignment/proposal_conflict_rate": (
+                    update_alignment_statistics.proposal_conflict_rate
+                ),
+                "optimizer/update_alignment/applied_conflict_rate": (
+                    update_alignment_statistics.applied_conflict_rate
+                ),
+                "optimizer/update_alignment/projection_rate": (
+                    update_alignment_statistics.projection_rate
+                ),
+                "optimizer/update_alignment/zero_proposal_steps": (
+                    update_alignment_statistics.zero_proposal_steps
+                ),
+                "optimizer/update_alignment/pareto_stationary_steps": (
+                    update_alignment_statistics.pareto_stationary_steps
+                ),
+                "optimizer/update_alignment/mean_correction_norm": (
+                    update_alignment_statistics.mean_correction_norm
+                ),
+                "optimizer/update_alignment/mean_relative_correction": (
+                    update_alignment_statistics.mean_relative_correction
+                ),
+                "optimizer/update_alignment/mean_metric_correction_norm": (
+                    update_alignment_statistics.mean_metric_correction_norm
+                ),
+                "optimizer/update_alignment/maximum_kkt_residual": (
+                    update_alignment_statistics.maximum_kkt_residual
+                ),
+            }
         diagnostics = frozendict(
             {
                 "profile_enabled": jnp.asarray(profile_adaptive),
@@ -1906,6 +2184,7 @@ def solve_gradient(
             | riemannian_diagnostics
             | mirror_diagnostics
             | iterative_diagnostics
+            | update_alignment_diagnostics
         )
         control.emit(
             TrainingIterationKind.RUN_TERMINAL,

--- a/phydrax/solver/_functional_solver.py
+++ b/phydrax/solver/_functional_solver.py
@@ -403,6 +403,7 @@ class FunctionalSolver(StrictModule):
         )
         with precision_context:
             return evaluate_prepared_objective(prepared, self.functions).total
+
     def update_kernel(
         self,
         optim: optax.GradientTransformation | optax.GradientTransformationExtraArgs,
@@ -420,7 +421,6 @@ class FunctionalSolver(StrictModule):
             parameter_subspace,
             jit=jit,
         )
-
 
     def solve(
         self,
@@ -478,6 +478,10 @@ class FunctionalSolver(StrictModule):
           membership.
         - Explicit parameter subspaces are initially supported only by standard and
           extra-argument Optax transformations.
+        - Experimental `FunctionalTrainingPlan.update_alignment` projects the exact
+          standard-Optax proposal against all authored physical objective components.
+          It requires one microstep, every term active, and no attached model losses;
+          nonstandard backends reject it before training.
 
         During training, each term receives the one-based iteration index as the
         JAX scalar keyword `iter_`, enabling scheduled coefficients.

--- a/phydrax/solver/_functional_training.py
+++ b/phydrax/solver/_functional_training.py
@@ -21,6 +21,10 @@ from .._training import TargetParameterState, TrainingProgress
 from ..domain import DomainFunction
 from ..enforcement import EnforcementState
 from ..optim._gradient_composition import ConflictFreeGradientPolicy
+from ..optim._update_alignment import (
+    ConflictFreeUpdatePolicy,
+    ConflictFreeUpdateStatistics,
+)
 from ..sampling.collocation import CausalTimeSlabSchedule
 from ..terms import ResidualBlockLayout, ResidualBlockRef
 
@@ -465,6 +469,7 @@ class FunctionalTrainingPlan(StrictModule, NonTrainableState):
     causal: tuple[CausalResidualPolicy, ...]
     term_balance: FunctionalTermBalancePolicy | None
     gradient_composition: ConflictFreeGradientPolicy | None
+    update_alignment: ConflictFreeUpdatePolicy | None
     diagnostics: FunctionalDiagnosticsPolicy | None
     selection: FunctionalSelectionPolicy | None
     checkpoint: FunctionalCheckpointPolicy | None
@@ -478,6 +483,7 @@ class FunctionalTrainingPlan(StrictModule, NonTrainableState):
         causal: Sequence[CausalResidualPolicy] = (),
         term_balance: FunctionalTermBalancePolicy | None = None,
         gradient_composition: ConflictFreeGradientPolicy | None = None,
+        update_alignment: ConflictFreeUpdatePolicy | None = None,
         diagnostics: FunctionalDiagnosticsPolicy | None = None,
         selection: FunctionalSelectionPolicy | None = None,
         checkpoint: FunctionalCheckpointPolicy | None = None,
@@ -505,6 +511,11 @@ class FunctionalTrainingPlan(StrictModule, NonTrainableState):
                 ConflictFreeGradientPolicy,
                 "gradient_composition",
             ),
+            (
+                update_alignment,
+                ConflictFreeUpdatePolicy,
+                "update_alignment",
+            ),
             (diagnostics, FunctionalDiagnosticsPolicy, "diagnostics"),
             (selection, FunctionalSelectionPolicy, "selection"),
             (checkpoint, FunctionalCheckpointPolicy, "checkpoint"),
@@ -521,62 +532,62 @@ class FunctionalTrainingPlan(StrictModule, NonTrainableState):
         self.causal = causal_
         self.term_balance = term_balance
         self.gradient_composition = gradient_composition
+        self.update_alignment = update_alignment
         self.diagnostics = diagnostics
         self.selection = selection
         self.checkpoint = checkpoint
         self.sharding = sharding
-        self.plan_id = canonical_fingerprint(
-            {
-                "kind": "functional-training-plan",
-                "pseudo_transient": [value.policy_id for value in pseudo],
-                "causal": [value.policy_id for value in causal_],
-                "term_balance": None if term_balance is None else term_balance.policy_id,
-                "gradient_composition": (
-                    None
-                    if gradient_composition is None
-                    else gradient_composition.policy_id
-                ),
-                "diagnostics": (
-                    None
-                    if diagnostics is None
-                    else {
-                        "every": diagnostics.every,
-                        "gradient_alignment": diagnostics.gradient_alignment,
-                        "ntk": diagnostics.ntk,
-                        "ntk_probes": diagnostics.ntk_probes,
-                        "ntk_eigenvalues": diagnostics.ntk_eigenvalues,
-                    }
-                ),
-                "selection": (
-                    None
-                    if selection is None
-                    else {
-                        "every": selection.every,
-                        "mode": selection.mode,
-                        "min_delta": selection.min_delta,
-                        "patience": selection.patience,
-                    }
-                ),
-                "checkpoint": (
-                    None
-                    if checkpoint is None
-                    else {
-                        "path": checkpoint.path,
-                        "every": checkpoint.every,
-                        "save_final": checkpoint.save_final,
-                    }
-                ),
-                "sharding": (
-                    None
-                    if sharding is None
-                    else {
-                        "policy_id": sharding.policy_id,
-                        "axis_mapping": dict(sharding.axis_mapping),
-                        "mesh_shape": dict(sharding.mesh.shape),
-                    }
-                ),
-            }
-        )
+        plan_contract = {
+            "kind": "functional-training-plan",
+            "pseudo_transient": [value.policy_id for value in pseudo],
+            "causal": [value.policy_id for value in causal_],
+            "term_balance": None if term_balance is None else term_balance.policy_id,
+            "gradient_composition": (
+                None if gradient_composition is None else gradient_composition.policy_id
+            ),
+            "diagnostics": (
+                None
+                if diagnostics is None
+                else {
+                    "every": diagnostics.every,
+                    "gradient_alignment": diagnostics.gradient_alignment,
+                    "ntk": diagnostics.ntk,
+                    "ntk_probes": diagnostics.ntk_probes,
+                    "ntk_eigenvalues": diagnostics.ntk_eigenvalues,
+                }
+            ),
+            "selection": (
+                None
+                if selection is None
+                else {
+                    "every": selection.every,
+                    "mode": selection.mode,
+                    "min_delta": selection.min_delta,
+                    "patience": selection.patience,
+                }
+            ),
+            "checkpoint": (
+                None
+                if checkpoint is None
+                else {
+                    "path": checkpoint.path,
+                    "every": checkpoint.every,
+                    "save_final": checkpoint.save_final,
+                }
+            ),
+            "sharding": (
+                None
+                if sharding is None
+                else {
+                    "policy_id": sharding.policy_id,
+                    "axis_mapping": dict(sharding.axis_mapping),
+                    "mesh_shape": dict(sharding.mesh.shape),
+                }
+            ),
+        }
+        if update_alignment is not None:
+            plan_contract["update_alignment"] = update_alignment.policy_id
+        self.plan_id = canonical_fingerprint(plan_contract)
 
     @property
     def stateful(self) -> bool:
@@ -596,6 +607,7 @@ class FunctionalTrainingState(StrictModule):
     pseudo_inverse_steps: tuple[Array, ...]
     term_multipliers: Array
     previous_gradient: PyTree[Any] | None
+    update_alignment_statistics: ConflictFreeUpdateStatistics | None
     progress: TrainingProgress = eqx.field(static=True)
     run_id: str = eqx.field(static=True)
     gradient_accumulation: int = eqx.field(static=True)
@@ -618,6 +630,7 @@ class FunctionalTrainingState(StrictModule):
         pseudo_inverse_steps: Sequence[ArrayLike] = (),
         term_multipliers: ArrayLike = (),
         previous_gradient: PyTree[Any] | None = None,
+        update_alignment_statistics: ConflictFreeUpdateStatistics | None = None,
         training_seconds: float = 0.0,
         resumed_from_step: int = 0,
     ):
@@ -631,6 +644,14 @@ class FunctionalTrainingState(StrictModule):
             enforcement_state, EnforcementState
         ):
             raise TypeError("enforcement_state must be EnforcementState or None.")
+        if update_alignment_statistics is not None and not isinstance(
+            update_alignment_statistics,
+            ConflictFreeUpdateStatistics,
+        ):
+            raise TypeError(
+                "update_alignment_statistics must be "
+                "ConflictFreeUpdateStatistics or None."
+            )
         identifier = str(run_id)
         seconds = float(training_seconds)
         resumed = int(resumed_from_step)
@@ -655,6 +676,7 @@ class FunctionalTrainingState(StrictModule):
         )
         self.term_multipliers = jnp.asarray(term_multipliers, dtype=float).reshape((-1,))
         self.previous_gradient = previous_gradient
+        self.update_alignment_statistics = update_alignment_statistics
         self.progress = progress
         self.run_id = identifier
         self.gradient_accumulation = accumulation

--- a/phydrax/solver/_functional_windows.py
+++ b/phydrax/solver/_functional_windows.py
@@ -18,6 +18,7 @@ from .._frozendict import frozendict
 from .._strict import AbstractAttribute, StrictModule
 from .._training import TrainingProgress
 from ..domain import DomainFunction
+from ..optim._update_alignment import ConflictFreeUpdateStatistics
 from ..sampling.collocation import CausalTimeSlabSchedule
 from ._functional_training import FunctionalTrainingPlan, FunctionalTrainingState
 
@@ -185,7 +186,12 @@ class FunctionalTimeWindowResult(StrictModule):
         return self.solvers[index]
 
 
-def _transfer_training_state(source: Any, target: Any, /):
+def _transfer_training_state(
+    source: Any,
+    target: Any,
+    training: FunctionalTrainingPlan,
+    /,
+):
     state = source.training_state
     if state is None:
         raise ValueError(
@@ -195,6 +201,15 @@ def _transfer_training_state(source: Any, target: Any, /):
     target_structure = jax.tree.structure(target.functions)
     if source_structure != target_structure:
         raise ValueError("Optimizer-state transfer requires identical function PyTrees.")
+    update_alignment_statistics = (
+        None
+        if training.update_alignment is None
+        else ConflictFreeUpdateStatistics.zeros(
+            jnp.float32
+            if state.update_alignment_statistics is None
+            else state.update_alignment_statistics.correction_norm_sum.dtype
+        )
+    )
     transferred = FunctionalTrainingState(
         current_functions=target.functions,
         best_functions=target.functions,
@@ -204,8 +219,9 @@ def _transfer_training_state(source: Any, target: Any, /):
         pseudo_inverse_steps=(),
         term_multipliers=(),
         previous_gradient=None,
+        update_alignment_statistics=update_alignment_statistics,
         progress=TrainingProgress(),
-        run_id=state.run_id,
+        run_id=training.plan_id,
         gradient_accumulation=state.gradient_accumulation,
         training_seconds=state.training_seconds,
         resumed_from_step=0,
@@ -248,7 +264,7 @@ def train_functional_time_windows(
                 "for every window."
             )
         if plan.transfer_optimizer_state and index > 0:
-            built = _transfer_training_state(current, built)
+            built = _transfer_training_state(current, built, training)
         current = built.solve(
             num_iter=plan.steps[index],
             optim=plan.optimizer(index),

--- a/tests/unit/nn/test_operator_training.py
+++ b/tests/unit/nn/test_operator_training.py
@@ -787,6 +787,72 @@ def test_fit_operator_resume_is_bitwise_exact_with_shuffle_and_accumulation(tmp_
     assert resumed.history == uninterrupted.history
 
 
+def test_fit_operator_alignment_statistics_resume_exactly(tmp_path):
+    dataset = _dataset(cases=4)
+    model = _fit_model(seed=22)
+    common: dict[str, Any] = {
+        "epochs": 1,
+        "batch_size": 2,
+        "gradient_accumulation": 1,
+        "include_model_losses": False,
+        "shuffle": False,
+        "seed": 23,
+        "checkpoint_every": 1,
+        "update_alignment": phx.optim.ConflictFreeUpdatePolicy(),
+        "jit": False,
+    }
+    uninterrupted = phx.nn.operator.training.fit_operator(
+        model,
+        dataset,
+        steps=2,
+        **common,
+    )
+    checkpoint = tmp_path / "aligned-fit-checkpoint"
+    phx.nn.operator.training.fit_operator(
+        model,
+        dataset,
+        steps=1,
+        checkpoint_path=checkpoint,
+        **common,
+    )
+    resumed = phx.nn.operator.training.fit_operator(
+        model,
+        dataset,
+        steps=2,
+        checkpoint_path=checkpoint,
+        resume=True,
+        **common,
+    )
+
+    full_leaves = jax.tree_util.tree_leaves(uninterrupted.last_execution_model)
+    resumed_leaves = jax.tree_util.tree_leaves(resumed.last_execution_model)
+    for full, restored in zip(full_leaves, resumed_leaves, strict=True):
+        if isinstance(full, jax.Array):
+            assert jnp.array_equal(full, restored)
+    assert resumed.history == uninterrupted.history
+    assert eqx.tree_equal(
+        resumed.update_alignment_statistics,
+        uninterrupted.update_alignment_statistics,
+    )
+
+    with pytest.raises(ValueError, match="checkpoint contract mismatch"):
+        phx.nn.operator.training.fit_operator(
+            model,
+            dataset,
+            steps=2,
+            checkpoint_path=checkpoint,
+            resume=True,
+            **(
+                common
+                | {
+                    "update_alignment": phx.optim.ConflictFreeUpdatePolicy(
+                        feasibility_tolerance=1e-8
+                    )
+                }
+            ),
+        )
+
+
 def test_fit_operator_returns_task_bound_physical_operator():
     dataset = _dataset(cases=4)
     task = phx.nn.operator.OperatorTask(

--- a/tests/unit/optim/test_gradient_composition.py
+++ b/tests/unit/optim/test_gradient_composition.py
@@ -12,6 +12,7 @@ from phydrax.optim import (
     conflict_free_gradient,
     ConflictFreeGradientPolicy,
     ConflictFreeGradientStatus,
+    ConflictFreeUpdatePolicy,
 )
 
 
@@ -117,6 +118,22 @@ class _ScaledOperator(phx.nn.operator.AbstractOperatorModel):
         return self.__call_operator_batch__(batch, key=key)
 
 
+def _fixed_additive_update(value: float):
+    def initialize(parameters):
+        del parameters
+        return ()
+
+    def update(gradients, state, parameters=None):
+        del parameters
+        updates = jax.tree.map(
+            lambda leaf: jnp.full_like(leaf, value),
+            gradients,
+        )
+        return updates, state
+
+    return optax.GradientTransformation(initialize, update)
+
+
 def _two_term_functional_solver():
     domain = phx.domain.Interval1d(0.0, 1.0)
     field = domain.Parameter(jnp.asarray([1.0]))
@@ -183,6 +200,47 @@ def test_functional_solver_composes_one_prepared_objective_vector():
         )
 
 
+def test_functional_solver_aligns_the_applied_optimizer_proposal():
+    trained = _two_term_functional_solver().solve(
+        num_iter=1,
+        optim=_fixed_additive_update(0.1),
+        keep_best=False,
+        log_every=0,
+        jit=True,
+        training=phx.solver.FunctionalTrainingPlan(
+            gradient_composition=ConflictFreeGradientPolicy(),
+            update_alignment=ConflictFreeUpdatePolicy(),
+        ),
+    )
+
+    np.testing.assert_allclose(trained.functions["u"].func(), (1.0,), atol=1e-10)
+    assert trained.training_state is not None
+    statistics = trained.training_state.update_alignment_statistics
+    assert statistics is not None
+    assert float(statistics.proposal_conflict_rate) == 1.0
+    assert float(statistics.applied_conflict_rate) == 0.0
+    assert float(statistics.projection_rate) == 1.0
+    assert (
+        float(
+            trained.training_diagnostics[
+                "optimizer/update_alignment/proposal_conflict_rate"
+            ]
+        )
+        == 1.0
+    )
+    with pytest.raises(ValueError, match="gradient accumulation"):
+        _two_term_functional_solver().solve(
+            num_iter=1,
+            optim=optax.sgd(0.1),
+            keep_best=False,
+            log_every=0,
+            gradient_accumulation=2,
+            training=phx.solver.FunctionalTrainingPlan(
+                update_alignment=ConflictFreeUpdatePolicy()
+            ),
+        )
+
+
 def test_operator_fit_composes_explicit_loss_terms():
     axis = phx.nn.operator.OperatorAxis("x", jnp.linspace(0.0, 1.0, 4))
     values = jnp.stack((axis.nodes, axis.nodes + 1.0), axis=0)
@@ -226,4 +284,63 @@ def test_operator_fit_composes_explicit_loss_terms():
             shuffle=False,
             output_field_map={"output": "solution"},
             jit=False,
+        )
+
+
+def test_operator_fit_aligns_an_ordinary_aggregate_optimizer_proposal():
+    axis = phx.nn.operator.OperatorAxis("x", jnp.linspace(0.0, 1.0, 4))
+    values = jnp.stack((axis.nodes, axis.nodes + 1.0), axis=0)
+    dataset = phx.nn.operator.training.operator_dataset_from_arrays(
+        {"state": values},
+        {"solution": 2.0 * values},
+        source_axes={"state": (axis,)},
+        query_axes=(axis,),
+    )
+    terms = (
+        phx.nn.operator.training.SupervisedOperatorLoss(name="first"),
+        phx.nn.operator.training.SupervisedOperatorLoss(name="second"),
+    )
+
+    result = phx.nn.operator.training.fit_operator(
+        _ScaledOperator(0.0),
+        dataset,
+        loss_terms=terms,
+        include_model_losses=False,
+        update_alignment=ConflictFreeUpdatePolicy(),
+        optimizer=_fixed_additive_update(-0.1),
+        optimizer_id="fixed-harmful-update",
+        epochs=1,
+        steps=1,
+        batch_size=2,
+        shuffle=False,
+        output_field_map={"output": "solution"},
+        jit=True,
+    )
+
+    np.testing.assert_allclose(result.last_execution_model.gain, 0.0, atol=1e-10)
+    statistics = result.update_alignment_statistics
+    assert statistics is not None
+    assert float(statistics.proposal_conflict_rate) == 1.0
+    assert float(statistics.applied_conflict_rate) == 0.0
+    assert result.history.train_metrics[0]["update_alignment/raw_conflict"] == 1.0
+    assert result.history.train_metrics[0]["update_alignment/applied_conflict"] == 0.0
+    with pytest.raises(ValueError, match="attached model losses"):
+        phx.nn.operator.training.fit_operator(
+            _ScaledOperator(0.0),
+            dataset,
+            loss_terms=terms,
+            update_alignment=ConflictFreeUpdatePolicy(),
+            epochs=1,
+            batch_size=2,
+        )
+    with pytest.raises(ValueError, match="gradient accumulation"):
+        phx.nn.operator.training.fit_operator(
+            _ScaledOperator(0.0),
+            dataset,
+            loss_terms=terms,
+            include_model_losses=False,
+            update_alignment=ConflictFreeUpdatePolicy(),
+            gradient_accumulation=2,
+            epochs=1,
+            batch_size=1,
         )

--- a/tests/unit/optim/test_update_alignment.py
+++ b/tests/unit/optim/test_update_alignment.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from phydrax.optim import (
+    ConflictFreeUpdatePolicy,
+    ConflictFreeUpdateStatistics,
+    ConflictFreeUpdateStatus,
+    project_conflict_free_direction,
+)
+
+
+def test_projection_is_exactly_inactive_for_feasible_updates_and_jittable():
+    gradients = (jnp.asarray((1.0, 0.0)), jnp.asarray((0.0, 1.0)))
+    proposal = jnp.asarray((1.0, 2.0))
+
+    eager = project_conflict_free_direction(proposal, gradients)
+    compiled = jax.jit(lambda value: project_conflict_free_direction(value, gradients))(
+        proposal
+    )
+
+    assert int(eager.status) == int(ConflictFreeUpdateStatus.ALREADY_FEASIBLE)
+    assert not bool(eager.projected)
+    assert bool(eager.successful)
+    assert jnp.array_equal(eager.direction, proposal)
+    assert jnp.array_equal(compiled.direction, proposal)
+    np.testing.assert_allclose(eager.multipliers, 0.0, atol=0.0)
+
+
+def test_exact_active_set_projects_edges_and_opposing_constraints():
+    orthant = project_conflict_free_direction(
+        jnp.asarray((-1.0, 2.0)),
+        (jnp.asarray((1.0, 0.0)), jnp.asarray((0.0, 1.0))),
+    )
+    opposing = project_conflict_free_direction(
+        jnp.asarray((1.0, 2.0)),
+        (jnp.asarray((1.0, 0.0)), jnp.asarray((-1.0, 0.0))),
+    )
+
+    np.testing.assert_allclose(orthant.direction, (0.0, 2.0), atol=1e-10)
+    np.testing.assert_allclose(opposing.direction, (0.0, 2.0), atol=1e-10)
+    assert bool(orthant.successful & opposing.successful)
+    assert bool(orthant.projected & opposing.projected)
+    assert not bool(jnp.any(orthant.aligned_conflicts))
+    assert not bool(jnp.any(opposing.aligned_conflicts))
+
+
+def test_diagonal_metric_changes_closest_feasible_direction():
+    gradient = (jnp.asarray((1.0, 1.0)),)
+    proposal = jnp.asarray((-2.0, 0.0))
+
+    euclidean = project_conflict_free_direction(proposal, gradient)
+    diagonal = project_conflict_free_direction(
+        proposal,
+        gradient,
+        metric_diagonal=jnp.asarray((1.0, 0.25)),
+    )
+
+    np.testing.assert_allclose(euclidean.direction, (-1.0, 1.0), atol=1e-10)
+    np.testing.assert_allclose(diagonal.direction, (-1.6, 1.6), atol=1e-10)
+    assert diagonal.metric_kind == "diagonal"
+    assert not bool(jnp.any(diagonal.aligned_conflicts))
+    assert not jnp.isclose(
+        diagonal.metric_correction_norm,
+        euclidean.metric_correction_norm,
+    )
+
+
+def test_rank_stationarity_activity_and_complex_geometry_are_distinct():
+    duplicate = project_conflict_free_direction(
+        jnp.asarray((-1.0, 1.0)),
+        (jnp.asarray((1.0, 0.0)), jnp.asarray((1.0, 0.0))),
+    )
+    inactive_nonfinite = project_conflict_free_direction(
+        jnp.asarray((1.0, 0.0)),
+        (jnp.asarray((1.0, 0.0)), jnp.asarray((jnp.nan, 0.0))),
+        active=jnp.asarray((True, False)),
+    )
+    stationary = project_conflict_free_direction(
+        jnp.asarray((1.0, 0.0)),
+        (jnp.zeros((2,)),),
+    )
+    complex_result = project_conflict_free_direction(
+        {"z": jnp.asarray((-1.0 - 1.0j,))},
+        ({"z": jnp.asarray((1.0 + 1.0j,))},),
+    )
+
+    np.testing.assert_allclose(duplicate.direction, (0.0, 1.0), atol=1e-10)
+    assert bool(duplicate.successful)
+    assert bool(inactive_nonfinite.successful)
+    assert jnp.isfinite(inactive_nonfinite.kkt_residual_norm)
+    assert int(stationary.status) == int(ConflictFreeUpdateStatus.NO_EFFECTIVE_OBJECTIVES)
+    assert bool(stationary.stationary[0])
+    np.testing.assert_allclose(complex_result.direction["z"], 0.0, atol=1e-10)
+    assert bool(complex_result.pareto_stationary)
+
+
+def test_large_objective_dual_and_failure_contracts_are_audited():
+    gradients = tuple(jnp.eye(4)[index] for index in range(4))
+    projected = project_conflict_free_direction(-jnp.ones((4,)), gradients)
+
+    assert projected.solver_method == "dense-primal-dual"
+    assert bool(projected.successful)
+    np.testing.assert_allclose(projected.direction, 0.0, atol=1e-7)
+    assert not bool(jnp.any(projected.aligned_conflicts))
+
+    invalid_metric = project_conflict_free_direction(
+        jnp.ones((2,)),
+        (jnp.ones((2,)),),
+        metric_diagonal=jnp.asarray((1.0, 0.0)),
+    )
+    assert not bool(invalid_metric.successful)
+    assert int(invalid_metric.status) == int(ConflictFreeUpdateStatus.INVALID_METRIC)
+    np.testing.assert_allclose(invalid_metric.direction, 0.0, atol=0.0)
+
+    nonfinite = project_conflict_free_direction(
+        jnp.ones((1,)),
+        (jnp.asarray((jnp.nan,)),),
+    )
+    assert int(nonfinite.status) == int(ConflictFreeUpdateStatus.NONFINITE)
+    with pytest.raises(eqx.EquinoxRuntimeError, match="could not be projected"):
+        checked = project_conflict_free_direction(
+            jnp.ones((1,)),
+            (jnp.asarray((jnp.nan,)),),
+            policy=ConflictFreeUpdatePolicy(failure="error"),
+        )
+        np.asarray(checked.direction)
+
+    with pytest.raises(ValueError, match="structures"):
+        project_conflict_free_direction(
+            {"x": jnp.ones((1,))},
+            ({"y": jnp.ones((1,))},),
+        )
+    with pytest.raises(ValueError, match="one Boolean"):
+        project_conflict_free_direction(
+            jnp.ones((1,)),
+            (jnp.ones((1,)),),
+            active=jnp.ones((2,), dtype=bool),
+        )
+
+
+def test_statistics_preserve_four_stage_mismatch_evidence():
+    result = project_conflict_free_direction(
+        jnp.asarray((-1.0, 2.0)),
+        (jnp.asarray((1.0, 0.0)), jnp.asarray((0.0, 1.0))),
+    )
+    statistics = ConflictFreeUpdateStatistics.zeros(jnp.float64).update(
+        result,
+        gradient_conflict=True,
+        constructed_conflict=False,
+    )
+
+    assert int(statistics.steps) == 1
+    assert float(statistics.gradient_conflict_rate) == 1.0
+    assert float(statistics.constructed_conflict_rate) == 0.0
+    assert float(statistics.proposal_conflict_rate) == 1.0
+    assert float(statistics.applied_conflict_rate) == 0.0
+    assert float(statistics.projection_rate) == 1.0
+    assert float(statistics.mean_correction_norm) > 0.0

--- a/tests/unit/solver/test_functional_sharding_windows.py
+++ b/tests/unit/solver/test_functional_sharding_windows.py
@@ -137,12 +137,19 @@ def test_functional_time_windows_transfer_optimizer_state_independently():
         _WindowAdapter(),
         lambda index: optax.adam(0.01),
         steps=1,
-        training=phx.solver.FunctionalTrainingPlan(),
+        training=phx.solver.FunctionalTrainingPlan(
+            update_alignment=phx.optim.ConflictFreeUpdatePolicy()
+        ),
         transfer_optimizer_state=True,
     )
     result = phx.solver.train_functional_time_windows(_scalar_solver(), plan)
     final_state = result.solvers[-1].training_state
     assert final_state is not None
+    for trained in result.solvers:
+        assert trained.training_state is not None
+        statistics = trained.training_state.update_alignment_statistics
+        assert statistics is not None
+        assert int(statistics.steps) == 1
     integer_scalars = tuple(
         int(value)
         for value in jax.tree.leaves(final_state.optimizer_state)

--- a/tests/unit/solver/test_functional_training_runtime.py
+++ b/tests/unit/solver/test_functional_training_runtime.py
@@ -170,7 +170,11 @@ def test_prepared_update_separates_equal_physical_and_untransformed_surrogate():
 
 def test_functional_checkpoint_resume_matches_uninterrupted_steps(tmp_path):
     plan = phx.solver.FunctionalTrainingPlan(
-        checkpoint=phx.solver.FunctionalCheckpointPolicy(tmp_path / "functional", every=1)
+        checkpoint=phx.solver.FunctionalCheckpointPolicy(
+            tmp_path / "functional",
+            every=1,
+        ),
+        update_alignment=phx.optim.ConflictFreeUpdatePolicy(),
     )
     target_policy = DelayedTargetPolicy(1)
     solver = _fixed_interval_solver()
@@ -266,7 +270,9 @@ def test_functional_checkpoint_resume_matches_uninterrupted_steps(tmp_path):
         optim=optax.sgd(0.05),
         keep_best=False,
         log_every=0,
-        training=phx.solver.FunctionalTrainingPlan(),
+        training=phx.solver.FunctionalTrainingPlan(
+            update_alignment=phx.optim.ConflictFreeUpdatePolicy()
+        ),
         target_policy=target_policy,
     )
     assert resumed.training_state.progress.update_step == 2
@@ -286,6 +292,14 @@ def test_functional_checkpoint_resume_matches_uninterrupted_steps(tmp_path):
     assert jnp.allclose(
         disk_resumed.training_state.current_functions["u"].func(),
         uninterrupted.training_state.current_functions["u"].func(),
+    )
+    assert eqx.tree_equal(
+        resumed.training_state.update_alignment_statistics,
+        uninterrupted.training_state.update_alignment_statistics,
+    )
+    assert eqx.tree_equal(
+        disk_resumed.training_state.update_alignment_statistics,
+        uninterrupted.training_state.update_alignment_statistics,
     )
 
 

--- a/tests/unit/solver/test_kfac_functional_solver.py
+++ b/tests/unit/solver/test_kfac_functional_solver.py
@@ -97,6 +97,19 @@ def test_public_kfac_optimizer_decreases_frozen_functional_loss():
     assert trained.training_diagnostics["optimizer/kfac/num_affine_blocks"] == 1
 
 
+def test_kfac_rejects_post_optimizer_update_alignment():
+    with pytest.raises(ValueError, match="unsupported by KFAC"):
+        _linear_solver().solve(
+            num_iter=1,
+            optim=phx.optim.kfac(),
+            keep_best=False,
+            log_every=0,
+            training=phx.solver.FunctionalTrainingPlan(
+                update_alignment=phx.optim.ConflictFreeUpdatePolicy()
+            ),
+        )
+
+
 def test_native_least_squares_method_uses_functional_residual_contract():
     solver = _linear_solver()
     initial = solver.loss(key=jr.key(20))

--- a/tools/pinn_training_strategy_campaign.py
+++ b/tools/pinn_training_strategy_campaign.py
@@ -21,6 +21,8 @@ from phydrax.solver._functional_objective import evaluate_prepared_objective
 _STRATEGIES = (
     "baseline",
     "conflict_free",
+    "update_aligned",
+    "conflict_free_update_aligned",
     "grad_norm",
     "ntk_trace",
     "pseudo",
@@ -114,7 +116,14 @@ def _problem(*, seed: int, samples: int, width: int, depth: int):
 def _training_plan(strategy: str):
     balance = None
     gradient_composition = (
-        phx.optim.ConflictFreeGradientPolicy() if strategy == "conflict_free" else None
+        phx.optim.ConflictFreeGradientPolicy()
+        if strategy in ("conflict_free", "conflict_free_update_aligned")
+        else None
+    )
+    update_alignment = (
+        phx.optim.ConflictFreeUpdatePolicy()
+        if strategy in ("update_aligned", "conflict_free_update_aligned")
+        else None
     )
     pseudo = ()
     diagnostics = phx.solver.FunctionalDiagnosticsPolicy(
@@ -157,6 +166,7 @@ def _training_plan(strategy: str):
         pseudo_transient=pseudo,
         term_balance=balance,
         gradient_composition=gradient_composition,
+        update_alignment=update_alignment,
         diagnostics=diagnostics,
     )
 
@@ -177,12 +187,25 @@ def _optimizer(name: str):
     raise ValueError(f"Unknown optimizer {name!r}.")
 
 
+def _optional_diagnostic(trained, name: str):
+    value = float(
+        trained.training_diagnostics.get(
+            name,
+            jnp.asarray(jnp.nan),
+        )
+    )
+    return value if math.isfinite(value) else None
+
+
 def run(args):
     samples = 16 if args.smoke else args.samples
     width = 8 if args.smoke else args.width
     depth = 1 if args.smoke else args.depth
     steps = 2 if args.smoke else args.steps
     solver = _problem(seed=args.seed, samples=samples, width=width, depth=depth)
+    training = _training_plan(args.strategy)
+    if args.optimizer == "kfac" and training.update_alignment is not None:
+        raise ValueError("Update-aligned strategies require Adam or SOAP.")
     prepared_evaluation = solver.objective.prepare_evaluation(
         key=jr.key(args.seed + 10),
         iteration=0,
@@ -197,7 +220,8 @@ def run(args):
         keep_best=False,
         log_every=0,
         seed=args.seed,
-        training=_training_plan(args.strategy),
+        profile_adaptive=True,
+        training=training,
     )
     jax.block_until_ready(trained.functions)
     elapsed = time.perf_counter() - started
@@ -218,11 +242,9 @@ def run(args):
         ),
         key=jr.key(args.seed + 21),
     )
-    alignment = float(
-        trained.training_diagnostics.get(
-            "gradient_alignment/intra",
-            jnp.asarray(jnp.nan),
-        )
+    alignment = _optional_diagnostic(trained, "gradient_alignment/intra")
+    alignment_policy_id = (
+        None if training.update_alignment is None else training.update_alignment.policy_id
     )
     return {
         "strategy": args.strategy,
@@ -238,7 +260,44 @@ def run(args):
         "ntk_trace": float(ntk_diagnostics.trace),
         "ntk_stable_rank": float(ntk_diagnostics.stable_rank),
         "ntk_effective_rank": float(ntk_diagnostics.effective_rank),
-        "gradient_alignment_intra": (alignment if math.isfinite(alignment) else None),
+        "gradient_alignment_intra": alignment,
+        "update_alignment_policy_id": alignment_policy_id,
+        "update_alignment_gradient_conflict_rate": _optional_diagnostic(
+            trained,
+            "optimizer/update_alignment/gradient_conflict_rate",
+        ),
+        "update_alignment_constructed_conflict_rate": _optional_diagnostic(
+            trained,
+            "optimizer/update_alignment/constructed_conflict_rate",
+        ),
+        "update_alignment_proposal_conflict_rate": _optional_diagnostic(
+            trained,
+            "optimizer/update_alignment/proposal_conflict_rate",
+        ),
+        "update_alignment_applied_conflict_rate": _optional_diagnostic(
+            trained,
+            "optimizer/update_alignment/applied_conflict_rate",
+        ),
+        "update_alignment_projection_rate": _optional_diagnostic(
+            trained,
+            "optimizer/update_alignment/projection_rate",
+        ),
+        "update_alignment_mean_relative_correction": _optional_diagnostic(
+            trained,
+            "optimizer/update_alignment/mean_relative_correction",
+        ),
+        "update_alignment_maximum_kkt_residual": _optional_diagnostic(
+            trained,
+            "optimizer/update_alignment/maximum_kkt_residual",
+        ),
+        "optimizer_first_step_wall_time_seconds": _optional_diagnostic(
+            trained,
+            "optimizer_first_step_wall_time_seconds",
+        ),
+        "optimizer_steady_step_wall_time_seconds": _optional_diagnostic(
+            trained,
+            "optimizer_steady_step_wall_time_seconds",
+        ),
     }
 
 


### PR DESCRIPTION
## Summary

- add a typed, PyTree-native projector that constrains the exact optimizer descent proposal against every active objective gradient
- integrate update alignment independently of gradient composition in FunctionalSolver and neural-operator fitting
- persist local and cumulative gradient–update mismatch evidence through checkpoints and physical time-window lifecycles
- expose the public policy, result, statistics, status, and projection function through `phydrax.optim`

## Numerical design

`project_conflict_free_direction` projects a positive descent proposal onto the simultaneous first-order nonascent cone. It preserves real Hilbert geometry for real or complex PyTrees and never materializes parameter coordinates.

- one-to-three objective problems use exact active-set enumeration with `phydrax.linalg.solve_small_linear`
- larger objective sets lower to the canonical nonnegative dual `QuadraticProgram`
- an optional positive diagonal metric changes closest-direction geometry without coupling to optimizer state
- inactive and stationary objectives remain distinct
- already-feasible proposals remain unchanged
- nonfinite inputs, invalid metrics, dual failures, and failed post-certification return explicit fail-closed statuses

## Functional training

`FunctionalTrainingPlan.update_alignment` operates at the standard-Optax application boundary:

1. evaluate one prepared objective realization
2. reuse its component VJP for ordinary aggregation or conflict-free gradient composition
3. obtain the exact additive Optax update
4. project its positive descent direction
5. apply the aligned additive update while retaining the optimizer's tentative next state

The cone uses authored physical objective components. Term balancing, causal transforms, and pseudo-transient continuation may alter the optimizer proposal without silently changing that cone. Cumulative component-gradient, constructed-direction, raw-proposal, and applied-direction conflict rates are checkpointed. Time-window optimizer-state transfer resets evidence for the new physical window.

KFAC, Evosax, line-search, iterative, mirror, and Riemannian backends reject configured alignment instead of ignoring it.

## Neural-operator training

`fit_operator(..., update_alignment=...)` supports ordinary aggregate gradients or simultaneous `ConflictFreeGradientPolicy`. Positive-support loss terms define cone constraints; zero-support terms remain inactive. The fit contract includes policy identity, per-step history records local alignment evidence, and checkpoint state preserves cumulative statistics exactly.

## Scope and limitations

The feature is explicitly experimental. Its guarantee is first order on the current prepared realization; it is not a finite-step or population-objective monotonicity claim. Objective grouping changes the cone, and projection may remove decoupled weight-decay components that conflict with declared objectives.

This change does not inspect or mutate Adam, RMSProp, or SOAP state. Optimizer-state alignment, gradient accumulation, attached model losses, loss scaling, and nonstandard optimizer geometries remain outside the supported boundary.

## Documentation and provenance

The functional training guide, optimization API, operator-learning cookbook, consolidated overview, changelog, and NOTICE describe the contract and limitations. The implementation is independent and cites Xiao et al., “Gradient-Update Mismatch: Rethinking Conflict-Free Training of Physics-Informed Neural Networks,” arXiv:2609.01558; no upstream source, data, runtime, or dependency is incorporated.