### PR TITLE
Add temporal and shadowing sensitivity infrastructure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 - Added fixed-recipe selective reliability with pure dense OOF assembly,
   empirical-mass tie-block risk curves and weighted midranks, group-safe paired
   locked-test loss inference, and direct scalar interval diagnostics.
+- Added inspectable temporal differentiation evidence; split composite,
+  pushforward, and checkpointed pullback routes for Diffrax-backed evolution;
+  matrix-free state and argument Jacobian actions; local derivative
+  certification; argument-native shadowing problems; segmented JAX NILSS;
+  discrete NILSAS with stored or recomputed adjoints and flow-neutral
+  constraints; generic shadowing qualification; and sensitivity benchmarks.
 - Added native orthonormal scalar spherical Legendre and angular/Cartesian
   spherical-harmonic evaluation with pole-safe derivatives, stable Cartesian
   normalization, lane-local zero/nonfinite refusal, and table-free evaluation

--- a/README.md
+++ b/README.md
@@ -265,7 +265,8 @@ Most workflows are composing a few primitives:
   pathwise evolution, mask-safe trajectory data, DMD/EDMD, strong/discrete/
   integral/weak and implicit SINDy, PDE-FIND, periodic orbits, continuation,
   Floquet/Lyapunov/covariant analysis, recurrence and statistical chaos
-  diagnostics, explicit uncertainty aggregation, and a shadowing solver boundary.
+  diagnostics, local derivative certification, explicit uncertainty aggregation,
+  and finite-horizon NILSS/NILSAS shadowing.
 - **Control and optimization**: typed finite-horizon problems, parameterized
   controls, sampled costs/constraints, linearization, frequency response,
   Lyapunov/Riccati equations, Gramians, LQR/iLQR, compiled QPs, multiple shooting,
@@ -574,11 +575,19 @@ convergence evidence rather than claiming automatic certificates. See the
 [nonlinear-dynamics cookbook](docs/cookbook/nonlinear_dynamics.md) and
 [dynamics API](docs/api/dynamics.md).
 
+Matrix-free state and argument actions share the evolution contract. Diffrax
+keeps bidirectional composition, forward pushforward, and checkpointed reverse
+pullback routes distinct with inspectable differentiation evidence. Segmented
+NILSS and discrete NILSAS provide tangent and adjoint long-time sensitivity,
+including explicit flow-neutral constraints, resource bounds, and
+store/recompute work evidence; finite horizons are not convergence certificates.
+
 Time integration preserves explicit, additive IMEX, residual, second-order,
 partitioned, stochastic, and geometric equation forms. Diffrax methods coexist with
 native SSPRK, endpoint theta, BDF1--BDF5, matrix-free Rosenbrock-W,
 generalized-alpha, multirate partitioned RK, Gauss--Legendre collocation, geometric,
-and exponential methods under explicit capability and provenance contracts. See the
+and exponential methods under explicit capability, differentiation, checkpointing,
+adaptive-decision, event, stochastic, and provenance contracts. See the
 [time-integrator API](docs/api/solver/time_integrators.md).
 
 Controlled-dynamics support includes explicit causal or offline differentiable

--- a/docs/all-of-phydrax.md
+++ b/docs/all-of-phydrax.md
@@ -1058,6 +1058,12 @@ interconnection, dissipation, control, and forcing components while preserving
 exact skew and semidefinite geometry; solver-owned isothermal dynamics add the
 matching thermal diffusion without creating a second dynamics hierarchy.
 
+Evolution linearizations expose separate matrix-free state and argument
+pushforwards/pullbacks. Diffrax-backed evolution distinguishes its bidirectional
+composition route from forward-mode actions and checkpointed reverse actions,
+and temporal evidence records derivative form, orientation, checkpointing,
+adaptive decisions, events, and stochastic semantics.
+
 Identification includes mask-safe DMD/DMDc and EDMD; strong, discrete, integral,
 and weak SINDy; polynomial, Fourier, tensor-product, transformed, symmetry, and
 custom feature libraries; STLSQ, SR3, temporally embargoed selection, and
@@ -1070,9 +1076,10 @@ Nonlinear analysis includes section crossings and return maps, multiple-shooting
 periodic orbits, dense or matrix-free monodromy/Floquet analysis, resumable
 finite-time Lyapunov spectra, covariant or adjoint directions, finite-size growth,
 RQA, the modified 0--1 test, correlation dimension, surrogate significance,
-explicit uncertainty-source aggregation, and a matrix-free shadowing-candidate
-boundary. Bifurcation flags and statistical diagnostics are finite-resolution
-evidence, not automatic certificates.
+explicit uncertainty-source aggregation, local derivative certification, and
+segmented tangent/adjoint shadowing. NILSS and NILSAS retain finite-horizon,
+resource, continuity, and flow-neutral evidence rather than claiming automatic
+infinite-time sensitivity certificates.
 
 See [Nonlinear-dynamics cookbook](cookbook/nonlinear_dynamics.md) and
 [API → Dynamical systems, identification, and chaos](api/dynamics.md).
@@ -2107,7 +2114,7 @@ Below are the common SciML regimes expressed in Phydrax’s primitives.
 - `phydrax.closure_data` for closure datasets, filters, targets, lineage,
   leakage-safe splits, normalization, and learned deployment bindings.
 - `phydrax.statistical_dynamics` for CE2/GCE2 cumulants, beta-plane coordinates,
-  NILSS, and logical shard/restart layouts.
+  segmented NILSS/NILSAS, and logical shard/restart layouts.
 - `phydrax.backends` for explicit lazy PETSc, SLEPc, PyAMGCL, and NVIDIA AmgX
   lifecycle bridges with availability, transfer, convergence, and provenance evidence.
 - `phydrax.metrix` for charts, tensors, metrics, curvature, and stochastic geometry.
@@ -2121,8 +2128,9 @@ Below are the common SciML regimes expressed in Phydrax’s primitives.
 - `phydrax.operators` for PDE operators.
 - `phydrax.nn` for models, wrappers, and the generic diagonal state-space mixer.
 - `phydrax.dynamics` for typed flow/map laws, pathwise evolution, trajectory
-  data, DMD/EDMD, SINDy/PDE-FIND, periodic-orbit and chaos analysis, uncertainty
-  aggregation, and the shadowing solver boundary.
+  data, matrix-free derivative certification, DMD/EDMD, SINDy/PDE-FIND,
+  periodic-orbit and chaos analysis, uncertainty aggregation, and shadowing
+  problem/candidate contracts.
 - `phydrax.stochastic` for process paths, trajectories, typed state-space
   problems and inputs, transition kernels, exact signature and log-signature
   features, and structural model compilation.

--- a/docs/api/dynamics.md
+++ b/docs/api/dynamics.md
@@ -46,7 +46,8 @@ states implicitly interpolable.
 | Correlation dimension | `correlation_dimension` | Pair counts on declared radii, Theiler exclusion, fit mask, local slopes, and fit evidence. |
 | Surrogate significance | `surrogate_significance` | Explicit null generator, alternative, RNG seed, plus-one p-value, and all surrogate statistics. |
 | Aggregate uncertainty | `summarize_chaos_uncertainty` | Weighted samples over named initial-condition, parameter, noise, process, or numerical axes plus bootstrap evidence. |
-| Connect a shadowing solver | `ShadowingSensitivityProblem`, `evaluate_shadowing_candidate` | Matrix-free tangent defects and response evidence for an externally supplied candidate; no hidden shadowing solve. |
+| Audit a local derivative | `EvolutionJacobianAction`, `EvolutionArgumentJacobianAction`, `certify_evolution_sensitivity` | Matrix-free state/argument actions plus finite-difference, duality, and optional reference evidence. |
+| Long-time sensitivity | `ShadowingSensitivityProblem`, `statistical_dynamics.NILSSPlan`, `statistical_dynamics.NILSASPlan` | Explicit finite-horizon tangent or adjoint shadowing with segmentation, resource, residual, and neutral-flow evidence. |
 
 ## Layouts, systems, grids, and evolution
 
@@ -77,6 +78,21 @@ physical-time normalization and iteration normalization remain distinct. An evol
 segment returns `EvolutionStep`; a tangent action returns `EvolutionTangentStep`.
 `EvolutionTrajectory.valid` is a node mask, while `status` and `backend_status` retain
 segment-level failure evidence.
+
+`AbstractDifferentiableEvolution` exposes prepared state and argument
+linearizations. `EvolutionJacobianAction` and
+`EvolutionArgumentJacobianAction` reuse their matrix-free pushforwards and
+pullbacks instead of materializing Jacobians. `DiffraxEvolution` keeps three
+derivative routes explicit: a bidirectional composite route for ordinary nested
+JAX transformations, `ForwardMode` for prepared pushforwards, and checkpointed
+reverse mode for prepared pullbacks. Their `TemporalDifferentiationEvidence`
+records orientation, checkpointing, adaptive-decision, event, and stochastic
+semantics separately.
+
+`certify_evolution_sensitivity` audits one local derivative against centered
+finite differences, Taylor remainders, transpose duality, and an optional
+tighter evolution. This is numerical evidence at the supplied point, not a
+proof for a parameter domain.
 
 ::: phydrax.dynamics.StateLayout
 
@@ -118,6 +134,14 @@ segment-level failure evidence.
 ::: phydrax.dynamics.EvolutionTrajectory
 
 ::: phydrax.dynamics.EvolutionJacobianAction
+
+::: phydrax.dynamics.EvolutionArgumentJacobianAction
+
+::: phydrax.dynamics.EvolutionSensitivityPolicy
+
+::: phydrax.dynamics.certify_evolution_sensitivity
+
+::: phydrax.dynamics.EvolutionSensitivityEvidence
 
 ::: phydrax.dynamics.evolve
 
@@ -559,17 +583,34 @@ corresponding solver or ensemble workflow.
 
 ::: phydrax.dynamics.analysis.ChaosUncertaintyResult
 
-## Shadowing sensitivity boundary
+## Shadowing sensitivity
 
-Phydrax exposes a solver boundary rather than claiming a universal shadowing algorithm.
-`ShadowingSensitivityProblem` declares an evolution, an integrated endpoint parameter
-forcing, an observable, optional observable derivatives, and optional neutral flow
-direction. `evaluate_shadowing_candidate` evaluates one externally supplied tangent path
-and time-dilation path. It returns dynamic defects, boundary residual, neutral-direction
-inner products, quadrature weights, directional observable response, masks, and status.
-`least_squares_residual()` supplies the residual vector for an external optimizer. It
-does not invoke the native segmented NILSS implementation below, and it hides no
-optimization, regularization, segment preconditioner, or convergence claim.
+`ShadowingSensitivityProblem` binds one argument-parameterized differentiable
+evolution and scalar observable. `evaluate_shadowing_candidate` derives the
+integrated parameter forcing through `EvolutionArgumentJacobianAction`, derives
+any direct observable argument derivative with JAX, and evaluates an externally
+supplied tangent and time-dilation path. It reports dynamic defects, boundary
+residual, neutral inner products, quadrature response, validity, and status
+without selecting an optimizer.
+
+`NILSSPlan` supplies the native segmented tangent solve. Preparation binds an
+existing trajectory, the full argument PyTree, one matching parameter
+direction, an explicit or seeded unstable basis, and byte limits. The solve
+propagates matrix-free homogeneous and inhomogeneous actions, performs segment
+QR, and solves one small constrained reduced system. For a `TimeGrid`, the
+declared neutral direction is projected at every step and the signed
+time-dilation path is retained.
+
+`NILSASPlan` supplies the discrete adjoint counterpart. It propagates reusable
+transpose actions backward, enforces segment continuity, and returns the
+gradient PyTree in one solve rather than one tangent solve per parameter.
+`memory_mode="store"` returns the adjoint shadowing path; `"recompute"` retains
+only segment seeds and replays each segment after the reduced solve. Time-grid
+execution additionally imposes one global neutral adjoint constraint. Both
+solvers initially require real Euclidean states and deterministic, event-free
+evolutions. Their results are finite-horizon approximations; horizon, segment,
+basis, and numerical refinement remain necessary before an infinite-time
+interpretation.
 
 ::: phydrax.dynamics.analysis.ShadowingSensitivityProblem
 
@@ -577,7 +618,23 @@ optimization, regularization, segment preconditioner, or convergence claim.
 
 ::: phydrax.dynamics.analysis.ShadowingCandidateResult
 
-## Statistical dynamics, beta-plane CE2/GCE2, and NILSS
+::: phydrax.statistical_dynamics.AbstractShadowingSolvePlan
+
+::: phydrax.statistical_dynamics.ShadowingSolveCost
+
+::: phydrax.statistical_dynamics.NILSSPlan
+
+::: phydrax.statistical_dynamics.PreparedNILSS
+
+::: phydrax.statistical_dynamics.NILSSResult
+
+::: phydrax.statistical_dynamics.NILSASPlan
+
+::: phydrax.statistical_dynamics.PreparedNILSAS
+
+::: phydrax.statistical_dynamics.NILSASResult
+
+## Statistical dynamics and beta-plane CE2/GCE2
 
 `BarotropicBetaPlane` owns doubly periodic modal vorticity with
 `zeta = Laplacian(psi)`, velocity `(-psi_y, psi_x)`, exact quadratic dealiasing, and
@@ -612,15 +669,6 @@ failed covariance silently.
 coordinates, materializes the QL- or GQL-selected quadratic tensor only inside the
 corresponding `prepare` call, and enforces explicit dimension and byte caps.
 
-`NILSSPlan.prepare()` differentiates a supplied real fixed-step map and scalar
-objective, estimates retained/workspace memory, and freezes dynamics/objective IDs,
-parameters, direction, and unstable basis. `PreparedNILSS.solve()` propagates
-homogeneous and inhomogeneous tangents, enforces QR-equivalent segment continuity in
-one constrained dense least-squares solve, and reports the directional average,
-continuity residual, orthogonality defect, linear status, and success. It is not a set
-of independent perturbation scores and is not evidence of converged infinite-time
-sensitivity without horizon/segment refinement.
-
 `DistributedBatchLayout`, `DistributedCovarianceLayout`, and
 `DistributedRestartRelation` describe balanced logical shards and topology-changing
 redistribution with unchanged semantic layout. Their `shard`, `assemble`, and
@@ -643,17 +691,6 @@ and restart algebra, not a multi-device or multi-host statistical solver.
 
 ---
 
-::: phydrax.statistical_dynamics.NILSSPlan
-
----
-
-::: phydrax.statistical_dynamics.PreparedNILSS
-
----
-
-::: phydrax.statistical_dynamics.NILSSResult
-
----
 
 ::: phydrax.statistical_dynamics.DistributedStatisticalLayout
 
@@ -707,6 +744,12 @@ covariance defects, tangent-evaluation counts, convergence/status evidence,
 environment, and one aggregate `passed` flag. It never constructs a dense
 Jacobian in the high-dimensional case. The checked reference run is stored at
 `benchmarks/dynamics_substrate.json`.
+
+`--scenarios sensitivity` adds a local Diffrax derivative certificate and a
+high-dimensional affine shadowing case. It reports NILSS/NILSAS timing,
+tangent-adjoint duality and analytic errors, retained/workspace bytes, and
+action counts demonstrating that the adjoint parameter-action count does not
+grow with parameter dimension.
 
 Opt in to learned thermodynamic comparisons with
 `--scenarios deterministic`, `--scenarios stochastic`, or

--- a/docs/api/solver/differential.md
+++ b/docs/api/solver/differential.md
@@ -108,6 +108,8 @@ solution = phx.solver.solve_diffrax(
 
 ::: phydrax.solver.solve_diffrax
 
+::: phydrax.solver.TemporalDifferentiationEvidence
+
 ---
 
 ::: phydrax.solver.TemporalPrecisionPolicy
@@ -128,6 +130,22 @@ solver rejects rather than silently summing the terms.
 `DifferentialSolution.temporal_evidence` records method capabilities and the complete
 solver/controller/adjoint/event configuration identity. `valid` remains per-output
 finite evidence; `successful` additionally requires an acceptable backend result.
+
+`temporal_evidence.differentiation` describes the derivative actually exposed by
+that solve: discretize-then-optimize, optimize-then-discretize, implicit solution
+map, or unknown; supported forward/reverse orientations; checkpointing policy and
+count; adaptive-decision, event, and stochastic semantics; implementation
+identity; and whether that classification is verified. These fields are separate
+from the time integrator's order and stability capabilities.
+
+For adaptive solves, `"frozen-adaptive-schedule"` means the accepted discrete
+schedule is differentiated branchwise; it is not a derivative of the
+accept/reject decision surface. Eventful Diffrax solves are likewise marked
+`"backend-branchwise-unqualified"` unless a method owns stronger replay
+semantics. Stochastic solves report fixed-realization pathwise differentiation,
+not a distributional derivative. Backsolve, checkpointed reverse, forward-mode,
+and bidirectional direct routes therefore remain distinguishable in persisted
+evidence.
 
 `TemporalPrecisionPolicy` separates coefficient, stored-state, stage, accumulation,
 residual, acceptance-decision, checkpoint, and returned-output precision. The

--- a/docs/cookbook/nonlinear_dynamics.md
+++ b/docs/cookbook/nonlinear_dynamics.md
@@ -400,52 +400,82 @@ The bootstrap resamples the declared weighted empirical cases. `source_variance`
 variance of source-level conditional means, not a general Sobol decomposition and not a
 causal attribution.
 
-## 9. Shadowing solver boundary
+## 9. Tangent and adjoint shadowing
 
-Phydrax evaluates a shadowing candidate but does not silently choose one shadowing
-algorithm, segmentation, regularizer, or preconditioner.
+`ShadowingSensitivityProblem` binds the parameter through the evolution's
+ordinary `args` PyTree. The candidate evaluator derives the integrated
+one-segment argument action; callers do not supply a second parameter-forcing
+callback.
 
-For the map \(x_{n+1}=0.8x_n+p\), the one-step inhomogeneous tangent with respect to
-\(p\) is exactly one, so the candidate can be constructed without a hidden solver.
+For the stable map \(x_{n+1}=0.8x_n+p\), the one-step argument tangent in the
+unit \(p\) direction is exactly one:
 
 ```python
 shadowing_evolution = phx.dynamics.DiscreteEvolution(
     phx.dynamics.DiscreteSystem(
-        lambda coordinate, state, args: 0.8 * state,
+        lambda coordinate, state, args: 0.8 * state + args,
         state_layout=phx.dynamics.StateLayout((1,)),
         system_id="contracting-map",
     )
 )
-shadowing_grid = phx.dynamics.IterationGrid.from_steps(5, iteration_id="shadowing-grid")
+shadowing_grid = phx.dynamics.IterationGrid.from_steps(
+    20,
+    iteration_id="shadowing-grid",
+)
+parameters = jnp.asarray([0.2])
+parameter_direction = jnp.asarray([1.0])
 shadowing_trajectory = phx.dynamics.evolve(
-    shadowing_evolution, jnp.asarray([2.0]), shadowing_grid
+    shadowing_evolution,
+    jnp.asarray([1.0]),
+    shadowing_grid,
+    args=parameters,
 )
 shadowing_problem = phx.dynamics.analysis.ShadowingSensitivityProblem(
     shadowing_evolution,
-    lambda state, source, target, args: jnp.ones_like(state),
     lambda coordinate, state, args: state[0],
     parameter_id="additive-offset",
     observable_id="state",
     problem_id="contracting-map-shadowing",
 )
+
 tangent_values = [jnp.asarray([0.0])]
 for _ in range(shadowing_grid.num_steps):
-    tangent_values.append(0.8 * tangent_values[-1] + 1.0)
+    tangent_values.append(0.8 * tangent_values[-1] + parameter_direction)
 tangent_path = jnp.stack(tuple(tangent_values))
-
 candidate = phx.dynamics.analysis.evaluate_shadowing_candidate(
     shadowing_problem,
     shadowing_trajectory,
     tangent_path,
+    parameter_direction,
+    args=parameters,
     boundary="free",
 )
-residual = candidate.least_squares_residual()
+
+nilss = phx.statistical_dynamics.NILSSPlan(1, 0, 0, 5, 4).prepare(
+    shadowing_problem,
+    shadowing_trajectory,
+    parameter_direction,
+    args=parameters,
+).solve()
+nilsas = phx.statistical_dynamics.NILSASPlan(1, 0, 0, 5, 4).prepare(
+    shadowing_problem,
+    shadowing_trajectory,
+    args=parameters,
+).solve()
 ```
 
-An external least-squares shadowing or NILSS solver can optimize this residual. Require
-small dynamic defects, the intended boundary residual, controlled neutral inner products,
-and convergence under segment/window refinement before interpreting
-`mean_directional_response`.
+`candidate.least_squares_residual()` remains useful for externally generated
+paths. `NILSSPlan` computes one directional tangent response; `NILSASPlan`
+computes the full argument-gradient PyTree by backward transpose actions. The
+zero basis is appropriate only because this example has no unstable direction.
+Chaotic runs must declare and refine their unstable and basis dimensions,
+horizon, and segmentation.
+
+Flow shadowing additionally requires a `TimeGrid`, `time_dilation="flow"`, and
+an explicit nonzero `neutral_direction`. NILSS projects tangents against that
+direction and returns signed step dilation. NILSAS includes the neutral adjoint
+in its basis and imposes one global neutral constraint. Neither finite-horizon
+result is an automatic infinite-time sensitivity certificate.
 
 ## 10. Interoperability recipes
 

--- a/phydrax/dynamics/__init__.py
+++ b/phydrax/dynamics/__init__.py
@@ -63,7 +63,7 @@ from ._evolution import (
 from ._grid import EvolutionGrid, IterationGrid, TimeGrid
 from ._layout import InputLayout, InputRole, StateLayout
 from ._linear_descriptor import DescriptorSystemEvidence, LinearDescriptorSystem
-from ._linearization import EvolutionJacobianAction
+from ._linearization import EvolutionArgumentJacobianAction, EvolutionJacobianAction
 from ._model_system import (
     continuous_model_system,
     ContinuousModelVectorField,
@@ -95,6 +95,12 @@ from ._second_order import (
     SecondOrderDifferentialProblem,
     SecondOrderDifferentialSystem,
     SecondOrderResidual,
+)
+from ._sensitivity import (
+    certify_evolution_sensitivity,
+    EvolutionSensitivityEvidence,
+    EvolutionSensitivityPolicy,
+    EvolutionSensitivityStatus,
 )
 from ._system import (
     AbstractInputPolicy,
@@ -194,10 +200,14 @@ __all__ = [
     "EVOLUTION_OUTSIDE_GEOMETRY",
     "EVOLUTION_SUCCESS",
     "EvolutionGrid",
+    "EvolutionArgumentJacobianAction",
     "EvolutionJacobianAction",
     "EvolutionStep",
     "EvolutionTangentStep",
     "EvolutionTrajectory",
+    "EvolutionSensitivityEvidence",
+    "EvolutionSensitivityPolicy",
+    "EvolutionSensitivityStatus",
     "InputDifferentialAlgebraicResidual",
     "InputContinuousVectorField",
     "InputDiscreteTransition",
@@ -215,6 +225,7 @@ __all__ = [
     "TimeGrid",
     "TrajectoryData",
     "TrajectoryTransitions",
+    "certify_evolution_sensitivity",
     "continuous_model_system",
     "discrete_model_system",
     "evolve",

--- a/phydrax/dynamics/_evolution.py
+++ b/phydrax/dynamics/_evolution.py
@@ -13,6 +13,7 @@ import jax.numpy as jnp
 from jaxtyping import Array, ArrayLike
 
 from .._strict import AbstractAttribute, StrictModule
+from ..linalg import ArraySpace, prepare_linearization, PreparedLinearization
 from ._grid import EvolutionGrid, IterationGrid, TimeGrid
 from ._layout import StateLayout
 from ._system import (
@@ -131,6 +132,8 @@ class AbstractDifferentiableEvolution(AbstractEvolution):
     """Pathwise evolution with an explicit local tangent action."""
 
     tangent_method_id: AbstractAttribute[str]
+    eventful: AbstractAttribute[bool]
+    stochastic: AbstractAttribute[bool]
 
     @abc.abstractmethod
     def tangent_action(
@@ -144,6 +147,32 @@ class AbstractDifferentiableEvolution(AbstractEvolution):
     ) -> EvolutionTangentStep:
         raise NotImplementedError
 
+    @abc.abstractmethod
+    def state_linearization(
+        self,
+        state: ArrayLike,
+        source_coordinate: ArrayLike,
+        target_coordinate: ArrayLike,
+        args: Any = None,
+        /,
+    ) -> PreparedLinearization:
+        """Linearize one endpoint with respect to its source state."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def argument_linearization(
+        self,
+        state: ArrayLike,
+        source_coordinate: ArrayLike,
+        target_coordinate: ArrayLike,
+        args: Any,
+        /,
+    ) -> PreparedLinearization:
+        """Linearize one endpoint with respect to the explicit argument PyTree."""
+        raise NotImplementedError(
+            f"{type(self).__name__} does not expose argument linearization."
+        )
+
 
 class DiscreteEvolution(AbstractDifferentiableEvolution):
     """One-step evolution and JVP for a declared discrete system."""
@@ -156,6 +185,8 @@ class DiscreteEvolution(AbstractDifferentiableEvolution):
     discretization_id: str = eqx.field(static=True)
     approximation_id: str = eqx.field(static=True)
     tangent_method_id: str = eqx.field(static=True)
+    eventful: bool = eqx.field(static=True)
+    stochastic: bool = eqx.field(static=True)
 
     def __init__(
         self,
@@ -194,6 +225,8 @@ class DiscreteEvolution(AbstractDifferentiableEvolution):
         self.discretization_id = "one-map-iterate"
         self.approximation_id = "exact-declared-transition"
         self.tangent_method_id = "jax-jvp:declared-transition"
+        self.eventful = False
+        self.stochastic = False
 
     def _map_result(
         self, context: DiscreteStepContext, state: Array, args: Any, /
@@ -336,6 +369,85 @@ class DiscreteEvolution(AbstractDifferentiableEvolution):
             valid=valid,
             status=status,
             tangent_method_id=self.tangent_method_id,
+        )
+
+    def state_linearization(
+        self,
+        state: ArrayLike,
+        source_coordinate: ArrayLike,
+        target_coordinate: ArrayLike,
+        args: Any = None,
+        /,
+    ) -> PreparedLinearization:
+        state_array = jnp.asarray(state)
+        if state_array.shape != self.state_layout.shape:
+            raise ValueError(
+                f"state must have shape {self.state_layout.shape}; got {state_array.shape}."
+            )
+        source = jnp.asarray(source_coordinate)
+        target = jnp.asarray(target_coordinate)
+        if source.shape != () or target.shape != ():
+            raise ValueError("Evolution segment coordinates must be scalar.")
+        context = DiscreteStepContext(source, target, jnp.asarray(0, dtype=jnp.int32))
+        space = ArraySpace(self.state_layout.shape, dtype=state_array.dtype)
+        geometry = self.state_layout.geometry
+        if geometry.trivial:
+            point = state_array
+
+            def endpoint(current_state):
+                return self._map(context, current_state, args)
+
+        else:
+            point = jnp.zeros_like(state_array)
+            primal = self.advance(state_array, source, target, args)
+
+            def endpoint(local):
+                perturbed = geometry.retract(state_array, local)
+                mapped = self._map(context, perturbed, args)
+                return geometry.inverse_retract(primal.final_state, mapped)
+
+        return prepare_linearization(
+            endpoint,
+            point,
+            source=space,
+            target=space,
+            linearization_id=(
+                f"{self.evolution_id}:state-linearization:{self.state_layout.layout_id}"
+            ),
+        )
+
+    def argument_linearization(
+        self,
+        state: ArrayLike,
+        source_coordinate: ArrayLike,
+        target_coordinate: ArrayLike,
+        args: Any,
+        /,
+    ) -> PreparedLinearization:
+        state_array = jnp.asarray(state)
+        if state_array.shape != self.state_layout.shape:
+            raise ValueError(
+                f"state must have shape {self.state_layout.shape}; got {state_array.shape}."
+            )
+        leaves = jax.tree.leaves(args)
+        if not leaves or any(not eqx.is_inexact_array(leaf) for leaf in leaves):
+            raise TypeError(
+                "Evolution argument linearization requires a nonempty PyTree "
+                "of inexact arrays."
+            )
+        source = jnp.asarray(source_coordinate)
+        target = jnp.asarray(target_coordinate)
+        if source.shape != () or target.shape != ():
+            raise ValueError("Evolution segment coordinates must be scalar.")
+        context = DiscreteStepContext(source, target, jnp.asarray(0, dtype=jnp.int32))
+        return prepare_linearization(
+            lambda current_args: self._map(context, state_array, current_args),
+            args,
+            target=ArraySpace(self.state_layout.shape, dtype=state_array.dtype),
+            linearization_id=(
+                f"{self.evolution_id}:argument-linearization:"
+                f"{self.state_layout.layout_id}"
+            ),
         )
 
 

--- a/phydrax/dynamics/_linearization.py
+++ b/phydrax/dynamics/_linearization.py
@@ -14,7 +14,7 @@ from .._fingerprint import canonical_fingerprint
 from ..linalg import (
     AbstractLinearOperator,
     ArraySpace,
-    LinearizationPolicy,
+    JacobianLinearOperator,
     OperatorCapabilities,
     OperatorProperties,
     PreparedLinearization,
@@ -61,9 +61,27 @@ class EvolutionJacobianAction(AbstractLinearOperator):
         self.target_coordinate = target
         self.args = args
         self.primal = evolution.advance(state_array, source, target, args)
-        space = ArraySpace(evolution.state_layout.shape, dtype=state_array.dtype)
-        self.source = space
-        self.target = space
+        linearization = evolution.state_linearization(
+            state_array,
+            source,
+            target,
+            args,
+        )
+        if not isinstance(linearization.source, ArraySpace) or not isinstance(
+            linearization.target, ArraySpace
+        ):
+            raise TypeError(
+                "Evolution state linearization must use ArraySpace endpoints."
+            )
+        if (
+            linearization.source.shape != evolution.state_layout.shape
+            or linearization.target.shape != evolution.state_layout.shape
+        ):
+            raise ValueError(
+                "Evolution state linearization spaces must match the state layout."
+            )
+        self.source = linearization.source
+        self.target = linearization.target
         self.properties = OperatorProperties()
         self.capabilities = OperatorCapabilities(
             transpose=True,
@@ -75,8 +93,9 @@ class EvolutionJacobianAction(AbstractLinearOperator):
             canonical_fingerprint(
                 {
                     "kind": "evolution-jacobian",
-                    "evolution": type(evolution).__qualname__,
-                    "space": space.space_id,
+                    "evolution": evolution.evolution_id,
+                    "source": linearization.source.space_id,
+                    "target": linearization.target.space_id,
                 }
             )
             if operator_id is None
@@ -84,38 +103,7 @@ class EvolutionJacobianAction(AbstractLinearOperator):
         )
         if not self.operator_id:
             raise ValueError("operator_id must be non-empty.")
-
-        def pushforward(tangent):
-            return evolution.tangent_action(
-                state_array,
-                tangent,
-                source,
-                target,
-                args,
-            ).tangent
-
-        transposed = jax.linear_transpose(pushforward, space.zeros())
-
-        def pullback(cotangent):
-            return transposed(cotangent)[0]
-
-        geometry = evolution.state_layout.geometry
-        linearization_point = (
-            state_array if geometry.trivial else jnp.zeros_like(state_array)
-        )
-        linearization_primal = (
-            self.primal.final_state if geometry.trivial else jnp.zeros_like(state_array)
-        )
-        self.linearization = PreparedLinearization(
-            source=space,
-            target=space,
-            point=linearization_point,
-            primal=linearization_primal,
-            pushforward=pushforward,
-            pullback=pullback,
-            policy=LinearizationPolicy(),
-            linearization_id=f"{self.operator_id}:prepared",
-        )
+        self.linearization = linearization
 
     @property
     def input_shape(self) -> tuple[int, ...]:
@@ -153,4 +141,84 @@ class EvolutionJacobianAction(AbstractLinearOperator):
         return self.as_dense(max_dimension=self.evolution.state_layout.size)
 
 
-__all__ = ["EvolutionJacobianAction"]
+class EvolutionArgumentJacobianAction(AbstractLinearOperator):
+    """Matrix-free endpoint derivative with respect to one argument PyTree."""
+
+    evolution: AbstractDifferentiableEvolution
+    state: Array
+    source_coordinate: Array
+    target_coordinate: Array
+    args: Any
+    primal: Any
+    linearization: PreparedLinearization
+    operator: JacobianLinearOperator
+
+    def __init__(
+        self,
+        evolution: AbstractDifferentiableEvolution,
+        state: ArrayLike,
+        source_coordinate: ArrayLike,
+        target_coordinate: ArrayLike,
+        args: Any,
+        /,
+        *,
+        operator_id: str | None = None,
+    ):
+        if not isinstance(evolution, AbstractDifferentiableEvolution):
+            raise TypeError("evolution must be an AbstractDifferentiableEvolution.")
+        state_array = jnp.asarray(state)
+        source = jnp.asarray(source_coordinate)
+        target = jnp.asarray(target_coordinate)
+        linearization = evolution.argument_linearization(
+            state_array,
+            source,
+            target,
+            args,
+        )
+        identifier = (
+            canonical_fingerprint(
+                {
+                    "kind": "evolution-argument-jacobian",
+                    "evolution": evolution.evolution_id,
+                    "source": linearization.source.space_id,
+                    "target": linearization.target.space_id,
+                }
+            )
+            if operator_id is None
+            else str(operator_id)
+        )
+        if not identifier:
+            raise ValueError("operator_id must be non-empty.")
+        operator = JacobianLinearOperator(
+            linearization,
+            operator_id=identifier,
+        )
+        self.evolution = evolution
+        self.state = state_array
+        self.source_coordinate = source
+        self.target_coordinate = target
+        self.args = args
+        self.primal = linearization.primal
+        self.linearization = linearization
+        self.operator = operator
+        self.source = operator.source
+        self.target = operator.target
+        self.properties = operator.properties
+        self.capabilities = operator.capabilities
+        self.batch_shape = operator.batch_shape
+        self.operator_id = operator.operator_id
+
+    def mv(self, vector: Any, /) -> Any:
+        return self.operator.mv(vector)
+
+    def transpose_mv(self, vector: Any, /) -> Any:
+        return self.operator.transpose_mv(vector)
+
+    def adjoint_mv(self, vector: Any, /) -> Any:
+        return self.operator.adjoint_mv(vector)
+
+    def _materialize(self, /) -> Array:
+        return self.operator._materialize()
+
+
+__all__ = ["EvolutionArgumentJacobianAction", "EvolutionJacobianAction"]

--- a/phydrax/dynamics/_sensitivity.py
+++ b/phydrax/dynamics/_sensitivity.py
@@ -1,0 +1,328 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from enum import IntEnum
+from math import isfinite
+from typing import Any
+
+import equinox as eqx
+import jax.numpy as jnp
+from jaxtyping import Array, ArrayLike
+
+from .._fingerprint import canonical_fingerprint
+from .._strict import StrictModule
+from .._trainable import NonTrainableState
+from ._evolution import AbstractDifferentiableEvolution
+from ._linearization import EvolutionJacobianAction
+
+
+class EvolutionSensitivityStatus(IntEnum):
+    SUCCESS = 0
+    PRIMAL_INVALID = 1
+    TANGENT_INVALID = 2
+    PERTURBATION_INVALID = 3
+    REFERENCE_INVALID = 4
+    NONFINITE = 5
+    JVP_MISMATCH = 6
+    DUALITY_MISMATCH = 7
+    REFERENCE_MISMATCH = 8
+
+
+class EvolutionSensitivityPolicy(StrictModule, NonTrainableState):
+    """Perturbation and acceptance policy for one evolution linearization audit."""
+
+    perturbations: tuple[float, float] = eqx.field(static=True)
+    relative_tolerance: float = eqx.field(static=True)
+    absolute_tolerance: float = eqx.field(static=True)
+    policy_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        perturbations: tuple[float, float] = (1.0e-4, 5.0e-5),
+        /,
+        *,
+        relative_tolerance: float = 2.0e-4,
+        absolute_tolerance: float = 1.0e-8,
+    ):
+        steps = tuple(float(value) for value in perturbations)
+        relative = float(relative_tolerance)
+        absolute = float(absolute_tolerance)
+        if (
+            len(steps) != 2
+            or any(not isfinite(value) or value <= 0.0 for value in steps)
+            or not steps[0] > steps[1]
+        ):
+            raise ValueError(
+                "perturbations must contain two finite positive decreasing values."
+            )
+        if not isfinite(relative) or relative < 0.0:
+            raise ValueError("relative_tolerance must be finite and nonnegative.")
+        if not isfinite(absolute) or absolute < 0.0:
+            raise ValueError("absolute_tolerance must be finite and nonnegative.")
+        if relative == 0.0 and absolute == 0.0:
+            raise ValueError("At least one sensitivity tolerance must be positive.")
+        self.perturbations = steps
+        self.relative_tolerance = relative
+        self.absolute_tolerance = absolute
+        self.policy_id = canonical_fingerprint(
+            {
+                "kind": "evolution-sensitivity-policy",
+                "perturbations": list(steps),
+                "relative_tolerance": relative,
+                "absolute_tolerance": absolute,
+            }
+        )
+
+
+class EvolutionSensitivityEvidence(StrictModule, NonTrainableState):
+    """Numerical consistency evidence for one local evolution derivative."""
+
+    jvp_defects: Array
+    taylor_remainders: Array
+    taylor_refinement_ratio: Array
+    duality_defect: Array
+    reference_tangent_defect: Array
+    perturbed_valid: Array
+    primal_valid: Array
+    tangent_valid: Array
+    finite: Array
+    valid: Array
+    status: Array
+    policy_id: str = eqx.field(static=True)
+    evolution_id: str = eqx.field(static=True)
+    tangent_method_id: str = eqx.field(static=True)
+    reference_evolution_id: str | None = eqx.field(static=True)
+    evidence_id: str = eqx.field(static=True)
+
+
+def _maximum_absolute(value: Array, /) -> Array:
+    return jnp.max(jnp.abs(value), initial=0.0)
+
+
+def certify_evolution_sensitivity(
+    evolution: AbstractDifferentiableEvolution,
+    state: ArrayLike,
+    direction: ArrayLike,
+    cotangent: ArrayLike,
+    source_coordinate: ArrayLike,
+    target_coordinate: ArrayLike,
+    /,
+    *,
+    args: Any = None,
+    policy: EvolutionSensitivityPolicy | None = None,
+    reference_evolution: AbstractDifferentiableEvolution | None = None,
+) -> EvolutionSensitivityEvidence:
+    """Audit JVP, transpose duality, Taylor behavior, and optional refinement."""
+    if not isinstance(evolution, AbstractDifferentiableEvolution):
+        raise TypeError("evolution must be an AbstractDifferentiableEvolution.")
+    if not evolution.state_layout.geometry.trivial:
+        raise ValueError(
+            "Evolution sensitivity certification initially requires Euclidean geometry."
+        )
+    selected = EvolutionSensitivityPolicy() if policy is None else policy
+    if not isinstance(selected, EvolutionSensitivityPolicy):
+        raise TypeError("policy must be EvolutionSensitivityPolicy or None.")
+    value = jnp.asarray(state)
+    tangent_direction = jnp.asarray(direction)
+    dual = jnp.asarray(cotangent)
+    expected = evolution.state_layout.shape
+    if (
+        value.shape != expected
+        or tangent_direction.shape != expected
+        or dual.shape != expected
+    ):
+        raise ValueError("state, direction, and cotangent must match the state layout.")
+    source = jnp.asarray(source_coordinate)
+    target = jnp.asarray(target_coordinate)
+    if source.shape != () or target.shape != ():
+        raise ValueError("Evolution segment coordinates must be scalar.")
+
+    primal = evolution.advance(value, source, target, args)
+    tangent = evolution.tangent_action(
+        value,
+        tangent_direction,
+        source,
+        target,
+        args,
+    )
+    action = EvolutionJacobianAction(
+        evolution,
+        value,
+        source,
+        target,
+        args=args,
+    )
+    transposed = action.transpose_mv(dual)
+
+    defects = []
+    remainders = []
+    perturbation_valid = []
+    for epsilon in selected.perturbations:
+        plus = evolution.advance(
+            value + epsilon * tangent_direction,
+            source,
+            target,
+            args,
+        )
+        minus = evolution.advance(
+            value - epsilon * tangent_direction,
+            source,
+            target,
+            args,
+        )
+        finite_difference = (plus.final_state - minus.final_state) / (2.0 * epsilon)
+        defects.append(_maximum_absolute(tangent.tangent - finite_difference))
+        remainders.append(
+            _maximum_absolute(
+                plus.final_state - primal.final_state - epsilon * tangent.tangent
+            )
+        )
+        perturbation_valid.append(plus.valid & minus.valid)
+    jvp_defects = jnp.stack(tuple(defects))
+    taylor_remainders = jnp.stack(tuple(remainders))
+    tiny = jnp.finfo(taylor_remainders.dtype).tiny
+    taylor_ratio = taylor_remainders[1] / jnp.maximum(taylor_remainders[0], tiny)
+    duality_forward = jnp.vdot(dual, tangent.tangent)
+    duality_reverse = jnp.vdot(transposed, tangent_direction)
+    duality = jnp.abs(duality_forward - duality_reverse)
+    perturbed_valid = jnp.stack(tuple(perturbation_valid))
+
+    if reference_evolution is None:
+        reference_defect = jnp.asarray(0.0, dtype=value.real.dtype)
+        reference_valid = jnp.asarray(True)
+        reference_id = None
+    else:
+        if not isinstance(reference_evolution, AbstractDifferentiableEvolution):
+            raise TypeError(
+                "reference_evolution must be AbstractDifferentiableEvolution or None."
+            )
+        if (
+            reference_evolution.system.system_id != evolution.system.system_id
+            or reference_evolution.state_layout.layout_id
+            != evolution.state_layout.layout_id
+        ):
+            raise ValueError(
+                "Reference evolution must preserve the system and state layout."
+            )
+        reference = reference_evolution.tangent_action(
+            value,
+            tangent_direction,
+            source,
+            target,
+            args,
+        )
+        reference_defect = _maximum_absolute(reference.tangent - tangent.tangent)
+        reference_valid = reference.valid
+        reference_id = reference_evolution.evolution_id
+
+    jvp_scale = jnp.maximum(1.0, _maximum_absolute(tangent.tangent))
+    jvp_threshold = selected.absolute_tolerance + selected.relative_tolerance * jvp_scale
+    duality_scale = jnp.maximum(
+        1.0,
+        jnp.maximum(jnp.abs(duality_forward), jnp.abs(duality_reverse)),
+    )
+    duality_threshold = (
+        selected.absolute_tolerance + selected.relative_tolerance * duality_scale
+    )
+    reference_scale = jnp.maximum(
+        1.0,
+        _maximum_absolute(tangent.tangent),
+    )
+    reference_threshold = (
+        selected.absolute_tolerance + selected.relative_tolerance * reference_scale
+    )
+    perturbations_valid = jnp.all(perturbed_valid)
+    finite = (
+        jnp.all(jnp.isfinite(primal.final_state))
+        & jnp.all(jnp.isfinite(tangent.tangent))
+        & jnp.all(jnp.isfinite(transposed))
+        & jnp.all(jnp.isfinite(jvp_defects))
+        & jnp.all(jnp.isfinite(taylor_remainders))
+        & jnp.isfinite(duality)
+        & jnp.isfinite(reference_defect)
+    )
+    jvp_valid = jnp.all(jvp_defects <= jvp_threshold)
+    duality_valid = duality <= duality_threshold
+    reference_matches = reference_defect <= reference_threshold
+    valid = (
+        primal.valid
+        & tangent.valid
+        & action.primal.valid
+        & perturbations_valid
+        & reference_valid
+        & finite
+        & jvp_valid
+        & duality_valid
+        & reference_matches
+    )
+    status = jnp.where(
+        ~primal.valid,
+        int(EvolutionSensitivityStatus.PRIMAL_INVALID),
+        jnp.where(
+            ~(tangent.valid & action.primal.valid),
+            int(EvolutionSensitivityStatus.TANGENT_INVALID),
+            jnp.where(
+                ~perturbations_valid,
+                int(EvolutionSensitivityStatus.PERTURBATION_INVALID),
+                jnp.where(
+                    ~reference_valid,
+                    int(EvolutionSensitivityStatus.REFERENCE_INVALID),
+                    jnp.where(
+                        ~finite,
+                        int(EvolutionSensitivityStatus.NONFINITE),
+                        jnp.where(
+                            ~jvp_valid,
+                            int(EvolutionSensitivityStatus.JVP_MISMATCH),
+                            jnp.where(
+                                ~duality_valid,
+                                int(EvolutionSensitivityStatus.DUALITY_MISMATCH),
+                                jnp.where(
+                                    ~reference_matches,
+                                    int(EvolutionSensitivityStatus.REFERENCE_MISMATCH),
+                                    int(EvolutionSensitivityStatus.SUCCESS),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    ).astype(jnp.int32)
+    evidence_id = canonical_fingerprint(
+        {
+            "kind": "evolution-sensitivity-evidence",
+            "policy": selected.policy_id,
+            "evolution": evolution.evolution_id,
+            "tangent_method": evolution.tangent_method_id,
+            "reference_evolution": reference_id,
+        }
+    )
+    return EvolutionSensitivityEvidence(
+        jvp_defects=jvp_defects,
+        taylor_remainders=taylor_remainders,
+        taylor_refinement_ratio=taylor_ratio,
+        duality_defect=duality,
+        reference_tangent_defect=reference_defect,
+        perturbed_valid=perturbed_valid,
+        primal_valid=primal.valid,
+        tangent_valid=tangent.valid,
+        finite=finite,
+        valid=valid,
+        status=status,
+        policy_id=selected.policy_id,
+        evolution_id=evolution.evolution_id,
+        tangent_method_id=evolution.tangent_method_id,
+        reference_evolution_id=reference_id,
+        evidence_id=evidence_id,
+    )
+
+
+__all__ = [
+    "EvolutionSensitivityEvidence",
+    "EvolutionSensitivityPolicy",
+    "EvolutionSensitivityStatus",
+    "certify_evolution_sensitivity",
+]

--- a/phydrax/dynamics/analysis/_shadowing.py
+++ b/phydrax/dynamics/analysis/_shadowing.py
@@ -15,6 +15,7 @@ from jaxtyping import Array, ArrayLike
 from ..._strict import StrictModule
 from .._evolution import AbstractDifferentiableEvolution, EvolutionTrajectory
 from .._grid import IterationGrid, TimeGrid
+from .._linearization import EvolutionArgumentJacobianAction
 
 
 ShadowingBoundary: TypeAlias = Literal["free", "zero", "periodic"]
@@ -27,30 +28,20 @@ SHADOWING_CANDIDATE_SHAPE_INVALID = 3
 
 
 class ShadowingSensitivityProblem(StrictModule):
-    """Matrix-free contract for least-squares or NILSS-style shadowing solvers.
-
-    ``inhomogeneous_tangent`` returns the endpoint tangent contribution of one unit
-    parameter perturbation over a declared evolution segment. It is not an
-    instantaneous vector-field derivative unless the evolution discretization makes
-    that equivalence explicit.
-    """
+    """Matrix-free shadowing contract over an argument-parameterized evolution."""
 
     evolution: AbstractDifferentiableEvolution
-    inhomogeneous_tangent: Callable[[Array, Array, Array, Any], Array]
     observable: Callable[[Array, Array, Any], Array]
     observable_state_gradient: Callable[[Array, Array, Any], Array] | None
-    observable_parameter_derivative: Callable[[Array, Array, Any], Array] | None
     neutral_direction: Callable[[Array, Array, Any], Array] | None
     parameter_id: str = eqx.field(static=True)
     observable_id: str = eqx.field(static=True)
     problem_id: str = eqx.field(static=True)
     time_dilation: ShadowingTimeDilation = eqx.field(static=True)
-    forcing_semantics: str = eqx.field(static=True)
 
     def __init__(
         self,
         evolution: AbstractDifferentiableEvolution,
-        inhomogeneous_tangent: Callable[[Array, Array, Array, Any], Array],
         observable: Callable[[Array, Array, Any], Array],
         /,
         *,
@@ -58,19 +49,14 @@ class ShadowingSensitivityProblem(StrictModule):
         observable_id: str,
         problem_id: str,
         observable_state_gradient: Callable[[Array, Array, Any], Array] | None = None,
-        observable_parameter_derivative: Callable[[Array, Array, Any], Array]
-        | None = None,
         neutral_direction: Callable[[Array, Array, Any], Array] | None = None,
         time_dilation: ShadowingTimeDilation = "none",
-        forcing_semantics: str = "integrated-endpoint-parameter-tangent",
     ):
         if not isinstance(evolution, AbstractDifferentiableEvolution):
             raise TypeError("evolution must be an AbstractDifferentiableEvolution.")
         callbacks = (
-            inhomogeneous_tangent,
             observable,
             observable_state_gradient,
-            observable_parameter_derivative,
             neutral_direction,
         )
         if any(value is not None and not callable(value) for value in callbacks):
@@ -83,21 +69,17 @@ class ShadowingSensitivityProblem(StrictModule):
             parameter_id,
             observable_id,
             problem_id,
-            forcing_semantics,
         )
         if any(not isinstance(value, str) or not value for value in identifiers):
             raise ValueError("Shadowing identifiers must be non-empty strings.")
         self.evolution = evolution
-        self.inhomogeneous_tangent = inhomogeneous_tangent
         self.observable = observable
         self.observable_state_gradient = observable_state_gradient
-        self.observable_parameter_derivative = observable_parameter_derivative
         self.neutral_direction = neutral_direction
         self.parameter_id = parameter_id
         self.observable_id = observable_id
         self.problem_id = problem_id
         self.time_dilation = time_dilation
-        self.forcing_semantics = forcing_semantics
 
 
 class ShadowingCandidateResult(StrictModule):
@@ -159,9 +141,10 @@ def evaluate_shadowing_candidate(
     problem: ShadowingSensitivityProblem,
     trajectory: EvolutionTrajectory,
     tangent_path: ArrayLike,
+    parameter_direction: Any,
     /,
     *,
-    args: Any = None,
+    args: Any,
     time_dilation: ArrayLike | None = None,
     boundary: ShadowingBoundary = "free",
 ) -> ShadowingCandidateResult:
@@ -174,6 +157,10 @@ def evaluate_shadowing_candidate(
         raise ValueError("trajectory and shadowing evolution IDs do not match.")
     if trajectory.state_layout.layout_id != problem.evolution.state_layout.layout_id:
         raise ValueError("trajectory and shadowing state layouts do not match.")
+    if not problem.evolution.state_layout.geometry.trivial:
+        raise ValueError("Shadowing initially requires Euclidean state geometry.")
+    if jax.tree.structure(parameter_direction) != jax.tree.structure(args):
+        raise ValueError("Parameter direction must match the argument PyTree.")
     if boundary not in ("free", "zero", "periodic"):
         raise ValueError("Unsupported shadowing boundary condition.")
     tangent = jnp.asarray(tangent_path)
@@ -188,8 +175,12 @@ def evaluate_shadowing_candidate(
     )
     if dilation.shape != (steps,):
         raise ValueError("time_dilation must have one scalar per evolution step.")
-    if problem.time_dilation == "none" and bool(jnp.any(dilation != 0.0)):
-        raise ValueError("Nonzero time dilation requires time_dilation='flow'.")
+    if problem.time_dilation == "none":
+        dilation = eqx.error_if(
+            dilation,
+            jnp.any(dilation != 0.0),
+            "Nonzero time dilation requires time_dilation='flow'.",
+        )
     defects = []
     defect_norms = []
     step_valid_values = []
@@ -204,11 +195,16 @@ def evaluate_shadowing_candidate(
             target,
             args,
         )
-        forcing = jnp.asarray(
-            problem.inhomogeneous_tangent(trajectory.states[index], source, target, args)
+        parameter_action = EvolutionArgumentJacobianAction(
+            problem.evolution,
+            trajectory.states[index],
+            source,
+            target,
+            args,
         )
+        forcing = jnp.asarray(parameter_action.mv(parameter_direction))
         if forcing.shape != problem.evolution.state_layout.shape:
-            raise ValueError("inhomogeneous_tangent returned the wrong shape.")
+            raise ValueError("Evolution argument action returned the wrong state shape.")
         if problem.neutral_direction is None:
             neutral = jnp.zeros_like(forcing)
         else:
@@ -266,15 +262,14 @@ def evaluate_shadowing_candidate(
             )
         if gradient.shape != problem.evolution.state_layout.shape:
             raise ValueError("observable_state_gradient returned the wrong shape.")
-        explicit = (
-            jnp.asarray(0.0, dtype=observable.dtype)
-            if problem.observable_parameter_derivative is None
-            else jnp.asarray(
-                problem.observable_parameter_derivative(coordinate, state, args)
-            )
+        _, explicit = jax.jvp(
+            lambda current_args: problem.observable(coordinate, state, current_args),
+            (args,),
+            (parameter_direction,),
         )
+        explicit = jnp.asarray(explicit)
         if explicit.shape != ():
-            raise ValueError("observable_parameter_derivative must return a scalar.")
+            raise ValueError("Observable argument derivative must return a scalar.")
         directional = (
             jnp.vdot(gradient.reshape((-1,)), tangent[index].reshape((-1,))).real
             + explicit
@@ -351,7 +346,7 @@ def evaluate_shadowing_candidate(
         trajectory=trajectory,
         boundary=boundary,
         boundary_enforced=boundary_enforced,
-        method_id="matrix-free-shadowing-candidate-residual",
+        method_id="matrix-free-argument-shadowing-candidate-residual",
         response_assumption=(
             "quadrature-average-tangent-response-with-flow-time-dilation"
             if problem.time_dilation == "flow"

--- a/phydrax/solver/__init__.py
+++ b/phydrax/solver/__init__.py
@@ -2027,10 +2027,17 @@ from ._symplectic import (
 )
 from ._temporal_method import (
     NoiseRequirement,
+    TemporalCheckpointing,
+    TemporalDecisionSemantics,
+    TemporalDifferentiationEvidence,
+    TemporalDifferentiationForm,
+    TemporalDifferentiationOrientation,
     TemporalEquationForm,
+    TemporalEventSemantics,
     TemporalMethodCapabilities,
     TemporalMethodClass,
     TemporalSolveEvidence,
+    TemporalStochasticSemantics,
 )
 from ._temporal_precision import TemporalPrecisionPolicy
 from ._tensor_open_quantum import (
@@ -3001,12 +3008,19 @@ __all__ = [
     "SSPRK33",
     "SSPRK54",
     "StatePartition",
+    "TemporalCheckpointing",
+    "TemporalDecisionSemantics",
+    "TemporalDifferentiationEvidence",
+    "TemporalDifferentiationForm",
+    "TemporalDifferentiationOrientation",
     "TemporalEquationForm",
+    "TemporalEventSemantics",
     "TemporalMethodCapabilities",
     "TemporalMethodClass",
     "DiffraxComplexStatePolicy",
     "DiffraxComplexStateStrategy",
     "TemporalSolveEvidence",
+    "TemporalStochasticSemantics",
     "TemporalPrecisionPolicy",
     "ThetaMethod",
     "VolterraFreeTerm",

--- a/phydrax/solver/_diffrax_backend.py
+++ b/phydrax/solver/_diffrax_backend.py
@@ -55,6 +55,7 @@ from ._split_differential import SplitDifferentialProblem
 from ._ssp_runge_kutta import SSPRK33, SSPRK54
 from ._temporal_method import (
     configuration_id,
+    diffrax_differentiation_evidence,
     diffrax_method_capabilities,
     TemporalMethodCapabilities,
     TemporalSolveEvidence,
@@ -701,7 +702,13 @@ def _solve_evidence(
     ):
         raise ValueError("solver_configuration_id must be non-empty or None.")
     controller_id = configuration_id(controller, prefix="controller")
-    adjoint_id = configuration_id(adjoint, prefix="adjoint")
+    differentiation = diffrax_differentiation_evidence(
+        adjoint,
+        adaptive=isinstance(controller, dfx.AbstractAdaptiveStepSizeController),
+        has_event=event is not None,
+        stochastic=problem.stochastic,
+        maximum_steps=max_steps,
+    )
     event_id = None if event is None else configuration_id(event, prefix="event")
     adapter_configuration = (
         () if state_adapter.evidence is None else (state_adapter.evidence.evidence_id,)
@@ -728,11 +735,11 @@ def _solve_evidence(
     )
     return TemporalSolveEvidence(
         _method_capabilities(solver),
+        differentiation,
         equation_form=_equation_form(problem),
         backend_id="backend:diffrax",
         configuration_id=resolved_configuration_id,
         controller_id=controller_id,
-        adjoint_id=adjoint_id,
         event_id=event_id,
         adaptive=isinstance(controller, dfx.AbstractAdaptiveStepSizeController),
         dense=dense,

--- a/phydrax/solver/_dynamics_evolution.py
+++ b/phydrax/solver/_dynamics_evolution.py
@@ -24,9 +24,19 @@ from ..dynamics import (
     EvolutionStep,
     EvolutionTangentStep,
 )
+from ..linalg import (
+    ArraySpace,
+    LinearizationPolicy,
+    PreparedLinearization,
+    PyTreeSpace,
+)
 from ._differential import DifferentialProblem
 from ._diffrax_backend import solve_diffrax
-from ._temporal_method import configuration_id
+from ._temporal_method import (
+    configuration_id,
+    diffrax_differentiation_evidence,
+    TemporalDifferentiationEvidence,
+)
 
 
 _DIFFRAX_SUCCESS = jax.tree.leaves(dfx.RESULTS.successful)[0]
@@ -39,6 +49,34 @@ def _identifier(value: str | None, default: str, owner: str, /) -> str:
     return resolved
 
 
+def _split_linearization(
+    forward_endpoint,
+    reverse_endpoint,
+    point,
+    source_space,
+    target_space,
+    linearization_id: str,
+    /,
+) -> PreparedLinearization:
+    point_ = source_space.validate(point)
+    _, pushforward = jax.linearize(forward_endpoint, point_)
+    primal, reverse_pullback = jax.vjp(reverse_endpoint, point_)
+
+    def pullback(cotangent):
+        return reverse_pullback(cotangent)[0]
+
+    return PreparedLinearization(
+        source=source_space,
+        target=target_space,
+        point=point_,
+        primal=target_space.validate(primal),
+        pushforward=pushforward,
+        pullback=pullback,
+        policy=LinearizationPolicy(),
+        linearization_id=linearization_id,
+    )
+
+
 class DiffraxEvolution(AbstractDifferentiableEvolution):
     """Deterministic continuous-system evolution through the canonical Diffrax backend."""
 
@@ -46,7 +84,12 @@ class DiffraxEvolution(AbstractDifferentiableEvolution):
     input_policy: AbstractInputPolicy | None
     solver: Any
     stepsize_controller: Any
-    adjoint: Any
+    reverse_adjoint: Any
+    forward_adjoint: Any
+    composite_adjoint: Any
+    reverse_differentiation: TemporalDifferentiationEvidence
+    forward_differentiation: TemporalDifferentiationEvidence
+    composite_differentiation: TemporalDifferentiationEvidence
     dt0: Array | None
     event: Any
     evolution_id: str = eqx.field(static=True)
@@ -55,6 +98,8 @@ class DiffraxEvolution(AbstractDifferentiableEvolution):
     discretization_id: str = eqx.field(static=True)
     approximation_id: str = eqx.field(static=True)
     tangent_method_id: str = eqx.field(static=True)
+    eventful: bool = eqx.field(static=True)
+    stochastic: bool = eqx.field(static=True)
     rtol: float = eqx.field(static=True)
     atol: float = eqx.field(static=True)
     max_steps: int | None = eqx.field(static=True)
@@ -67,7 +112,9 @@ class DiffraxEvolution(AbstractDifferentiableEvolution):
         input_policy: AbstractInputPolicy | None = None,
         solver: Any = None,
         stepsize_controller: Any = None,
-        adjoint: Any = None,
+        reverse_adjoint: Any = None,
+        forward_adjoint: Any = None,
+        composite_adjoint: Any = None,
         dt0: ArrayLike | None = None,
         event: Any = None,
         rtol: float = 1.0e-6,
@@ -108,13 +155,82 @@ class DiffraxEvolution(AbstractDifferentiableEvolution):
         ):
             raise ValueError("dt0 must be a finite scalar or None.")
 
+        selected_reverse = (
+            dfx.RecursiveCheckpointAdjoint()
+            if reverse_adjoint is None
+            else reverse_adjoint
+        )
+        selected_forward = (
+            dfx.ForwardMode() if forward_adjoint is None else forward_adjoint
+        )
+        selected_composite = (
+            dfx.DirectAdjoint() if composite_adjoint is None else composite_adjoint
+        )
+        adaptive = stepsize_controller is None or isinstance(
+            stepsize_controller,
+            dfx.AbstractAdaptiveStepSizeController,
+        )
+        reverse_evidence = diffrax_differentiation_evidence(
+            selected_reverse,
+            adaptive=adaptive,
+            has_event=event is not None,
+            stochastic=False,
+            maximum_steps=step_limit,
+        )
+        forward_evidence = diffrax_differentiation_evidence(
+            selected_forward,
+            adaptive=adaptive,
+            has_event=event is not None,
+            stochastic=False,
+            maximum_steps=step_limit,
+        )
+        composite_evidence = diffrax_differentiation_evidence(
+            selected_composite,
+            adaptive=adaptive,
+            has_event=event is not None,
+            stochastic=False,
+            maximum_steps=step_limit,
+        )
+        if (
+            reverse_evidence.orientations
+            and "reverse" not in reverse_evidence.orientations
+        ):
+            raise ValueError("reverse_adjoint must support reverse-mode differentiation.")
+        if (
+            forward_evidence.orientations
+            and "forward" not in forward_evidence.orientations
+        ):
+            raise ValueError("forward_adjoint must support forward-mode differentiation.")
+        if composite_evidence.orientations and not {
+            "forward",
+            "reverse",
+        }.issubset(composite_evidence.orientations):
+            raise ValueError(
+                "composite_adjoint must support forward- and reverse-mode "
+                "differentiation."
+            )
+        if (
+            not reverse_evidence.orientations
+            or not forward_evidence.orientations
+            or not composite_evidence.orientations
+        ) and evolution_id is None:
+            raise ValueError(
+                "Unclassified Diffrax adjoints require an explicit evolution_id."
+            )
         self.system = system
         self.input_policy = input_policy
         self.solver = solver
         self.stepsize_controller = stepsize_controller
-        self.adjoint = dfx.DirectAdjoint() if adjoint is None else adjoint
+        self.reverse_adjoint = selected_reverse
+        self.forward_adjoint = selected_forward
+        self.composite_adjoint = selected_composite
+        self.reverse_differentiation = reverse_evidence
+        self.forward_differentiation = forward_evidence
+        self.composite_differentiation = composite_evidence
         self.dt0 = initial_step
         self.event = event
+        self.eventful = event is not None
+        self.stochastic = False
         self.evolution_id = _identifier(
             evolution_id,
             f"{system.system_id}:diffrax-evolution",
@@ -124,7 +240,9 @@ class DiffraxEvolution(AbstractDifferentiableEvolution):
             (
                 solver,
                 stepsize_controller,
-                self.adjoint,
+                self.reverse_adjoint,
+                self.forward_adjoint,
+                self.composite_adjoint,
                 None if dt0 is None else repr(dt0),
                 event,
                 relative_tolerance,
@@ -156,6 +274,8 @@ class DiffraxEvolution(AbstractDifferentiableEvolution):
         target: Array,
         args: Any,
         /,
+        *,
+        adjoint: Any,
     ):
         problem = DifferentialProblem(
             self._vector_field,
@@ -170,7 +290,7 @@ class DiffraxEvolution(AbstractDifferentiableEvolution):
             save_times=jnp.asarray([target]),
             solver=self.solver,
             stepsize_controller=self.stepsize_controller,
-            adjoint=self.adjoint,
+            adjoint=adjoint,
             dt0=self.dt0,
             event=self.event,
             rtol=self.rtol,
@@ -187,8 +307,16 @@ class DiffraxEvolution(AbstractDifferentiableEvolution):
         target: Array,
         args: Any,
         /,
+        *,
+        adjoint: Any,
     ) -> tuple[Array, Array]:
-        solution = self._solve(state, source, target, args)
+        solution = self._solve(
+            state,
+            source,
+            target,
+            args,
+            adjoint=adjoint,
+        )
         backend_status = jax.tree.leaves(solution.backend_result)[0]
         return solution.states[-1], backend_status
 
@@ -253,7 +381,13 @@ class DiffraxEvolution(AbstractDifferentiableEvolution):
             )
         if source.shape != () or target.shape != ():
             raise ValueError("Evolution segment coordinates must be scalar.")
-        final_state, backend_status = self._solve_data(state_array, source, target, args)
+        final_state, backend_status = self._solve_data(
+            state_array,
+            source,
+            target,
+            args,
+            adjoint=self.composite_adjoint,
+        )
         return self._step(final_state, backend_status, source, target)
 
     def tangent_action(
@@ -283,19 +417,35 @@ class DiffraxEvolution(AbstractDifferentiableEvolution):
         geometry = self.state_layout.geometry
         if geometry.trivial:
             (final_state, backend_status), (propagated, _) = jax.jvp(
-                lambda point: self._solve_data(point, source, target, args),
+                lambda point: self._solve_data(
+                    point,
+                    source,
+                    target,
+                    args,
+                    adjoint=self.forward_adjoint,
+                ),
                 (state_array,),
                 (vector,),
             )
         else:
             final_state, backend_status = self._solve_data(
-                state_array, source, target, args
+                state_array,
+                source,
+                target,
+                args,
+                adjoint=self.forward_adjoint,
             )
             zero = jnp.zeros_like(state_array)
 
             def local_flow(local):
                 perturbed = geometry.retract(state_array, local)
-                endpoint, _ = self._solve_data(perturbed, source, target, args)
+                endpoint, _ = self._solve_data(
+                    perturbed,
+                    source,
+                    target,
+                    args,
+                    adjoint=self.forward_adjoint,
+                )
                 return geometry.inverse_retract(final_state, endpoint)
 
             _, propagated = jax.jvp(local_flow, (zero,), (vector,))
@@ -313,6 +463,136 @@ class DiffraxEvolution(AbstractDifferentiableEvolution):
             valid=valid,
             status=status,
             tangent_method_id=self.tangent_method_id,
+        )
+
+    def state_linearization(
+        self,
+        state: ArrayLike,
+        source_coordinate: ArrayLike,
+        target_coordinate: ArrayLike,
+        args: Any = None,
+        /,
+    ) -> PreparedLinearization:
+        state_array = jnp.asarray(state)
+        if state_array.shape != self.state_layout.shape:
+            raise ValueError(
+                f"state must have shape {self.state_layout.shape}; got {state_array.shape}."
+            )
+        source = jnp.asarray(source_coordinate)
+        target = jnp.asarray(target_coordinate)
+        if source.shape != () or target.shape != ():
+            raise ValueError("Evolution segment coordinates must be scalar.")
+        space = ArraySpace(self.state_layout.shape, dtype=state_array.dtype)
+        geometry = self.state_layout.geometry
+        if geometry.trivial:
+            point = state_array
+
+            def forward_endpoint(current_state):
+                return self._solve_data(
+                    current_state,
+                    source,
+                    target,
+                    args,
+                    adjoint=self.forward_adjoint,
+                )[0]
+
+            def reverse_endpoint(current_state):
+                return self._solve_data(
+                    current_state,
+                    source,
+                    target,
+                    args,
+                    adjoint=self.reverse_adjoint,
+                )[0]
+
+        else:
+            point = jnp.zeros_like(state_array)
+            base, _ = self._solve_data(
+                state_array,
+                source,
+                target,
+                args,
+                adjoint=self.reverse_adjoint,
+            )
+
+            def forward_endpoint(local):
+                endpoint, _ = self._solve_data(
+                    geometry.retract(state_array, local),
+                    source,
+                    target,
+                    args,
+                    adjoint=self.forward_adjoint,
+                )
+                return geometry.inverse_retract(base, endpoint)
+
+            def reverse_endpoint(local):
+                endpoint, _ = self._solve_data(
+                    geometry.retract(state_array, local),
+                    source,
+                    target,
+                    args,
+                    adjoint=self.reverse_adjoint,
+                )
+                return geometry.inverse_retract(base, endpoint)
+
+        return _split_linearization(
+            forward_endpoint,
+            reverse_endpoint,
+            point,
+            space,
+            space,
+            (f"{self.evolution_id}:state-linearization:{self.state_layout.layout_id}"),
+        )
+
+    def argument_linearization(
+        self,
+        state: ArrayLike,
+        source_coordinate: ArrayLike,
+        target_coordinate: ArrayLike,
+        args: Any,
+        /,
+    ) -> PreparedLinearization:
+        state_array = jnp.asarray(state)
+        if state_array.shape != self.state_layout.shape:
+            raise ValueError(
+                f"state must have shape {self.state_layout.shape}; got {state_array.shape}."
+            )
+        leaves = jax.tree.leaves(args)
+        if not leaves or any(not eqx.is_inexact_array(leaf) for leaf in leaves):
+            raise TypeError(
+                "Evolution argument linearization requires a nonempty PyTree "
+                "of inexact arrays."
+            )
+        source = jnp.asarray(source_coordinate)
+        target = jnp.asarray(target_coordinate)
+        if source.shape != () or target.shape != ():
+            raise ValueError("Evolution segment coordinates must be scalar.")
+
+        def forward_endpoint(current_args):
+            return self._solve_data(
+                state_array,
+                source,
+                target,
+                current_args,
+                adjoint=self.forward_adjoint,
+            )[0]
+
+        def reverse_endpoint(current_args):
+            return self._solve_data(
+                state_array,
+                source,
+                target,
+                current_args,
+                adjoint=self.reverse_adjoint,
+            )[0]
+
+        return _split_linearization(
+            forward_endpoint,
+            reverse_endpoint,
+            args,
+            PyTreeSpace(args),
+            ArraySpace(self.state_layout.shape, dtype=state_array.dtype),
+            (f"{self.evolution_id}:argument-linearization:{self.state_layout.layout_id}"),
         )
 
 

--- a/phydrax/solver/_implicit_runge_kutta.py
+++ b/phydrax/solver/_implicit_runge_kutta.py
@@ -30,6 +30,7 @@ from ..nonlinear import (
 from ._differential import DifferentialProblem, DifferentialSolution
 from ._temporal_method import (
     configuration_id,
+    native_differentiation_evidence,
     TemporalMethodCapabilities,
     TemporalSolveEvidence,
 )
@@ -352,6 +353,10 @@ def solve_implicit_runge_kutta(
     )
     evidence = TemporalSolveEvidence(
         selected.capabilities,
+        native_differentiation_evidence(
+            "adjoint:jax-discrete-implicit-root",
+            adaptive=False,
+        ),
         equation_form="explicit-ode",
         backend_id="backend:phydrax:gauss-irk",
         configuration_id=configuration_id(
@@ -366,7 +371,6 @@ def solve_implicit_runge_kutta(
             prefix="temporal-configuration",
         ),
         controller_id=f"controller:fixed-grid:{time_grid.time_id}",
-        adjoint_id="adjoint:jax-discrete-implicit-root",
         event_id=None,
         adaptive=False,
         dense=dense,

--- a/phydrax/solver/_multirate.py
+++ b/phydrax/solver/_multirate.py
@@ -25,6 +25,7 @@ from ._differential import DifferentialSolution, DifferentialVectorField
 from ._state_partition import StatePartition
 from ._temporal_method import (
     configuration_id,
+    native_differentiation_evidence,
     TemporalMethodCapabilities,
     TemporalSolveEvidence,
 )
@@ -245,6 +246,10 @@ def solve_multirate(
     successful = jnp.all(valid)
     evidence = TemporalSolveEvidence(
         selected.capabilities,
+        native_differentiation_evidence(
+            "adjoint:jax-explicit-scan",
+            adaptive=False,
+        ),
         equation_form="partitioned",
         backend_id="backend:phydrax:multirate-rk",
         configuration_id=configuration_id(
@@ -257,7 +262,6 @@ def solve_multirate(
             prefix="temporal-configuration",
         ),
         controller_id=f"controller:fixed-grid:{time_grid.time_id}",
-        adjoint_id="adjoint:jax-explicit-scan",
         event_id=None,
         adaptive=False,
         dense=False,

--- a/phydrax/solver/_rosenbrock.py
+++ b/phydrax/solver/_rosenbrock.py
@@ -28,6 +28,7 @@ from ..linalg import (
 from ._differential import DifferentialProblem, DifferentialSolution
 from ._temporal_method import (
     configuration_id,
+    native_differentiation_evidence,
     TemporalMethodCapabilities,
     TemporalSolveEvidence,
 )
@@ -357,6 +358,10 @@ def solve_rosenbrock(
     valid = jnp.concatenate((jnp.asarray([True]), step_valid))
     evidence = TemporalSolveEvidence(
         selected.capabilities,
+        native_differentiation_evidence(
+            "adjoint:jax-discrete-linear-solves",
+            adaptive=False,
+        ),
         equation_form="explicit-ode",
         backend_id="backend:phydrax:rosenbrock-w",
         configuration_id=configuration_id(
@@ -364,7 +369,6 @@ def solve_rosenbrock(
             prefix="temporal-configuration",
         ),
         controller_id=f"controller:fixed-grid:{time_grid.time_id}",
-        adjoint_id="adjoint:jax-discrete-linear-solves",
         event_id=None,
         adaptive=False,
         dense=False,
@@ -613,6 +617,11 @@ def solve_rosenbrock_adaptive(
     successful = completed & jnp.all(valid)
     evidence = TemporalSolveEvidence(
         selected.capabilities,
+        native_differentiation_evidence(
+            "adjoint:frozen-accepted-grid-linear-solves",
+            adaptive=True,
+            checkpointing="full-replay",
+        ),
         equation_form="explicit-ode",
         backend_id="backend:phydrax:rosenbrock-w",
         configuration_id=configuration_id(
@@ -626,7 +635,6 @@ def solve_rosenbrock_adaptive(
             prefix="temporal-configuration",
         ),
         controller_id=configuration_id(controller, prefix="controller"),
-        adjoint_id="adjoint:frozen-accepted-grid-linear-solves",
         event_id=None,
         adaptive=True,
         dense=False,

--- a/phydrax/solver/_spectral_coordinates.py
+++ b/phydrax/solver/_spectral_coordinates.py
@@ -27,6 +27,7 @@ from ..dynamics._system import (
     DiscreteTransitionEvidence,
     DiscreteTransitionResult,
 )
+from ..linalg import ArraySpace, PreparedLinearization
 
 
 HERMITIAN_COORDINATE_INVALID = -1
@@ -107,6 +108,8 @@ class HermitianCoordinateEvolution(AbstractDifferentiableEvolution):
     discretization_id: str = eqx.field(static=True)
     approximation_id: str = eqx.field(static=True)
     tangent_method_id: str = eqx.field(static=True)
+    eventful: bool = eqx.field(static=True)
+    stochastic: bool = eqx.field(static=True)
 
     def __init__(
         self,
@@ -164,6 +167,8 @@ class HermitianCoordinateEvolution(AbstractDifferentiableEvolution):
         self.tangent_method_id = (
             f"{evolution.tangent_method_id}:hermitian-coordinate-conjugation"
         )
+        self.eventful = evolution.eventful
+        self.stochastic = evolution.stochastic
 
     def advance(
         self,
@@ -290,6 +295,113 @@ class HermitianCoordinateEvolution(AbstractDifferentiableEvolution):
                 HERMITIAN_COORDINATE_INVALID,
             ),
             tangent_method_id=self.tangent_method_id,
+        )
+
+    def state_linearization(
+        self,
+        state: ArrayLike,
+        source_coordinate: ArrayLike,
+        target_coordinate: ArrayLike,
+        args: Any = None,
+        /,
+    ) -> PreparedLinearization:
+        coordinates = self.coordinates.validate_coordinates(state)
+        source = jnp.asarray(source_coordinate)
+        target = jnp.asarray(target_coordinate)
+        if source.shape != () or target.shape != ():
+            raise ValueError("Evolution segment coordinates must be scalar.")
+        inner = self.evolution.state_linearization(
+            self.coordinates.from_real_coordinates(coordinates),
+            source,
+            target,
+            args,
+        )
+        coordinate_space = ArraySpace(coordinates.shape, dtype=coordinates.dtype)
+
+        def from_coordinates(value):
+            return self.coordinates.from_real_coordinates(value)
+
+        def to_coordinates(value):
+            return self.coordinates.to_real_coordinates(self.coordinates.project(value))
+
+        def pushforward(tangent):
+            return to_coordinates(inner.jvp(from_coordinates(tangent)))
+
+        output_transpose = jax.linear_transpose(
+            to_coordinates,
+            inner.target.zeros(),
+        )
+        input_transpose = jax.linear_transpose(
+            from_coordinates,
+            coordinate_space.zeros(),
+        )
+
+        def pullback(cotangent):
+            full_output = output_transpose(cotangent)[0]
+            full_input = inner.vjp(full_output)
+            return input_transpose(full_input)[0]
+
+        return PreparedLinearization(
+            source=coordinate_space,
+            target=coordinate_space,
+            point=coordinates,
+            primal=self.advance(coordinates, source, target, args).final_state,
+            pushforward=pushforward,
+            pullback=pullback,
+            policy=inner.policy,
+            linearization_id=(
+                f"{inner.linearization_id}:hermitian-coordinate-state:"
+                f"{self.coordinates.coordinate_id}"
+            ),
+        )
+
+    def argument_linearization(
+        self,
+        state: ArrayLike,
+        source_coordinate: ArrayLike,
+        target_coordinate: ArrayLike,
+        args: Any,
+        /,
+    ) -> PreparedLinearization:
+        coordinates = self.coordinates.validate_coordinates(state)
+        source = jnp.asarray(source_coordinate)
+        target = jnp.asarray(target_coordinate)
+        if source.shape != () or target.shape != ():
+            raise ValueError("Evolution segment coordinates must be scalar.")
+        inner = self.evolution.argument_linearization(
+            self.coordinates.from_real_coordinates(coordinates),
+            source,
+            target,
+            args,
+        )
+
+        def to_coordinates(value):
+            return self.coordinates.to_real_coordinates(self.coordinates.project(value))
+
+        def pushforward(tangent):
+            return to_coordinates(inner.jvp(tangent))
+
+        coordinate_transpose = jax.linear_transpose(
+            to_coordinates,
+            jnp.zeros_like(inner.primal),
+        )
+
+        def pullback(cotangent):
+            return inner.vjp(coordinate_transpose(cotangent)[0])
+
+        primal = to_coordinates(inner.primal)
+        return PreparedLinearization(
+            source=inner.source,
+            target=ArraySpace(primal.shape, dtype=primal.dtype),
+            point=inner.point,
+            primal=primal,
+            pushforward=pushforward,
+            pullback=pullback,
+            policy=inner.policy,
+            linearization_id=(
+                f"{inner.linearization_id}:hermitian-coordinates:"
+                f"{self.coordinates.coordinate_id}"
+            ),
         )
 
 

--- a/phydrax/solver/_temporal_method.py
+++ b/phydrax/solver/_temporal_method.py
@@ -47,6 +47,34 @@ TemporalMethodClass: TypeAlias = Literal[
     "unknown",
 ]
 NoiseRequirement: TypeAlias = Literal["none", "additive", "commutative", "general"]
+TemporalDifferentiationForm: TypeAlias = Literal[
+    "discretize-then-optimize",
+    "optimize-then-discretize",
+    "implicit-solution-map",
+    "unknown",
+]
+TemporalDifferentiationOrientation: TypeAlias = Literal["forward", "reverse"]
+TemporalCheckpointing: TypeAlias = Literal[
+    "none",
+    "online-binomial",
+    "bounded-rematerialization",
+    "full-replay",
+    "chunked-replay",
+    "backend-defined",
+]
+TemporalDecisionSemantics: TypeAlias = Literal[
+    "fixed-grid", "frozen-adaptive-schedule", "backend-defined"
+]
+TemporalEventSemantics: TypeAlias = Literal[
+    "none",
+    "backend-branchwise-unqualified",
+    "implicit-event-replay",
+    "unsupported",
+    "unknown",
+]
+TemporalStochasticSemantics: TypeAlias = Literal[
+    "deterministic", "fixed-realization-pathwise", "distributional", "unknown"
+]
 
 
 class TemporalMethodCapabilities(StrictModule, NonTrainableState):
@@ -162,15 +190,125 @@ class TemporalMethodCapabilities(StrictModule, NonTrainableState):
         return None
 
 
+class TemporalDifferentiationEvidence(StrictModule, NonTrainableState):
+    """Static semantics of the derivative exposed by one temporal solve."""
+
+    form: TemporalDifferentiationForm = eqx.field(static=True)
+    orientations: tuple[TemporalDifferentiationOrientation, ...] = eqx.field(static=True)
+    checkpointing: TemporalCheckpointing = eqx.field(static=True)
+    checkpoint_count: int | None = eqx.field(static=True)
+    decision_semantics: TemporalDecisionSemantics = eqx.field(static=True)
+    event_semantics: TemporalEventSemantics = eqx.field(static=True)
+    stochastic_semantics: TemporalStochasticSemantics = eqx.field(static=True)
+    implementation_id: str = eqx.field(static=True)
+    verified: bool = eqx.field(static=True)
+    evidence_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        form: TemporalDifferentiationForm,
+        orientations: tuple[TemporalDifferentiationOrientation, ...],
+        checkpointing: TemporalCheckpointing,
+        checkpoint_count: int | None,
+        decision_semantics: TemporalDecisionSemantics,
+        event_semantics: TemporalEventSemantics,
+        stochastic_semantics: TemporalStochasticSemantics,
+        implementation_id: str,
+        verified: bool = True,
+    ):
+        if form not in (
+            "discretize-then-optimize",
+            "optimize-then-discretize",
+            "implicit-solution-map",
+            "unknown",
+        ):
+            raise ValueError("Unknown temporal differentiation form.")
+        directions = tuple(orientations)
+        if len(set(directions)) != len(directions) or any(
+            value not in ("forward", "reverse") for value in directions
+        ):
+            raise ValueError(
+                "Temporal differentiation orientations must be unique forward/reverse values."
+            )
+        if checkpointing not in (
+            "none",
+            "online-binomial",
+            "bounded-rematerialization",
+            "full-replay",
+            "chunked-replay",
+            "backend-defined",
+        ):
+            raise ValueError("Unknown temporal checkpointing semantics.")
+        count = None if checkpoint_count is None else int(checkpoint_count)
+        if count is not None and count < 1:
+            raise ValueError("Temporal checkpoint_count must be positive or None.")
+        if decision_semantics not in (
+            "fixed-grid",
+            "frozen-adaptive-schedule",
+            "backend-defined",
+        ):
+            raise ValueError("Unknown temporal decision derivative semantics.")
+        if event_semantics not in (
+            "none",
+            "backend-branchwise-unqualified",
+            "implicit-event-replay",
+            "unsupported",
+            "unknown",
+        ):
+            raise ValueError("Unknown temporal event derivative semantics.")
+        if stochastic_semantics not in (
+            "deterministic",
+            "fixed-realization-pathwise",
+            "distributional",
+            "unknown",
+        ):
+            raise ValueError("Unknown temporal stochastic derivative semantics.")
+        identifier = str(implementation_id)
+        if not identifier:
+            raise ValueError(
+                "Temporal differentiation implementation_id must be non-empty."
+            )
+        if checkpointing == "online-binomial" and "reverse" not in directions:
+            raise ValueError(
+                "Online binomial checkpointing requires reverse differentiation."
+            )
+        if form == "optimize-then-discretize" and "forward" in directions:
+            raise ValueError("Continuous backsolve differentiation is reverse-only.")
+        self.form = form
+        self.orientations = directions
+        self.checkpointing = checkpointing
+        self.checkpoint_count = count
+        self.decision_semantics = decision_semantics
+        self.event_semantics = event_semantics
+        self.stochastic_semantics = stochastic_semantics
+        self.implementation_id = identifier
+        self.verified = bool(verified)
+        self.evidence_id = canonical_fingerprint(
+            {
+                "kind": "temporal-differentiation-evidence",
+                "form": form,
+                "orientations": list(directions),
+                "checkpointing": checkpointing,
+                "checkpoint_count": count,
+                "decision_semantics": decision_semantics,
+                "event_semantics": event_semantics,
+                "stochastic_semantics": stochastic_semantics,
+                "implementation_id": identifier,
+                "verified": bool(verified),
+            }
+        )
+
+
 class TemporalSolveEvidence(StrictModule, NonTrainableState):
     """Static method/backend configuration retained by a temporal solution."""
 
     capabilities: TemporalMethodCapabilities
+    differentiation: TemporalDifferentiationEvidence
     equation_form: TemporalEquationForm = eqx.field(static=True)
     backend_id: str = eqx.field(static=True)
     configuration_id: str = eqx.field(static=True)
     controller_id: str = eqx.field(static=True)
-    adjoint_id: str = eqx.field(static=True)
     event_id: str | None = eqx.field(static=True)
     adaptive: bool = eqx.field(static=True)
     dense: bool = eqx.field(static=True)
@@ -181,13 +319,13 @@ class TemporalSolveEvidence(StrictModule, NonTrainableState):
     def __init__(
         self,
         capabilities: TemporalMethodCapabilities,
+        differentiation: TemporalDifferentiationEvidence,
         /,
         *,
         equation_form: TemporalEquationForm,
         backend_id: str,
         configuration_id: str,
         controller_id: str,
-        adjoint_id: str,
         event_id: str | None,
         adaptive: bool,
         dense: bool,
@@ -197,13 +335,14 @@ class TemporalSolveEvidence(StrictModule, NonTrainableState):
     ):
         if not isinstance(capabilities, TemporalMethodCapabilities):
             raise TypeError("capabilities must be TemporalMethodCapabilities.")
+        if not isinstance(differentiation, TemporalDifferentiationEvidence):
+            raise TypeError("differentiation must be TemporalDifferentiationEvidence.")
         values = tuple(
             str(value)
             for value in (
                 backend_id,
                 configuration_id,
                 controller_id,
-                adjoint_id,
             )
         )
         if any(not value for value in values):
@@ -224,10 +363,9 @@ class TemporalSolveEvidence(StrictModule, NonTrainableState):
         ):
             raise TypeError("state_coordinates must be RealCoordinateEvidence or None.")
         self.capabilities = capabilities
+        self.differentiation = differentiation
         self.equation_form = equation_form
-        self.backend_id, self.configuration_id, self.controller_id, self.adjoint_id = (
-            values
-        )
+        self.backend_id, self.configuration_id, self.controller_id = values
         self.event_id = None if event_id is None else str(event_id)
         self.adaptive = bool(adaptive)
         self.dense = bool(dense)
@@ -250,6 +388,94 @@ def configuration_id(value: Any, /, *, prefix: str) -> str:
     configuration ID instead of treating this digest as portable provenance.
     """
     return f"{prefix}:{canonical_fingerprint({'type': qualified_type_name(value), 'representation': repr(value)})}"
+
+
+def diffrax_differentiation_evidence(
+    adjoint: Any,
+    /,
+    *,
+    adaptive: bool,
+    has_event: bool,
+    stochastic: bool,
+    maximum_steps: int | None,
+) -> TemporalDifferentiationEvidence:
+    """Classify one Diffrax derivative route without probing numerical execution."""
+    implementation_id = configuration_id(adjoint, prefix="adjoint")
+    decision_semantics: TemporalDecisionSemantics = (
+        "frozen-adaptive-schedule" if adaptive else "fixed-grid"
+    )
+    stochastic_semantics: TemporalStochasticSemantics = (
+        "fixed-realization-pathwise" if stochastic else "deterministic"
+    )
+    event_semantics: TemporalEventSemantics = (
+        "backend-branchwise-unqualified" if has_event else "none"
+    )
+    checkpoint_count: int | None = None
+    verified = True
+    if isinstance(adjoint, dfx.RecursiveCheckpointAdjoint):
+        form: TemporalDifferentiationForm = "discretize-then-optimize"
+        orientations: tuple[TemporalDifferentiationOrientation, ...] = ("reverse",)
+        checkpointing: TemporalCheckpointing = "online-binomial"
+        checkpoint_count = adjoint.checkpoints
+        verified = checkpoint_count is not None or maximum_steps is not None
+    elif isinstance(adjoint, dfx.ForwardMode):
+        form = "discretize-then-optimize"
+        orientations = ("forward",)
+        checkpointing = "none"
+    elif isinstance(adjoint, dfx.DirectAdjoint):
+        form = "discretize-then-optimize"
+        orientations = ("forward", "reverse")
+        checkpointing = "bounded-rematerialization"
+        verified = maximum_steps is not None
+    elif isinstance(adjoint, dfx.ImplicitAdjoint):
+        form = "implicit-solution-map"
+        orientations = ("reverse",)
+        checkpointing = "backend-defined"
+    elif isinstance(adjoint, dfx.BacksolveAdjoint):
+        form = "optimize-then-discretize"
+        orientations = ("reverse",)
+        checkpointing = "none"
+        event_semantics = "unsupported" if has_event else "none"
+        verified = not has_event and not stochastic
+    else:
+        form = "unknown"
+        orientations = ()
+        checkpointing = "backend-defined"
+        decision_semantics = "backend-defined"
+        event_semantics = "unknown" if has_event else "none"
+        stochastic_semantics = "unknown" if stochastic else "deterministic"
+        verified = False
+    return TemporalDifferentiationEvidence(
+        form=form,
+        orientations=orientations,
+        checkpointing=checkpointing,
+        checkpoint_count=checkpoint_count,
+        decision_semantics=decision_semantics,
+        event_semantics=event_semantics,
+        stochastic_semantics=stochastic_semantics,
+        implementation_id=implementation_id,
+        verified=verified,
+    )
+
+
+def native_differentiation_evidence(
+    implementation_id: str,
+    /,
+    *,
+    adaptive: bool,
+    checkpointing: TemporalCheckpointing = "none",
+) -> TemporalDifferentiationEvidence:
+    """Describe a native JAX derivative of one declared temporal computation."""
+    return TemporalDifferentiationEvidence(
+        form="discretize-then-optimize",
+        orientations=("forward", "reverse"),
+        checkpointing=checkpointing,
+        checkpoint_count=None,
+        decision_semantics=("frozen-adaptive-schedule" if adaptive else "fixed-grid"),
+        event_semantics="none",
+        stochastic_semantics="deterministic",
+        implementation_id=implementation_id,
+    )
 
 
 def _capabilities(
@@ -579,11 +805,20 @@ def diffrax_method_capabilities(solver: Any, /) -> TemporalMethodCapabilities:
 
 __all__ = [
     "NoiseRequirement",
+    "TemporalCheckpointing",
+    "TemporalDecisionSemantics",
+    "TemporalDifferentiationEvidence",
+    "TemporalDifferentiationForm",
+    "TemporalDifferentiationOrientation",
     "TemporalEquationForm",
+    "TemporalEventSemantics",
     "TemporalMethodCapabilities",
     "TemporalMethodClass",
     "TemporalSolveEvidence",
+    "TemporalStochasticSemantics",
     "configuration_id",
+    "diffrax_differentiation_evidence",
     "diffrax_method_capabilities",
+    "native_differentiation_evidence",
     "qualified_type_name",
 ]

--- a/phydrax/statistical_dynamics/__init__.py
+++ b/phydrax/statistical_dynamics/__init__.py
@@ -47,12 +47,8 @@ from ._interactions import (
     NonlinearInteractions,
     QuasilinearInteractions,
 )
-from ._nilss import (
-    NILSSCost,
-    NILSSPlan,
-    NILSSResult,
-    PreparedNILSS,
-)
+from ._nilsas import NILSASPlan, NILSASResult, PreparedNILSAS
+from ._nilss import NILSSPlan, NILSSResult, PreparedNILSS
 from ._plan import (
     ClosureKind,
     DenseCumulantTendency,
@@ -69,10 +65,17 @@ from ._plan import (
     StatisticalStepEvidence,
     StatisticalStepResult,
 )
+from ._shadowing_solve import (
+    AbstractShadowingSolvePlan,
+    ShadowingMemoryMode,
+    ShadowingSolveCost,
+    ShadowingSolveStatus,
+)
 
 
 __all__ = [
     "AbstractInteractionModel",
+    "AbstractShadowingSolvePlan",
     "BarotropicBetaPlane",
     "BetaPlaneBudgets",
     "BetaPlaneCumulantSystem",
@@ -96,10 +99,12 @@ __all__ = [
     "InteractionContinuationStage",
     "InteractionKind",
     "InteractionPartition",
-    "NILSSCost",
+    "NonlinearInteractions",
+    "NILSASPlan",
+    "NILSASResult",
     "NILSSPlan",
     "NILSSResult",
-    "NonlinearInteractions",
+    "PreparedNILSAS",
     "PreparedNILSS",
     "PreparedStatisticalDynamics",
     "QuadraticDynamics",
@@ -108,6 +113,9 @@ __all__ = [
     "RankAdaptationPolicy",
     "RankAdaptationResult",
     "SecondCumulantLayout",
+    "ShadowingMemoryMode",
+    "ShadowingSolveCost",
+    "ShadowingSolveStatus",
     "StationaryCovarianceResult",
     "StatisticalContinuationResult",
     "StatisticalContinuationStageEvidence",

--- a/phydrax/statistical_dynamics/_nilsas.py
+++ b/phydrax/statistical_dynamics/_nilsas.py
@@ -1,0 +1,698 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from typing import Any
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jaxtyping import Array, ArrayLike, PyTree
+
+from phydrax import ein
+
+from .._fingerprint import array_tree_fingerprint, canonical_fingerprint
+from .._strict import StrictModule
+from .._trainable import NonTrainableState
+from ..dynamics import (
+    EvolutionArgumentJacobianAction,
+    EvolutionJacobianAction,
+    EvolutionTrajectory,
+)
+from ..dynamics._grid import IterationGrid, TimeGrid
+from ..dynamics.analysis import ShadowingSensitivityProblem
+from ..dynamics.analysis._shadowing import _quadrature_weights
+from ._shadowing_solve import (
+    AbstractShadowingSolvePlan,
+    orthonormalize_shadowing_basis,
+    shadowing_plan_id,
+    ShadowingMemoryMode,
+    ShadowingSolveCost,
+    ShadowingSolveStatus,
+    solve_reduced_shadowing,
+    validate_shadowing_plan,
+)
+
+
+def _tree_add(left: PyTree[Array], right: PyTree[Array], /) -> PyTree[Array]:
+    return jax.tree.map(lambda x, y: x + y, left, right)
+
+
+def _tree_finite(tree: PyTree[Array], /) -> Array:
+    leaves = jax.tree.leaves(tree)
+    return jnp.all(jnp.stack(tuple(jnp.all(jnp.isfinite(leaf)) for leaf in leaves)))
+
+
+def _observable_state_gradient(
+    problem: ShadowingSensitivityProblem,
+    coordinate: Array,
+    state: Array,
+    args: Any,
+    /,
+) -> Array:
+    if problem.observable_state_gradient is None:
+        return jax.grad(lambda value: problem.observable(coordinate, value, args))(state)
+    return jnp.asarray(problem.observable_state_gradient(coordinate, state, args))
+
+
+def _observable_parameter_pullback(
+    problem: ShadowingSensitivityProblem,
+    coordinate: Array,
+    state: Array,
+    args: PyTree[Array],
+    weight: Array,
+    /,
+) -> PyTree[Array]:
+    value, pullback = jax.vjp(
+        lambda current_args: problem.observable(coordinate, state, current_args),
+        args,
+    )
+    if jnp.asarray(value).shape != ():
+        raise ValueError("Shadowing observable must return a scalar.")
+    return pullback(weight)[0]
+
+
+def _transpose_columns(action: EvolutionJacobianAction, basis: Array, /) -> Array:
+    if basis.shape[1] == 0:
+        return basis
+    columns = eqx.filter_vmap(action.transpose_mv)(basis.T)
+    return columns.T
+
+
+class NILSASPlan(AbstractShadowingSolvePlan):
+    """Segmented non-intrusive least-squares adjoint shadowing policy."""
+
+    method: str = eqx.field(static=True)
+    state_dimension: int = eqx.field(static=True)
+    unstable_dimension: int = eqx.field(static=True)
+    basis_dimension: int = eqx.field(static=True)
+    segment_steps: int = eqx.field(static=True)
+    segment_count: int = eqx.field(static=True)
+    regularization: float = eqx.field(static=True)
+    rank_tolerance: float = eqx.field(static=True)
+    memory_mode: ShadowingMemoryMode = eqx.field(static=True)
+    maximum_retained_bytes: int = eqx.field(static=True)
+    maximum_workspace_bytes: int = eqx.field(static=True)
+    plan_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        state_dimension: int,
+        unstable_dimension: int,
+        basis_dimension: int,
+        segment_steps: int,
+        segment_count: int,
+        /,
+        *,
+        regularization: float = 0.0,
+        rank_tolerance: float = 1.0e-10,
+        memory_mode: ShadowingMemoryMode = "store",
+        maximum_retained_bytes: int = 2 * 1024 * 1024 * 1024,
+        maximum_workspace_bytes: int = 4 * 1024 * 1024 * 1024,
+    ):
+        values = validate_shadowing_plan(
+            "nilsas",
+            state_dimension,
+            unstable_dimension,
+            basis_dimension,
+            segment_steps,
+            segment_count,
+            regularization,
+            rank_tolerance,
+            memory_mode,
+            maximum_retained_bytes,
+            maximum_workspace_bytes,
+        )
+        (
+            self.state_dimension,
+            self.unstable_dimension,
+            self.basis_dimension,
+            self.segment_steps,
+            self.segment_count,
+            self.regularization,
+            self.rank_tolerance,
+            self.maximum_retained_bytes,
+            self.maximum_workspace_bytes,
+        ) = values
+        self.method = "nilsas"
+        self.memory_mode = memory_mode
+        self.plan_id = shadowing_plan_id("nilsas", values, memory_mode)
+
+    def prepare(
+        self,
+        problem: ShadowingSensitivityProblem,
+        trajectory: EvolutionTrajectory,
+        /,
+        *,
+        args: PyTree[Array],
+        terminal_basis: ArrayLike | None = None,
+        key: Array | None = None,
+    ) -> "PreparedNILSAS":
+        if not isinstance(problem, ShadowingSensitivityProblem):
+            raise TypeError("problem must be a ShadowingSensitivityProblem.")
+        if not isinstance(trajectory, EvolutionTrajectory):
+            raise TypeError("trajectory must be an EvolutionTrajectory.")
+        if problem.evolution.eventful:
+            raise ValueError("NILSAS requires event-free evolution segments.")
+        if problem.evolution.stochastic:
+            raise ValueError("NILSAS requires deterministic evolution segments.")
+        if trajectory.evolution_id != problem.evolution.evolution_id:
+            raise ValueError("Trajectory and shadowing evolution IDs must match.")
+        if trajectory.grid.num_steps != self.horizon_steps:
+            raise ValueError("Trajectory horizon does not match the NILSAS plan.")
+        if trajectory.state_layout.shape != (self.state_dimension,):
+            raise ValueError("NILSAS requires the declared one-dimensional state vector.")
+        if not trajectory.state_layout.geometry.trivial:
+            raise ValueError("NILSAS initially requires Euclidean state geometry.")
+        if not jnp.issubdtype(trajectory.states.dtype, jnp.floating):
+            raise TypeError("NILSAS requires a real floating trajectory.")
+        argument_leaves = jax.tree.leaves(args)
+        if not argument_leaves or any(
+            not eqx.is_inexact_array(leaf) for leaf in argument_leaves
+        ):
+            raise TypeError("NILSAS args must be a nonempty PyTree of inexact arrays.")
+        if isinstance(trajectory.grid, IterationGrid):
+            if problem.time_dilation != "none":
+                raise ValueError("Discrete-map NILSAS does not use flow time dilation.")
+        elif isinstance(trajectory.grid, TimeGrid):
+            if problem.time_dilation != "flow":
+                raise ValueError("Time-grid NILSAS requires flow time dilation.")
+            if self.basis_dimension < self.unstable_dimension + 1:
+                raise ValueError(
+                    "Flow NILSAS basis_dimension must include the neutral adjoint."
+                )
+        else:
+            raise TypeError("NILSAS requires an IterationGrid or TimeGrid trajectory.")
+
+        if self.basis_dimension == 0:
+            if terminal_basis is not None or key is not None:
+                raise ValueError(
+                    "A zero-dimensional NILSAS basis accepts no initializer."
+                )
+            basis = jnp.zeros((self.state_dimension, 0), dtype=trajectory.states.dtype)
+            terminal_defect = jnp.asarray(0.0, dtype=trajectory.states.dtype)
+        else:
+            if (terminal_basis is None) == (key is None):
+                raise ValueError("Provide exactly one of terminal_basis and key.")
+            basis = (
+                jax.random.normal(
+                    key,
+                    (self.state_dimension, self.basis_dimension),
+                    dtype=trajectory.states.dtype,
+                )
+                if terminal_basis is None
+                else jnp.asarray(terminal_basis, dtype=trajectory.states.dtype)
+            )
+            if basis.shape != (self.state_dimension, self.basis_dimension):
+                raise ValueError("terminal_basis has an incompatible shape.")
+            basis, _, terminal_defect, basis_valid = orthonormalize_shadowing_basis(
+                basis,
+                rank_tolerance=self.rank_tolerance,
+            )
+            if not bool(np.asarray(basis_valid)):
+                raise ValueError("NILSAS terminal basis lost numerical rank.")
+
+        itemsize = np.dtype(trajectory.states.dtype).itemsize
+        horizon = self.horizon_steps
+        boundary_storage = (
+            self.segment_count * self.state_dimension * (self.basis_dimension + 1)
+        )
+        path_storage = (
+            horizon * self.state_dimension * 2 * (self.basis_dimension + 1)
+            if self.memory_mode == "store"
+            else 0
+        )
+        reduced_storage = self.segment_count * (
+            self.basis_dimension**2 + 3 * self.basis_dimension + 1
+        )
+        retained = itemsize * (boundary_storage + path_storage + reduced_storage)
+        variables = self.segment_count * self.basis_dimension
+        constraints = max(self.segment_count - 1, 0) * self.basis_dimension
+        if problem.time_dilation == "flow":
+            constraints += 1
+        workspace = retained + itemsize * (variables + constraints) ** 2
+        if retained > self.maximum_retained_bytes:
+            raise MemoryError("NILSAS state exceeds maximum_retained_bytes.")
+        if workspace > self.maximum_workspace_bytes:
+            raise MemoryError("NILSAS reduced solve exceeds maximum_workspace_bytes.")
+        cost = ShadowingSolveCost(
+            method=self.method,
+            state_dimension=self.state_dimension,
+            unstable_dimension=self.unstable_dimension,
+            basis_dimension=self.basis_dimension,
+            horizon_steps=horizon,
+            segment_count=self.segment_count,
+            input_trajectory_bytes=int(trajectory.states.size) * itemsize,
+            retained_bytes=retained,
+            workspace_bytes=workspace,
+            maximum_retained_bytes=self.maximum_retained_bytes,
+            maximum_workspace_bytes=self.maximum_workspace_bytes,
+        )
+        return PreparedNILSAS(
+            plan=self,
+            cost=cost,
+            problem=problem,
+            trajectory=trajectory,
+            args=args,
+            terminal_basis=basis,
+            terminal_basis_defect=terminal_defect,
+        )
+
+
+class PreparedNILSAS(StrictModule, NonTrainableState):
+    plan: NILSASPlan
+    cost: ShadowingSolveCost
+    problem: ShadowingSensitivityProblem
+    trajectory: EvolutionTrajectory
+    args: PyTree[Array]
+    terminal_basis: Array
+    terminal_basis_defect: Array
+    prepared_id: str = eqx.field(static=True)
+
+    def __init__(
+        self,
+        *,
+        plan: NILSASPlan,
+        cost: ShadowingSolveCost,
+        problem: ShadowingSensitivityProblem,
+        trajectory: EvolutionTrajectory,
+        args: PyTree[Array],
+        terminal_basis: Array,
+        terminal_basis_defect: ArrayLike,
+    ):
+        self.plan = plan
+        self.cost = cost
+        self.problem = problem
+        self.trajectory = trajectory
+        self.args = args
+        self.terminal_basis = terminal_basis
+        self.terminal_basis_defect = jnp.asarray(terminal_basis_defect)
+        self.prepared_id = canonical_fingerprint(
+            {
+                "kind": "prepared-nilsas",
+                "plan": plan.plan_id,
+                "problem": problem.problem_id,
+                "trajectory": trajectory.evolution_id,
+                "args": array_tree_fingerprint(args),
+                "terminal_basis": array_tree_fingerprint(terminal_basis),
+            }
+        )
+
+    @eqx.filter_jit
+    def solve(self, /) -> "NILSASResult":
+        plan = self.plan
+        problem = self.problem
+        trajectory = self.trajectory
+        weights = _quadrature_weights(trajectory)
+        dtype = trajectory.states.dtype
+        n = plan.state_dimension
+        m = plan.basis_dimension
+        horizon = plan.horizon_steps
+        segments = plan.segment_count
+
+        objective_values = jax.vmap(
+            lambda coordinate, state: jnp.asarray(
+                problem.observable(coordinate, state, self.args)
+            )
+        )(trajectory.grid.coordinates, trajectory.states)
+        if objective_values.shape != (horizon + 1,):
+            raise ValueError("NILSAS observable must return one scalar per node.")
+        terminal_gradient = _observable_state_gradient(
+            problem,
+            trajectory.grid.coordinates[-1],
+            trajectory.states[-1],
+            self.args,
+        )
+        basis = self.terminal_basis
+        inhomogeneous = weights[-1] * terminal_gradient
+        terminal_basis_seeds = jnp.zeros((segments, n, m), dtype=dtype)
+        terminal_inhomogeneous_seeds = jnp.zeros((segments, n), dtype=dtype)
+        covariances = jnp.zeros((segments, m, m), dtype=dtype)
+        linear_terms = jnp.zeros((segments, m), dtype=dtype)
+        neutral_basis = jnp.zeros((segments, m), dtype=dtype)
+        neutral_offsets = jnp.zeros((segments,), dtype=dtype)
+        relations = jnp.zeros((max(segments - 1, 0), m, m), dtype=dtype)
+        offsets = jnp.zeros((max(segments - 1, 0), m), dtype=dtype)
+        endpoint_bases = jnp.zeros((horizon, n, m), dtype=dtype)
+        endpoint_inhomogeneous = jnp.zeros((horizon, n), dtype=dtype)
+        node_bases = jnp.zeros((horizon, n, m), dtype=dtype)
+        node_inhomogeneous = jnp.zeros((horizon, n), dtype=dtype)
+        valid_values: list[Array] = []
+        orthogonality_defects: list[Array] = [self.terminal_basis_defect]
+
+        for segment in range(segments - 1, -1, -1):
+            terminal_basis_seeds = terminal_basis_seeds.at[segment].set(basis)
+            terminal_inhomogeneous_seeds = terminal_inhomogeneous_seeds.at[segment].set(
+                inhomogeneous
+            )
+            covariance = jnp.zeros((m, m), dtype=dtype)
+            linear = jnp.zeros((m,), dtype=dtype)
+            neutral_row = jnp.zeros((m,), dtype=dtype)
+            neutral_value = jnp.asarray(0.0, dtype=dtype)
+            if segment == segments - 1:
+                covariance = (
+                    covariance
+                    + weights[-1] * ein.contract("ia,ib->ab", jnp.conj(basis), basis).real
+                )
+                linear = (
+                    linear
+                    + weights[-1]
+                    * ein.contract("ia,i->a", jnp.conj(basis), inhomogeneous).real
+                )
+                if problem.time_dilation == "flow":
+                    assert problem.neutral_direction is not None
+                    neutral = jnp.asarray(
+                        problem.neutral_direction(
+                            trajectory.grid.coordinates[-1],
+                            trajectory.states[-1],
+                            self.args,
+                        )
+                    )
+                    neutral_row = (
+                        neutral_row
+                        + weights[-1]
+                        * ein.contract("ia,i->a", jnp.conj(basis), neutral).real
+                    )
+                    neutral_value = (
+                        neutral_value
+                        + weights[-1] * jnp.vdot(inhomogeneous, neutral).real
+                    )
+
+            start = segment * plan.segment_steps
+            stop = (segment + 1) * plan.segment_steps
+            for index in range(stop - 1, start - 1, -1):
+                if plan.memory_mode == "store":
+                    endpoint_bases = endpoint_bases.at[index].set(basis)
+                    endpoint_inhomogeneous = endpoint_inhomogeneous.at[index].set(
+                        inhomogeneous
+                    )
+                action = EvolutionJacobianAction(
+                    problem.evolution,
+                    trajectory.states[index],
+                    trajectory.grid.coordinates[index],
+                    trajectory.grid.coordinates[index + 1],
+                    args=self.args,
+                )
+                previous_basis = _transpose_columns(action, basis)
+                state_gradient = _observable_state_gradient(
+                    problem,
+                    trajectory.grid.coordinates[index],
+                    trajectory.states[index],
+                    self.args,
+                )
+                previous_inhomogeneous = (
+                    action.transpose_mv(inhomogeneous) + weights[index] * state_gradient
+                )
+                if plan.memory_mode == "store":
+                    node_bases = node_bases.at[index].set(previous_basis)
+                    node_inhomogeneous = node_inhomogeneous.at[index].set(
+                        previous_inhomogeneous
+                    )
+                covariance = (
+                    covariance
+                    + weights[index]
+                    * ein.contract(
+                        "ia,ib->ab", jnp.conj(previous_basis), previous_basis
+                    ).real
+                )
+                linear = (
+                    linear
+                    + weights[index]
+                    * ein.contract(
+                        "ia,i->a", jnp.conj(previous_basis), previous_inhomogeneous
+                    ).real
+                )
+                step_valid = (
+                    action.primal.valid
+                    & jnp.all(jnp.isfinite(previous_basis))
+                    & jnp.all(jnp.isfinite(previous_inhomogeneous))
+                    & jnp.all(jnp.isfinite(state_gradient))
+                )
+                if problem.time_dilation == "flow":
+                    assert problem.neutral_direction is not None
+                    neutral = jnp.asarray(
+                        problem.neutral_direction(
+                            trajectory.grid.coordinates[index],
+                            trajectory.states[index],
+                            self.args,
+                        )
+                    )
+                    neutral_row = (
+                        neutral_row
+                        + weights[index]
+                        * ein.contract("ia,i->a", jnp.conj(previous_basis), neutral).real
+                    )
+                    neutral_value = (
+                        neutral_value
+                        + weights[index] * jnp.vdot(previous_inhomogeneous, neutral).real
+                    )
+                    step_valid = step_valid & jnp.all(jnp.isfinite(neutral))
+                valid_values.append(step_valid)
+                basis = previous_basis
+                inhomogeneous = previous_inhomogeneous
+
+            covariances = covariances.at[segment].set(covariance)
+            linear_terms = linear_terms.at[segment].set(linear)
+            neutral_basis = neutral_basis.at[segment].set(neutral_row)
+            neutral_offsets = neutral_offsets.at[segment].set(neutral_value)
+            if segment > 0:
+                basis, relation, defect, rank_valid = orthonormalize_shadowing_basis(
+                    basis,
+                    rank_tolerance=plan.rank_tolerance,
+                )
+                offset = (
+                    ein.contract("ia,i->a", jnp.conj(basis), inhomogeneous).real
+                    if m
+                    else jnp.zeros((0,), dtype=dtype)
+                )
+                inhomogeneous = inhomogeneous - (
+                    ein.contract("ia,a->i", basis, offset)
+                    if m
+                    else jnp.zeros_like(inhomogeneous)
+                )
+                relations = relations.at[segment - 1].set(relation)
+                offsets = offsets.at[segment - 1].set(offset)
+                orthogonality_defects.append(defect)
+                valid_values.append(rank_valid)
+
+        reduced = solve_reduced_shadowing(
+            covariances,
+            linear_terms,
+            relations,
+            offsets,
+            regularization=plan.regularization,
+            neutral_basis=neutral_basis if problem.time_dilation == "flow" else None,
+            neutral_offset=(
+                jnp.sum(neutral_offsets) if problem.time_dilation == "flow" else None
+            ),
+            relation_orientation="backward",
+            solve_id=self.prepared_id,
+        )
+
+        parameter_gradient = jax.tree.map(jnp.zeros_like, self.args)
+        for index in range(horizon + 1):
+            direct = _observable_parameter_pullback(
+                problem,
+                trajectory.grid.coordinates[index],
+                trajectory.states[index],
+                self.args,
+                weights[index],
+            )
+            parameter_gradient = _tree_add(parameter_gradient, direct)
+
+        if plan.memory_mode == "store":
+            shadowing_path = jnp.zeros((horizon + 1, n), dtype=dtype)
+            for index in range(horizon):
+                segment = min(index // plan.segment_steps, segments - 1)
+                coefficient = reduced.coefficients[segment]
+                shadowing_path = shadowing_path.at[index].set(
+                    node_inhomogeneous[index]
+                    + (
+                        ein.contract("ia,a->i", node_bases[index], coefficient)
+                        if m
+                        else jnp.zeros((n,), dtype=dtype)
+                    )
+                )
+                endpoint = endpoint_inhomogeneous[index] + (
+                    ein.contract("ia,a->i", endpoint_bases[index], coefficient)
+                    if m
+                    else jnp.zeros((n,), dtype=dtype)
+                )
+                parameter_action = EvolutionArgumentJacobianAction(
+                    problem.evolution,
+                    trajectory.states[index],
+                    trajectory.grid.coordinates[index],
+                    trajectory.grid.coordinates[index + 1],
+                    self.args,
+                )
+                parameter_gradient = _tree_add(
+                    parameter_gradient,
+                    parameter_action.transpose_mv(endpoint),
+                )
+            final_coefficient = reduced.coefficients[-1]
+            shadowing_path = shadowing_path.at[-1].set(
+                terminal_inhomogeneous_seeds[-1]
+                + (
+                    ein.contract("ia,a->i", terminal_basis_seeds[-1], final_coefficient)
+                    if m
+                    else jnp.zeros((n,), dtype=dtype)
+                )
+            )
+        else:
+            shadowing_path = jnp.zeros((0, n), dtype=dtype)
+            for segment in range(segments - 1, -1, -1):
+                basis = terminal_basis_seeds[segment]
+                inhomogeneous = terminal_inhomogeneous_seeds[segment]
+                coefficient = reduced.coefficients[segment]
+                start = segment * plan.segment_steps
+                stop = (segment + 1) * plan.segment_steps
+                for index in range(stop - 1, start - 1, -1):
+                    endpoint = inhomogeneous + (
+                        ein.contract("ia,a->i", basis, coefficient)
+                        if m
+                        else jnp.zeros((n,), dtype=dtype)
+                    )
+                    parameter_action = EvolutionArgumentJacobianAction(
+                        problem.evolution,
+                        trajectory.states[index],
+                        trajectory.grid.coordinates[index],
+                        trajectory.grid.coordinates[index + 1],
+                        self.args,
+                    )
+                    parameter_gradient = _tree_add(
+                        parameter_gradient,
+                        parameter_action.transpose_mv(endpoint),
+                    )
+                    action = EvolutionJacobianAction(
+                        problem.evolution,
+                        trajectory.states[index],
+                        trajectory.grid.coordinates[index],
+                        trajectory.grid.coordinates[index + 1],
+                        args=self.args,
+                    )
+                    basis = _transpose_columns(action, basis)
+                    inhomogeneous = action.transpose_mv(inhomogeneous) + weights[
+                        index
+                    ] * _observable_state_gradient(
+                        problem,
+                        trajectory.grid.coordinates[index],
+                        trajectory.states[index],
+                        self.args,
+                    )
+
+        maximum_orthogonality_defect = jnp.max(
+            jnp.stack(tuple(orthogonality_defects)), initial=0.0
+        )
+        propagation_valid = jnp.all(jnp.stack(tuple(valid_values)))
+        finite = (
+            _tree_finite(self.args)
+            & _tree_finite(parameter_gradient)
+            & jnp.all(jnp.isfinite(reduced.coefficients))
+            & jnp.all(jnp.isfinite(objective_values))
+            & jnp.isfinite(maximum_orthogonality_defect)
+        )
+        tolerance = 100.0 * plan.rank_tolerance
+        neutral_valid = (
+            reduced.neutral_residual <= tolerance
+            if problem.time_dilation == "flow"
+            else jnp.asarray(True)
+        )
+        successful = (
+            trajectory.successful
+            & propagation_valid
+            & reduced.successful
+            & finite
+            & (reduced.continuity_residual <= tolerance)
+            & (maximum_orthogonality_defect <= tolerance)
+            & neutral_valid
+        )
+        status = jnp.where(
+            ~trajectory.successful,
+            int(ShadowingSolveStatus.TRAJECTORY_INVALID),
+            jnp.where(
+                ~propagation_valid,
+                int(ShadowingSolveStatus.BASIS_RANK_LOST),
+                jnp.where(
+                    ~reduced.successful,
+                    int(ShadowingSolveStatus.LINEAR_SOLVE_FAILED),
+                    jnp.where(
+                        ~finite,
+                        int(ShadowingSolveStatus.NONFINITE),
+                        jnp.where(
+                            reduced.continuity_residual > tolerance,
+                            int(ShadowingSolveStatus.CONTINUITY_FAILED),
+                            jnp.where(
+                                ~neutral_valid,
+                                int(ShadowingSolveStatus.NEUTRAL_CONSTRAINT_FAILED),
+                                int(ShadowingSolveStatus.SUCCESS),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        ).astype(jnp.int32)
+        base_actions = horizon * (m + 1)
+        replay_actions = base_actions if plan.memory_mode == "recompute" else 0
+        return NILSASResult(
+            trajectory=trajectory,
+            parameter_gradient=parameter_gradient,
+            adjoint_shadowing_path=shadowing_path,
+            segment_coefficients=reduced.coefficients,
+            objective_average=jnp.sum(weights * objective_values),
+            continuity_residual=reduced.continuity_residual,
+            neutral_constraint_residual=reduced.neutral_residual,
+            maximum_orthogonality_defect=maximum_orthogonality_defect,
+            finite=finite,
+            successful=successful,
+            status=status,
+            linear_status=reduced.linear_status,
+            linear_rank=reduced.rank,
+            linear_condition_estimate=reduced.condition_estimate,
+            adjoint_action_count=jnp.asarray(
+                base_actions + replay_actions, dtype=jnp.int32
+            ),
+            parameter_action_count=jnp.asarray(horizon, dtype=jnp.int32),
+            replay_action_count=jnp.asarray(replay_actions, dtype=jnp.int32),
+            cost=self.cost,
+            prepared_id=self.prepared_id,
+            problem_id=problem.problem_id,
+            parameter_id=problem.parameter_id,
+            objective_id=problem.observable_id,
+            approximation=(
+                "finite-horizon-discrete-adjoint-shadowing"
+                if isinstance(trajectory.grid, IterationGrid)
+                else "finite-horizon-time-discrete-flow-adjoint-shadowing"
+            ),
+        )
+
+
+class NILSASResult(StrictModule):
+    trajectory: EvolutionTrajectory
+    parameter_gradient: PyTree[Array]
+    adjoint_shadowing_path: Array
+    segment_coefficients: Array
+    objective_average: Array
+    continuity_residual: Array
+    neutral_constraint_residual: Array
+    maximum_orthogonality_defect: Array
+    finite: Array
+    successful: Array
+    status: Array
+    linear_status: Array
+    linear_rank: Array
+    linear_condition_estimate: Array
+    adjoint_action_count: Array
+    parameter_action_count: Array
+    replay_action_count: Array
+    cost: ShadowingSolveCost
+    prepared_id: str = eqx.field(static=True)
+    problem_id: str = eqx.field(static=True)
+    parameter_id: str = eqx.field(static=True)
+    objective_id: str = eqx.field(static=True)
+    approximation: str = eqx.field(static=True)
+
+
+__all__ = ["NILSASPlan", "NILSASResult", "PreparedNILSAS"]

--- a/phydrax/statistical_dynamics/_nilss.py
+++ b/phydrax/statistical_dynamics/_nilss.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import Any
 
 import equinox as eqx
@@ -13,81 +12,106 @@ import jax.numpy as jnp
 import numpy as np
 from jaxtyping import Array, ArrayLike, PyTree
 
-import phydrax.ein as ein
+from phydrax import ein
 
 from .._fingerprint import array_tree_fingerprint, canonical_fingerprint
 from .._strict import StrictModule
 from .._trainable import NonTrainableState
-from ..linalg import DenseLinearOperator, HermitianSpectrum, LinearSystem, solve
+from ..dynamics import EvolutionArgumentJacobianAction, EvolutionTrajectory
+from ..dynamics._grid import IterationGrid, TimeGrid
+from ..dynamics.analysis import (
+    evaluate_shadowing_candidate,
+    ShadowingCandidateResult,
+    ShadowingSensitivityProblem,
+)
+from ..dynamics.analysis._shadowing import _quadrature_weights
+from ._shadowing_solve import (
+    AbstractShadowingSolvePlan,
+    orthonormalize_shadowing_basis,
+    shadowing_plan_id,
+    ShadowingMemoryMode,
+    ShadowingSolveCost,
+    ShadowingSolveStatus,
+    solve_reduced_shadowing,
+    validate_shadowing_plan,
+)
 
 
-StepFunction = Callable[[Array, PyTree[Any]], Array]
-ObjectiveFunction = Callable[[Array, PyTree[Any]], Array]
+def _tree_finite(tree: PyTree[Array], /) -> Array:
+    leaves = jax.tree.leaves(tree)
+    return jnp.all(jnp.stack(tuple(jnp.all(jnp.isfinite(leaf)) for leaf in leaves)))
 
 
-def _orthonormalize(
+def _propagate_columns(
+    problem: ShadowingSensitivityProblem,
+    state: Array,
     basis: Array,
+    source: Array,
+    target: Array,
+    args: Any,
+    /,
+) -> tuple[Array, Array]:
+    if basis.shape[1] == 0:
+        return basis, jnp.asarray(True)
+
+    def propagate(column):
+        result = problem.evolution.tangent_action(
+            state,
+            column,
+            source,
+            target,
+            args,
+        )
+        return result.tangent, result.valid
+
+    columns, valid = eqx.filter_vmap(propagate)(basis.T)
+    return columns.T, jnp.all(valid)
+
+
+def _project_flow_tangents(
+    basis: Array,
+    inhomogeneous: Array,
+    neutral: Array,
     /,
     *,
-    rank_tolerance: float,
-) -> tuple[Array, Array, Array]:
-    real_dtype = jnp.empty((), dtype=basis.dtype).real.dtype
-    effective_tolerance = max(
-        rank_tolerance,
-        10.0 * np.finfo(np.dtype(real_dtype)).eps * max(basis.shape),
+    tolerance: float,
+) -> tuple[Array, Array, Array, Array, Array]:
+    denominator = jnp.vdot(neutral, neutral).real
+    safe = jnp.where(denominator > tolerance, denominator, 1.0)
+    basis_coefficients = (
+        ein.contract("i,ia->a", jnp.conj(neutral), basis).real / safe
+        if basis.shape[1]
+        else jnp.zeros((0,), dtype=inhomogeneous.dtype)
     )
-    gram = ein.contract("ia,ib->ab", jnp.conj(basis), basis)
-    spectrum = HermitianSpectrum(gram, tolerance=effective_tolerance)
-    values = spectrum.eigenvalues
-    scale = jnp.maximum(jnp.max(jnp.abs(values), initial=0.0), 1.0)
-    threshold = effective_tolerance * scale
-    valid = spectrum.valid & jnp.all(values > threshold)
-    if not bool(np.asarray(valid)):
-        raise ValueError("NILSS homogeneous tangent basis lost numerical rank.")
-    vectors = spectrum.eigenvectors
-    inverse_sqrt = vectors * (1.0 / jnp.sqrt(values))[None, :]
-    inverse_sqrt = ein.contract("ia,ja->ij", inverse_sqrt, jnp.conj(vectors))
-    square_root = vectors * jnp.sqrt(values)[None, :]
-    square_root = ein.contract("ia,ja->ij", square_root, jnp.conj(vectors))
-    orthonormal = ein.contract("ia,ab->ib", basis, inverse_sqrt)
-    relation = square_root
-    defect = jnp.max(
-        jnp.abs(
-            ein.contract("ia,ib->ab", jnp.conj(orthonormal), orthonormal)
-            - jnp.eye(values.size, dtype=basis.dtype)
-        ),
-        initial=0.0,
+    inhomogeneous_coefficient = jnp.vdot(neutral, inhomogeneous).real / safe
+    projected_basis = basis - neutral[:, None] * basis_coefficients[None, :]
+    projected_inhomogeneous = inhomogeneous - neutral * inhomogeneous_coefficient
+    valid = (
+        (denominator > tolerance)
+        & jnp.all(jnp.isfinite(projected_basis))
+        & jnp.all(jnp.isfinite(projected_inhomogeneous))
     )
-    return orthonormal, relation, defect
+    return (
+        projected_basis,
+        projected_inhomogeneous,
+        -basis_coefficients,
+        -inhomogeneous_coefficient,
+        valid,
+    )
 
 
-class NILSSCost(StrictModule, NonTrainableState):
+class NILSSPlan(AbstractShadowingSolvePlan):
+    """Matrix-free segmented non-intrusive least-squares shadowing policy."""
+
+    method: str = eqx.field(static=True)
     state_dimension: int = eqx.field(static=True)
     unstable_dimension: int = eqx.field(static=True)
-    horizon_steps: int = eqx.field(static=True)
-    segment_count: int = eqx.field(static=True)
-    retained_bytes: int = eqx.field(static=True)
-    workspace_bytes: int = eqx.field(static=True)
-    maximum_retained_bytes: int = eqx.field(static=True)
-    maximum_workspace_bytes: int = eqx.field(static=True)
-
-
-class NILSSPlan(StrictModule, NonTrainableState):
-    """Segmented non-intrusive least-squares shadowing policy.
-
-    Homogeneous and inhomogeneous tangents are obtained only by differentiating
-    the supplied time-step map.  Segment-boundary coefficients satisfy the
-    exact QR-equivalent continuity constraints, and one constrained global
-    least-squares problem is solved; this is not a set of independently scored
-    perturbation candidates.
-    """
-
-    state_dimension: int = eqx.field(static=True)
-    unstable_dimension: int = eqx.field(static=True)
+    basis_dimension: int = eqx.field(static=True)
     segment_steps: int = eqx.field(static=True)
     segment_count: int = eqx.field(static=True)
     regularization: float = eqx.field(static=True)
     rank_tolerance: float = eqx.field(static=True)
+    memory_mode: ShadowingMemoryMode = eqx.field(static=True)
     maximum_retained_bytes: int = eqx.field(static=True)
     maximum_workspace_bytes: int = eqx.field(static=True)
     plan_id: str = eqx.field(static=True)
@@ -96,6 +120,7 @@ class NILSSPlan(StrictModule, NonTrainableState):
         self,
         state_dimension: int,
         unstable_dimension: int,
+        basis_dimension: int,
         segment_steps: int,
         segment_count: int,
         /,
@@ -105,402 +130,521 @@ class NILSSPlan(StrictModule, NonTrainableState):
         maximum_retained_bytes: int = 2 * 1024 * 1024 * 1024,
         maximum_workspace_bytes: int = 4 * 1024 * 1024 * 1024,
     ):
-        dimension = int(state_dimension)
-        unstable = int(unstable_dimension)
-        length = int(segment_steps)
-        count = int(segment_count)
-        regularization_ = float(regularization)
-        rank = float(rank_tolerance)
-        retained_limit = int(maximum_retained_bytes)
-        workspace_limit = int(maximum_workspace_bytes)
-        if (
-            dimension < 1
-            or unstable < 1
-            or unstable > dimension
-            or length < 1
-            or count < 1
-            or not np.isfinite(regularization_)
-            or regularization_ < 0.0
-            or not np.isfinite(rank)
-            or rank <= 0.0
-            or retained_limit <= 0
-            or workspace_limit <= 0
-        ):
-            raise ValueError("NILSS dimensions, tolerances, or resources are invalid.")
-        self.state_dimension = dimension
-        self.unstable_dimension = unstable
-        self.segment_steps = length
-        self.segment_count = count
-        self.regularization = regularization_
-        self.rank_tolerance = rank
-        self.maximum_retained_bytes = retained_limit
-        self.maximum_workspace_bytes = workspace_limit
-        self.plan_id = canonical_fingerprint(
-            {
-                "kind": "nilss-plan",
-                "state_dimension": dimension,
-                "unstable_dimension": unstable,
-                "segment_steps": length,
-                "segment_count": count,
-                "regularization": regularization_,
-                "rank_tolerance": rank,
-                "maximum_retained_bytes": retained_limit,
-                "maximum_workspace_bytes": workspace_limit,
-                "formulation": "segmented-constrained-least-squares-shadowing",
-            }
+        values = validate_shadowing_plan(
+            "nilss",
+            state_dimension,
+            unstable_dimension,
+            basis_dimension,
+            segment_steps,
+            segment_count,
+            regularization,
+            rank_tolerance,
+            "store",
+            maximum_retained_bytes,
+            maximum_workspace_bytes,
         )
-
-    @property
-    def horizon_steps(self) -> int:
-        return self.segment_steps * self.segment_count
+        (
+            self.state_dimension,
+            self.unstable_dimension,
+            self.basis_dimension,
+            self.segment_steps,
+            self.segment_count,
+            self.regularization,
+            self.rank_tolerance,
+            self.maximum_retained_bytes,
+            self.maximum_workspace_bytes,
+        ) = values
+        self.method = "nilss"
+        self.memory_mode = "store"
+        self.plan_id = shadowing_plan_id("nilss", values, self.memory_mode)
 
     def prepare(
         self,
-        step: StepFunction,
-        objective: ObjectiveFunction,
-        initial_state: ArrayLike,
-        parameters: PyTree[Any],
-        direction: PyTree[Any],
+        problem: ShadowingSensitivityProblem,
+        trajectory: EvolutionTrajectory,
+        parameter_direction: PyTree[Any],
         /,
         *,
-        dynamics_id: str,
-        objective_id: str,
+        args: PyTree[Array],
         initial_basis: ArrayLike | None = None,
+        key: Array | None = None,
     ) -> "PreparedNILSS":
-        if not callable(step) or not callable(objective):
-            raise TypeError("step and objective must be callable.")
-        dynamics_identifier = str(dynamics_id)
-        objective_identifier = str(objective_id)
-        if not dynamics_identifier or not objective_identifier:
-            raise ValueError("dynamics_id and objective_id must be non-empty.")
-        initial = jnp.asarray(initial_state)
-        if initial.shape != (self.state_dimension,) or not jnp.issubdtype(
-            initial.dtype, jnp.floating
+        if not isinstance(problem, ShadowingSensitivityProblem):
+            raise TypeError("problem must be a ShadowingSensitivityProblem.")
+        if not isinstance(trajectory, EvolutionTrajectory):
+            raise TypeError("trajectory must be an EvolutionTrajectory.")
+        if problem.evolution.eventful:
+            raise ValueError("NILSS requires event-free evolution segments.")
+        if problem.evolution.stochastic:
+            raise ValueError("NILSS requires deterministic evolution segments.")
+        if trajectory.evolution_id != problem.evolution.evolution_id:
+            raise ValueError("Trajectory and shadowing evolution IDs must match.")
+        if trajectory.grid.num_steps != self.horizon_steps:
+            raise ValueError("Trajectory horizon does not match the NILSS plan.")
+        if trajectory.state_layout.shape != (self.state_dimension,):
+            raise ValueError("NILSS requires the declared one-dimensional state vector.")
+        if not trajectory.state_layout.geometry.trivial:
+            raise ValueError("NILSS initially requires Euclidean state geometry.")
+        if not jnp.issubdtype(trajectory.states.dtype, jnp.floating):
+            raise TypeError("NILSS requires a real floating trajectory.")
+        if jax.tree.structure(args) != jax.tree.structure(parameter_direction):
+            raise ValueError("Parameter direction must match the argument PyTree.")
+        argument_leaves = jax.tree.leaves(args)
+        direction_leaves = jax.tree.leaves(parameter_direction)
+        if not argument_leaves or any(
+            not eqx.is_inexact_array(leaf) for leaf in argument_leaves
         ):
-            raise ValueError("NILSS initial_state must be a real state vector.")
-        if not bool(np.asarray(jnp.all(jnp.isfinite(initial)))):
-            raise ValueError("NILSS initial_state must be finite.")
-        parameter_structure = jax.tree.structure(parameters)
-        if parameter_structure != jax.tree.structure(direction):
-            raise ValueError("Parameter direction must match the parameter PyTree.")
-        basis = (
-            jnp.eye(self.state_dimension, self.unstable_dimension, dtype=initial.dtype)
-            if initial_basis is None
-            else jnp.asarray(initial_basis, dtype=initial.dtype)
-        )
-        if basis.shape != (self.state_dimension, self.unstable_dimension):
-            raise ValueError("initial_basis has an incompatible shape.")
-        basis, _, defect = _orthonormalize(basis, rank_tolerance=self.rank_tolerance)
-        if not bool(np.asarray(jnp.all(jnp.isfinite(basis)))):
-            raise ValueError("NILSS initial_basis must be finite.")
-        itemsize = np.dtype(initial.dtype).itemsize
+            raise TypeError("NILSS args must be a nonempty PyTree of inexact arrays.")
+        if any(
+            argument.shape != direction.shape or argument.dtype != direction.dtype
+            for argument, direction in zip(argument_leaves, direction_leaves, strict=True)
+        ):
+            raise ValueError(
+                "Parameter directions must match argument shapes and dtypes."
+            )
+        if isinstance(trajectory.grid, IterationGrid):
+            if problem.time_dilation != "none":
+                raise ValueError("Discrete-map NILSS does not use flow time dilation.")
+        elif isinstance(trajectory.grid, TimeGrid):
+            if problem.time_dilation != "flow":
+                raise ValueError("Time-grid NILSS requires flow time dilation.")
+        else:
+            raise TypeError("NILSS requires an IterationGrid or TimeGrid trajectory.")
+
+        if self.basis_dimension == 0:
+            if initial_basis is not None or key is not None:
+                raise ValueError("A zero-dimensional NILSS basis accepts no initializer.")
+            basis = jnp.zeros((self.state_dimension, 0), dtype=trajectory.states.dtype)
+            initial_defect = jnp.asarray(0.0, dtype=trajectory.states.dtype)
+        else:
+            if (initial_basis is None) == (key is None):
+                raise ValueError("Provide exactly one of initial_basis and key.")
+            basis = (
+                jax.random.normal(
+                    key,
+                    (self.state_dimension, self.basis_dimension),
+                    dtype=trajectory.states.dtype,
+                )
+                if initial_basis is None
+                else jnp.asarray(initial_basis, dtype=trajectory.states.dtype)
+            )
+            if basis.shape != (self.state_dimension, self.basis_dimension):
+                raise ValueError("initial_basis has an incompatible shape.")
+            if problem.time_dilation == "flow":
+                assert problem.neutral_direction is not None
+                neutral = jnp.asarray(
+                    problem.neutral_direction(
+                        trajectory.grid.coordinates[0],
+                        trajectory.states[0],
+                        args,
+                    )
+                )
+                basis, _, _, _, neutral_valid = _project_flow_tangents(
+                    basis,
+                    jnp.zeros((self.state_dimension,), dtype=basis.dtype),
+                    neutral,
+                    tolerance=self.rank_tolerance,
+                )
+                if not bool(np.asarray(neutral_valid)):
+                    raise ValueError("Initial NILSS neutral direction is singular.")
+            basis, _, initial_defect, basis_valid = orthonormalize_shadowing_basis(
+                basis,
+                rank_tolerance=self.rank_tolerance,
+            )
+            if not bool(np.asarray(basis_valid)):
+                raise ValueError("NILSS initial basis lost numerical rank.")
+
+        itemsize = np.dtype(trajectory.states.dtype).itemsize
         horizon = self.horizon_steps
         retained = itemsize * (
-            (horizon + 1) * self.state_dimension
-            + horizon * self.state_dimension * (self.unstable_dimension + 1)
-            + self.segment_count * self.unstable_dimension**2
+            (horizon + 1) * self.state_dimension * (self.basis_dimension + 2)
+            + horizon * (self.basis_dimension + 1)
+            + self.segment_count * self.basis_dimension**2
         )
-        variables = self.segment_count * self.unstable_dimension
-        constraints = (self.segment_count - 1) * self.unstable_dimension
+        variables = self.segment_count * self.basis_dimension
+        constraints = max(self.segment_count - 1, 0) * self.basis_dimension
         workspace = retained + itemsize * (variables + constraints) ** 2
         if retained > self.maximum_retained_bytes:
             raise MemoryError("NILSS trajectory exceeds maximum_retained_bytes.")
         if workspace > self.maximum_workspace_bytes:
-            raise MemoryError("NILSS constrained solve exceeds maximum_workspace_bytes.")
-        cost = NILSSCost(
+            raise MemoryError("NILSS reduced solve exceeds maximum_workspace_bytes.")
+        cost = ShadowingSolveCost(
+            method=self.method,
             state_dimension=self.state_dimension,
             unstable_dimension=self.unstable_dimension,
+            basis_dimension=self.basis_dimension,
             horizon_steps=horizon,
             segment_count=self.segment_count,
+            input_trajectory_bytes=int(trajectory.states.size) * itemsize,
             retained_bytes=retained,
             workspace_bytes=workspace,
             maximum_retained_bytes=self.maximum_retained_bytes,
             maximum_workspace_bytes=self.maximum_workspace_bytes,
         )
         return PreparedNILSS(
-            self,
-            cost,
-            step,
-            objective,
-            initial,
-            parameters,
-            direction,
-            basis,
-            dynamics_id=dynamics_identifier,
-            objective_id=objective_identifier,
-            initial_basis_defect=defect,
+            plan=self,
+            cost=cost,
+            problem=problem,
+            trajectory=trajectory,
+            args=args,
+            direction=parameter_direction,
+            initial_basis=basis,
+            initial_basis_defect=initial_defect,
         )
 
 
 class PreparedNILSS(StrictModule, NonTrainableState):
     plan: NILSSPlan
-    cost: NILSSCost
-    step_function: StepFunction = eqx.field(static=True)
-    objective_function: ObjectiveFunction = eqx.field(static=True)
-    initial_state: Array
-    parameters: PyTree[Any]
-    direction: PyTree[Any]
+    cost: ShadowingSolveCost
+    problem: ShadowingSensitivityProblem
+    trajectory: EvolutionTrajectory
+    args: PyTree[Array]
+    direction: PyTree[Array]
     initial_basis: Array
     initial_basis_defect: Array
-    dynamics_id: str = eqx.field(static=True)
-    objective_id: str = eqx.field(static=True)
     prepared_id: str = eqx.field(static=True)
 
     def __init__(
         self,
-        plan: NILSSPlan,
-        cost: NILSSCost,
-        step: StepFunction,
-        objective: ObjectiveFunction,
-        initial_state: Array,
-        parameters: PyTree[Any],
-        direction: PyTree[Any],
-        initial_basis: Array,
-        /,
         *,
-        dynamics_id: str,
-        objective_id: str,
+        plan: NILSSPlan,
+        cost: ShadowingSolveCost,
+        problem: ShadowingSensitivityProblem,
+        trajectory: EvolutionTrajectory,
+        args: PyTree[Array],
+        direction: PyTree[Array],
+        initial_basis: Array,
         initial_basis_defect: ArrayLike,
     ):
         self.plan = plan
         self.cost = cost
-        self.step_function = step
-        self.objective_function = objective
-        self.initial_state = initial_state
-        self.parameters = parameters
+        self.problem = problem
+        self.trajectory = trajectory
+        self.args = args
         self.direction = direction
         self.initial_basis = initial_basis
         self.initial_basis_defect = jnp.asarray(initial_basis_defect)
-        self.dynamics_id = dynamics_id
-        self.objective_id = objective_id
         self.prepared_id = canonical_fingerprint(
             {
                 "kind": "prepared-nilss",
                 "plan": plan.plan_id,
-                "dynamics": dynamics_id,
-                "objective": objective_id,
-                "initial_state": array_tree_fingerprint(initial_state),
-                "parameters": array_tree_fingerprint(parameters),
+                "problem": problem.problem_id,
+                "trajectory": trajectory.evolution_id,
+                "args": array_tree_fingerprint(args),
                 "direction": array_tree_fingerprint(direction),
                 "initial_basis": array_tree_fingerprint(initial_basis),
             }
         )
 
+    @eqx.filter_jit
     def solve(self, /) -> "NILSSResult":
         plan = self.plan
-        m = plan.unstable_dimension
-        segments = plan.segment_count
-        x = self.initial_state
+        problem = self.problem
+        trajectory = self.trajectory
         basis = self.initial_basis
-        inhomogeneous = jnp.zeros_like(x)
-        trajectory: list[Array] = [x]
-        local_bases: list[Array] = []
-        local_inhomogeneous: list[Array] = []
-        local_objectives: list[Array] = []
-        boundary_relations: list[Array] = []
-        boundary_offsets: list[Array] = []
+        inhomogeneous = jnp.zeros((plan.state_dimension,), dtype=trajectory.states.dtype)
+        basis_samples: list[Array] = []
+        inhomogeneous_samples: list[Array] = []
+        dilation_basis_samples: list[Array] = []
+        dilation_inhomogeneous_samples: list[Array] = []
+        relations: list[Array] = []
+        offsets: list[Array] = []
         orthogonality_defects: list[Array] = [self.initial_basis_defect]
-        for segment in range(segments):
-            for _ in range(plan.segment_steps):
-                local_bases.append(basis)
-                local_inhomogeneous.append(inhomogeneous)
-                objective_value = jnp.asarray(self.objective_function(x, self.parameters))
-                if objective_value.shape != ():
-                    raise ValueError("NILSS objective must return a scalar.")
-                local_objectives.append(objective_value)
-                state_jacobian = jax.jacfwd(
-                    lambda state: self.step_function(state, self.parameters)
-                )(x)
-                if state_jacobian.shape != (plan.state_dimension, plan.state_dimension):
-                    raise ValueError(
-                        "NILSS step function must preserve the state vector shape."
-                    )
-                next_state, parameter_tangent = jax.jvp(
-                    lambda parameters: self.step_function(x, parameters),
-                    (self.parameters,),
-                    (self.direction,),
+        valid_values: list[Array] = []
+        primal_defects: list[Array] = []
+
+        for segment in range(plan.segment_count):
+            for local_step in range(plan.segment_steps):
+                index = segment * plan.segment_steps + local_step
+                state = trajectory.states[index]
+                source = trajectory.grid.coordinates[index]
+                target = trajectory.grid.coordinates[index + 1]
+                basis_samples.append(basis)
+                inhomogeneous_samples.append(inhomogeneous)
+                propagated_basis, basis_valid = _propagate_columns(
+                    problem,
+                    state,
+                    basis,
+                    source,
+                    target,
+                    self.args,
                 )
-                inhomogeneous = (
-                    ein.contract("ij,j->i", state_jacobian, inhomogeneous)
-                    + parameter_tangent
+                inhomogeneous_step = problem.evolution.tangent_action(
+                    state,
+                    inhomogeneous,
+                    source,
+                    target,
+                    self.args,
                 )
-                basis = ein.contract("ij,ja->ia", state_jacobian, basis)
-                x = jnp.asarray(next_state)
-                if x.shape != (plan.state_dimension,):
-                    raise ValueError(
-                        "NILSS step function returned an incompatible state."
+                parameter_action = EvolutionArgumentJacobianAction(
+                    problem.evolution,
+                    state,
+                    source,
+                    target,
+                    self.args,
+                )
+                propagated_inhomogeneous = inhomogeneous_step.tangent + jnp.asarray(
+                    parameter_action.mv(self.direction)
+                )
+                endpoint_defect = jnp.max(
+                    jnp.abs(
+                        jnp.asarray(parameter_action.primal)
+                        - trajectory.states[index + 1]
+                    ),
+                    initial=0.0,
+                )
+                scale = jnp.maximum(
+                    1.0,
+                    jnp.max(jnp.abs(trajectory.states[index + 1]), initial=0.0),
+                )
+                step_valid = (
+                    basis_valid
+                    & inhomogeneous_step.valid
+                    & jnp.all(jnp.isfinite(propagated_basis))
+                    & jnp.all(jnp.isfinite(propagated_inhomogeneous))
+                    & (endpoint_defect <= 100.0 * plan.rank_tolerance * scale)
+                )
+                if problem.time_dilation == "flow":
+                    assert problem.neutral_direction is not None
+                    neutral = jnp.asarray(
+                        problem.neutral_direction(
+                            target,
+                            trajectory.states[index + 1],
+                            self.args,
+                        )
                     )
-                trajectory.append(x)
-            if segment + 1 < segments:
-                next_basis, relation, defect = _orthonormalize(
+                    (
+                        propagated_basis,
+                        propagated_inhomogeneous,
+                        dilation_basis,
+                        dilation_inhomogeneous,
+                        projection_valid,
+                    ) = _project_flow_tangents(
+                        propagated_basis,
+                        propagated_inhomogeneous,
+                        neutral,
+                        tolerance=plan.rank_tolerance,
+                    )
+                    step_valid = step_valid & projection_valid
+                else:
+                    dilation_basis = jnp.zeros(
+                        (plan.basis_dimension,), dtype=trajectory.states.dtype
+                    )
+                    dilation_inhomogeneous = jnp.asarray(
+                        0.0, dtype=trajectory.states.dtype
+                    )
+                dilation_basis_samples.append(dilation_basis)
+                dilation_inhomogeneous_samples.append(dilation_inhomogeneous)
+                valid_values.append(step_valid)
+                primal_defects.append(endpoint_defect)
+                basis = propagated_basis
+                inhomogeneous = propagated_inhomogeneous
+
+            if segment + 1 < plan.segment_count:
+                basis, relation, defect, rank_valid = orthonormalize_shadowing_basis(
                     basis,
                     rank_tolerance=plan.rank_tolerance,
                 )
-                offset = ein.contract("ia,i->a", jnp.conj(next_basis), inhomogeneous)
-                inhomogeneous = inhomogeneous - ein.contract(
-                    "ia,a->i", next_basis, offset
+                offset = (
+                    ein.contract("ia,i->a", jnp.conj(basis), inhomogeneous).real
+                    if plan.basis_dimension
+                    else jnp.zeros((0,), dtype=inhomogeneous.dtype)
                 )
-                basis = next_basis
-                boundary_relations.append(relation)
-                boundary_offsets.append(offset)
+                inhomogeneous = inhomogeneous - (
+                    ein.contract("ia,a->i", basis, offset)
+                    if plan.basis_dimension
+                    else jnp.zeros_like(inhomogeneous)
+                )
+                relations.append(relation)
+                offsets.append(offset)
                 orthogonality_defects.append(defect)
-        basis_samples = jnp.stack(tuple(local_bases), axis=0)
-        inhomogeneous_samples = jnp.stack(tuple(local_inhomogeneous), axis=0)
-        objective_samples = jnp.stack(tuple(local_objectives), axis=0)
-        coefficient_count = segments * m
-        constraint_count = (segments - 1) * m
-        hessian = np.zeros(
-            (coefficient_count, coefficient_count), dtype=np.asarray(x).dtype
+                valid_values.append(rank_valid)
+
+        basis_samples.append(basis)
+        inhomogeneous_samples.append(inhomogeneous)
+        bases = jnp.stack(tuple(basis_samples), axis=0)
+        inhomogeneous_values = jnp.stack(tuple(inhomogeneous_samples), axis=0)
+        dilation_bases = jnp.stack(tuple(dilation_basis_samples), axis=0)
+        dilation_offsets = jnp.stack(tuple(dilation_inhomogeneous_samples), axis=0)
+        relation_values = (
+            jnp.stack(tuple(relations), axis=0)
+            if relations
+            else jnp.zeros(
+                (0, plan.basis_dimension, plan.basis_dimension),
+                dtype=trajectory.states.dtype,
+            )
         )
-        gradient = np.zeros((coefficient_count,), dtype=np.asarray(x).dtype)
-        for segment in range(segments):
+        offset_values = (
+            jnp.stack(tuple(offsets), axis=0)
+            if offsets
+            else jnp.zeros((0, plan.basis_dimension), dtype=trajectory.states.dtype)
+        )
+        weights = _quadrature_weights(trajectory)
+        covariances = []
+        linear_terms = []
+        for segment in range(plan.segment_count):
             start = segment * plan.segment_steps
-            stop = start + plan.segment_steps
-            samples = basis_samples[start:stop]
-            offsets = inhomogeneous_samples[start:stop]
-            block_hessian = np.asarray(
-                ein.contract("tia,tib->ab", jnp.conj(samples), samples)
+            stop = (
+                (segment + 1) * plan.segment_steps
+                if segment + 1 < plan.segment_count
+                else plan.horizon_steps + 1
             )
-            block_gradient = np.asarray(
-                ein.contract("tia,ti->a", jnp.conj(samples), offsets)
+            local_basis = bases[start:stop]
+            local_inhomogeneous = inhomogeneous_values[start:stop]
+            local_weights = weights[start:stop]
+            covariances.append(
+                ein.contract(
+                    "t,tia,tib->ab",
+                    local_weights,
+                    jnp.conj(local_basis),
+                    local_basis,
+                ).real
             )
-            block = slice(segment * m, (segment + 1) * m)
-            hessian[block, block] = block_hessian + plan.regularization * np.eye(m)
-            gradient[block] = block_gradient
-        constraints = np.zeros(
-            (constraint_count, coefficient_count), dtype=np.asarray(x).dtype
+            linear_terms.append(
+                ein.contract(
+                    "t,tia,ti->a",
+                    local_weights,
+                    jnp.conj(local_basis),
+                    local_inhomogeneous,
+                ).real
+            )
+        covariance_values = jnp.stack(tuple(covariances), axis=0)
+        linear_values = jnp.stack(tuple(linear_terms), axis=0)
+
+        neutral_basis = None
+        neutral_offset = None
+        reduced = solve_reduced_shadowing(
+            covariance_values,
+            linear_values,
+            relation_values,
+            offset_values,
+            regularization=plan.regularization,
+            neutral_basis=neutral_basis,
+            neutral_offset=neutral_offset,
+            solve_id=self.prepared_id,
         )
-        constraint_rhs = np.zeros((constraint_count,), dtype=np.asarray(x).dtype)
-        for boundary, (relation, offset) in enumerate(
-            zip(boundary_relations, boundary_offsets, strict=True)
-        ):
-            row = slice(boundary * m, (boundary + 1) * m)
-            left = slice(boundary * m, (boundary + 1) * m)
-            right = slice((boundary + 1) * m, (boundary + 2) * m)
-            constraints[row, left] = -np.asarray(relation)
-            constraints[row, right] = np.eye(m)
-            constraint_rhs[row] = np.asarray(offset)
-        if constraint_count:
-            kkt = np.block(
-                [
-                    [hessian, constraints.T],
-                    [
-                        constraints,
-                        np.zeros(
-                            (constraint_count, constraint_count), dtype=hessian.dtype
-                        ),
-                    ],
-                ]
-            )
-            rhs = np.concatenate((-gradient, constraint_rhs))
-        else:
-            kkt = hessian
-            rhs = -gradient
-        operator = DenseLinearOperator(
-            jnp.asarray(kkt),
-            operator_id=canonical_fingerprint(
-                {
-                    "kind": "nilss-kkt",
-                    "prepared": self.prepared_id,
-                    "dimension": int(kkt.shape[0]),
-                }
-            ),
+        node_segments = jnp.minimum(
+            jnp.arange(plan.horizon_steps + 1) // plan.segment_steps,
+            plan.segment_count - 1,
         )
-        linear_result = solve(LinearSystem(operator), jnp.asarray(rhs))
-        if not bool(np.asarray(linear_result.successful)):
-            raise ValueError("NILSS constrained least-squares solve did not converge.")
-        coefficients = jnp.asarray(linear_result.value[:coefficient_count]).reshape(
-            (segments, m)
+        selected_coefficients = reduced.coefficients[node_segments]
+        tangent_path = inhomogeneous_values + ein.contract(
+            "tia,ta->ti", bases, selected_coefficients
         )
-        tangent_samples: list[Array] = []
-        for sample in range(plan.horizon_steps):
-            segment = sample // plan.segment_steps
-            tangent_samples.append(
-                inhomogeneous_samples[sample]
-                + ein.contract("ia,a->i", basis_samples[sample], coefficients[segment])
-            )
-        tangents = jnp.stack(tuple(tangent_samples), axis=0)
-        direct_derivatives: list[Array] = []
-        state_derivatives: list[Array] = []
-        for state, tangent in zip(trajectory[:-1], tangents, strict=True):
-            direct = jax.jvp(
-                lambda parameters: self.objective_function(state, parameters),
-                (self.parameters,),
-                (self.direction,),
-            )[1]
-            state_gradient = jax.grad(
-                lambda current: self.objective_function(current, self.parameters)
-            )(state)
-            state_derivatives.append(ein.contract("i,i->", state_gradient, tangent))
-            direct_derivatives.append(direct)
-        instantaneous = jnp.stack(tuple(state_derivatives)) + jnp.stack(
-            tuple(direct_derivatives)
+        step_segments = jnp.arange(plan.horizon_steps) // plan.segment_steps
+        step_coefficients = reduced.coefficients[step_segments]
+        dilation = dilation_offsets + ein.contract(
+            "ta,ta->t", dilation_bases, step_coefficients
         )
-        directional_gradient = jnp.mean(instantaneous)
-        continuity_residual = (
-            jnp.max(
-                jnp.abs(
-                    jnp.asarray(constraints) @ coefficients.reshape((-1,))
-                    - jnp.asarray(constraint_rhs)
-                ),
-                initial=0.0,
-            )
-            if constraint_count
-            else jnp.asarray(0.0, dtype=x.dtype)
+        candidate = evaluate_shadowing_candidate(
+            problem,
+            trajectory,
+            tangent_path,
+            self.direction,
+            args=self.args,
+            time_dilation=dilation,
+            boundary="free",
         )
         maximum_orthogonality_defect = jnp.max(
             jnp.stack(tuple(orthogonality_defects)), initial=0.0
         )
+        propagation_valid = jnp.all(jnp.stack(tuple(valid_values)))
+        maximum_primal_defect = jnp.max(jnp.stack(tuple(primal_defects)), initial=0.0)
         finite = (
-            jnp.all(jnp.isfinite(jnp.stack(tuple(trajectory))))
-            & jnp.all(jnp.isfinite(tangents))
-            & jnp.isfinite(directional_gradient)
+            candidate.valid
+            & jnp.all(jnp.isfinite(tangent_path))
+            & jnp.all(jnp.isfinite(dilation))
+            & jnp.all(jnp.isfinite(reduced.coefficients))
+            & jnp.isfinite(maximum_orthogonality_defect)
+            & jnp.isfinite(maximum_primal_defect)
         )
-        real_dtype = jnp.empty((), dtype=x.dtype).real.dtype
-        effective_tolerance = max(
-            plan.rank_tolerance,
-            10.0
-            * np.finfo(np.dtype(real_dtype)).eps
-            * max(plan.state_dimension, plan.unstable_dimension),
-        )
+        tolerance = 100.0 * plan.rank_tolerance
         successful = (
-            finite
-            & (continuity_residual <= 100.0 * effective_tolerance)
-            & (maximum_orthogonality_defect <= 100.0 * effective_tolerance)
+            trajectory.successful
+            & propagation_valid
+            & reduced.successful
+            & candidate.valid
+            & finite
+            & (reduced.continuity_residual <= tolerance)
+            & (reduced.neutral_residual <= tolerance)
+            & (maximum_orthogonality_defect <= tolerance)
         )
+        status = jnp.where(
+            ~trajectory.successful,
+            int(ShadowingSolveStatus.TRAJECTORY_INVALID),
+            jnp.where(
+                ~propagation_valid,
+                int(ShadowingSolveStatus.BASIS_RANK_LOST),
+                jnp.where(
+                    ~reduced.successful,
+                    int(ShadowingSolveStatus.LINEAR_SOLVE_FAILED),
+                    jnp.where(
+                        ~finite,
+                        int(ShadowingSolveStatus.NONFINITE),
+                        jnp.where(
+                            reduced.continuity_residual > tolerance,
+                            int(ShadowingSolveStatus.CONTINUITY_FAILED),
+                            jnp.where(
+                                reduced.neutral_residual > tolerance,
+                                int(ShadowingSolveStatus.NEUTRAL_CONSTRAINT_FAILED),
+                                int(ShadowingSolveStatus.SUCCESS),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        ).astype(jnp.int32)
         return NILSSResult(
-            trajectory=jnp.stack(tuple(trajectory)),
-            shadowing_tangent=tangents,
-            segment_coefficients=coefficients,
-            instantaneous_directional_derivative=instantaneous,
-            objective_average=jnp.mean(objective_samples),
-            directional_gradient=directional_gradient,
-            continuity_residual=continuity_residual,
+            trajectory=trajectory,
+            candidate=candidate,
+            shadowing_tangent=tangent_path,
+            time_dilation=dilation,
+            segment_coefficients=reduced.coefficients,
+            objective_average=candidate.observable_mean,
+            directional_gradient=candidate.mean_directional_response,
+            continuity_residual=reduced.continuity_residual,
+            neutral_constraint_residual=reduced.neutral_residual,
             maximum_orthogonality_defect=maximum_orthogonality_defect,
+            maximum_primal_defect=maximum_primal_defect,
             finite=finite,
             successful=successful,
-            linear_status=linear_result.status,
+            status=status,
+            linear_status=reduced.linear_status,
+            tangent_evaluations=jnp.asarray(
+                plan.horizon_steps * (plan.basis_dimension + 1), dtype=jnp.int32
+            ),
+            parameter_action_count=jnp.asarray(plan.horizon_steps, dtype=jnp.int32),
+            cost=self.cost,
             prepared_id=self.prepared_id,
-            dynamics_id=self.dynamics_id,
-            objective_id=self.objective_id,
+            problem_id=problem.problem_id,
+            parameter_id=problem.parameter_id,
+            objective_id=problem.observable_id,
         )
 
 
 class NILSSResult(StrictModule):
-    trajectory: Array
+    trajectory: EvolutionTrajectory
+    candidate: ShadowingCandidateResult
     shadowing_tangent: Array
+    time_dilation: Array
     segment_coefficients: Array
-    instantaneous_directional_derivative: Array
     objective_average: Array
     directional_gradient: Array
     continuity_residual: Array
+    neutral_constraint_residual: Array
     maximum_orthogonality_defect: Array
+    maximum_primal_defect: Array
     finite: Array
     successful: Array
+    status: Array
     linear_status: Array
+    tangent_evaluations: Array
+    parameter_action_count: Array
+    cost: ShadowingSolveCost
     prepared_id: str = eqx.field(static=True)
-    dynamics_id: str = eqx.field(static=True)
+    problem_id: str = eqx.field(static=True)
+    parameter_id: str = eqx.field(static=True)
     objective_id: str = eqx.field(static=True)
 
 
-__all__ = ["NILSSCost", "NILSSPlan", "NILSSResult", "PreparedNILSS"]
+__all__ = ["NILSSPlan", "NILSSResult", "PreparedNILSS"]

--- a/phydrax/statistical_dynamics/_shadowing_solve.py
+++ b/phydrax/statistical_dynamics/_shadowing_solve.py
@@ -1,0 +1,321 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from enum import IntEnum
+from math import isfinite
+from typing import Literal, TypeAlias
+
+import equinox as eqx
+import jax.numpy as jnp
+import numpy as np
+from jaxtyping import Array
+
+from .._fingerprint import canonical_fingerprint
+from .._strict import AbstractAttribute, StrictModule
+from .._trainable import NonTrainableState
+from ..linalg import DenseLinearOperator, LinearSystem, solve
+
+
+ShadowingMemoryMode: TypeAlias = Literal["store", "recompute"]
+
+
+class ShadowingSolveStatus(IntEnum):
+    SUCCESS = 0
+    TRAJECTORY_INVALID = 1
+    BASIS_RANK_LOST = 2
+    LINEAR_SOLVE_FAILED = 3
+    NONFINITE = 4
+    CONTINUITY_FAILED = 5
+    NEUTRAL_CONSTRAINT_FAILED = 6
+
+
+class ShadowingSolveCost(StrictModule, NonTrainableState):
+    method: str = eqx.field(static=True)
+    state_dimension: int = eqx.field(static=True)
+    unstable_dimension: int = eqx.field(static=True)
+    basis_dimension: int = eqx.field(static=True)
+    horizon_steps: int = eqx.field(static=True)
+    segment_count: int = eqx.field(static=True)
+    input_trajectory_bytes: int = eqx.field(static=True)
+    retained_bytes: int = eqx.field(static=True)
+    workspace_bytes: int = eqx.field(static=True)
+    maximum_retained_bytes: int = eqx.field(static=True)
+    maximum_workspace_bytes: int = eqx.field(static=True)
+
+
+class AbstractShadowingSolvePlan(StrictModule, NonTrainableState):
+    method: AbstractAttribute[str]
+    state_dimension: AbstractAttribute[int]
+    unstable_dimension: AbstractAttribute[int]
+    basis_dimension: AbstractAttribute[int]
+    segment_steps: AbstractAttribute[int]
+    segment_count: AbstractAttribute[int]
+    regularization: AbstractAttribute[float]
+    rank_tolerance: AbstractAttribute[float]
+    memory_mode: AbstractAttribute[ShadowingMemoryMode]
+    maximum_retained_bytes: AbstractAttribute[int]
+    maximum_workspace_bytes: AbstractAttribute[int]
+    plan_id: AbstractAttribute[str]
+
+    @property
+    def horizon_steps(self) -> int:
+        return self.segment_steps * self.segment_count
+
+
+def validate_shadowing_plan(
+    method: str,
+    state_dimension: int,
+    unstable_dimension: int,
+    basis_dimension: int,
+    segment_steps: int,
+    segment_count: int,
+    regularization: float,
+    rank_tolerance: float,
+    memory_mode: ShadowingMemoryMode,
+    maximum_retained_bytes: int,
+    maximum_workspace_bytes: int,
+    /,
+) -> tuple[int, int, int, int, int, float, float, int, int]:
+    dimension = int(state_dimension)
+    unstable = int(unstable_dimension)
+    basis = int(basis_dimension)
+    length = int(segment_steps)
+    count = int(segment_count)
+    penalty = float(regularization)
+    rank = float(rank_tolerance)
+    retained = int(maximum_retained_bytes)
+    workspace = int(maximum_workspace_bytes)
+    if (
+        not method
+        or dimension < 1
+        or unstable < 0
+        or basis < unstable
+        or basis > dimension
+        or length < 1
+        or count < 1
+        or not isfinite(penalty)
+        or penalty < 0.0
+        or not isfinite(rank)
+        or rank <= 0.0
+        or memory_mode not in ("store", "recompute")
+        or retained <= 0
+        or workspace <= 0
+    ):
+        raise ValueError("Shadowing dimensions, tolerances, or resources are invalid.")
+    return dimension, unstable, basis, length, count, penalty, rank, retained, workspace
+
+
+def shadowing_plan_id(
+    method: str,
+    values: tuple[int, int, int, int, int, float, float, int, int],
+    memory_mode: ShadowingMemoryMode,
+    /,
+) -> str:
+    (
+        dimension,
+        unstable,
+        basis,
+        length,
+        count,
+        regularization,
+        rank,
+        retained,
+        workspace,
+    ) = values
+    return canonical_fingerprint(
+        {
+            "kind": "shadowing-solve-plan",
+            "method": method,
+            "state_dimension": dimension,
+            "unstable_dimension": unstable,
+            "basis_dimension": basis,
+            "segment_steps": length,
+            "segment_count": count,
+            "regularization": regularization,
+            "rank_tolerance": rank,
+            "memory_mode": memory_mode,
+            "maximum_retained_bytes": retained,
+            "maximum_workspace_bytes": workspace,
+        }
+    )
+
+
+def orthonormalize_shadowing_basis(
+    basis: Array,
+    /,
+    *,
+    rank_tolerance: float,
+) -> tuple[Array, Array, Array, Array]:
+    columns = int(basis.shape[1])
+    if columns == 0:
+        zero = jnp.asarray(0.0, dtype=basis.real.dtype)
+        return basis, jnp.zeros((0, 0), dtype=basis.dtype), zero, jnp.asarray(True)
+    orthonormal, relation = jnp.linalg.qr(basis, mode="reduced")
+    diagonal = jnp.diag(relation)
+    signs = jnp.where(diagonal < 0.0, -1.0, 1.0).astype(basis.dtype)
+    orthonormal = orthonormal * signs[None, :]
+    relation = signs[:, None] * relation
+    gram = jnp.conj(orthonormal).T @ orthonormal
+    defect = jnp.max(
+        jnp.abs(gram - jnp.eye(columns, dtype=basis.dtype)),
+        initial=0.0,
+    )
+    singular_values = jnp.linalg.svd(relation, compute_uv=False)
+    scale = jnp.maximum(jnp.max(singular_values, initial=0.0), 1.0)
+    real_dtype = np.dtype(jnp.empty((), dtype=basis.dtype).real.dtype)
+    threshold = (
+        max(
+            rank_tolerance,
+            10.0 * np.finfo(real_dtype).eps * max(basis.shape),
+        )
+        * scale
+    )
+    valid = (
+        jnp.all(jnp.isfinite(orthonormal))
+        & jnp.all(jnp.isfinite(relation))
+        & jnp.all(singular_values > threshold)
+    )
+    return orthonormal, relation, defect, valid
+
+
+class ReducedShadowingResult(StrictModule):
+    coefficients: Array
+    multipliers: Array
+    continuity_residual: Array
+    neutral_residual: Array
+    rank: Array
+    condition_estimate: Array
+    linear_status: Array
+    successful: Array
+
+
+def solve_reduced_shadowing(
+    covariances: Array,
+    linear_terms: Array,
+    relations: Array,
+    offsets: Array,
+    /,
+    *,
+    regularization: float,
+    neutral_basis: Array | None = None,
+    neutral_offset: Array | None = None,
+    relation_orientation: Literal["forward", "backward"] = "forward",
+    solve_id: str,
+) -> ReducedShadowingResult:
+    segments, basis_dimension = linear_terms.shape
+    coefficient_count = segments * basis_dimension
+    continuity_count = max(segments - 1, 0) * basis_dimension
+    neutral_count = 0 if neutral_basis is None else 1
+    constraint_count = continuity_count + neutral_count
+    dtype = linear_terms.dtype
+    if relation_orientation not in ("forward", "backward"):
+        raise ValueError("Unknown reduced shadowing relation orientation.")
+    if coefficient_count == 0:
+        return ReducedShadowingResult(
+            coefficients=jnp.zeros((segments, 0), dtype=dtype),
+            multipliers=jnp.zeros((0,), dtype=dtype),
+            continuity_residual=jnp.asarray(0.0, dtype=dtype),
+            neutral_residual=jnp.asarray(0.0, dtype=dtype),
+            rank=jnp.asarray(0, dtype=jnp.int32),
+            condition_estimate=jnp.asarray(1.0, dtype=dtype),
+            linear_status=jnp.asarray(0, dtype=jnp.int32),
+            successful=jnp.asarray(True),
+        )
+
+    hessian = jnp.zeros((coefficient_count, coefficient_count), dtype=dtype)
+    gradient = linear_terms.reshape((-1,))
+    identity = jnp.eye(basis_dimension, dtype=dtype)
+    for segment in range(segments):
+        block = slice(segment * basis_dimension, (segment + 1) * basis_dimension)
+        hessian = hessian.at[block, block].set(
+            covariances[segment] + regularization * identity
+        )
+    constraints = jnp.zeros((constraint_count, coefficient_count), dtype=dtype)
+    constraint_rhs = jnp.zeros((constraint_count,), dtype=dtype)
+    for boundary in range(segments - 1):
+        row = slice(boundary * basis_dimension, (boundary + 1) * basis_dimension)
+        left = slice(boundary * basis_dimension, (boundary + 1) * basis_dimension)
+        right = slice(
+            (boundary + 1) * basis_dimension,
+            (boundary + 2) * basis_dimension,
+        )
+        if relation_orientation == "forward":
+            constraints = constraints.at[row, left].set(-relations[boundary])
+            constraints = constraints.at[row, right].set(identity)
+        else:
+            constraints = constraints.at[row, left].set(identity)
+            constraints = constraints.at[row, right].set(-relations[boundary])
+        constraint_rhs = constraint_rhs.at[row].set(offsets[boundary])
+    if neutral_basis is not None:
+        if neutral_basis.shape != (segments, basis_dimension):
+            raise ValueError("neutral_basis has an incompatible shape.")
+        if neutral_offset is None or jnp.asarray(neutral_offset).shape != ():
+            raise ValueError("neutral_offset must be scalar when a constraint is used.")
+        constraints = constraints.at[-1].set(neutral_basis.reshape((-1,)))
+        constraint_rhs = constraint_rhs.at[-1].set(-jnp.asarray(neutral_offset))
+
+    if constraint_count:
+        kkt = jnp.block(
+            [
+                [hessian, constraints.T],
+                [
+                    constraints,
+                    jnp.zeros((constraint_count, constraint_count), dtype=dtype),
+                ],
+            ]
+        )
+        rhs = jnp.concatenate((-gradient, constraint_rhs))
+    else:
+        kkt = hessian
+        rhs = -gradient
+    operator = DenseLinearOperator(
+        kkt,
+        operator_id=canonical_fingerprint(
+            {
+                "kind": "shadowing-reduced-kkt",
+                "solve": solve_id,
+                "size": kkt.shape[0],
+            }
+        ),
+    )
+    linear = solve(LinearSystem(operator), rhs)
+    raw = linear.value[:coefficient_count].reshape((segments, basis_dimension))
+    coefficients = jnp.where(linear.successful, raw, jnp.full_like(raw, jnp.nan))
+    continuity = (
+        jnp.max(
+            jnp.abs(
+                constraints[:continuity_count] @ coefficients.reshape((-1,))
+                - constraint_rhs[:continuity_count]
+            ),
+            initial=0.0,
+        )
+        if continuity_count
+        else jnp.asarray(0.0, dtype=dtype)
+    )
+    neutral = (
+        jnp.abs(constraints[-1] @ coefficients.reshape((-1,)) - constraint_rhs[-1])
+        if neutral_count
+        else jnp.asarray(0.0, dtype=dtype)
+    )
+    return ReducedShadowingResult(
+        coefficients=coefficients,
+        multipliers=linear.value[coefficient_count:],
+        continuity_residual=continuity,
+        neutral_residual=neutral,
+        rank=linear.diagnostics.rank,
+        condition_estimate=linear.diagnostics.condition_estimate,
+        linear_status=linear.status,
+        successful=linear.successful,
+    )
+
+
+__all__ = [
+    "AbstractShadowingSolvePlan",
+    "ReducedShadowingResult",
+    "ShadowingMemoryMode",
+    "ShadowingSolveCost",
+    "ShadowingSolveStatus",
+]

--- a/phydrax/transport/continuous/_density.py
+++ b/phydrax/transport/continuous/_density.py
@@ -177,7 +177,7 @@ def _solve_augmented(
         save_times=jnp.asarray([transport.target_coordinate]),
         solver=evolution.solver,
         stepsize_controller=evolution.stepsize_controller,
-        adjoint=evolution.adjoint,
+        adjoint=evolution.reverse_adjoint,
         dt0=evolution.dt0,
         event=None,
         rtol=evolution.rtol,

--- a/tests/unit/dynamics/test_core.py
+++ b/tests/unit/dynamics/test_core.py
@@ -110,30 +110,63 @@ def test_state_layout_equal_space_defaults_preserve_point_metadata():
     assert layout.tangent_component_names == layout.component_names
 
 
-def test_discrete_evolution_rollout_and_jacobian_share_one_transition():
+def test_discrete_evolution_rollout_and_jacobians_share_one_transition():
     state_layout = phx.dynamics.StateLayout((2,), component_names=("x", "y"))
     matrix = jnp.asarray([[1.1, 0.2], [0.0, 0.9]])
+    parameter_matrix = jnp.asarray([[1.0, -0.5], [0.2, 0.3]])
     system = phx.dynamics.DiscreteSystem(
-        lambda step, state, args: matrix @ state,
+        lambda step, state, args: matrix @ state + parameter_matrix @ args,
         state_layout=state_layout,
         system_id="linear-map",
     )
     evolution = phx.dynamics.DiscreteEvolution(system)
     grid = phx.dynamics.IterationGrid.from_steps(5, iteration_id="linear-map-steps")
     initial = jnp.asarray([0.4, -0.3])
+    args = jnp.asarray([0.1, -0.2])
 
-    rollout = eqx.filter_jit(phx.dynamics.evolve)(evolution, initial, grid)
+    rollout = eqx.filter_jit(phx.dynamics.evolve)(
+        evolution,
+        initial,
+        grid,
+        args=args,
+    )
     expected = [initial]
     for _ in range(5):
-        expected.append(matrix @ expected[-1])
+        expected.append(matrix @ expected[-1] + parameter_matrix @ args)
     np.testing.assert_allclose(rollout.states, jnp.stack(expected), atol=1e-13)
     assert bool(rollout.successful)
 
-    action = phx.dynamics.EvolutionJacobianAction(evolution, initial, 0, 1)
+    action = phx.dynamics.EvolutionJacobianAction(
+        evolution,
+        initial,
+        0,
+        1,
+        args=args,
+    )
     np.testing.assert_allclose(action.as_dense(), matrix, atol=1e-13)
     vector = jnp.asarray([0.2, 0.7])
     np.testing.assert_allclose(action.mv(vector), matrix @ vector, atol=1e-13)
     np.testing.assert_allclose(action.transpose_mv(vector), matrix.T @ vector, atol=1e-13)
+
+    argument_action = phx.dynamics.EvolutionArgumentJacobianAction(
+        evolution,
+        initial,
+        0,
+        1,
+        args,
+    )
+    direction = jnp.asarray([-0.4, 0.6])
+    cotangent = jnp.asarray([0.3, -0.8])
+    np.testing.assert_allclose(
+        argument_action.mv(direction),
+        parameter_matrix @ direction,
+        atol=1e-13,
+    )
+    np.testing.assert_allclose(
+        argument_action.transpose_mv(cotangent),
+        parameter_matrix.T @ cotangent,
+        atol=1e-13,
+    )
 
 
 def test_input_policy_is_bound_and_differentiated_with_the_map():
@@ -298,6 +331,73 @@ def test_diffrax_evolution_rollout_and_numerical_flow_jvp_share_system():
         atol=2.0e-7,
     )
     assert bool(tangent.valid)
+
+    assert isinstance(evolution.reverse_adjoint, dfx.RecursiveCheckpointAdjoint)
+    assert isinstance(evolution.forward_adjoint, dfx.ForwardMode)
+    assert isinstance(evolution.composite_adjoint, dfx.DirectAdjoint)
+    assert evolution.reverse_differentiation.orientations == ("reverse",)
+    assert evolution.reverse_differentiation.checkpointing == "online-binomial"
+    assert evolution.forward_differentiation.orientations == ("forward",)
+    assert evolution.forward_differentiation.checkpointing == "none"
+    assert evolution.composite_differentiation.orientations == (
+        "forward",
+        "reverse",
+    )
+    assert (
+        evolution.forward_differentiation.decision_semantics == "frozen-adaptive-schedule"
+    )
+    state_action = phx.dynamics.EvolutionJacobianAction(
+        evolution,
+        jnp.asarray([2.0]),
+        0.0,
+        1.0,
+        args=jnp.asarray(0.7),
+    )
+    np.testing.assert_allclose(
+        state_action.transpose_mv(jnp.asarray([1.0])),
+        jnp.asarray([jnp.exp(-0.7)]),
+        rtol=2.0e-6,
+        atol=2.0e-7,
+    )
+    argument_action = phx.dynamics.EvolutionArgumentJacobianAction(
+        evolution,
+        jnp.asarray([2.0]),
+        0.0,
+        1.0,
+        jnp.asarray(0.7),
+    )
+    expected_argument_tangent = jnp.asarray([-2.0 * jnp.exp(-0.7)])
+    np.testing.assert_allclose(
+        argument_action.mv(jnp.asarray(1.0)),
+        expected_argument_tangent,
+        rtol=2.0e-6,
+        atol=2.0e-7,
+    )
+    np.testing.assert_allclose(
+        argument_action.transpose_mv(jnp.asarray([1.0])),
+        expected_argument_tangent[0],
+        rtol=2.0e-6,
+        atol=2.0e-7,
+    )
+
+
+def test_diffrax_evolution_rejects_misoriented_derivative_routes():
+    system = phx.dynamics.ContinuousSystem(
+        lambda time, state, args: -state,
+        state_layout=phx.dynamics.StateLayout((1,)),
+        system_id="misoriented-differentiation-flow",
+    )
+
+    with pytest.raises(ValueError, match="reverse_adjoint"):
+        phx.solver.DiffraxEvolution(
+            system,
+            reverse_adjoint=dfx.ForwardMode(),
+        )
+    with pytest.raises(ValueError, match="forward_adjoint"):
+        phx.solver.DiffraxEvolution(
+            system,
+            forward_adjoint=dfx.RecursiveCheckpointAdjoint(),
+        )
 
 
 def test_diffrax_evolution_reports_backend_failure_without_method_fallback():

--- a/tests/unit/dynamics/test_covariant_shadowing.py
+++ b/tests/unit/dynamics/test_covariant_shadowing.py
@@ -71,27 +71,40 @@ def test_covariant_store_and_recompute_modes_match_diagonal_map():
     )
 
 
-def test_shadowing_boundary_reports_exact_inhomogeneous_tangent_candidate():
-    evolution = _linear_map(jnp.asarray([[0.8]]), system_id="shadowing-map")
+def test_shadowing_boundary_derives_exact_argument_tangent_candidate():
+    system = phx.dynamics.DiscreteSystem(
+        lambda coordinate, state, args: 0.8 * state + args,
+        state_layout=phx.dynamics.StateLayout((1,)),
+        system_id="shadowing-map",
+    )
+    evolution = phx.dynamics.DiscreteEvolution(system)
     grid = phx.dynamics.IterationGrid.from_steps(5, iteration_id="shadowing-grid")
-    trajectory = phx.dynamics.evolve(evolution, jnp.asarray([2.0]), grid)
+    args = jnp.asarray([0.0])
+    direction = jnp.asarray([1.0])
+    trajectory = phx.dynamics.evolve(
+        evolution,
+        jnp.asarray([2.0]),
+        grid,
+        args=args,
+    )
     problem = phx.dynamics.analysis.ShadowingSensitivityProblem(
         evolution,
-        lambda state, source, target, args: jnp.ones((1,)),
-        lambda coordinate, state, args: state[0],
+        lambda coordinate, state, parameters: state[0],
         parameter_id="offset",
         observable_id="state",
         problem_id="linear-shadowing-boundary",
     )
     tangent = [jnp.asarray([0.0])]
     for _ in range(grid.num_steps):
-        tangent.append(0.8 * tangent[-1] + 1.0)
+        tangent.append(0.8 * tangent[-1] + direction)
     tangent_path = jnp.stack(tuple(tangent))
 
     candidate = phx.dynamics.analysis.evaluate_shadowing_candidate(
         problem,
         trajectory,
         tangent_path,
+        direction,
+        args=args,
         boundary="free",
     )
 

--- a/tests/unit/dynamics/test_sensitivity.py
+++ b/tests/unit/dynamics/test_sensitivity.py
@@ -1,0 +1,42 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax.numpy as jnp
+import numpy as np
+
+import phydrax as phx
+
+
+def test_evolution_sensitivity_certificate_checks_jvp_and_transpose_duality():
+    matrix = jnp.asarray([[1.2, -0.3], [0.4, 0.8]])
+    system = phx.dynamics.DiscreteSystem(
+        lambda coordinate, state, args: matrix @ state + args,
+        state_layout=phx.dynamics.StateLayout((2,)),
+        system_id="sensitivity-certificate-map",
+    )
+    evolution = phx.dynamics.DiscreteEvolution(system)
+    policy = phx.dynamics.EvolutionSensitivityPolicy(
+        (1.0e-3, 5.0e-4),
+        relative_tolerance=1.0e-9,
+        absolute_tolerance=1.0e-11,
+    )
+
+    evidence = phx.dynamics.certify_evolution_sensitivity(
+        evolution,
+        jnp.asarray([0.2, -0.4]),
+        jnp.asarray([0.7, 0.1]),
+        jnp.asarray([-0.5, 0.9]),
+        0,
+        1,
+        args=jnp.asarray([0.3, -0.2]),
+        policy=policy,
+        reference_evolution=evolution,
+    )
+
+    assert bool(evidence.valid)
+    assert int(evidence.status) == int(phx.dynamics.EvolutionSensitivityStatus.SUCCESS)
+    assert evidence.reference_evolution_id == evolution.evolution_id
+    np.testing.assert_allclose(evidence.jvp_defects, 0.0, atol=1e-12)
+    np.testing.assert_allclose(evidence.duality_defect, 0.0, atol=1e-12)
+    np.testing.assert_allclose(evidence.reference_tangent_defect, 0.0, atol=1e-12)

--- a/tests/unit/solver/test_time_integrators.py
+++ b/tests/unit/solver/test_time_integrators.py
@@ -43,6 +43,14 @@ def test_diffrax_preflight_resolves_fixed_solver_and_records_configuration():
     assert solution.successful
     assert solution.temporal_evidence is not None
     assert not solution.temporal_evidence.adaptive
+    differentiation = solution.temporal_evidence.differentiation
+    assert differentiation.form == "discretize-then-optimize"
+    assert differentiation.orientations == ("reverse",)
+    assert differentiation.checkpointing == "online-binomial"
+    assert differentiation.decision_semantics == "fixed-grid"
+    assert differentiation.event_semantics == "none"
+    assert differentiation.stochastic_semantics == "deterministic"
+    assert differentiation.verified
     assert solution.problem_id == "test-decay-1.0-1.0"
     assert jnp.allclose(solution.states[-1, 0], jnp.exp(-1.0), rtol=8e-4)
 
@@ -217,6 +225,10 @@ def test_adaptive_rosenbrock_replays_a_frozen_accepted_grid():
     value, gradient = jax.jit(jax.value_and_grad(terminal))(jnp.asarray(10.0))
     assert solution.successful
     assert solution.temporal_evidence.adaptive
+    differentiation = solution.temporal_evidence.differentiation
+    assert differentiation.orientations == ("forward", "reverse")
+    assert differentiation.checkpointing == "full-replay"
+    assert differentiation.decision_semantics == "frozen-adaptive-schedule"
     assert int(solution.stats["accepted_steps"]) > grid.num_steps
     assert jnp.allclose(value, jnp.exp(-10.0), rtol=3e-4)
     assert jnp.allclose(gradient, -jnp.exp(-10.0), rtol=3e-4)

--- a/tests/unit/statistical_dynamics/test_nilsas.py
+++ b/tests/unit/statistical_dynamics/test_nilsas.py
@@ -1,0 +1,125 @@
+#
+# Copyright © 2026 PHYDRA, Inc. All rights reserved.
+#
+
+import jax.numpy as jnp
+import numpy as np
+
+import phydrax as phx
+
+
+def _affine_shadowing_case(*, memory_mode):
+    system = phx.dynamics.DiscreteSystem(
+        lambda coordinate, state, args: 0.5 * state + args["offset"],
+        state_layout=phx.dynamics.StateLayout((1,)),
+        system_id="adjoint-contracting-affine-map",
+    )
+    evolution = phx.dynamics.DiscreteEvolution(system)
+    args = {"offset": jnp.asarray([1.0]), "unused": jnp.asarray(0.3)}
+    grid = phx.dynamics.IterationGrid.from_steps(
+        100,
+        iteration_id="adjoint-contracting-grid",
+    )
+    trajectory = phx.dynamics.evolve(
+        evolution,
+        jnp.asarray([2.0]),
+        grid,
+        args=args,
+    )
+    problem = phx.dynamics.analysis.ShadowingSensitivityProblem(
+        evolution,
+        lambda coordinate, state, parameters: state[0],
+        parameter_id="affine-offset",
+        observable_id="state-average",
+        problem_id="adjoint-contracting-affine-shadowing",
+    )
+    result = (
+        phx.statistical_dynamics.NILSASPlan(
+            1,
+            0,
+            0,
+            10,
+            10,
+            memory_mode=memory_mode,
+        )
+        .prepare(problem, trajectory, args=args)
+        .solve()
+    )
+    return result
+
+
+def test_nilsas_store_and_recompute_match_exact_discrete_gradient():
+    stored = _affine_shadowing_case(memory_mode="store")
+    recomputed = _affine_shadowing_case(memory_mode="recompute")
+    expected = 2.0 - 4.0 * (1.0 - 0.5**101) / 101.0
+
+    assert bool(stored.successful)
+    assert bool(recomputed.successful)
+    assert stored.adjoint_shadowing_path.shape == (101, 1)
+    assert recomputed.adjoint_shadowing_path.shape == (0, 1)
+    assert int(stored.parameter_action_count) == 100
+    assert int(stored.replay_action_count) == 0
+    assert int(recomputed.replay_action_count) == 100
+    np.testing.assert_allclose(
+        stored.parameter_gradient["offset"],
+        expected,
+        atol=1e-12,
+    )
+    np.testing.assert_allclose(stored.parameter_gradient["unused"], 0.0, atol=1e-12)
+    for name in stored.parameter_gradient:
+        np.testing.assert_allclose(
+            recomputed.parameter_gradient[name],
+            stored.parameter_gradient[name],
+            atol=1e-12,
+        )
+
+
+def test_nilsas_enforces_declared_flow_neutral_constraint():
+    matrix = jnp.diag(jnp.asarray([0.8, 0.5]))
+    system = phx.dynamics.DiscreteSystem(
+        lambda coordinate, state, args: matrix @ state + args,
+        state_layout=phx.dynamics.StateLayout((2,)),
+        system_id="flow-neutral-affine-map",
+    )
+    evolution = phx.dynamics.DiscreteEvolution(system)
+    args = jnp.asarray([0.0, 1.0])
+    grid = phx.dynamics.TimeGrid(
+        jnp.linspace(0.0, 1.0, 5),
+        time_id="flow-neutral-grid",
+    )
+    trajectory = phx.dynamics.evolve(
+        evolution,
+        jnp.asarray([0.0, 2.0]),
+        grid,
+        args=args,
+    )
+    problem = phx.dynamics.analysis.ShadowingSensitivityProblem(
+        evolution,
+        lambda coordinate, state, parameters: state[1],
+        parameter_id="flow-offset",
+        observable_id="second-state-average",
+        problem_id="flow-neutral-shadowing",
+        neutral_direction=lambda coordinate, state, parameters: jnp.asarray([1.0, 0.0]),
+        time_dilation="flow",
+    )
+    result = (
+        phx.statistical_dynamics.NILSASPlan(
+            2,
+            0,
+            1,
+            2,
+            2,
+            regularization=1.0e-12,
+        )
+        .prepare(
+            problem,
+            trajectory,
+            args=args,
+            terminal_basis=jnp.asarray([[1.0], [0.0]]),
+        )
+        .solve()
+    )
+
+    assert bool(result.successful)
+    assert result.approximation == "finite-horizon-time-discrete-flow-adjoint-shadowing"
+    np.testing.assert_allclose(result.neutral_constraint_residual, 0.0, atol=1e-10)

--- a/tests/unit/statistical_dynamics/test_nilss.py
+++ b/tests/unit/statistical_dynamics/test_nilss.py
@@ -6,68 +6,151 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from phydrax.statistical_dynamics._nilss import NILSSPlan
+import phydrax as phx
 
 
-def test_nilss_solves_global_shadowing_coefficients_and_directional_gradient():
-    def step(state, parameter):
-        return 0.5 * state + jnp.asarray([parameter])
-
-    def objective(state, parameter):
-        del parameter
-        return state[0]
-
-    prepared = NILSSPlan(
-        1,
-        1,
-        10,
-        10,
-        regularization=1.0e-12,
-    ).prepare(
-        step,
-        objective,
-        jnp.asarray([0.0]),
-        jnp.asarray(1.0),
-        jnp.asarray(1.0),
-        dynamics_id="contracting-affine-map",
-        objective_id="state-average",
+def _affine_shadowing_case(*, steps: int):
+    system = phx.dynamics.DiscreteSystem(
+        lambda coordinate, state, args: 0.5 * state + args,
+        state_layout=phx.dynamics.StateLayout((1,)),
+        system_id="contracting-affine-map",
     )
-    result = prepared.solve()
+    evolution = phx.dynamics.DiscreteEvolution(system)
+    args = jnp.asarray([1.0])
+    grid = phx.dynamics.IterationGrid.from_steps(
+        steps,
+        iteration_id=f"contracting-grid-{steps}",
+    )
+    trajectory = phx.dynamics.evolve(
+        evolution,
+        jnp.asarray([2.0]),
+        grid,
+        args=args,
+    )
+    problem = phx.dynamics.analysis.ShadowingSensitivityProblem(
+        evolution,
+        lambda coordinate, state, parameters: state[0],
+        parameter_id="affine-offset",
+        observable_id="state-average",
+        problem_id="contracting-affine-shadowing",
+    )
+    return problem, trajectory, args
+
+
+def test_nilss_solves_matrix_free_parameter_directional_gradient():
+    problem, trajectory, args = _affine_shadowing_case(steps=100)
+    plan = phx.statistical_dynamics.NILSSPlan(1, 0, 0, 10, 10)
+
+    result = plan.prepare(
+        problem,
+        trajectory,
+        jnp.asarray([1.0]),
+        args=args,
+    ).solve()
+
+    expected = 2.0 - 4.0 * (1.0 - 0.5**101) / 101.0
+    assert bool(result.successful)
+    assert result.segment_coefficients.shape == (10, 0)
+    assert result.shadowing_tangent.shape == (101, 1)
+    assert int(result.tangent_evaluations) == 100
+    assert int(result.parameter_action_count) == 100
+    np.testing.assert_allclose(result.continuity_residual, 0.0, atol=1e-12)
+    np.testing.assert_allclose(result.candidate.defects, 0.0, atol=1e-12)
+    np.testing.assert_allclose(result.directional_gradient, expected, atol=1e-12)
+
+
+def test_nilss_projects_flow_neutral_direction_and_records_time_dilation():
+    matrix = jnp.diag(jnp.asarray([1.0, 0.5]))
+    system = phx.dynamics.DiscreteSystem(
+        lambda coordinate, state, args: matrix @ state + args,
+        state_layout=phx.dynamics.StateLayout((2,)),
+        system_id="nilss-flow-neutral-map",
+    )
+    evolution = phx.dynamics.DiscreteEvolution(system)
+    args = jnp.zeros(2)
+    trajectory = phx.dynamics.evolve(
+        evolution,
+        jnp.zeros(2),
+        phx.dynamics.TimeGrid(
+            jnp.linspace(0.0, 1.0, 5),
+            time_id="nilss-flow-neutral-grid",
+        ),
+        args=args,
+    )
+    problem = phx.dynamics.analysis.ShadowingSensitivityProblem(
+        evolution,
+        lambda coordinate, state, parameters: state[1],
+        parameter_id="flow-offset",
+        observable_id="second-state-average",
+        problem_id="nilss-flow-neutral-shadowing",
+        neutral_direction=lambda coordinate, state, parameters: jnp.asarray([1.0, 0.0]),
+        time_dilation="flow",
+    )
+
+    result = (
+        phx.statistical_dynamics.NILSSPlan(2, 0, 0, 2, 2)
+        .prepare(
+            problem,
+            trajectory,
+            jnp.ones(2),
+            args=args,
+        )
+        .solve()
+    )
 
     assert bool(result.successful)
-    assert result.segment_coefficients.shape == (10, 1)
-    assert result.shadowing_tangent.shape == (100, 1)
-    np.testing.assert_allclose(result.continuity_residual, 0.0, atol=1e-11)
-    np.testing.assert_allclose(result.directional_gradient, 2.0, atol=7e-2)
+    np.testing.assert_allclose(result.time_dilation, -1.0, atol=1e-12)
+    np.testing.assert_allclose(
+        result.candidate.neutral_inner_product,
+        0.0,
+        atol=1e-12,
+    )
+    np.testing.assert_allclose(result.candidate.defects, 0.0, atol=1e-12)
+    np.testing.assert_allclose(result.directional_gradient, 1.296875, atol=1e-12)
 
 
 def test_nilss_resource_and_rank_preflight_refuse_unsupported_runs():
+    problem, trajectory, args = _affine_shadowing_case(steps=4)
     with pytest.raises(MemoryError, match="maximum_retained_bytes"):
-        NILSSPlan(
-            10,
+        phx.statistical_dynamics.NILSSPlan(
+            1,
+            0,
+            0,
             2,
-            100,
-            10,
+            2,
             maximum_retained_bytes=1,
         ).prepare(
-            lambda state, parameter: state + parameter,
-            lambda state, parameter: jnp.sum(state + parameter),
-            jnp.zeros(10),
-            jnp.asarray(0.0),
-            jnp.asarray(1.0),
-            dynamics_id="resource-refusal",
-            objective_id="sum",
+            problem,
+            trajectory,
+            jnp.asarray([1.0]),
+            args=args,
         )
 
-    plan = NILSSPlan(2, 2, 2, 2)
+    rank_system = phx.dynamics.DiscreteSystem(
+        lambda coordinate, state, parameters: state + parameters,
+        state_layout=phx.dynamics.StateLayout((2,)),
+        system_id="nilss-rank-refusal-map",
+    )
+    rank_evolution = phx.dynamics.DiscreteEvolution(rank_system)
+    rank_args = jnp.zeros(2)
+    rank_trajectory = phx.dynamics.evolve(
+        rank_evolution,
+        jnp.zeros(2),
+        phx.dynamics.IterationGrid.from_steps(4, iteration_id="nilss-rank-grid"),
+        args=rank_args,
+    )
+    rank_problem = phx.dynamics.analysis.ShadowingSensitivityProblem(
+        rank_evolution,
+        lambda coordinate, state, parameters: jnp.sum(state),
+        parameter_id="rank-offset",
+        observable_id="sum",
+        problem_id="nilss-rank-refusal",
+    )
     with pytest.raises(ValueError, match="lost numerical rank"):
-        plan.prepare(
-            lambda state, parameter: state + parameter,
-            lambda state, parameter: jnp.sum(state + parameter),
-            jnp.zeros(2),
-            jnp.asarray(0.0),
-            jnp.asarray(1.0),
-            dynamics_id="rank-refusal",
-            objective_id="sum",
+        phx.statistical_dynamics.NILSSPlan(2, 2, 2, 2, 2).prepare(
+            rank_problem,
+            rank_trajectory,
+            jnp.ones(2),
+            args=rank_args,
             initial_basis=jnp.ones((2, 2)),
         )

--- a/tests/unit/test_portfolio_qualification_tools.py
+++ b/tests/unit/test_portfolio_qualification_tools.py
@@ -56,6 +56,7 @@ from phydrax.statistical_dynamics._interactions import (
     NonlinearInteractions,
     QuasilinearInteractions,
 )
+from phydrax.statistical_dynamics._nilsas import NILSASPlan
 from phydrax.statistical_dynamics._nilss import NILSSPlan
 from phydrax.statistical_dynamics._plan import (
     QuadraticDynamics,
@@ -504,13 +505,18 @@ def test_statistical_labels_resources_and_topology_restart_are_isolated():
     with pytest.raises(ValueError, match="cannot describe"):
         statistical_candidate_profile(nl, model_label="ce2")
     with pytest.raises(ValueError, match="only for the NL DNS route"):
-        statistical_candidate_profile(ql, nilss=NILSSPlan(2, 1, 2, 2))
+        statistical_candidate_profile(
+            ql,
+            shadowing=NILSSPlan(2, 1, 1, 2, 2),
+        )
 
     source = _statistical_layout(1)
     target = _statistical_layout(2)
     restart = DistributedRestartRelation(source, target)
-    nilss = NILSSPlan(2, 1, 2, 2)
-    profile = statistical_candidate_profile(nl, distributed_layout=target, nilss=nilss)
+    shadowing = NILSASPlan(2, 1, 1, 2, 2)
+    profile = statistical_candidate_profile(
+        nl, distributed_layout=target, shadowing=shadowing
+    )
     evidence = tuple(
         _evidence(kind, nl.model_id)
         for kind in ("scientific", "performance", "operational", "security")
@@ -522,14 +528,15 @@ def test_statistical_labels_resources_and_topology_restart_are_isolated():
         evidence,
         at_time=10,
         resource_measurements={
-            "retained_bytes": 1024,
-            "nilss_workspace_bytes": 2048,
+            "shadowing_retained_bytes": 1024,
+            "shadowing_workspace_bytes": 2048,
         },
         distributed_layout=target,
         restart_relation=restart,
-        nilss=nilss,
+        shadowing=shadowing,
     )
     assert candidate["model_label"] == "nl-dns"
+    assert candidate["shadowing"]["method"] == "nilsas"
     assert candidate["restart"]["accepted"] is True
     assert candidate["restart"]["topology_changed"] is True
     assert candidate["gates"]["operational"]["outcome"] == "passed"
@@ -541,12 +548,12 @@ def test_statistical_labels_resources_and_topology_restart_are_isolated():
         evidence,
         at_time=10,
         resource_measurements={
-            "retained_bytes": 1024,
-            "nilss_workspace_bytes": 2048,
+            "shadowing_retained_bytes": 1024,
+            "shadowing_workspace_bytes": 2048,
         },
         distributed_layout=target,
         restart_relation=restart,
-        nilss=nilss,
+        shadowing=shadowing,
     )
 
     constrained = _cumulant_plan("ce2", "ql")

--- a/tools/dynamics_benchmarks.py
+++ b/tools/dynamics_benchmarks.py
@@ -12,6 +12,7 @@ import time
 from collections.abc import Callable, Sequence
 from typing import Any
 
+import diffrax as dfx
 import equinox as eqx
 import jax
 import jax.numpy as jnp
@@ -976,6 +977,186 @@ def _learned_discrete_benchmark(
     }
 
 
+def _sensitivity_benchmark(
+    *,
+    dimension: int,
+    num_steps: int,
+    repeats: int,
+    quick: bool,
+) -> dict[str, Any]:
+    temporal_layout = phx.dynamics.StateLayout((1,))
+    temporal_system = phx.dynamics.ContinuousSystem(
+        lambda time_, state_, rate_: -rate_ * state_,
+        state_layout=temporal_layout,
+        system_id="benchmark:sensitivity:decay",
+    )
+    fixed_evolution = phx.solver.DiffraxEvolution(
+        temporal_system,
+        solver=dfx.Tsit5(),
+        stepsize_controller=dfx.ConstantStepSize(),
+        dt0=1.0 / (64 if quick else 256),
+        rtol=1e-9,
+        atol=1e-11,
+    )
+    reference_evolution = phx.solver.DiffraxEvolution(
+        temporal_system,
+        rtol=1e-11,
+        atol=1e-13,
+    )
+    policy = phx.dynamics.EvolutionSensitivityPolicy(
+        (1e-4, 5e-5),
+        relative_tolerance=2e-5,
+        absolute_tolerance=1e-9,
+    )
+    certificate, certificate_mean_ms, certificate_std_ms = _measure(
+        lambda: phx.dynamics.certify_evolution_sensitivity(
+            fixed_evolution,
+            jnp.asarray([2.0]),
+            jnp.asarray([0.7]),
+            jnp.asarray([-0.4]),
+            0.0,
+            1.0,
+            args=jnp.asarray(0.6),
+            policy=policy,
+            reference_evolution=reference_evolution,
+        ),
+        repeats=repeats,
+    )
+
+    shadowing_dimension = min(dimension, 32 if quick else 128)
+    segment_count = min(4, num_steps)
+    segment_steps = max(1, num_steps // segment_count)
+    horizon = segment_steps * segment_count
+    multipliers = jnp.linspace(0.2, 0.8, shadowing_dimension)
+    parameters = jnp.linspace(-0.3, 0.5, shadowing_dimension)
+    direction = jnp.cos(jnp.arange(shadowing_dimension, dtype=parameters.dtype))
+    shadowing_layout = phx.dynamics.StateLayout((shadowing_dimension,))
+    shadowing_system = phx.dynamics.DiscreteSystem(
+        lambda coordinate_, state_, args_: multipliers * state_ + args_,
+        state_layout=shadowing_layout,
+        system_id=f"benchmark:sensitivity:affine:{shadowing_dimension}",
+    )
+    shadowing_evolution = phx.dynamics.DiscreteEvolution(shadowing_system)
+    shadowing_grid = phx.dynamics.IterationGrid.from_steps(
+        horizon,
+        iteration_id=f"benchmark:sensitivity:grid:{horizon}",
+    )
+    trajectory = phx.dynamics.evolve(
+        shadowing_evolution,
+        parameters / (1.0 - multipliers),
+        shadowing_grid,
+        args=parameters,
+    )
+    problem = phx.dynamics.analysis.ShadowingSensitivityProblem(
+        shadowing_evolution,
+        lambda coordinate_, state_, args_: jnp.mean(state_),
+        parameter_id="benchmark-affine-parameter",
+        observable_id="mean-state",
+        problem_id="benchmark-affine-shadowing",
+    )
+    nilss = phx.statistical_dynamics.NILSSPlan(
+        shadowing_dimension,
+        0,
+        0,
+        segment_steps,
+        segment_count,
+    ).prepare(
+        problem,
+        trajectory,
+        direction,
+        args=parameters,
+    )
+    nilsas = phx.statistical_dynamics.NILSASPlan(
+        shadowing_dimension,
+        0,
+        0,
+        segment_steps,
+        segment_count,
+        memory_mode="store",
+    ).prepare(
+        problem,
+        trajectory,
+        args=parameters,
+    )
+    tangent_result, tangent_mean_ms, tangent_std_ms = _measure(
+        nilss.solve,
+        repeats=repeats,
+    )
+    adjoint_result, adjoint_mean_ms, adjoint_std_ms = _measure(
+        nilsas.solve,
+        repeats=repeats,
+    )
+    powers = jnp.arange(1, horizon + 1, dtype=parameters.dtype)[:, None]
+    node_derivatives = (1.0 - multipliers[None, :] ** powers) / (
+        1.0 - multipliers[None, :]
+    )
+    expected_gradient = jnp.sum(node_derivatives, axis=0) / (
+        shadowing_dimension * (horizon + 1)
+    )
+    expected_directional = jnp.vdot(expected_gradient, direction).real
+    adjoint_directional = jnp.vdot(adjoint_result.parameter_gradient, direction).real
+    tangent_error = float(
+        jnp.abs(tangent_result.directional_gradient - expected_directional)
+    )
+    adjoint_error = float(
+        jnp.max(jnp.abs(adjoint_result.parameter_gradient - expected_gradient))
+    )
+    duality_error = float(
+        jnp.abs(tangent_result.directional_gradient - adjoint_directional)
+    )
+    action_scaling_valid = (
+        int(tangent_result.parameter_action_count) == horizon
+        and int(adjoint_result.parameter_action_count) == horizon
+    )
+    passed = (
+        bool(certificate.valid)
+        and bool(tangent_result.successful)
+        and bool(adjoint_result.successful)
+        and action_scaling_valid
+        and tangent_error <= 1e-9
+        and adjoint_error <= 1e-9
+        and duality_error <= 1e-9
+    )
+    return {
+        "temporal_certificate": {
+            "mean_ms": certificate_mean_ms,
+            "standard_deviation_ms": certificate_std_ms,
+            "valid": bool(certificate.valid),
+            "status": int(certificate.status),
+            "maximum_jvp_defect": float(jnp.max(certificate.jvp_defects)),
+            "duality_defect": float(certificate.duality_defect),
+            "reference_tangent_defect": float(certificate.reference_tangent_defect),
+        },
+        "shadowing": {
+            "dimension": shadowing_dimension,
+            "parameter_dimension": shadowing_dimension,
+            "horizon_steps": horizon,
+            "dense_jacobian_materialized": False,
+            "action_count_independent_of_parameter_dimension": action_scaling_valid,
+            "nilss": {
+                "mean_ms": tangent_mean_ms,
+                "standard_deviation_ms": tangent_std_ms,
+                "directional_error": tangent_error,
+                "tangent_evaluations": int(tangent_result.tangent_evaluations),
+                "parameter_action_count": int(tangent_result.parameter_action_count),
+                "retained_bytes": tangent_result.cost.retained_bytes,
+                "workspace_bytes": tangent_result.cost.workspace_bytes,
+            },
+            "nilsas": {
+                "mean_ms": adjoint_mean_ms,
+                "standard_deviation_ms": adjoint_std_ms,
+                "gradient_maximum_error": adjoint_error,
+                "adjoint_action_count": int(adjoint_result.adjoint_action_count),
+                "parameter_action_count": int(adjoint_result.parameter_action_count),
+                "retained_bytes": adjoint_result.cost.retained_bytes,
+                "workspace_bytes": adjoint_result.cost.workspace_bytes,
+            },
+            "tangent_adjoint_duality_error": duality_error,
+        },
+        "passed": passed,
+    }
+
+
 def run_benchmarks(
     *,
     sparse_samples: int,
@@ -989,10 +1170,16 @@ def run_benchmarks(
     seeds: Sequence[int] = (0, 1, 2),
     quick: bool = False,
 ) -> dict[str, Any]:
-    """Benchmark baseline and opt-in thermodynamic dynamics scenarios."""
+    """Benchmark baseline and opt-in dynamics and sensitivity scenarios."""
     requested_scenarios = tuple(str(value) for value in scenarios)
     if "all" in requested_scenarios:
-        resolved_scenarios = ("baseline", "deterministic", "stochastic", "learned")
+        resolved_scenarios = (
+            "baseline",
+            "deterministic",
+            "stochastic",
+            "learned",
+            "sensitivity",
+        )
     elif "thermodynamic" in requested_scenarios:
         resolved_scenarios = tuple(
             dict.fromkeys(
@@ -1007,13 +1194,19 @@ def run_benchmarks(
         )
     else:
         resolved_scenarios = requested_scenarios
-    valid_scenarios = {"baseline", "deterministic", "stochastic", "learned"}
+    valid_scenarios = {
+        "baseline",
+        "deterministic",
+        "stochastic",
+        "learned",
+        "sensitivity",
+    }
     if not resolved_scenarios or any(
         scenario not in valid_scenarios for scenario in resolved_scenarios
     ):
         raise ValueError(
             "scenarios must select baseline, deterministic, stochastic, learned, "
-            "thermodynamic, or all."
+            "sensitivity, thermodynamic, or all."
         )
     supported_architectures = (
         "unstructured_mlp",
@@ -1083,6 +1276,15 @@ def run_benchmarks(
         )
         result["learned_discrete_map"] = learned
         passed = passed and learned["passed"]
+    if "sensitivity" in resolved_scenarios:
+        sensitivity = _sensitivity_benchmark(
+            dimension=dimension,
+            num_steps=num_steps,
+            repeats=repeats,
+            quick=quick,
+        )
+        result["sensitivity_analysis"] = sensitivity
+        passed = passed and sensitivity["passed"]
     thermodynamic: dict[str, Any] = {}
     if "deterministic" in resolved_scenarios:
         deterministic = _deterministic_thermodynamic_benchmark(
@@ -1145,7 +1347,7 @@ def main(argv: Sequence[str] | None = None) -> None:
         default=("baseline",),
         help=(
             "Comma-separated: baseline, deterministic, stochastic, learned, "
-            "thermodynamic, all."
+            "sensitivity, thermodynamic, all."
         ),
     )
     parser.add_argument(

--- a/tools/statistical_dynamics_qualification.py
+++ b/tools/statistical_dynamics_qualification.py
@@ -21,8 +21,10 @@ from phydrax.statistical_dynamics._distributed import (
     DistributedStatisticalLayout,
 )
 from phydrax.statistical_dynamics._interactions import AbstractInteractionModel
-from phydrax.statistical_dynamics._nilss import NILSSPlan
 from phydrax.statistical_dynamics._plan import StatisticalDynamicsPlan
+from phydrax.statistical_dynamics._shadowing_solve import (
+    AbstractShadowingSolvePlan,
+)
 
 
 _GATE_KINDS = {
@@ -55,7 +57,7 @@ def _model_id(model: AbstractInteractionModel | StatisticalDynamicsPlan, /) -> s
 
 def _validate_route(
     model: AbstractInteractionModel | StatisticalDynamicsPlan,
-    nilss: NILSSPlan | None,
+    shadowing: AbstractShadowingSolvePlan | None,
     model_label: str | None,
     /,
 ) -> str:
@@ -64,10 +66,10 @@ def _validate_route(
         raise ValueError(
             f"Model label {model_label!r} cannot describe the bound {label!r} API."
         )
-    if nilss is not None and not isinstance(nilss, NILSSPlan):
-        raise TypeError("nilss must be a NILSSPlan or None.")
-    if nilss is not None and label != "nl-dns":
-        raise ValueError("NILSS evidence is admitted only for the NL DNS route.")
+    if shadowing is not None and not isinstance(shadowing, AbstractShadowingSolvePlan):
+        raise TypeError("shadowing must be an AbstractShadowingSolvePlan or None.")
+    if shadowing is not None and label != "nl-dns":
+        raise ValueError("Shadowing evidence is admitted only for the NL DNS route.")
     return label
 
 
@@ -76,10 +78,10 @@ def statistical_support_tuple(
     /,
     *,
     distributed_layout: DistributedStatisticalLayout | None = None,
-    nilss: NILSSPlan | None = None,
+    shadowing: AbstractShadowingSolvePlan | None = None,
     model_label: str | None = None,
 ) -> SupportTuple:
-    label = _validate_route(model, nilss, model_label)
+    label = _validate_route(model, shadowing, model_label)
     if distributed_layout is not None and not isinstance(
         distributed_layout, DistributedStatisticalLayout
     ):
@@ -105,9 +107,10 @@ def statistical_support_tuple(
         if distributed_layout is None
         else distributed_layout.covariance.storage,
     }
-    if nilss is not None:
-        attributes["nilss_plan_id"] = nilss.plan_id
-        attributes["differentiation"] = "segmented-nilss"
+    if shadowing is not None:
+        attributes["shadowing_plan_id"] = shadowing.plan_id
+        attributes["differentiation"] = "segmented-shadowing"
+        attributes["shadowing_method"] = shadowing.method
     else:
         attributes["differentiation"] = "route-native"
     return SupportTuple("statistical-dynamics", attributes)
@@ -118,14 +121,14 @@ def statistical_candidate_profile(
     /,
     *,
     distributed_layout: DistributedStatisticalLayout | None = None,
-    nilss: NILSSPlan | None = None,
+    shadowing: AbstractShadowingSolvePlan | None = None,
     model_label: str | None = None,
     dependencies: Sequence[SupportDependency] = (),
 ) -> CapabilityProfile:
     support = statistical_support_tuple(
         model,
         distributed_layout=distributed_layout,
-        nilss=nilss,
+        shadowing=shadowing,
         model_label=model_label,
     )
     return CapabilityProfile(
@@ -207,7 +210,7 @@ def _gate(
 
 def _resource_failures(
     model: AbstractInteractionModel | StatisticalDynamicsPlan,
-    nilss: NILSSPlan | None,
+    shadowing: AbstractShadowingSolvePlan | None,
     measurements: Mapping[str, int | float],
     /,
 ) -> tuple[tuple[str, ...], tuple[str, ...], dict[str, float]]:
@@ -223,10 +226,10 @@ def _resource_failures(
             state_bytes=model.maximum_state_bytes,
             workspace_bytes=model.maximum_workspace_bytes,
         )
-    if nilss is not None:
+    if shadowing is not None:
         limits.update(
-            retained_bytes=nilss.maximum_retained_bytes,
-            nilss_workspace_bytes=nilss.maximum_workspace_bytes,
+            shadowing_retained_bytes=shadowing.maximum_retained_bytes,
+            shadowing_workspace_bytes=shadowing.maximum_workspace_bytes,
         )
     failed = tuple(
         f"resource-budget:{name}:{normalized[name]}>{limit}"
@@ -252,17 +255,17 @@ def build_statistical_dynamics_candidate(
     resource_measurements: Mapping[str, int | float],
     distributed_layout: DistributedStatisticalLayout | None = None,
     restart_relation: DistributedRestartRelation | None = None,
-    nilss: NILSSPlan | None = None,
+    shadowing: AbstractShadowingSolvePlan | None = None,
     model_label: str | None = None,
     reference_manifests: Sequence[ReferenceArtifactManifest] = (),
 ) -> dict[str, object]:
     """Build one exact model candidate with isolated resource/restart gates."""
 
-    label = _validate_route(model, nilss, model_label)
+    label = _validate_route(model, shadowing, model_label)
     expected_support = statistical_support_tuple(
         model,
         distributed_layout=distributed_layout,
-        nilss=nilss,
+        shadowing=shadowing,
         model_label=label,
     )
     if not isinstance(profile, CapabilityProfile):
@@ -320,7 +323,7 @@ def build_statistical_dynamics_candidate(
         for name, values in grouped.items()
     }
     resource_failed, resource_gaps, resource_values = _resource_failures(
-        model, nilss, resource_measurements
+        model, shadowing, resource_measurements
     )
     operational_failures: list[str] = []
     operational_gaps: list[str] = []
@@ -435,15 +438,18 @@ def build_statistical_dynamics_candidate(
         "support_tuple": expected_support.to_record(),
         "profile": statistical_profile_record(profile),
         "model": model_record,
-        "nilss": None
-        if nilss is None
+        "shadowing": None
+        if shadowing is None
         else {
-            "plan_id": nilss.plan_id,
-            "state_dimension": nilss.state_dimension,
-            "unstable_dimension": nilss.unstable_dimension,
-            "horizon_steps": nilss.horizon_steps,
-            "maximum_retained_bytes": nilss.maximum_retained_bytes,
-            "maximum_workspace_bytes": nilss.maximum_workspace_bytes,
+            "method": shadowing.method,
+            "plan_id": shadowing.plan_id,
+            "state_dimension": shadowing.state_dimension,
+            "unstable_dimension": shadowing.unstable_dimension,
+            "basis_dimension": shadowing.basis_dimension,
+            "horizon_steps": shadowing.horizon_steps,
+            "memory_mode": shadowing.memory_mode,
+            "maximum_retained_bytes": shadowing.maximum_retained_bytes,
+            "maximum_workspace_bytes": shadowing.maximum_workspace_bytes,
         },
         "resources": resource_values,
         "topology": topology_record,


### PR DESCRIPTION
## Summary

- add inspectable temporal differentiation evidence across Diffrax and native temporal solvers
- separate composite, forward pushforward, and checkpointed reverse pullback routes in `DiffraxEvolution`
- expose matrix-free state and argument linearizations plus local derivative certification
- migrate shadowing problems to the evolution's ordinary argument PyTree
- replace the prior host-oriented NILSS path with a JAX-native segmented solver
- add discrete NILSAS with full argument-gradient PyTrees, stored/recomputed adjoints, and flow-neutral constraints
- generalize statistical qualification, public exports, documentation, and dynamics benchmark coverage around the shared shadowing plan contract

## Temporal differentiation contracts

`TemporalSolveEvidence` now owns a `TemporalDifferentiationEvidence` record describing:

- discretize-then-optimize, optimize-then-discretize, implicit-solution-map, or unknown form
- supported forward and reverse orientations
- checkpointing semantics and optional checkpoint count
- fixed-grid, frozen-adaptive-schedule, or backend-defined decision semantics
- event and stochastic derivative semantics
- implementation identity and verification status

Diffrax configurations are classified from their concrete adjoint route. Native implicit Runge-Kutta, multirate, Rosenbrock-W, and frozen accepted-grid replay paths now emit the same evidence contract.

## Evolution derivatives

`AbstractDifferentiableEvolution` now exposes prepared state and argument linearizations and declares whether segments are eventful or stochastic. `DiscreteEvolution`, `DiffraxEvolution`, and Hermitian coordinate evolution implement the complete contract.

`DiffraxEvolution` uses three explicit routes:

- `DirectAdjoint` for bidirectional nested JAX composition
- `ForwardMode` for prepared pushforwards
- `RecursiveCheckpointAdjoint` for prepared pullbacks

Orientation mismatches fail during construction. `EvolutionJacobianAction` consumes the state linearization, while the new `EvolutionArgumentJacobianAction` provides matrix-free argument pushforwards and pullbacks over arbitrary inexact-array PyTrees.

`certify_evolution_sensitivity` records centered finite-difference defects, Taylor remainders, transpose duality, optional reference-evolution agreement, validity, and precise failure status.

## Shadowing solvers

`ShadowingSensitivityProblem` now binds only the evolution and scalar observable. Segment parameter forcing is derived from `EvolutionArgumentJacobianAction`, and direct observable parameter derivatives are derived from the same argument PyTree.

The NILSS implementation now:

- propagates homogeneous and inhomogeneous tangents without materializing state Jacobians
- performs segment QR and one reduced constrained solve in JAX
- reports continuity, orthogonality, primal, resource, and action-count evidence
- projects declared flow-neutral directions and retains signed time dilation

The new NILSAS implementation:

- propagates reusable transpose actions backward
- returns the complete argument-gradient PyTree without one tangent solve per parameter
- supports stored adjoint paths or segment-seed recomputation
- enforces backward segment continuity
- imposes one global neutral-adjoint constraint for time-grid flows
- reports retained/workspace bounds and replay/action counts

Both routes require real Euclidean states and deterministic, event-free segments. Their results remain explicitly finite-horizon approximations.

## Integration and cutover

- statistical qualification accepts the shared `AbstractShadowingSolvePlan` and records method-neutral shadowing metadata
- public dynamics, solver, and statistical-dynamics facades expose the new contracts
- continuous density transport uses the explicit reverse route
- the dynamics benchmark gains an opt-in sensitivity scenario with analytic tangent/adjoint comparisons and parameter-dimension-independent action evidence
- API guides, the nonlinear-dynamics cookbook, README, portfolio documentation, and changelog describe the new contracts and limitations

This is a clean cutover: the former single `DiffraxEvolution.adjoint` option, manually supplied shadowing forcing callbacks, NILSS-specific qualification keys, and the previous NILSS preparation interface are not retained as aliases.